### PR TITLE
fix(explore): Set correct height on spans sub table

### DIFF
--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -28,7 +28,7 @@ export function StyledPanelHeader({
   ...props
 }: StyledPanelHeaderProps) {
   return (
-    <Flex justify={justify} radius={radius}>
+    <Flex justify={justify} radius={radius} height="100%">
       {flexProps => (
         <Text as="div" wrap="nowrap">
           <PanelHeader lightText={lightText} {...flexProps} {...props}>


### PR DESCRIPTION
One of the span sub-table headers didn't have any height to it, so the element below it in the grid started to bleed into it. Adding a height of 100% to the panel header resolves that issue:

Before:
<img width="1227" height="87" alt="Screenshot 2025-12-30 at 07 27 33" src="https://github.com/user-attachments/assets/294b0962-7f34-4314-ac2e-7319b78e6046" />

After:
<img width="1221" height="85" alt="Screenshot 2025-12-30 at 07 27 42" src="https://github.com/user-attachments/assets/8976f760-b23d-4a75-8087-a431986a7db9" />