### PR TITLE
chore(core-ui): Remove to prop from being rendered

### DIFF
--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -16,8 +16,6 @@ describe('Link', () => {
 
       expect(screen.getByText('Link')).toBeEnabled();
       expect(screen.getByText('Link')).not.toHaveAttribute('href');
-      expect(screen.getByText('Link')).toHaveAttribute('aria-disabled', 'true');
-      expect(screen.getByText('Link')).toHaveAttribute('role', 'link');
     });
 
     it('renders links with LocationDescriptor to prop render as <a> with no href', () => {
@@ -29,8 +27,6 @@ describe('Link', () => {
 
       expect(screen.getByText('Link')).toBeEnabled();
       expect(screen.getByText('Link')).not.toHaveAttribute('href');
-      expect(screen.getByText('Link')).toHaveAttribute('aria-disabled', 'true');
-      expect(screen.getByText('Link')).toHaveAttribute('role', 'link');
     });
   });
 

--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -4,16 +4,34 @@ import {ExternalLink, Link} from 'sentry/components/core/link';
 
 describe('Link', () => {
   // Note: Links should not support a disabled option, as disabled links are just text elements
-  it('disabled links render as <a> with no href', () => {
-    render(
-      // eslint-disable-next-line no-restricted-syntax
-      <Link disabled to="https://www.sentry.io/">
-        Link
-      </Link>
-    );
 
-    expect(screen.getByText('Link')).toBeEnabled();
-    expect(screen.getByText('Link')).not.toHaveAttribute('href');
+  describe('disabled links', () => {
+    it('renders links with string to prop render as <a> with no href', () => {
+      render(
+        // eslint-disable-next-line no-restricted-syntax
+        <Link disabled to="https://www.sentry.io/">
+          Link
+        </Link>
+      );
+
+      expect(screen.getByText('Link')).toBeEnabled();
+      expect(screen.getByText('Link')).not.toHaveAttribute('href');
+      expect(screen.getByText('Link')).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByText('Link')).toHaveAttribute('role', 'link');
+    });
+
+    it('renders links with LocationDescriptor to prop render as <a> with no href', () => {
+      render(
+        <Link disabled to={{pathname: '/settings/account/'}}>
+          Link
+        </Link>
+      );
+
+      expect(screen.getByText('Link')).toBeEnabled();
+      expect(screen.getByText('Link')).not.toHaveAttribute('href');
+      expect(screen.getByText('Link')).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByText('Link')).toHaveAttribute('role', 'link');
+    });
   });
 
   it('links render as <a> with href', () => {

--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -64,7 +64,11 @@ export const Link = styled((props: LinkProps) => {
   const {Component, behavior} = useLinkBehavior(props);
 
   if (props.disabled) {
-    return <Anchor {...props} />;
+    // Removing the "to" prop here to prevent the anchor from being rendered with to="
+    // [object Object]" when "to" prop is a LocationDescriptor object. Have to create a
+    // new object here, as we can't delete the "to" prop as it is a required prop.
+    const {to: _to, ...restProps} = props;
+    return <Anchor aria-disabled="true" role="link" {...restProps} />;
   }
 
   return <Component {...behavior()} />;

--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -68,7 +68,7 @@ export const Link = styled((props: LinkProps) => {
     // [object Object]" when "to" prop is a LocationDescriptor object. Have to create a
     // new object here, as we can't delete the "to" prop as it is a required prop.
     const {to: _to, ...restProps} = props;
-    return <Anchor aria-disabled="true" role="link" {...restProps} />;
+    return <Anchor {...restProps} />;
   }
 
   return <Component {...behavior()} />;


### PR DESCRIPTION
This PR fixes an edge case with `Links` where if a `to` prop is set to a `LocationDescriptor` object, it would pass the `to` prop along and render `to="[object Object]"` in the rendered HTML.