### PR TITLE
fix(cmdk): border misalignment in searchbar

### DIFF
--- a/static/app/components/modals/deprecatedCommandPalette.tsx
+++ b/static/app/components/modals/deprecatedCommandPalette.tsx
@@ -58,6 +58,8 @@ function DeprecatedCommandPalette({Body, closeModal}: ModalRenderProps) {
 export default DeprecatedCommandPalette;
 
 const InputWithoutFocusStyles = styled(InputGroup.Input)`
+  border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
+
   &:focus,
   &:active,
   &:hover {


### PR DESCRIPTION
There's a slight misalignment between the radius of the searchbar and the parent container for the old cmd-k palette:
<img width="110" height="161" alt="Screenshot 2025-12-27 at 11 57 57 AM" src="https://github.com/user-attachments/assets/3bffccf5-d43e-4305-827a-cc2aa7ff7bd6" />

New:
<img width="125" height="89" alt="Screenshot 2025-12-29 at 9 15 03 AM" src="https://github.com/user-attachments/assets/085c991d-ce0b-49c0-8e6d-1c30e406e095" />

