### PR TITLE
test(ui): Migrate globalSelectionLink off of deprecatedRouterMocks

### DIFF
--- a/static/app/components/globalSelectionLink.spec.tsx
+++ b/static/app/components/globalSelectionLink.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
@@ -7,34 +5,33 @@ import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 const path = '/some-path/';
 
 describe('GlobalSelectionLink', () => {
-  const getRouter = (query?: {environment: string; project: string[]}) =>
-    RouterFixture({location: {query}});
-
   it('has global selection values in query', async () => {
     const query = {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const router = getRouter(query);
 
-    render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    const {router} = render(
+      <GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>,
+      {
+        initialRouterConfig: {
+          location: {pathname: '/', query},
+        },
+      }
+    );
+
     expect(screen.getByText('Go somewhere!')).toHaveAttribute(
       'href',
       '/some-path/?environment=staging&project=foo&project=bar'
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
-    expect(router.push).toHaveBeenCalledWith({pathname: path, query});
+    expect(router.location.pathname).toBe(path);
+    expect(router.location.query).toEqual(query);
   });
 
   it('does not have global selection values in query', () => {
-    render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>, {
-      router: getRouter(),
-      deprecatedRouterMocks: true,
-    });
+    render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>);
 
     expect(screen.getByText('Go somewhere!')).toHaveAttribute('href', path);
   });
@@ -44,22 +41,25 @@ describe('GlobalSelectionLink', () => {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const router = getRouter(query);
     const customQuery = {query: 'something'};
-    render(
+
+    const {router} = render(
       <GlobalSelectionLink to={{pathname: path, query: customQuery}}>
         Go somewhere!
       </GlobalSelectionLink>,
       {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {pathname: '/', query},
+        },
       }
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
-    expect(router.push).toHaveBeenCalledWith({
-      pathname: path,
-      query: {project: ['foo', 'bar'], environment: 'staging', query: 'something'},
+    expect(router.location.pathname).toBe(path);
+    expect(router.location.query).toEqual({
+      project: ['foo', 'bar'],
+      environment: 'staging',
+      query: 'something',
     });
   });
 
@@ -68,17 +68,18 @@ describe('GlobalSelectionLink', () => {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const router = getRouter(query);
-    render(
+
+    const {router} = render(
       <GlobalSelectionLink to={{pathname: path}}>Go somewhere!</GlobalSelectionLink>,
       {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {pathname: '/', query},
+        },
       }
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
-
-    expect(router.push).toHaveBeenCalledWith({pathname: path, query});
+    expect(router.location.pathname).toBe(path);
+    expect(router.location.query).toEqual(query);
   });
 });


### PR DESCRIPTION
Migrate to the in-memory test router
