### PR TITLE
fix(search): Handle many parens in query values

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -230,6 +230,33 @@ describe('utils/tokenizeSearch', () => {
           ],
         },
       },
+      {
+        name: 'should handle trailing paren when quoted value contains parens',
+        string: '(key:"value with (parens)")',
+        object: {
+          tokens: [
+            {type: TokenType.OPERATOR, value: '('},
+            {type: TokenType.FILTER, key: 'key', value: 'value with (parens)'},
+            {type: TokenType.OPERATOR, value: ')'},
+          ],
+        },
+      },
+      {
+        name: 'should handle complex SQL-like query in quoted value with grouping parens',
+        string: '(span.category:db description:"SELECT * FROM users WHERE id = func(1)")',
+        object: {
+          tokens: [
+            {type: TokenType.OPERATOR, value: '('},
+            {type: TokenType.FILTER, key: 'span.category', value: 'db'},
+            {
+              type: TokenType.FILTER,
+              key: 'description',
+              value: 'SELECT * FROM users WHERE id = func(1)',
+            },
+            {type: TokenType.OPERATOR, value: ')'},
+          ],
+        },
+      },
     ];
 
     for (const {name, string, object} of cases) {
@@ -650,6 +677,20 @@ describe('utils/tokenizeSearch', () => {
         name: 'handles ends with filter',
         object: new MutableSearch(['message:\uf00dEndsWith\uf00d"test value"']),
         string: 'message:\uf00dEndsWith\uf00d"test value"',
+      },
+      {
+        name: 'should preserve grouping parens when quoted value contains parens',
+        object: new MutableSearch(['(key:"value with (parens)")']),
+        string: '( key:"value with (parens)" )',
+      },
+      {
+        name: 'should preserve complex query with SQL-like quoted value and grouping parens',
+        object: new MutableSearch([
+          '(span.category:db',
+          'description:"SELECT * FROM users WHERE id = func(1)")',
+        ]),
+        string:
+          '( span.category:db description:"SELECT * FROM users WHERE id = func(1)" )',
       },
     ];
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -50,6 +50,19 @@ function isParen(token: Token, character: '(' | ')') {
   );
 }
 
+function hasUnquotedOpenParen(s: string): boolean {
+  let inQuotes = false;
+  for (let i = 0; i < s.length; i++) {
+    const char = s[i];
+    if (char === '"' && (i === 0 || s[i - 1] !== '\\')) {
+      inQuotes = !inQuotes;
+    } else if (char === '(' && !inQuotes) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isProperlyBracketed(value: string): boolean {
   return /^\[.*\]$/.test(value);
 }
@@ -193,7 +206,7 @@ export class MutableSearch {
       }
 
       let trailingParen = '';
-      if (token.endsWith(')') && !token.includes('(')) {
+      if (token.endsWith(')') && !hasUnquotedOpenParen(token)) {
         const parenMatch = token.match(/\)+$/g);
         if (parenMatch) {
           trailingParen = parenMatch[0];


### PR DESCRIPTION
Fixing an edge case with `MutableSearch` not handling values with many parens will. This PR aims to handle cases like `(key:"value with (parens)")` without causing any issues.