### PR TITLE
chore(sentry-apps): prepare to hard delete sentry apps and installs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3777,6 +3777,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Manual option for hard deleting sentry apps and installations.
+register(
+    "sentry-apps.hard-delete",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for web vital issue detection
 register(
     "issue-detection.web-vitals-detection.enabled",

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -132,8 +132,8 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
 
             if options.get("sentry-apps.hard-delete"):
                 # actually delete the object. we need to delete all soft-deleted objects before removing ParanoidModel
-                for outbox in self.outboxes_for_update():
-                    outbox.save()  # mimics ControlOutboxProducingModel
+                for update_outbox in self.outboxes_for_update():
+                    update_outbox.save()  # mimics ControlOutboxProducingModel
 
                 return models.Model.delete(self, *args, **kwargs)
 

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -132,6 +132,9 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
 
             if options.get("sentry-apps.hard-delete"):
                 # actually delete the object. we need to delete all soft-deleted objects before removing ParanoidModel
+                for outbox in self.outboxes_for_update():
+                    outbox.save()  # mimics ControlOutboxProducingModel
+
                 return models.Model.delete(self, *args, **kwargs)
 
             return super().delete(*args, **kwargs)

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -8,6 +8,7 @@ from django.db import models, router, transaction
 from django.utils import timezone
 from jsonschema import ValidationError
 
+from sentry import options
 from sentry.api.exceptions import BadRequest
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.backup.scopes import RelocationScope
@@ -128,6 +129,11 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         with outbox_context(transaction.atomic(using=router.db_for_write(SentryAppInstallation))):
             for outbox in self.outboxes_for_delete():
                 outbox.save()
+
+            if options.get("sentry-apps.hard-delete"):
+                # actually delete the object. we need to delete all soft-deleted objects before removing ParanoidModel
+                return models.Model.delete(self, *args, **kwargs)
+
             return super().delete(*args, **kwargs)
 
     @property

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -13,7 +13,12 @@ from sentry.api.exceptions import BadRequest
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import SentryAppInstallationStatus
-from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, control_silo_model
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    Model,
+    control_silo_model,
+)
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.paranoia import ParanoidManager, ParanoidModel
@@ -135,7 +140,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 for update_outbox in self.outboxes_for_update():
                     update_outbox.save()  # mimics ControlOutboxProducingModel
 
-                return models.Model.delete(self, *args, **kwargs)
+                return super(Model, self).delete(*args, **kwargs)
 
             return super().delete(*args, **kwargs)
 

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -13,12 +13,7 @@ from sentry.api.exceptions import BadRequest
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import SentryAppInstallationStatus
-from sentry.db.models import (
-    BoundedPositiveIntegerField,
-    FlexibleForeignKey,
-    Model,
-    control_silo_model,
-)
+from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, control_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.paranoia import ParanoidManager, ParanoidModel
@@ -140,7 +135,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 for update_outbox in self.outboxes_for_update():
                     update_outbox.save()  # mimics ControlOutboxProducingModel
 
-                return super(Model, self).delete(*args, **kwargs)
+                return models.Model.delete(self, *args, **kwargs)
 
             return super().delete(*args, **kwargs)
 


### PR DESCRIPTION
Add an option that will toggle hard deleting Sentry apps and installs. This will bypass the `ParanoidModel` `delete()` function which soft-deletes the objects.

We need to do this first without removing the `ParanoidModel` class from these models so we can delete the existing soft-deleted objects. The `ParanoidModel` manager filters out soft-deleted objects -- if we remove it, then we will start showing them.