### PR TITLE
ref(settings): Remove usages of `deprecatedRouteProps` for `SettingsLayout` routes

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -499,7 +499,6 @@ function buildRoutes(): RouteObject[] {
     name: t('Account'),
     component: make(() => import('sentry/views/settings/account/accountSettingsLayout')),
     children: accountSettingsChildren,
-    deprecatedRouteProps: true,
   };
 
   const projectSettingsChildren: SentryRouteObject[] = [
@@ -1271,7 +1270,6 @@ function buildRoutes(): RouteObject[] {
       () => import('sentry/views/settings/organization/organizationSettingsLayout')
     ),
     children: orgSettingsChildren,
-    deprecatedRouteProps: true,
   };
 
   const subscriptionSettingsRoutes = routeHook('routes:subscription-settings');
@@ -2764,7 +2762,6 @@ function buildRoutes(): RouteObject[] {
     path: '/manage/',
     component: make(() => import('sentry/views/admin/adminLayout')),
     children: adminManageChildren,
-    deprecatedRouteProps: true,
   };
 
   const legacyOrganizationRootChildren: SentryRouteObject[] = [

--- a/static/app/views/admin/adminLayout.tsx
+++ b/static/app/views/admin/adminLayout.tsx
@@ -1,8 +1,8 @@
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 import {BreadcrumbProvider} from 'sentry/views/settings/components/settingsBreadcrumb/context';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
@@ -40,23 +40,19 @@ export function AdminNavigation() {
   );
 }
 
