### PR TITLE
fix(aci): Use notification_uuid from WorkflowFireHistory when sending notifications

### DIFF
--- a/src/sentry/integrations/discord/handlers/discord_handler.py
+++ b/src/sentry/integrations/discord/handlers/discord_handler.py
@@ -53,5 +53,15 @@ class DiscordActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/discord/handlers/discord_handler.py
+++ b/src/sentry/integrations/discord/handlers/discord_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.action_handler_registry.base import (
@@ -50,5 +52,6 @@ class DiscordActionHandler(IntegrationActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(DiscordActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/integrations/discord/handlers/discord_handler.py
+++ b/src/sentry/integrations/discord/handlers/discord_handler.py
@@ -53,15 +53,5 @@ class DiscordActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/msteams/handlers/msteams_handler.py
+++ b/src/sentry/integrations/msteams/handlers/msteams_handler.py
@@ -35,15 +35,5 @@ class MSTeamsActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/msteams/handlers/msteams_handler.py
+++ b/src/sentry/integrations/msteams/handlers/msteams_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
     IntegrationActionHandler,
@@ -32,5 +34,6 @@ class MSTeamsActionHandler(IntegrationActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(MSTeamsActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/integrations/msteams/handlers/msteams_handler.py
+++ b/src/sentry/integrations/msteams/handlers/msteams_handler.py
@@ -35,5 +35,15 @@ class MSTeamsActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
+++ b/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
@@ -40,5 +40,15 @@ class OpsgenieActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
+++ b/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
@@ -40,15 +40,5 @@ class OpsgenieActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
+++ b/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.integrations.opsgenie.utils import OPSGENIE_CUSTOM_PRIORITIES
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
@@ -37,5 +39,6 @@ class OpsgenieActionHandler(IntegrationActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(OpsgenieActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
+++ b/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
@@ -40,15 +40,5 @@ class PagerdutyActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
+++ b/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
@@ -40,5 +40,15 @@ class PagerdutyActionHandler(IntegrationActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
+++ b/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.integrations.pagerduty.client import PagerdutySeverity
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
@@ -37,5 +39,6 @@ class PagerdutyActionHandler(IntegrationActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(PagerdutyActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/integrations/slack/handlers/slack_action_handler.py
+++ b/src/sentry/integrations/slack/handlers/slack_action_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
     IntegrationActionHandler,
@@ -36,6 +38,7 @@ class SlackActionHandler(IntegrationActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(SlackActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -32,6 +32,7 @@ from sentry.integrations.repository import (
     get_default_metric_alert_repository,
     get_default_notification_action_repository,
 )
+from sentry.integrations.repository.base import BaseNewNotificationMessage
 from sentry.integrations.repository.metric_alert import (
     MetricAlertNotificationMessage,
     MetricAlertNotificationMessageRepository,
@@ -234,7 +235,7 @@ def _build_notification_payload(
     return attachments, text
 
 
-def _send_notification(
+def _send_notification[Msg: BaseNewNotificationMessage, Repo](
     integration: RpcIntegration,
     metric_issue_context: MetricIssueContext,
     attachments: str,
@@ -242,13 +243,9 @@ def _send_notification(
     channel: str,
     thread_ts: str | None,
     reply_broadcast: bool,
-    notification_message_object: (
-        NewMetricAlertNotificationMessage | NewNotificationActionNotificationMessage
-    ),
-    save_notification_method: Callable,
-    repository: (
-        MetricAlertNotificationMessageRepository | NotificationActionNotificationMessageRepository
-    ),
+    notification_message_object: Msg,
+    save_notification_method: Callable[[Msg, Repo], None],
+    repository: Repo,
 ) -> bool:
     with MessagingInteractionEvent(
         interaction_type=MessagingInteractionType.SEND_INCIDENT_ALERT_NOTIFICATION,

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -61,5 +61,15 @@ class TicketingActionHandler(IntegrationActionHandler, ABC):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_issue_alert_handler(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_issue_alert_handler(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC
+from typing import override
 
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
@@ -59,5 +60,6 @@ class TicketingActionHandler(IntegrationActionHandler, ABC):
         return TargetTypeConfigTransformer.from_config_schema(TicketingActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_issue_alert_handler(invocation)

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -61,15 +61,5 @@ class TicketingActionHandler(IntegrationActionHandler, ABC):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_issue_alert_handler(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_issue_alert_handler(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -65,5 +65,15 @@ class EmailActionHandler(ActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.notifications.types import FallthroughChoiceType
@@ -62,5 +64,6 @@ class EmailActionHandler(ActionHandler):
         return cls._config_transformer
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -65,15 +65,5 @@ class EmailActionHandler(ActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -32,5 +34,6 @@ class PluginActionHandler(ActionHandler):
         return None
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
@@ -35,15 +35,5 @@ class PluginActionHandler(ActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
@@ -35,5 +35,15 @@ class PluginActionHandler(ActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -49,15 +49,5 @@ class SentryAppActionHandler(ActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -49,5 +49,15 @@ class SentryAppActionHandler(ActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action
@@ -46,5 +48,6 @@ class SentryAppActionHandler(ActionHandler):
         return TargetTypeConfigTransformer.from_config_schema(SentryAppActionHandler.config_schema)
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -35,15 +35,5 @@ class WebhookActionHandler(ActionHandler):
 
     @staticmethod
     @override
-<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
-=======
-    def execute(
-        job: WorkflowEventData,
-        action: Action,
-        detector: Detector,
-        notification_uuid: str,
-    ) -> None:
-        execute_via_group_type_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -35,5 +35,15 @@ class WebhookActionHandler(ActionHandler):
 
     @staticmethod
     @override
+<<<<<<< HEAD
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)
+=======
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+        notification_uuid: str,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -32,5 +34,6 @@ class WebhookActionHandler(ActionHandler):
         return None
 
     @staticmethod
+    @override
     def execute(invocation: ActionInvocation) -> None:
         execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
@@ -19,13 +19,8 @@ class IssueAlertRegistryHandler(LegacyRegistryHandler):
     @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
-<<<<<<< HEAD
             handler = issue_alert_handler_registry.get(invocation.action.type)
             handler.invoke_legacy_registry(invocation)
-=======
-            handler = issue_alert_handler_registry.get(action.type)
-            handler.invoke_legacy_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
         except NoRegistrationExistsError:
             logger.exception(
                 "No issue alert handler found for action type: %s",

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
@@ -19,8 +19,13 @@ class IssueAlertRegistryHandler(LegacyRegistryHandler):
     @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
+<<<<<<< HEAD
             handler = issue_alert_handler_registry.get(invocation.action.type)
             handler.invoke_legacy_registry(invocation)
+=======
+            handler = issue_alert_handler_registry.get(action.type)
+            handler.invoke_legacy_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
         except NoRegistrationExistsError:
             logger.exception(
                 "No issue alert handler found for action type: %s",

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
@@ -1,4 +1,5 @@
 import logging
+from typing import override
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.notifications.notification_action.registry import (
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 @group_type_notification_registry.register(ErrorGroupType.slug)
 class IssueAlertRegistryHandler(LegacyRegistryHandler):
     @staticmethod
+    @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
             handler = issue_alert_handler_registry.get(invocation.action.type)

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -23,8 +23,13 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
     @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
+<<<<<<< HEAD
             handler = metric_alert_handler_registry.get(invocation.action.type)
             handler.invoke_legacy_registry(invocation)
+=======
+            handler = metric_alert_handler_registry.get(action.type)
+            handler.invoke_legacy_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
         except NoRegistrationExistsError:
             logger.exception(
                 "No metric alert handler found for action type: %s",

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -23,13 +23,8 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
     @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
-<<<<<<< HEAD
             handler = metric_alert_handler_registry.get(invocation.action.type)
             handler.invoke_legacy_registry(invocation)
-=======
-            handler = metric_alert_handler_registry.get(action.type)
-            handler.invoke_legacy_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
         except NoRegistrationExistsError:
             logger.exception(
                 "No metric alert handler found for action type: %s",

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -1,4 +1,5 @@
 import logging
+from typing import override
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.organizationmember import OrganizationMember
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 @group_type_notification_registry.register(MetricIssue.slug)
 class MetricAlertRegistryHandler(LegacyRegistryHandler):
     @staticmethod
+    @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
         try:
             handler = metric_alert_handler_registry.get(invocation.action.type)

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import asdict
@@ -316,8 +315,6 @@ class BaseIssueAlertHandler(ABC):
         2. activate_downstream_actions
         3. execute_futures (also in post_process process_rules)
         """
-        # Use provided notification_uuid or generate a new one as fallback
-        notification_uuid = str(uuid.uuid4())
 
         # Create a rule
         rule = cls.create_rule_instance_from_action(
@@ -494,8 +491,6 @@ class BaseMetricAlertHandler(ABC):
 
         trigger_status = cls.get_trigger_status(invocation.event_data.group)
 
-        # Use provided notification_uuid or generate a new one as fallback
-        notification_uuid = str(uuid.uuid4())
 
         logger.info(
             "notification_action.execute_via_metric_alert_handler",

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import asdict
@@ -315,6 +316,8 @@ class BaseIssueAlertHandler(ABC):
         2. activate_downstream_actions
         3. execute_futures (also in post_process process_rules)
         """
+        # Generate a notification UUID for this invocation
+        notification_uuid = str(uuid.uuid4())
 
         # Create a rule
         rule = cls.create_rule_instance_from_action(
@@ -491,6 +494,8 @@ class BaseMetricAlertHandler(ABC):
 
         trigger_status = cls.get_trigger_status(invocation.event_data.group)
 
+        # Generate a notification UUID for this invocation
+        notification_uuid = str(uuid.uuid4())
 
         logger.info(
             "notification_action.execute_via_metric_alert_handler",

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -316,7 +316,7 @@ class BaseIssueAlertHandler(ABC):
         2. activate_downstream_actions
         3. execute_futures (also in post_process process_rules)
         """
-        # Create a notification uuid
+        # Use provided notification_uuid or generate a new one as fallback
         notification_uuid = str(uuid.uuid4())
 
         # Create a rule
@@ -494,6 +494,7 @@ class BaseMetricAlertHandler(ABC):
 
         trigger_status = cls.get_trigger_status(invocation.event_data.group)
 
+        # Use provided notification_uuid or generate a new one as fallback
         notification_uuid = str(uuid.uuid4())
 
         logger.info(

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import asdict
@@ -316,9 +315,6 @@ class BaseIssueAlertHandler(ABC):
         2. activate_downstream_actions
         3. execute_futures (also in post_process process_rules)
         """
-        # Generate a notification UUID for this invocation
-        notification_uuid = str(uuid.uuid4())
-
         # Create a rule
         rule = cls.create_rule_instance_from_action(
             invocation.action, invocation.detector, invocation.event_data
@@ -338,7 +334,7 @@ class BaseIssueAlertHandler(ABC):
             },
         )
         # Get the futures
-        futures = cls.get_rule_futures(invocation.event_data, rule, notification_uuid)
+        futures = cls.get_rule_futures(invocation.event_data, rule, invocation.notification_uuid)
 
         # Execute the futures
         # If the rule id is -1, we are sending a test notification
@@ -494,9 +490,6 @@ class BaseMetricAlertHandler(ABC):
 
         trigger_status = cls.get_trigger_status(invocation.event_data.group)
 
-        # Generate a notification UUID for this invocation
-        notification_uuid = str(uuid.uuid4())
-
         logger.info(
             "notification_action.execute_via_metric_alert_handler",
             extra={
@@ -516,7 +509,7 @@ class BaseMetricAlertHandler(ABC):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=trigger_status,
-            notification_uuid=notification_uuid,
+            notification_uuid=invocation.notification_uuid,
             organization=invocation.detector.project.organization,
             project=invocation.detector.project,
         )

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -52,36 +52,21 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
             invocation.event_data.event.type in BaseMetricAlertHandler.ACTIVITIES_TO_INVOKE_ON
             and invocation.event_data.group.type == MetricIssue.type_id
         ):
-<<<<<<< HEAD
             return execute_via_metric_alert_handler(invocation)
         return invocation.event_data.event.send_notification()
 
     try:
         handler = group_type_notification_registry.get(invocation.detector.type)
         handler.handle_workflow_action(invocation)
-=======
-            return execute_via_metric_alert_handler(event_data, action, detector, notification_uuid)
-        return event_data.event.send_notification()
-
-    try:
-        handler = group_type_notification_registry.get(detector.type)
-        handler.handle_workflow_action(event_data, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         # If the grouptype is not registered, we can just use the issue alert handler
         # This is so that notifications will still be sent for that group type if we forget to register a handler
         # Most grouptypes are sent to issue alert handlers
         logger.warning(
             "group_type_notification_registry.get.NoRegistrationExistsError",
-<<<<<<< HEAD
             extra={"detector_id": invocation.detector.id, "action_id": invocation.action.id},
         )
         return execute_via_issue_alert_handler(invocation)
-=======
-            extra={"detector_id": detector.id, "action_id": action.id},
-        )
-        return execute_via_issue_alert_handler(event_data, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
     except Exception:
         logger.exception(
             "Error executing via group type registry",
@@ -96,13 +81,8 @@ def execute_via_issue_alert_handler(invocation: ActionInvocation) -> None:
     ensure that the same thread is used for the notification action.
     """
     try:
-<<<<<<< HEAD
         handler = issue_alert_handler_registry.get(invocation.action.type)
         handler.invoke_legacy_registry(invocation)
-=======
-        handler = issue_alert_handler_registry.get(action.type)
-        handler.invoke_legacy_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         logger.exception(
             "No notification handler found for action type: %s",
@@ -123,13 +103,8 @@ def execute_via_metric_alert_handler(invocation: ActionInvocation) -> None:
     This exists so that all metric alert resolution actions can use the same handler as metric alerts
     """
     try:
-<<<<<<< HEAD
         handler = metric_alert_handler_registry.get(invocation.action.type)
         handler.invoke_legacy_registry(invocation)
-=======
-        handler = metric_alert_handler_registry.get(action.type)
-        handler.invoke_legacy_registry(job, action, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         logger.exception(
             "No notification handler found for action type: %s",

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -52,21 +52,36 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
             invocation.event_data.event.type in BaseMetricAlertHandler.ACTIVITIES_TO_INVOKE_ON
             and invocation.event_data.group.type == MetricIssue.type_id
         ):
+<<<<<<< HEAD
             return execute_via_metric_alert_handler(invocation)
         return invocation.event_data.event.send_notification()
 
     try:
         handler = group_type_notification_registry.get(invocation.detector.type)
         handler.handle_workflow_action(invocation)
+=======
+            return execute_via_metric_alert_handler(event_data, action, detector, notification_uuid)
+        return event_data.event.send_notification()
+
+    try:
+        handler = group_type_notification_registry.get(detector.type)
+        handler.handle_workflow_action(event_data, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         # If the grouptype is not registered, we can just use the issue alert handler
         # This is so that notifications will still be sent for that group type if we forget to register a handler
         # Most grouptypes are sent to issue alert handlers
         logger.warning(
             "group_type_notification_registry.get.NoRegistrationExistsError",
+<<<<<<< HEAD
             extra={"detector_id": invocation.detector.id, "action_id": invocation.action.id},
         )
         return execute_via_issue_alert_handler(invocation)
+=======
+            extra={"detector_id": detector.id, "action_id": action.id},
+        )
+        return execute_via_issue_alert_handler(event_data, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
     except Exception:
         logger.exception(
             "Error executing via group type registry",
@@ -81,8 +96,13 @@ def execute_via_issue_alert_handler(invocation: ActionInvocation) -> None:
     ensure that the same thread is used for the notification action.
     """
     try:
+<<<<<<< HEAD
         handler = issue_alert_handler_registry.get(invocation.action.type)
         handler.invoke_legacy_registry(invocation)
+=======
+        handler = issue_alert_handler_registry.get(action.type)
+        handler.invoke_legacy_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         logger.exception(
             "No notification handler found for action type: %s",
@@ -103,8 +123,13 @@ def execute_via_metric_alert_handler(invocation: ActionInvocation) -> None:
     This exists so that all metric alert resolution actions can use the same handler as metric alerts
     """
     try:
+<<<<<<< HEAD
         handler = metric_alert_handler_registry.get(invocation.action.type)
         handler.invoke_legacy_registry(invocation)
+=======
+        handler = metric_alert_handler_registry.get(action.type)
+        handler.invoke_legacy_registry(job, action, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
     except NoRegistrationExistsError:
         logger.exception(
             "No notification handler found for action type: %s",

--- a/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 import sentry_sdk
 
@@ -15,7 +16,10 @@ def test_fire_action(action: Action, event_data: WorkflowEventData) -> list[str]
     """
     action_exceptions = []
     try:
-        action.trigger(event_data)
+        action.trigger(
+            event_data=event_data,
+            notification_uuid=str(uuid.uuid4()),
+        )
     except Exception as exc:
         if isinstance(exc, IntegrationFormError):
             logger.warning("%s.test_alert.integration_error", action.type, extra={"exc": exc})

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -123,7 +123,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, event_data: WorkflowEventData, notification_uuid: str | None = None) -> None:
+    def trigger(self, event_data: WorkflowEventData, notification_uuid: str) -> None:
         from sentry.workflow_engine.processors.detector import get_detector_from_event_data
 
         detector = get_detector_from_event_data(event_data)

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -134,12 +134,16 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             sample_rate=1.0,
         ):
             handler = self.get_handler()
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data,
                 action=self,
                 detector=detector,
             )
             handler.execute(invocation)
+=======
+            handler.execute(event_data, self, detector, notification_uuid)
+>>>>>>> 80f720e8db7 (cleanup)
 
         metrics.incr(
             "workflow_engine.action.trigger",

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -134,16 +134,12 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             sample_rate=1.0,
         ):
             handler = self.get_handler()
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data,
                 action=self,
                 detector=detector,
             )
             handler.execute(invocation)
-=======
-            handler.execute(event_data, self, detector, notification_uuid)
->>>>>>> 80f720e8db7 (cleanup)
 
         metrics.incr(
             "workflow_engine.action.trigger",

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -138,6 +138,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
                 event_data=event_data,
                 action=self,
                 detector=detector,
+                notification_uuid=notification_uuid,
             )
             handler.execute(invocation)
 

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -123,7 +123,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, event_data: WorkflowEventData) -> None:
+    def trigger(self, event_data: WorkflowEventData, notification_uuid: str | None = None) -> None:
         from sentry.workflow_engine.processors.detector import get_detector_from_event_data
 
         detector = get_detector_from_event_data(event_data)

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -197,15 +197,7 @@ def fire_actions(
     deduped_actions = get_unique_active_actions(actions)
 
     for action in deduped_actions:
-        task_params = build_trigger_action_task_params(action, event_data)
-
-        # Add notification_uuid if available from workflow_uuid_map
-        # workflow_id is annotated in the queryset by filter_recently_fired_workflow_actions
-        if workflow_uuid_map:
-            workflow_id = getattr(action, "workflow_id", None)
-            if workflow_id is not None and workflow_id in workflow_uuid_map:
-                task_params["notification_uuid"] = workflow_uuid_map[workflow_id]
-
+        task_params = build_trigger_action_task_params(action, event_data, workflow_uuid_map)
         trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})
 
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -192,7 +192,7 @@ def get_unique_active_actions(
 def fire_actions(
     actions: BaseQuerySet[Action],
     event_data: WorkflowEventData,
-    workflow_uuid_map: dict[int, str] | None = None,
+    workflow_uuid_map: dict[int, str],
 ) -> None:
     deduped_actions = get_unique_active_actions(actions)
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -199,10 +199,11 @@ def fire_actions(
     for action in deduped_actions:
         task_params = build_trigger_action_task_params(action, event_data)
 
-        # Add notification_uuid if available
-        if workflow_uuid_map and hasattr(action, "workflow_id"):
-            workflow_id = getattr(action, "workflow_id")
-            if workflow_id in workflow_uuid_map:
+        # Add notification_uuid if available from workflow_uuid_map
+        # workflow_id is annotated in the queryset by filter_recently_fired_workflow_actions
+        if workflow_uuid_map:
+            workflow_id = getattr(action, "workflow_id", None)
+            if workflow_id is not None and workflow_id in workflow_uuid_map:
                 task_params["notification_uuid"] = workflow_uuid_map[workflow_id]
 
         trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -749,6 +749,14 @@ def fire_actions_for_groups(
                     start_timestamp=start_timestamp,
                 )
 
+                # Create mapping: workflow_id -> notification_uuid for propagation
+                workflow_uuid_map: dict[int, str] = {}
+                if workflow_fire_histories:
+                    workflow_uuid_map = {
+                        history.workflow_id: str(history.notification_uuid)
+                        for history in workflow_fire_histories
+                    }
+
                 event_id = (
                     workflow_event_data.event.event_id
                     if isinstance(workflow_event_data.event, GroupEvent)
@@ -767,7 +775,9 @@ def fire_actions_for_groups(
                 )
                 total_actions += len(filtered_actions)
 
-                fire_actions(filtered_actions, workflow_event_data)
+                fire_actions(
+                    filtered_actions, workflow_event_data, workflow_uuid_map=workflow_uuid_map
+                )
 
     logger.debug(
         "workflow_engine.delayed_workflow.triggered_actions_summary",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -547,7 +547,7 @@ def process_workflows(
         )
 
     should_trigger_actions = should_fire_workflow_actions(organization, event_data.group.type)
-    create_workflow_fire_histories(
+    fire_histories = create_workflow_fire_histories(
         actions,
         event_data,
         should_trigger_actions,
@@ -555,6 +555,13 @@ def process_workflows(
         start_timestamp=event_start_time,
     )
 
-    fire_actions(actions, event_data)
+    # Create mapping: workflow_id -> notification_uuid for propagation
+    workflow_uuid_map: dict[int, str] = {}
+    if fire_histories:
+        workflow_uuid_map = {
+            history.workflow_id: str(history.notification_uuid) for history in fire_histories
+        }
+
+    fire_actions(actions, event_data, workflow_uuid_map=workflow_uuid_map)
 
     return WorkflowEvaluation(tainted=False, data=workflow_evaluation_data)

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -75,6 +75,7 @@ def trigger_action(
     has_reappeared: bool,
     has_escalated: bool,
     detector_id: int | None = None,  # TODO: remove
+    notification_uuid: str | None = None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.processors.detector import get_detector_from_event_data
@@ -127,7 +128,7 @@ def trigger_action(
         # Set up a timeout grouping context because we want to make sure any Sentry timeout reporting
         # in this scope is grouped properly.
         with timeout_grouping_context(action.type):
-            action.trigger(event_data)
+            action.trigger(event_data, notification_uuid=notification_uuid)
     else:
         logger.info(
             "workflow_engine.triggered_actions.dry-run",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -77,8 +77,14 @@ def trigger_action(
     detector_id: int | None = None,  # TODO: remove
     notification_uuid: str | None = None,
 ) -> None:
+    import uuid
+
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.processors.detector import get_detector_from_event_data
+
+    # Generate UUID if not provided (handles version skew at task boundary)
+    if notification_uuid is None:
+        notification_uuid = str(uuid.uuid4())
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -107,6 +107,7 @@ class ActionInvocation:
     event_data: WorkflowEventData
     action: Action
     detector: Detector
+    notification_uuid: str
 
 
 class WorkflowEvaluationSnapshot(TypedDict):

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -89,7 +89,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -97,11 +96,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -176,7 +170,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -184,14 +177,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -89,6 +89,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -96,6 +97,11 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -170,6 +176,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -177,6 +184,14 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -89,10 +89,13 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -170,10 +173,13 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -92,10 +92,13 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -174,10 +177,13 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -92,7 +92,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -100,11 +99,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -180,7 +174,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -188,14 +181,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -92,6 +92,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -99,6 +100,11 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -174,6 +180,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -181,6 +188,14 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -88,10 +88,13 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -169,10 +172,13 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -88,7 +88,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -96,11 +95,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -175,7 +169,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -183,14 +176,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -88,6 +88,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -95,6 +96,11 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -169,6 +175,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -176,6 +183,14 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -79,6 +79,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.OpsgenieMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -86,6 +87,11 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -162,6 +168,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -169,6 +176,14 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -79,7 +79,6 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.OpsgenieMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -87,11 +86,6 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -168,7 +162,6 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -176,14 +169,6 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -79,10 +79,13 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.OpsgenieMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -162,10 +165,13 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -77,7 +77,6 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.PagerDutyMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -85,11 +84,6 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -166,7 +160,6 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -174,14 +167,6 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -77,10 +77,13 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.PagerDutyMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -160,10 +163,13 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -77,6 +77,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.PagerDutyMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -84,6 +85,11 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -160,6 +166,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -167,6 +174,14 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -96,7 +96,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -104,11 +103,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
         assert mock_send_alert.call_count == 1
         (
             notification_context,
@@ -182,7 +176,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -190,14 +183,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -96,10 +96,13 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -176,10 +179,13 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -96,6 +96,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -103,6 +104,11 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
         assert mock_send_alert.call_count == 1
         (
             notification_context,
@@ -176,6 +182,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -183,6 +190,14 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -92,6 +92,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -99,6 +100,11 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -173,6 +179,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -180,6 +187,14 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -92,10 +92,13 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -173,10 +176,13 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -92,7 +92,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -100,11 +99,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (
@@ -179,7 +173,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
@@ -187,14 +180,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 import pytest
@@ -35,10 +36,13 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             IssueAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -60,10 +64,13 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             MetricAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -71,10 +78,13 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.activity, group=self.group)
 
         with mock.patch.object(self.activity, "send_notification"):
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             execute_via_group_type_registry(invocation)
             self.activity.send_notification.assert_called_once_with()
@@ -88,10 +98,13 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         )
         self.event_data = WorkflowEventData(event=activity, group=group)
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
         execute_via_group_type_registry(invocation)
         mock_execute_metric_alert_handler.assert_called_once_with(invocation)
@@ -114,10 +127,13 @@ class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
     ) -> None:
         """Test that handle_workflow_action invokes the when no handler exists"""
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
         execute_via_group_type_registry(invocation)
         mock_execute_via_issue_alert_handler.assert_called_once_with(invocation)

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -92,7 +92,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
             execute_via_group_type_registry(invocation)
 =======
             execute_via_group_type_registry(
-                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+                self.event_data, self.action, self.detector, str(uuid.uuid4())
             )
 >>>>>>> 9511567f9cf (tests)
             self.activity.send_notification.assert_called_once_with()
@@ -114,11 +114,15 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
 =======
         notification_uuid = str(uuid.uuid4())
         execute_via_group_type_registry(
-            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
+            self.event_data, self.action, self.detector, notification_uuid
         )
         mock_execute_metric_alert_handler.assert_called_once_with(
+<<<<<<< HEAD
             self.event_data, self.action, self.detector, notification_uuid=notification_uuid
 >>>>>>> 9511567f9cf (tests)
+=======
+            self.event_data, self.action, self.detector, notification_uuid
+>>>>>>> 80f720e8db7 (cleanup)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_metric_alert_handler.assert_called_once_with(invocation)
@@ -148,11 +152,15 @@ class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
             detector=self.detector,
 =======
         execute_via_group_type_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+            self.event_data, self.action, self.detector, str(uuid.uuid4())
         )
         mock_execute_via_issue_alert_handler.assert_called_once_with(
+<<<<<<< HEAD
             self.event_data, self.action, self.detector, notification_uuid=ANY
 >>>>>>> 9511567f9cf (tests)
+=======
+            self.event_data, self.action, self.detector, ANY
+>>>>>>> 80f720e8db7 (cleanup)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_via_issue_alert_handler.assert_called_once_with(invocation)

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -1,6 +1,4 @@
-import uuid
 from unittest import mock
-from unittest.mock import ANY
 
 import pytest
 
@@ -37,15 +35,10 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
-=======
-            IssueAlertRegistryHandler.handle_workflow_action(
-                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
->>>>>>> 9511567f9cf (tests)
             )
             IssueAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -67,15 +60,10 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
-=======
-            MetricAlertRegistryHandler.handle_workflow_action(
-                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
->>>>>>> 9511567f9cf (tests)
             )
             MetricAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -83,18 +71,12 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.activity, group=self.group)
 
         with mock.patch.object(self.activity, "send_notification"):
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
             )
             execute_via_group_type_registry(invocation)
-=======
-            execute_via_group_type_registry(
-                self.event_data, self.action, self.detector, str(uuid.uuid4())
-            )
->>>>>>> 9511567f9cf (tests)
             self.activity.send_notification.assert_called_once_with()
 
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_metric_alert_handler")
@@ -106,23 +88,10 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         )
         self.event_data = WorkflowEventData(event=activity, group=group)
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
-=======
-        notification_uuid = str(uuid.uuid4())
-        execute_via_group_type_registry(
-            self.event_data, self.action, self.detector, notification_uuid
-        )
-        mock_execute_metric_alert_handler.assert_called_once_with(
-<<<<<<< HEAD
-            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
->>>>>>> 9511567f9cf (tests)
-=======
-            self.event_data, self.action, self.detector, notification_uuid
->>>>>>> 80f720e8db7 (cleanup)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_metric_alert_handler.assert_called_once_with(invocation)
@@ -145,22 +114,10 @@ class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
     ) -> None:
         """Test that handle_workflow_action invokes the when no handler exists"""
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
-=======
-        execute_via_group_type_registry(
-            self.event_data, self.action, self.detector, str(uuid.uuid4())
-        )
-        mock_execute_via_issue_alert_handler.assert_called_once_with(
-<<<<<<< HEAD
-            self.event_data, self.action, self.detector, notification_uuid=ANY
->>>>>>> 9511567f9cf (tests)
-=======
-            self.event_data, self.action, self.detector, ANY
->>>>>>> 80f720e8db7 (cleanup)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_via_issue_alert_handler.assert_called_once_with(invocation)

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -1,4 +1,6 @@
+import uuid
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 
@@ -35,10 +37,15 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+=======
+            IssueAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+>>>>>>> 9511567f9cf (tests)
             )
             IssueAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -60,10 +67,15 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+=======
+            MetricAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+>>>>>>> 9511567f9cf (tests)
             )
             MetricAlertRegistryHandler.handle_workflow_action(invocation)
 
@@ -71,12 +83,18 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.activity, group=self.group)
 
         with mock.patch.object(self.activity, "send_notification"):
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
             )
             execute_via_group_type_registry(invocation)
+=======
+            execute_via_group_type_registry(
+                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+            )
+>>>>>>> 9511567f9cf (tests)
             self.activity.send_notification.assert_called_once_with()
 
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_metric_alert_handler")
@@ -88,10 +106,19 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         )
         self.event_data = WorkflowEventData(event=activity, group=group)
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+=======
+        notification_uuid = str(uuid.uuid4())
+        execute_via_group_type_registry(
+            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
+        )
+        mock_execute_metric_alert_handler.assert_called_once_with(
+            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
+>>>>>>> 9511567f9cf (tests)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_metric_alert_handler.assert_called_once_with(invocation)
@@ -114,10 +141,18 @@ class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
     ) -> None:
         """Test that handle_workflow_action invokes the when no handler exists"""
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+=======
+        execute_via_group_type_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+        mock_execute_via_issue_alert_handler.assert_called_once_with(
+            self.event_data, self.action, self.detector, notification_uuid=ANY
+>>>>>>> 9511567f9cf (tests)
         )
         execute_via_group_type_registry(invocation)
         mock_execute_via_issue_alert_handler.assert_called_once_with(invocation)

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -265,7 +265,6 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         mock_futures = [mock.Mock()]
         mock_activate_downstream_actions.return_value = {"some_key": (mock_callback, mock_futures)}
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -273,11 +272,6 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         )
 
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         # Verify activate_downstream_actions called with correct args
         mock_activate_downstream_actions.assert_called_once_with(

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -265,6 +265,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         mock_futures = [mock.Mock()]
         mock_activate_downstream_actions.return_value = {"some_key": (mock_callback, mock_futures)}
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
@@ -272,6 +273,11 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         )
 
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         # Verify activate_downstream_actions called with correct args
         mock_activate_downstream_actions.assert_called_once_with(

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -265,10 +265,13 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         mock_futures = [mock.Mock()]
         mock_activate_downstream_actions.return_value = {"some_key": (mock_callback, mock_futures)}
 
+        notification_uuid = str(uuid.uuid4())
+
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
 
         self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -298,10 +298,13 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError):
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             self.handler.invoke_legacy_registry(invocation)
 
@@ -423,10 +426,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
 
     @mock.patch.object(TestHandler, "send_alert")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+        notification_uuid = str(uuid.uuid4())
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
         self.handler.invoke_legacy_registry(invocation)
 
@@ -505,10 +510,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
         self.handler.invoke_legacy_registry(invocation)
 
@@ -577,10 +584,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+        notification_uuid = str(uuid.uuid4())
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
+            notification_uuid=notification_uuid,
         )
         self.handler.invoke_legacy_registry(invocation)
 
@@ -644,10 +653,13 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError, match="Activity data is required for alert context"):
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             self.handler.invoke_legacy_registry(invocation)
 
@@ -670,9 +682,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         with pytest.raises(
             TypeError
         ):  # MetricIssueEvidenceData will raise TypeError for missing args
+            notification_uuid = str(uuid.uuid4())
+
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
+                notification_uuid=notification_uuid,
             )
             self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -298,18 +298,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError):
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
             )
             self.handler.invoke_legacy_registry(invocation)
-=======
-            self.handler.invoke_legacy_registry(
-                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-            )
->>>>>>> 9511567f9cf (tests)
 
     def test_get_incident_status(self) -> None:
         # Initial priority is high -> incident is critical
@@ -429,18 +423,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
 
     @mock.patch.object(TestHandler, "send_alert")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -517,21 +505,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -598,21 +577,12 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
-<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
-=======
-        self.handler.invoke_legacy_registry(
-            event_data_with_activity,
-            self.action,
-            self.detector,
-            notification_uuid=str(uuid.uuid4()),
-        )
->>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -674,18 +644,10 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError, match="Activity data is required for alert context"):
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
-=======
-            self.handler.invoke_legacy_registry(
-                event_data_with_activity,
-                self.action,
-                self.detector,
-                notification_uuid=str(uuid.uuid4()),
->>>>>>> 9511567f9cf (tests)
             )
             self.handler.invoke_legacy_registry(invocation)
 
@@ -708,17 +670,9 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         with pytest.raises(
             TypeError
         ):  # MetricIssueEvidenceData will raise TypeError for missing args
-<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
-=======
-            self.handler.invoke_legacy_registry(
-                event_data_with_activity,
-                self.action,
-                self.detector,
-                notification_uuid=str(uuid.uuid4()),
->>>>>>> 9511567f9cf (tests)
             )
             self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -298,12 +298,18 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError):
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=self.event_data,
                 action=self.action,
                 detector=self.detector,
             )
             self.handler.invoke_legacy_registry(invocation)
+=======
+            self.handler.invoke_legacy_registry(
+                self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+            )
+>>>>>>> 9511567f9cf (tests)
 
     def test_get_incident_status(self) -> None:
         # Initial priority is high -> incident is critical
@@ -423,12 +429,18 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
 
     @mock.patch.object(TestHandler, "send_alert")
     def test_invoke_legacy_registry(self, mock_send_alert: mock.MagicMock) -> None:
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=self.event_data,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            self.event_data, self.action, self.detector, notification_uuid=str(uuid.uuid4())
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -505,12 +517,21 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -577,12 +598,21 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
         )
 
+<<<<<<< HEAD
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
         )
         self.handler.invoke_legacy_registry(invocation)
+=======
+        self.handler.invoke_legacy_registry(
+            event_data_with_activity,
+            self.action,
+            self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+>>>>>>> 9511567f9cf (tests)
 
         assert mock_send_alert.call_count == 1
 
@@ -644,10 +674,18 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         with pytest.raises(ValueError, match="Activity data is required for alert context"):
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
+=======
+            self.handler.invoke_legacy_registry(
+                event_data_with_activity,
+                self.action,
+                self.detector,
+                notification_uuid=str(uuid.uuid4()),
+>>>>>>> 9511567f9cf (tests)
             )
             self.handler.invoke_legacy_registry(invocation)
 
@@ -670,9 +708,17 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         with pytest.raises(
             TypeError
         ):  # MetricIssueEvidenceData will raise TypeError for missing args
+<<<<<<< HEAD
             invocation = ActionInvocation(
                 event_data=event_data_with_activity,
                 action=self.action,
                 detector=self.detector,
+=======
+            self.handler.invoke_legacy_registry(
+                event_data_with_activity,
+                self.action,
+                self.detector,
+                notification_uuid=str(uuid.uuid4()),
+>>>>>>> 9511567f9cf (tests)
             )
             self.handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 from rest_framework.serializers import ErrorDetail
@@ -167,4 +168,6 @@ class TestSentryAppActionValidator(BaseWorkflowTest):
         action = validator.save()
 
         setattr(action, "workflow_id", self.workflow.id)
-        action.trigger(self.event_data)  # action should be triggerable
+        action.trigger(
+            self.event_data, notification_uuid=str(uuid.uuid4())
+        )  # action should be triggerable

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -46,7 +46,7 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         assert invocation.detector == self.detector
 =======
         mock_handler.handle_workflow_action.assert_called_once_with(
-            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
+            self.event_data, self.action, self.detector, notification_uuid
         )
 >>>>>>> 9511567f9cf (tests)
 
@@ -89,7 +89,7 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         assert invocation.detector == self.detector
 =======
         mock_handler.handle_workflow_action.assert_called_once_with(
-            self.event_data, self.action, self.detector, notification_uuid=ANY
+            self.event_data, self.action, self.detector, ANY
         )
 >>>>>>> 9511567f9cf (tests)
 

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -1,6 +1,5 @@
 import uuid
 from unittest import mock
-from unittest.mock import ANY
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
@@ -37,18 +36,12 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         self.action.trigger(self.event_data, notification_uuid=notification_uuid)
 
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
-<<<<<<< HEAD
         assert mock_handler.handle_workflow_action.call_count == 1
         invocation = mock_handler.handle_workflow_action.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
         assert invocation.detector == self.detector
-=======
-        mock_handler.handle_workflow_action.assert_called_once_with(
-            self.event_data, self.action, self.detector, notification_uuid
-        )
->>>>>>> 9511567f9cf (tests)
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.group_type_notification_registry.get"
@@ -80,18 +73,12 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         self.action.trigger(self.event_data, notification_uuid=str(uuid.uuid4()))
 
         mock_registry_get.assert_called_once_with(MetricIssue.slug)
-<<<<<<< HEAD
         assert mock_handler.handle_workflow_action.call_count == 1
         invocation = mock_handler.handle_workflow_action.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
         assert invocation.detector == self.detector
-=======
-        mock_handler.handle_workflow_action.assert_called_once_with(
-            self.event_data, self.action, self.detector, ANY
-        )
->>>>>>> 9511567f9cf (tests)
 
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_issue_alert_handler")
     @mock.patch(

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -1,4 +1,6 @@
+import uuid
 from unittest import mock
+from unittest.mock import ANY
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
@@ -31,15 +33,22 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        self.action.trigger(self.event_data)
+        notification_uuid = str(uuid.uuid4())
+        self.action.trigger(self.event_data, notification_uuid=notification_uuid)
 
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
+<<<<<<< HEAD
         assert mock_handler.handle_workflow_action.call_count == 1
         invocation = mock_handler.handle_workflow_action.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
         assert invocation.detector == self.detector
+=======
+        mock_handler.handle_workflow_action.assert_called_once_with(
+            self.event_data, self.action, self.detector, notification_uuid=notification_uuid
+        )
+>>>>>>> 9511567f9cf (tests)
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.group_type_notification_registry.get"
@@ -68,15 +77,21 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        self.action.trigger(self.event_data)
+        self.action.trigger(self.event_data, notification_uuid=str(uuid.uuid4()))
 
         mock_registry_get.assert_called_once_with(MetricIssue.slug)
+<<<<<<< HEAD
         assert mock_handler.handle_workflow_action.call_count == 1
         invocation = mock_handler.handle_workflow_action.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
         assert invocation.detector == self.detector
+=======
+        mock_handler.handle_workflow_action.assert_called_once_with(
+            self.event_data, self.action, self.detector, notification_uuid=ANY
+        )
+>>>>>>> 9511567f9cf (tests)
 
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_issue_alert_handler")
     @mock.patch(
@@ -92,7 +107,7 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
     ) -> None:
         """Test that execute does nothing when we can't find the detector"""
 
-        self.action.trigger(self.event_data)
+        self.action.trigger(self.event_data, notification_uuid=str(uuid.uuid4()))
 
         mock_logger.warning.assert_called_once_with(
             "group_type_notification_registry.get.NoRegistrationExistsError",

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -81,18 +81,12 @@ class TestAction(TestCase):
         with patch.object(self.action, "get_handler", return_value=mock_handler):
             self.action.trigger(self.mock_event, notification_uuid=notification_uuid)
 
-<<<<<<< HEAD
             assert mock_handler.execute.call_count == 1
             invocation = mock_handler.execute.call_args[0][0]
             assert isinstance(invocation, ActionInvocation)
             assert invocation.event_data == self.mock_event
             assert invocation.action == self.action
             assert invocation.detector == mock_detector
-=======
-            mock_handler.execute.assert_called_once_with(
-                self.mock_event, self.action, mock_get_detector.return_value, notification_uuid
-            )
->>>>>>> 9511567f9cf (tests)
 
     @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -90,10 +90,7 @@ class TestAction(TestCase):
             assert invocation.detector == mock_detector
 =======
             mock_handler.execute.assert_called_once_with(
-                self.mock_event,
-                self.action,
-                mock_get_detector.return_value,
-                notification_uuid=notification_uuid,
+                self.mock_event, self.action, mock_get_detector.return_value, notification_uuid
             )
 >>>>>>> 9511567f9cf (tests)
 

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -76,15 +77,25 @@ class TestAction(TestCase):
         mock_detector = Mock(spec=Detector, type="error")
         mock_get_detector.return_value = mock_detector
 
+        notification_uuid = str(uuid.uuid4())
         with patch.object(self.action, "get_handler", return_value=mock_handler):
-            self.action.trigger(self.mock_event)
+            self.action.trigger(self.mock_event, notification_uuid=notification_uuid)
 
+<<<<<<< HEAD
             assert mock_handler.execute.call_count == 1
             invocation = mock_handler.execute.call_args[0][0]
             assert isinstance(invocation, ActionInvocation)
             assert invocation.event_data == self.mock_event
             assert invocation.action == self.action
             assert invocation.detector == mock_detector
+=======
+            mock_handler.execute.assert_called_once_with(
+                self.mock_event,
+                self.action,
+                mock_get_detector.return_value,
+                notification_uuid=notification_uuid,
+            )
+>>>>>>> 9511567f9cf (tests)
 
     @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:
@@ -94,7 +105,7 @@ class TestAction(TestCase):
 
         with patch.object(self.action, "get_handler", return_value=mock_handler):
             with pytest.raises(Exception, match="Handler failed"):
-                self.action.trigger(self.mock_event)
+                self.action.trigger(self.mock_event, notification_uuid=str(uuid.uuid4()))
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
@@ -103,7 +114,7 @@ class TestAction(TestCase):
         mock_get_detector.return_value = Mock(spec=Detector, type="error")
 
         with patch.object(self.action, "get_handler", return_value=mock_handler):
-            self.action.trigger(self.mock_event)
+            self.action.trigger(self.mock_event, notification_uuid=str(uuid.uuid4()))
 
             mock_handler.execute.assert_called_once()
             mock_incr.assert_called_once_with(

--- a/tests/sentry/workflow_engine/tasks/test_actions.py
+++ b/tests/sentry/workflow_engine/tasks/test_actions.py
@@ -14,7 +14,6 @@ class TestBuildTriggerActionTaskParams(TestCase):
         self.group = self.create_group(project=self.project)
 
     def test_build_trigger_action_task_params_basic(self) -> None:
-        """Test basic parameter building without workflow_uuid_map"""
         mock_group_event = Mock(spec=GroupEvent)
         mock_group_event.event_id = "event-123"
         mock_group_event.occurrence_id = "occurrence-456"
@@ -26,7 +25,7 @@ class TestBuildTriggerActionTaskParams(TestCase):
         # Annotate workflow_id on action as the queryset would
         setattr(action, "workflow_id", 42)
 
-        params = build_trigger_action_task_params(action, event_data)
+        params = build_trigger_action_task_params(action, event_data, {})
 
         assert params["action_id"] == 1
         assert params["workflow_id"] == 42
@@ -36,7 +35,6 @@ class TestBuildTriggerActionTaskParams(TestCase):
         assert "notification_uuid" not in params
 
     def test_build_trigger_action_task_params_with_workflow_uuid_map(self) -> None:
-        """Test that notification_uuid is added when workflow_id is in workflow_uuid_map"""
         mock_group_event = Mock(spec=GroupEvent)
         mock_group_event.event_id = "event-123"
         mock_group_event.occurrence_id = "occurrence-456"
@@ -58,7 +56,6 @@ class TestBuildTriggerActionTaskParams(TestCase):
         assert params["notification_uuid"] == expected_notification_uuid
 
     def test_build_trigger_action_task_params_workflow_not_in_map(self) -> None:
-        """Test that notification_uuid is not added when workflow_id is not in workflow_uuid_map"""
         mock_group_event = Mock(spec=GroupEvent)
         mock_group_event.event_id = "event-123"
         mock_group_event.occurrence_id = "occurrence-456"
@@ -80,7 +77,6 @@ class TestBuildTriggerActionTaskParams(TestCase):
         assert "notification_uuid" not in params
 
     def test_build_trigger_action_task_params_no_workflow_id(self) -> None:
-        """Test that notification_uuid is not added when action has no workflow_id"""
         mock_group_event = Mock(spec=GroupEvent)
         mock_group_event.event_id = "event-123"
         mock_group_event.occurrence_id = "occurrence-456"

--- a/tests/sentry/workflow_engine/tasks/test_actions.py
+++ b/tests/sentry/workflow_engine/tasks/test_actions.py
@@ -1,0 +1,100 @@
+import uuid
+from unittest.mock import Mock
+
+from sentry.services.eventstore.models import GroupEvent
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params
+from sentry.workflow_engine.types import WorkflowEventData
+
+
+class TestBuildTriggerActionTaskParams(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.group = self.create_group(project=self.project)
+
+    def test_build_trigger_action_task_params_basic(self) -> None:
+        """Test basic parameter building without workflow_uuid_map"""
+        mock_group_event = Mock(spec=GroupEvent)
+        mock_group_event.event_id = "event-123"
+        mock_group_event.occurrence_id = "occurrence-456"
+        mock_group_event.group_id = self.group.id
+
+        event_data = WorkflowEventData(event=mock_group_event, group=self.group)
+        action = Action(id=1, type=Action.Type.SLACK)
+
+        # Annotate workflow_id on action as the queryset would
+        setattr(action, "workflow_id", 42)
+
+        params = build_trigger_action_task_params(action, event_data)
+
+        assert params["action_id"] == 1
+        assert params["workflow_id"] == 42
+        assert params["event_id"] == "event-123"
+        assert params["occurrence_id"] == "occurrence-456"
+        assert params["group_id"] == self.group.id
+        assert "notification_uuid" not in params
+
+    def test_build_trigger_action_task_params_with_workflow_uuid_map(self) -> None:
+        """Test that notification_uuid is added when workflow_id is in workflow_uuid_map"""
+        mock_group_event = Mock(spec=GroupEvent)
+        mock_group_event.event_id = "event-123"
+        mock_group_event.occurrence_id = "occurrence-456"
+        mock_group_event.group_id = self.group.id
+
+        event_data = WorkflowEventData(event=mock_group_event, group=self.group)
+        action = Action(id=1, type=Action.Type.SLACK)
+
+        # Annotate workflow_id on action as the queryset would
+        setattr(action, "workflow_id", 42)
+
+        expected_notification_uuid = str(uuid.uuid4())
+        workflow_uuid_map = {42: expected_notification_uuid}
+
+        params = build_trigger_action_task_params(action, event_data, workflow_uuid_map)
+
+        assert params["action_id"] == 1
+        assert params["workflow_id"] == 42
+        assert params["notification_uuid"] == expected_notification_uuid
+
+    def test_build_trigger_action_task_params_workflow_not_in_map(self) -> None:
+        """Test that notification_uuid is not added when workflow_id is not in workflow_uuid_map"""
+        mock_group_event = Mock(spec=GroupEvent)
+        mock_group_event.event_id = "event-123"
+        mock_group_event.occurrence_id = "occurrence-456"
+        mock_group_event.group_id = self.group.id
+
+        event_data = WorkflowEventData(event=mock_group_event, group=self.group)
+        action = Action(id=1, type=Action.Type.SLACK)
+
+        # Annotate workflow_id on action
+        setattr(action, "workflow_id", 42)
+
+        # workflow_uuid_map has different workflow_id
+        workflow_uuid_map = {99: str(uuid.uuid4())}
+
+        params = build_trigger_action_task_params(action, event_data, workflow_uuid_map)
+
+        assert params["action_id"] == 1
+        assert params["workflow_id"] == 42
+        assert "notification_uuid" not in params
+
+    def test_build_trigger_action_task_params_no_workflow_id(self) -> None:
+        """Test that notification_uuid is not added when action has no workflow_id"""
+        mock_group_event = Mock(spec=GroupEvent)
+        mock_group_event.event_id = "event-123"
+        mock_group_event.occurrence_id = "occurrence-456"
+        mock_group_event.group_id = self.group.id
+
+        event_data = WorkflowEventData(event=mock_group_event, group=self.group)
+        action = Action(id=1, type=Action.Type.SLACK)
+
+        # No workflow_id annotation
+
+        workflow_uuid_map = {42: str(uuid.uuid4())}
+
+        params = build_trigger_action_task_params(action, event_data, workflow_uuid_map)
+
+        assert params["action_id"] == 1
+        assert params["workflow_id"] is None
+        assert "notification_uuid" not in params


### PR DESCRIPTION
When investigating links sent via notification, we usually have access to the notification_uuid url param which is unique per notification.
To make this useful, we thread through the notification_uuid from WorkflowFireHistory, which was previously unused, to make it easy to associate with a history entry and thus a workflow/group/etc. 