### PR TITLE
ref(dashboards): Migrate tests for widget builder component off of `deprecatedRouterMocks`

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -1,7 +1,7 @@
 import {DashboardFixture} from 'sentry-fixture/dashboard';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -10,23 +10,15 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 
-const {organization, projects, router} = initializeOrg({
-  organization: {
-    features: ['open-membership', 'visibility-explore-view'],
-  },
-  projects: [
-    {id: '1', slug: 'project-1', isMember: true},
-    {id: '2', slug: 'project-2', isMember: true},
-    {id: '3', slug: 'project-3', isMember: false},
-  ],
-  router: {
-    location: {
-      pathname: '/organizations/org-slug/dashboard/1/',
-      query: {project: '-1'},
-    },
-    params: {},
-  },
+const organization = OrganizationFixture({
+  features: ['open-membership', 'visibility-explore-view'],
 });
+
+const projects = [
+  ProjectFixture({id: '1', slug: 'project-1', isMember: true}),
+  ProjectFixture({id: '2', slug: 'project-2', isMember: true}),
+  ProjectFixture({id: '3', slug: 'project-3', isMember: false}),
+];
 
 describe('NewWidgetBuilder', () => {
   const onCloseMock = jest.fn();
@@ -119,9 +111,13 @@ describe('NewWidgetBuilder', () => {
         />
       </PageFiltersContainer>,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {project: '-1'},
+          },
+        },
       }
     );
 
@@ -167,14 +163,6 @@ describe('NewWidgetBuilder', () => {
   });
 
   it('render the filter alias field and add filter button on chart widgets', async () => {
-    const chartsRouter = RouterFixture({
-      ...router,
-      location: {
-        ...router.location,
-        query: {...router.location.query, displayType: 'line'},
-      },
-    });
-
     render(
       <WidgetBuilderV2
         isOpen
@@ -186,9 +174,13 @@ describe('NewWidgetBuilder', () => {
         setOpenWidgetTemplates={jest.fn()}
       />,
       {
-        router: chartsRouter,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {project: '-1', displayType: 'line'},
+          },
+        },
       }
     );
 
@@ -215,9 +207,13 @@ describe('NewWidgetBuilder', () => {
         setOpenWidgetTemplates={jest.fn()}
       />,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {project: '-1'},
+          },
+        },
       }
     );
 
@@ -230,14 +226,6 @@ describe('NewWidgetBuilder', () => {
   });
 
   it('renders the group by field on chart widgets', async () => {
-    const chartsRouter = RouterFixture({
-      ...router,
-      location: {
-        ...router.location,
-        query: {...router.location.query, displayType: 'line'},
-      },
-    });
-
     render(
       <WidgetBuilderV2
         isOpen
@@ -249,9 +237,13 @@ describe('NewWidgetBuilder', () => {
         setOpenWidgetTemplates={jest.fn()}
       />,
       {
-        router: chartsRouter,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {project: '-1', displayType: 'line'},
+          },
+        },
       }
     );
 
@@ -272,9 +264,13 @@ describe('NewWidgetBuilder', () => {
         setOpenWidgetTemplates={jest.fn()}
       />,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {project: '-1'},
+          },
+        },
       }
     );
 


### PR DESCRIPTION
Migrating these tests off of `deprecatedRouterMocks`.