### PR TITLE
fix(preprod): Display error for mismatched build configurations (EME-699)

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -85,7 +85,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         if not features.has(
             "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         logger.info(
             "preprod.size_analysis.compare.api.get",
@@ -93,7 +93,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         )
 
         if head_artifact.project.id != project.id:
-            return Response({"error": "Project not found"}, status=404)
+            return Response({"detail": "Project not found"}, status=404)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[head_artifact.id],
@@ -108,7 +108,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             )
 
         if base_artifact.project.id != project.id:
-            return Response({"error": "Project not found"}, status=404)
+            return Response({"detail": "Project not found"}, status=404)
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[base_artifact.id],
@@ -271,7 +271,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         if not features.has(
             "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         logger.info(
             "preprod.size_analysis.compare.api.post",
@@ -280,7 +280,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
 
         if head_artifact.build_configuration != base_artifact.build_configuration:
             return Response(
-                {"error": "Head and base build configurations must be the same."}, status=400
+                {"detail": "Head and base build configurations must be the same."}, status=400
             )
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -110,9 +110,8 @@ export function SizeCompareMainContent() {
     },
     onError: error => {
       const errorMessage =
-        (typeof error?.responseJSON?.error === 'string'
-          ? error?.responseJSON.error
-          : null) ?? t('Failed to trigger comparison. Please try again.');
+        error.responseJSON?.detail ??
+        t('Failed to trigger comparison. Please try again.');
       addErrorMessage(errorMessage);
     },
   });
@@ -157,7 +156,8 @@ export function SizeCompareMainContent() {
       <BuildError
         title={t('Size comparison data unavailable')}
         message={
-          sizeComparisonQuery.error?.message || t('Failed to load size comparison data')
+          sizeComparisonQuery.error?.responseJSON?.detail ??
+          t('Failed to load size comparison data')
         }
       />
     );

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -110,7 +110,12 @@ export function SizeCompareMainContent() {
       );
     },
     onError: error => {
-      addErrorMessage(parseApiError(error));
+      const errorMessage = parseApiError(error);
+      addErrorMessage(
+        errorMessage === 'Unknown API Error'
+          ? t('Failed to trigger comparison. Please try again.')
+          : errorMessage
+      );
     },
   });
 
@@ -150,10 +155,15 @@ export function SizeCompareMainContent() {
   }
 
   if (sizeComparisonQuery.isError || !sizeComparisonQuery.data) {
+    const errorMessage = parseApiError(sizeComparisonQuery.error);
     return (
       <BuildError
         title={t('Size comparison data unavailable')}
-        message={parseApiError(sizeComparisonQuery.error)}
+        message={
+          errorMessage === 'Unknown API Error'
+            ? t('Failed to load size comparison data')
+            : errorMessage
+        }
       />
     );
   }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -110,10 +110,7 @@ export function SizeCompareMainContent() {
       );
     },
     onError: error => {
-      const errorMessage = error.responseJSON
-        ? parseApiError(error)
-        : t('Failed to trigger comparison. Please try again.');
-      addErrorMessage(errorMessage);
+      addErrorMessage(parseApiError(error));
     },
   });
 
@@ -156,11 +153,7 @@ export function SizeCompareMainContent() {
     return (
       <BuildError
         title={t('Size comparison data unavailable')}
-        message={
-          sizeComparisonQuery.error?.responseJSON
-            ? parseApiError(sizeComparisonQuery.error)
-            : t('Failed to load size comparison data')
-        }
+        message={parseApiError(sizeComparisonQuery.error)}
       />
     );
   }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -12,6 +12,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconChevron, IconRefresh, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import parseApiError from 'sentry/utils/parseApiError';
 import {fetchMutation, useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -109,9 +110,9 @@ export function SizeCompareMainContent() {
       );
     },
     onError: error => {
-      const errorMessage =
-        error.responseJSON?.detail ??
-        t('Failed to trigger comparison. Please try again.');
+      const errorMessage = error.responseJSON
+        ? parseApiError(error)
+        : t('Failed to trigger comparison. Please try again.');
       addErrorMessage(errorMessage);
     },
   });
