### PR TITLE
chore(aci): update copy for metric monitor resolution threshold

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.spec.tsx
@@ -58,7 +58,7 @@ describe('MetricDetectorDetailsDetect', () => {
 
     expect(screen.getByText('Resolved')).toBeInTheDocument();
     expect(
-      screen.getByText(/Less than 8% lower than the previous 1 minute/)
+      screen.getByText(/Below or equal to 8% lower than the previous 1 minute/)
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -113,7 +113,7 @@ export function getConditionDescription({
 
     if (condition.conditionResult === DetectorPriorityLevel.OK) {
       return t(
-        `Less than %(comparisonValue)s%(unit)s %(direction)s than the previous %(timeRange)s`,
+        `Below or equal to %(comparisonValue)s%(unit)s %(direction)s than the previous %(timeRange)s`,
         {
           comparisonValue,
           unit,

--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -158,8 +158,8 @@ export function ResolveSection() {
         <DescriptionContainer onClick={e => e.preventDefault()}>
           <Text>
             {conditionType === DataConditionType.GREATER
-              ? t('Less than')
-              : t('More than')}
+              ? t('Below or equal to')
+              : t('Above or equal to')}
           </Text>
           <ThresholdField
             hideLabel

--- a/static/app/views/detectors/utils/getDetectorResolutionDescription.spec.tsx
+++ b/static/app/views/detectors/utils/getDetectorResolutionDescription.spec.tsx
@@ -99,7 +99,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 25% higher than the previous 1 hour.'
+        'Issue will be resolved when the query value is below or equal to 25% higher than the previous 1 hour.'
       );
     });
 
@@ -140,7 +140,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 15% lower than the previous 2 hours.'
+        'Issue will be resolved when the query value is below or equal to 15% lower than the previous 2 hours.'
       );
     });
 
@@ -155,7 +155,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 20% higher than the previous 5 minutes.'
+        'Issue will be resolved when the query value is below or equal to 20% higher than the previous 5 minutes.'
       );
     });
 
@@ -170,7 +170,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 15% higher than the previous 1 hour.'
+        'Issue will be resolved when the query value is below or equal to 15% higher than the previous 1 hour.'
       );
     });
   });

--- a/static/app/views/detectors/utils/getDetectorResolutionDescription.spec.tsx
+++ b/static/app/views/detectors/utils/getDetectorResolutionDescription.spec.tsx
@@ -26,7 +26,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 100%.'
+        'Issue will be resolved when the query value is below or equal to 100%.'
       );
     });
 
@@ -40,7 +40,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is more than 50ms.'
+        'Issue will be resolved when the query value is above or equal to 50ms.'
       );
     });
 
@@ -54,7 +54,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 100.'
+        'Issue will be resolved when the query value is below or equal to 100.'
       );
     });
 
@@ -68,7 +68,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is less than 75%.'
+        'Issue will be resolved when the query value is below or equal to 75%.'
       );
     });
 
@@ -82,7 +82,7 @@ describe('getDetectorResolutionDescription', () => {
       });
 
       expect(result).toBe(
-        'Issue will be resolved when the query value is more than 80ms.'
+        'Issue will be resolved when the query value is above or equal to 80ms.'
       );
     });
   });

--- a/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
+++ b/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
@@ -76,13 +76,13 @@ export function getResolutionDescription(params: ResolutionDescriptionParams): s
     const delta = params.comparisonDelta ?? 3600;
     if (params.conditionType === DataConditionType.GREATER) {
       return t(
-        'Issue will be resolved when the query value is less than %s%% higher than the previous %s.',
+        'Issue will be resolved when the query value is below or equal to %s%% higher than the previous %s.',
         threshold,
         getDuration(delta)
       );
     }
     return t(
-      'Issue will be resolved when the query value is less than %s%% lower than the previous %s.',
+      'Issue will be resolved when the query value is below or equal to %s%% lower than the previous %s.',
       threshold,
       getDuration(delta)
     );

--- a/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
+++ b/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
@@ -60,13 +60,13 @@ export function getResolutionDescription(params: ResolutionDescriptionParams): s
   if (params.detectionType === 'static') {
     if (params.conditionType === DataConditionType.GREATER) {
       return t(
-        'Issue will be resolved when the query value is less than %s%s.',
+        'Issue will be resolved when the query value is below or equal to %s%s.',
         threshold,
         suffix
       );
     }
     return t(
-      'Issue will be resolved when the query value is more than %s%s.',
+      'Issue will be resolved when the query value is above or equal to %s%s.',
       threshold,
       suffix
     );


### PR DESCRIPTION
the resolution condition is always LTE/GTE, so the metric monitor create/edit form should follow the same "above/below or equal to" wording as the monitor details page

form:
<img width="521" height="312" alt="Screenshot 2025-12-29 at 3 09 53 PM" src="https://github.com/user-attachments/assets/669b38a4-c3ce-425f-9413-cf4096c5b989" />


details:
<img width="296" height="102" alt="Screenshot 2025-12-29 at 3 10 07 PM" src="https://github.com/user-attachments/assets/536d04f1-869c-4e74-b315-1c9a4160b74f" />
