### PR TITLE
fix(code-review): Fix config check for code review beta orgs

### DIFF
--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -205,7 +205,15 @@ class CodeReviewRepoSettingsEndpoint(Endpoint):
 
         if repo_settings is None:
             organization = Organization.objects.filter(id=sentry_org_id).first()
-            if organization and features.has("organizations:code-review-beta", organization):
+            if organization and (
+                features.has("organizations:code-review-beta", organization)
+                or bool(
+                    organization.get_option(
+                        "sentry:enable_pr_review_test_generation",
+                        False,
+                    )
+                )
+            ):
                 return Response(
                     {
                         "enabledCodeReview": True,

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -581,6 +581,30 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
         ["test-secret"],
     )
+    def test_returns_enabled_with_default_triggers_when_pr_review_test_generation_enabled(self):
+        org = self.create_organization()
+        org.update_option("sentry:enable_pr_review_test_generation", True)
+
+        url = reverse("sentry-api-0-code-review-repo-settings")
+        params = {
+            "sentryOrgId": str(org.id),
+            "externalRepoId": "nonexistent-repo-id",
+            "provider": "integrations:github",
+        }
+        auth = self._auth_header_for_get(url, params, "test-secret")
+
+        resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
+
+        assert resp.status_code == 200
+        assert resp.data == {
+            "enabledCodeReview": True,
+            "codeReviewTriggers": DEFAULT_CODE_REVIEW_TRIGGERS,
+        }
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        ["test-secret"],
+    )
     def test_returns_repo_settings_when_exist(self):
         org = self.create_organization()
         project = self.create_project(organization=org)


### PR DESCRIPTION
Pass back the existing default config for code review beta orgs that dynamically checks the value of the toggle instead of the hardcoded list only.