### PR TITLE
ci: Clear Python cache in setup-sentry action

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -80,6 +80,15 @@ runs:
           echo "TOTAL_TEST_GROUPS=$MATRIX_INSTANCE_TOTAL" >> $GITHUB_ENV
         fi
 
+    - name: Clear Python cache
+      shell: bash --noprofile --norc -eo pipefail -ux {0}
+      env:
+        WORKDIR: ${{ inputs.workdir }}
+      run: |
+        cd "$WORKDIR"
+        find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+        find . -type f -name "*.pyc" -delete
+
     - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
       with:
         version: '0.8.2'

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -87,7 +87,7 @@ runs:
       run: |
         cd "$WORKDIR"
         find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-        find . -type f -name "*.pyc" -delete
+        find . -type f -name "*.pyc" -delete 2>/dev/null || true
 
     - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
       with:


### PR DESCRIPTION
Add a step to clear __pycache__ directories and .pyc files before running tests to prevent import mismatches caused by corrupted cache.

This resolves CI errors like:
```
  imported module 'test_utils' has this __file__ attribute:
    /home/runner/work/sentry/sentry/tests/sentry/profiles/test_utils.py
  which is not the same as the test file we want to collect:
    /home/runner/work/sentry/sentry/tests/sentry/seer/code_review/test_utils.py
```