### PR TITLE
fix(dashboards): remove linked dashboard flag check in field renderer

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -59,7 +59,6 @@ import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
-import {hasDrillDownFlowsFeature} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
 import {
   DashboardFilterKeys,
   type DashboardFilters,
@@ -1421,7 +1420,7 @@ function wrapFieldRendererInDashboardLink(
       widget,
       dashboardFilters
     );
-    if (hasDrillDownFlowsFeature(organization) && dashboardUrl) {
+    if (dashboardUrl) {
       return <Link to={dashboardUrl}>{renderer(data, baggage)}</Link>;
     }
     return renderer(data, baggage);

--- a/static/app/views/dashboards/hooks/useHasDrillDownFlows.tsx
+++ b/static/app/views/dashboards/hooks/useHasDrillDownFlows.tsx
@@ -6,6 +6,6 @@ export function useHasDrillDownFlows() {
   return hasDrillDownFlowsFeature(organization);
 }
 
-export function hasDrillDownFlowsFeature(organization: Organization) {
+function hasDrillDownFlowsFeature(organization: Organization) {
   return organization.features.includes('dashboards-drilldown-flow');
 }


### PR DESCRIPTION
We shouldn't have this flag check, it causes an issue where users who have the queries prebuilt dashboards enabled aren't seeing links from query summary to query details. We only need to check against this flag to check if the user can create their own dashboard links.