@@ -156,8 +157,9 @@ export function SizeCompareMainContent() {
       <BuildError
         title={t('Size comparison data unavailable')}
         message={
-          sizeComparisonQuery.error?.responseJSON?.detail ??
-          t('Failed to load size comparison data')
+          sizeComparisonQuery.error?.responseJSON
+            ? parseApiError(sizeComparisonQuery.error)
+            : t('Failed to load size comparison data')
         }
       />
     );

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -155,7 +155,9 @@ export function SizeCompareMainContent() {
   }
 
   if (sizeComparisonQuery.isError || !sizeComparisonQuery.data) {
-    const errorMessage = parseApiError(sizeComparisonQuery.error);
+    const errorMessage = sizeComparisonQuery.error
+      ? parseApiError(sizeComparisonQuery.error)
+      : 'Unknown API Error';
     return (
       <BuildError
         title={t('Size comparison data unavailable')}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -124,7 +124,12 @@ export function SizeCompareSelectionContent({
       );
     },
     onError: error => {
-      addErrorMessage(parseApiError(error));
+      const errorMessage = parseApiError(error);
+      addErrorMessage(
+        errorMessage === 'Unknown API Error'
+          ? t('Failed to trigger comparison. Please try again.')
+          : errorMessage
+      );
     },
   });
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -25,6 +25,7 @@ import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import parseApiError from 'sentry/utils/parseApiError';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery, useMutation, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -123,9 +124,9 @@ export function SizeCompareSelectionContent({
       );
     },
     onError: error => {
-      const errorMessage =
-        error.responseJSON?.detail ??
-        t('Failed to trigger comparison. Please try again.');
+      const errorMessage = error.responseJSON
+        ? parseApiError(error)
+        : t('Failed to trigger comparison. Please try again.');
       addErrorMessage(errorMessage);
     },
   });

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -123,9 +123,10 @@ export function SizeCompareSelectionContent({
       );
     },
     onError: error => {
-      addErrorMessage(
-        error?.message || t('Failed to trigger comparison. Please try again.')
-      );
+      const errorMessage =
+        error.responseJSON?.detail ??
+        t('Failed to trigger comparison. Please try again.');
+      addErrorMessage(errorMessage);
     },
   });
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -124,10 +124,7 @@ export function SizeCompareSelectionContent({
       );
     },
     onError: error => {
-      const errorMessage = error.responseJSON
-        ? parseApiError(error)
-        : t('Failed to trigger comparison. Please try again.');
-      addErrorMessage(errorMessage);
+      addErrorMessage(parseApiError(error));
     },
   });
 

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -371,7 +371,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             self.base_artifact.id,
             status_code=403,
         )
-        assert response.data["error"] == "Feature not enabled"
+        assert response.data["detail"] == "Feature not enabled"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_multiple_metrics(self):
@@ -770,4 +770,4 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             method="post",
             status_code=400,
         )
-        assert response.data["error"] == "Head and base build configurations must be the same."
+        assert response.data["detail"] == "Head and base build configurations must be the same."


### PR DESCRIPTION
## Summary

When comparing builds with different build configurations, the API returns a 400 error with message `{"detail":"Head and base build configurations must be the same."}` but the UI was not displaying it properly.

This adjusts the message in the corner to use the message from the API instead of a generic error message.

## Changes

- Standardized error responses in the size comparison endpoint to consistently use `detail` field instead of `error` field. It is a [Django Framework best practice](https://www.django-rest-framework.org/api-guide/exceptions/) to use the `detail` field instead of the `error` field. Some responses were already using `detail`. This makes it so that they all use it the `project_preprod_size_analysis_compare.py` object.

Here's a screenshot of what the error looks like (with spotlight dancing on top)
<img width="482" height="90" alt="Screenshot 2025-12-30 at 10 23 34" src="https://github.com/user-attachments/assets/fe04156b-bd49-46b9-afbc-7b20202722bf" />