-type Props = {
-  children: React.ReactNode;
-} & RouteComponentProps;
-
-function AdminLayout({children, ...props}: Props) {
+export default function AdminLayout() {
   return (
     <SentryDocumentTitle noSuffix title={t('Sentry Admin')}>
       <Page>
         <BreadcrumbProvider>
-          <SettingsLayout {...props}>{children}</SettingsLayout>
+          <SettingsLayout>
+            <Outlet />
+          </SettingsLayout>
         </BreadcrumbProvider>
       </Page>
     </SentryDocumentTitle>
   );
 }
-
-export default AdminLayout;
 
 const Page = styled('div')`
   display: flex;

--- a/static/app/views/settings/account/accountSettingsLayout.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.tsx
@@ -1,9 +1,11 @@
+import {Outlet} from 'react-router-dom';
+
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
-interface Props extends React.ComponentProps<typeof SettingsLayout> {}
-
-function AccountSettingsLayout({children, ...props}: Props) {
-  return <SettingsLayout {...props}>{children}</SettingsLayout>;
+export default function AccountSettingsLayout() {
+  return (
+    <SettingsLayout>
+      <Outlet />
+    </SettingsLayout>
+  );
 }
-
-export default AccountSettingsLayout;

--- a/static/app/views/settings/components/settingsLayout.spec.tsx
+++ b/static/app/views/settings/components/settingsLayout.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
@@ -8,8 +7,6 @@ import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 import {BreadcrumbProvider} from './settingsBreadcrumb/context';
 
 describe('SettingsLayout', () => {
-  const {routerProps} = initializeOrg();
-
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -33,7 +30,7 @@ describe('SettingsLayout', () => {
   it('renders', () => {
     render(
       <BreadcrumbProvider>
-        <SettingsLayout {...routerProps}>content</SettingsLayout>
+        <SettingsLayout>content</SettingsLayout>
       </BreadcrumbProvider>
     );
   });

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -1,31 +1,29 @@
-import {isValidElement} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {useParams} from 'sentry/utils/useParams';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 import SettingsBreadcrumb from './settingsBreadcrumb';
 import SettingsHeader from './settingsHeader';
 import SettingsSearch from './settingsSearch';
 
-type Props = {children: React.ReactNode} & RouteComponentProps;
+interface Props {
+  children: React.ReactNode;
+}
 
-function SettingsLayout(props: Props) {
-  const {children, params, routes} = props;
-
-  // We want child's view's props
-  const childProps =
-    children && isValidElement(children) ? (children.props as Props) : props;
-  const childRoutes = childProps.routes || routes || [];
+export default function SettingsLayout({children}: Props) {
+  const params = useParams();
+  const routes = useRoutes();
 
   return (
     <SettingsColumn>
       <SettingsHeader>
         <Flex align="center" justify="between">
-          <StyledSettingsBreadcrumb params={params} routes={childRoutes} />
+          <StyledSettingsBreadcrumb params={params} routes={routes} />
           <SettingsSearch />
         </Flex>
       </SettingsHeader>
@@ -79,5 +77,3 @@ const Content = styled('div')`
     padding: 0;
   }
 `;
-
-export default SettingsLayout;

--- a/static/app/views/settings/organization/organizationSettingsLayout.tsx
+++ b/static/app/views/settings/organization/organizationSettingsLayout.tsx
@@ -1,12 +1,11 @@
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {Outlet} from 'react-router-dom';
+
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
-type Props = RouteComponentProps & {
-  children: React.ReactNode;
-};
-
-function OrganizationSettingsLayout(props: Props) {
-  return <SettingsLayout {...props} />;
+export default function OrganizationSettingsLayout() {
+  return (
+    <SettingsLayout>
+      <Outlet />
+    </SettingsLayout>
+  );
 }
-
-export default OrganizationSettingsLayout;

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -1,19 +1,10 @@
 import {Outlet, useOutletContext} from 'react-router-dom';
 
-import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import ProjectContext from 'sentry/views/projects/projectContext';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
-
-type InnerProps = {
-  params: {projectId: string};
-  project: Project;
-  routes: PlainRoute[];
-};
 
 type ProjectSettingsOutletContext = {
   project: Project;
@@ -27,9 +18,7 @@ export function useProjectSettingsOutlet() {
   return useOutletContext<ProjectSettingsOutletContext>();
 }
 
-function InnerProjectSettingsLayout({params, routes, project}: InnerProps) {
-  const location = useLocation();
-
+function InnerProjectSettingsLayout({project}: {project: Project}) {
   // set analytics params for route based analytics
   useRouteAnalyticsParams({
     project_id: project.id,
@@ -37,14 +26,7 @@ function InnerProjectSettingsLayout({params, routes, project}: InnerProps) {
   });
 
   return (
-    <SettingsLayout
-      params={params}
-      routes={routes}
-      location={location}
-      router={undefined as any}
-      route={undefined as any}
-      routeParams={undefined as any}
-    >
+    <SettingsLayout>
       <ProjectSettingsOutlet project={project} />
     </SettingsLayout>
   );
@@ -52,13 +34,10 @@ function InnerProjectSettingsLayout({params, routes, project}: InnerProps) {
 
 export default function ProjectSettingsLayout() {
   const params = useParams<{projectId: string}>();
-  const routes = useRoutes();
 
   return (
     <ProjectContext projectSlug={params.projectId}>
-      {({project}) => (
-        <InnerProjectSettingsLayout params={params} routes={routes} project={project} />
-      )}
+      {({project}) => <InnerProjectSettingsLayout project={project} />}
     </ProjectContext>
   );
 }

--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -6,13 +6,12 @@ import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import SettingsBreadcrumb from 'sentry/views/settings/components/settingsBreadcrumb';
 import type {RouteWithName} from 'sentry/views/settings/components/settingsBreadcrumb/types';
 import SettingsHeader from 'sentry/views/settings/components/settingsHeader';
+import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 import SettingsSearch from 'sentry/views/settings/components/settingsSearch';
-import OrganizationSettingsLayout from 'sentry/views/settings/organization/organizationSettingsLayout';
 
 import {hasNewBillingUI} from 'getsentry/utils/billing';
 
@@ -20,14 +19,13 @@ type Props = {
   children: React.ReactNode;
 };
 
-function SubscriptionSettingsLayout(props: Props) {
+export default function SubscriptionSettingsLayout(props: Props) {
   const organization = useOrganization();
   const isNewBillingUI = hasNewBillingUI(organization);
 
   const location = useLocation();
   const params = useParams();
   const routes = useRoutes();
-  const router = useRouter();
   const {children} = props;
   let feedbackSource = location.pathname;
   for (let i = routes.length - 1; i >= 0; i--) {
@@ -38,17 +36,7 @@ function SubscriptionSettingsLayout(props: Props) {
     }
   }
   if (!isNewBillingUI) {
-    return (
-      <OrganizationSettingsLayout
-        {...props}
-        params={params}
-        routes={routes}
-        location={location}
-        router={router}
-        routeParams={params}
-        route={routes[0]!} // XXX: this component doesn't actually use the route prop so i think this is okay to satisfy RouteComponentProps
-      />
-    );
+    return <SettingsLayout>{children}</SettingsLayout>;
   }
 
   return (
@@ -80,8 +68,6 @@ function SubscriptionSettingsLayout(props: Props) {
     </SettingsColumn>
   );
 }
-
-export default SubscriptionSettingsLayout;
 
 const SettingsColumn = styled(Flex)`
   footer {


### PR DESCRIPTION
Migrates the `AccountSettingsLayout`, `OrganizationSettingsLayout`, and `AdminLayout` off of `deprecatedRouteProps`. `ProjectSettingsLayout` was already migrated off of the deprecated router in https://github.com/getsentry/sentry/pull/102709, so this PR also updates the props passed there. Modifies the `SubscriptionSettingsLayout` to use `SettingsLayout` directly rather than through `OrganizationSettingsLayout` as an intermediary.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7