### PR TITLE
fix(explore): Fix traces table header radii

### DIFF
--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -2,6 +2,8 @@ import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -69,27 +71,33 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
     <Fragment>
       <StyledPanel>
         <TracePanelContent>
-          <StyledPanelHeader align="left" lightText>
+          <StyledPanelHeader align="left" lightText radius="md 0 0 0">
             {t('Trace ID')}
           </StyledPanelHeader>
+
           <StyledPanelHeader align="left" lightText>
             {t('Trace Root')}
           </StyledPanelHeader>
+
           <StyledPanelHeader align="right" lightText>
             {query ? t('Matching Spans') : t('Total Spans')}
           </StyledPanelHeader>
+
           <StyledPanelHeader align="left" lightText>
             {t('Timeline')}
           </StyledPanelHeader>
+
           <StyledPanelHeader align="right" lightText>
             {t('Root Duration')}
           </StyledPanelHeader>
-          <StyledPanelHeader align="right" lightText>
-            <Header>
+
+          <StyledPanelHeader align="right" lightText radius="0 md 0 0">
+            <Flex gap="xs">
               {t('Timestamp')}
               <IconArrow size="xs" direction="down" />
-            </Header>
+            </Flex>
           </StyledPanelHeader>
+
           {isPending && (
             <StyledPanelItem span={6} overflow>
               <LoadingIndicator />
@@ -290,11 +298,6 @@ function Breakdown({trace}: {trace: TraceResult}) {
     </BreakdownPanelItem>
   );
 }
-
-const Header = styled('span')`
-  display: flex;
-  gap: ${space(0.5)};
-`;
 
 const StyledButton = styled(Button)`
   margin-right: ${space(0.5)};

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -71,27 +71,27 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
     <Fragment>
       <StyledPanel>
         <TracePanelContent>
-          <StyledPanelHeader align="left" lightText radius="md 0 0 0">
+          <StyledPanelHeader justify="start" lightText radius="md 0 0 0">
             {t('Trace ID')}
           </StyledPanelHeader>
 
-          <StyledPanelHeader align="left" lightText>
+          <StyledPanelHeader justify="start" lightText>
             {t('Trace Root')}
           </StyledPanelHeader>
 
-          <StyledPanelHeader align="right" lightText>
+          <StyledPanelHeader justify="end" lightText>
             {query ? t('Matching Spans') : t('Total Spans')}
           </StyledPanelHeader>
 
-          <StyledPanelHeader align="left" lightText>
+          <StyledPanelHeader justify="start" lightText>
             {t('Timeline')}
           </StyledPanelHeader>
 
-          <StyledPanelHeader align="right" lightText>
+          <StyledPanelHeader justify="end" lightText>
             {t('Root Duration')}
           </StyledPanelHeader>
 
-          <StyledPanelHeader align="right" lightText radius="0 md 0 0">
+          <StyledPanelHeader justify="end" lightText radius="0 md 0 0">
             <Flex gap="xs">
               {t('Timestamp')}
               <IconArrow size="xs" direction="down" />

--- a/static/app/views/explore/tables/tracesTable/spansTable.tsx
+++ b/static/app/views/explore/tables/tracesTable/spansTable.tsx
@@ -68,17 +68,17 @@ export function SpanTable({trace}: {trace: TraceResult}) {
     <SpanTablePanelItem span={6} overflow>
       <StyledPanel>
         <SpanPanelContent>
-          <StyledPanelHeader align="left" lightText>
+          <StyledPanelHeader justify="start" lightText>
             {t('Span ID')}
           </StyledPanelHeader>
-          <StyledPanelHeader align="left" lightText>
+          <StyledPanelHeader justify="start" lightText>
             {t('Span Description')}
           </StyledPanelHeader>
-          <StyledPanelHeader align="right" lightText />
-          <StyledPanelHeader align="right" lightText>
+          <StyledPanelHeader justify="end" lightText />
+          <StyledPanelHeader justify="end" lightText>
             {t('Span Duration')}
           </StyledPanelHeader>
-          <StyledPanelHeader align="right" lightText>
+          <StyledPanelHeader justify="end" lightText>
             {t('Timestamp')}
           </StyledPanelHeader>
           {isPending && (

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -30,7 +30,7 @@ export function StyledPanelHeader({
   return (
     <Flex justify={justify} radius={radius ? radius : '0'}>
       {flexProps => (
-        <Text wrap="nowrap">
+        <Text as="div" wrap="nowrap">
           <PanelHeader lightText {...flexProps} {...props}>
             {children}
           </PanelHeader>

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -3,6 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -12,9 +13,6 @@ export const StyledPanel = styled(Panel)`
   margin-bottom: 0px;
 `;
 
-const StyledFlex = styled(Flex)`
-  white-space: nowrap;
-`;
 interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
   align: 'left' | 'right';
   children?: React.ReactNode;
@@ -30,13 +28,15 @@ export function StyledPanelHeader({
   const justify = align === 'left' ? 'start' : 'end';
 
   return (
-    <StyledFlex justify={justify} radius={radius ? radius : '0'}>
+    <Flex justify={justify} radius={radius ? radius : '0'}>
       {flexProps => (
-        <PanelHeader lightText {...flexProps} {...props}>
-          {children}
-        </PanelHeader>
+        <Text wrap="nowrap">
+          <PanelHeader lightText {...flexProps} {...props}>
+            {children}
+          </PanelHeader>
+        </Text>
       )}
-    </StyledFlex>
+    </Flex>
   );
 }
 

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -16,20 +16,22 @@ export const StyledPanel = styled(Panel)`
 interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
   justify: ComponentProps<typeof Flex>['justify'];
   children?: React.ReactNode;
+  lightText?: boolean;
   radius?: ComponentProps<typeof Flex>['radius'];
 }
 
 export function StyledPanelHeader({
   children,
   justify,
-  radius,
+  radius = '0',
+  lightText = false,
   ...props
 }: StyledPanelHeaderProps) {
   return (
-    <Flex justify={justify} radius={radius ? radius : '0'}>
+    <Flex justify={justify} radius={radius}>
       {flexProps => (
         <Text as="div" wrap="nowrap">
-          <PanelHeader lightText {...flexProps} {...props}>
+          <PanelHeader lightText={lightText} {...flexProps} {...props}>
             {children}
           </PanelHeader>
         </Text>

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -1,20 +1,44 @@
-import type {CSSProperties} from 'react';
+import type {ComponentProps, CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
 
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
-import {space} from 'sentry/styles/space';
 
 export const StyledPanel = styled(Panel)`
   margin-bottom: 0px;
 `;
 
-export const StyledPanelHeader = styled(PanelHeader)<{align: 'left' | 'right'}>`
+const StyledFlex = styled(Flex)`
   white-space: nowrap;
-  justify-content: ${p => (p.align === 'left' ? 'flex-start' : 'flex-end')};
 `;
+interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
+  align: 'left' | 'right';
+  children: React.ReactNode;
+  radius?: ComponentProps<typeof Flex>['radius'];
+}
+
+export function StyledPanelHeader({
+  children,
+  align,
+  radius,
+  ...props
+}: StyledPanelHeaderProps) {
+  const justify = align === 'left' ? 'start' : 'end';
+
+  return (
+    <StyledFlex justify={justify} radius={radius ? radius : '0'}>
+      {flexProps => (
+        <PanelHeader lightText {...flexProps} {...props}>
+          {children}
+        </PanelHeader>
+      )}
+    </StyledFlex>
+  );
+}
 
 export const TracePanelContent = styled('div')`
   width: 100%;
@@ -28,7 +52,7 @@ export const StyledPanelItem = styled(PanelItem)<{
   span?: number;
 }>`
   align-items: center;
-  padding: ${space(1)} ${space(2)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
   ${p => (p.align === 'left' ? 'justify-content: flex-start;' : null)}
   ${p => (p.align === 'right' ? 'justify-content: flex-end;' : null)}
   ${p => (p.overflow ? p.theme.overflowEllipsis : null)};
@@ -94,7 +118,7 @@ export const EmptyStateText = styled('div')<{
 }>`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSize[p.size]};
-  padding-bottom: ${space(1)};
+  padding-bottom: ${p => p.theme.space.md};
   ${p => p.textAlign && `text-align: ${p.textAlign}`};
 `;
 

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -14,19 +14,17 @@ export const StyledPanel = styled(Panel)`
 `;
 
 interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
-  align: 'left' | 'right';
+  justify: ComponentProps<typeof Flex>['justify'];
   children?: React.ReactNode;
   radius?: ComponentProps<typeof Flex>['radius'];
 }
 
 export function StyledPanelHeader({
   children,
-  align,
+  justify,
   radius,
   ...props
 }: StyledPanelHeaderProps) {
-  const justify = align === 'left' ? 'start' : 'end';
-
   return (
     <Flex justify={justify} radius={radius ? radius : '0'}>
       {flexProps => (

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -17,7 +17,7 @@ const StyledFlex = styled(Flex)`
 `;
 interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
   align: 'left' | 'right';
-  children: React.ReactNode;
+  children?: React.ReactNode;
   radius?: ComponentProps<typeof Flex>['radius'];
 }
 


### PR DESCRIPTION
Noticed that the traces table header styles was a bit off, so this PR fixes up those issues.

Before:
<img width="853" height="52" alt="Screenshot 2025-12-29 at 11 19 16" src="https://github.com/user-attachments/assets/65ec35d5-50b3-4b31-93d4-ee07fd19aaf5" />

After:
<img width="853" height="96" alt="Screenshot 2025-12-29 at 11 19 07" src="https://github.com/user-attachments/assets/68472470-1564-45b9-a3c8-6deeb258cef9" />