### PR TITLE
feat(tracemetrics): Add Open in Metrics action

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -90,6 +90,7 @@ import {
   getWidgetExploreUrl,
   getWidgetTableRowExploreUrlFunction,
 } from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {
   SESSION_DURATION_ALERT,
   WidgetDescription,
@@ -911,6 +912,10 @@ function OpenButton({
     case WidgetType.LOGS:
       openLabel = t('Open in Explore');
       path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
+      break;
+    case WidgetType.TRACEMETRICS:
+      openLabel = t('Open in Metrics');
+      path = getWidgetMetricsUrl(widget, dashboardFilters, selection, organization);
       break;
     case WidgetType.DISCOVER:
     default:

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
@@ -1,0 +1,452 @@
+import qs from 'query-string';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import type {PageFilters} from 'sentry/types/core';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import {getWidgetMetricsUrl} from './getWidgetMetricsUrl';
+
+function parseMetricsUrl(url: string) {
+  const [pathname, search] = url.split('?');
+  const params = qs.parse(search ?? '');
+  return {pathname, params};
+}
+
+describe('getWidgetMetricsUrl', () => {
+  const organization = OrganizationFixture({slug: 'test-org'});
+  const selection: PageFilters = {
+    datetime: {
+      start: null,
+      end: null,
+      period: '14d',
+      utc: null,
+    },
+    environments: ['production'],
+    projects: [1, 2],
+  };
+
+  describe('basic functionality', () => {
+    it('generates URL for single query with single aggregate', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Test Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: 'transaction:"/api/users"',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {pathname, params} = parseMetricsUrl(url);
+
+      expect(pathname).toBe('/organizations/test-org/explore/metrics/');
+      expect(params.project).toEqual(['1', '2']);
+      expect(params.environment).toBe('production');
+      expect(params.statsPeriod).toBe('14d');
+      expect(params.title).toBe('Test Widget');
+      expect(params.referrer).toBe('dashboards');
+      expect(params.metric).toBeDefined();
+      expect(Array.isArray(params.metric) ? params.metric.length : 1).toBe(1);
+    });
+
+    it('generates URL for multiple aggregates', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Multi Aggregate',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: [
+              'avg(value,duration,d,-)',
+              'p95(value,duration,d,-)',
+              'count(value,duration,d,-)',
+            ],
+            columns: [],
+            conditions: 'transaction:"/api/users"',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      // Should have 3 metric query parameters (one for each aggregate)
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      expect(metrics).toHaveLength(3);
+    });
+
+    it('generates URL with group by columns', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Grouped Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: ['transaction', 'http.status_code'],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      // Decode and parse the metric query to check for group by fields
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateFields).toBeDefined();
+      // Should have visualize + 2 group bys
+      expect(metricQuery.aggregateFields).toHaveLength(3);
+      expect(metricQuery.aggregateFields).toEqual([
+        {chartType: ChartType.LINE, yAxes: ['avg(value,duration,d,-)']},
+        {groupBy: 'transaction'},
+        {groupBy: 'http.status_code'},
+      ]);
+    });
+
+    it('applies dashboard filters to query conditions', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Filtered Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: 'transaction:"/api/users"',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const dashboardFilters: DashboardFilters = {
+        release: ['v1.0.0'],
+      };
+
+      const url = getWidgetMetricsUrl(widget, dashboardFilters, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      // Dashboard filters should be applied to the query
+      expect(metricQuery.query).toContain('release');
+      expect(metricQuery.query).toContain('v1.0.0');
+      expect(metricQuery.query).toContain('transaction:"/api/users"');
+    });
+
+    it('handles sort/orderby parameters', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Sorted Widget',
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: ['transaction'],
+            conditions: '',
+            orderby: '-avg(value,duration,d,-)',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateSortBys).toBeDefined();
+      expect(metricQuery.aggregateSortBys).toHaveLength(1);
+      expect(metricQuery.aggregateSortBys[0].field).toBe('avg(value,duration,d,-)');
+      expect(metricQuery.aggregateSortBys[0].kind).toBe('desc');
+    });
+  });
+
+  describe('multiple queries', () => {
+    it('creates metric queries for each (aggregate, query) combination', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Multi Query Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)', 'p95(value,duration,d,-)'],
+            columns: [],
+            conditions: 'transaction:"/api/users"',
+            orderby: '',
+            fieldAliases: [],
+          },
+          {
+            name: 'Query 2',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)', 'p95(value,duration,d,-)'],
+            columns: [],
+            conditions: 'transaction:"/api/posts"',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      // Should have 4 metric queries (2 aggregates × 2 queries)
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      expect(metrics).toHaveLength(4);
+
+      // Should be grouped by aggregate (all avg together, then all p95 together)
+      const parsedMetrics = metrics.map(metric => JSON.parse(metric as string));
+      const avgMetrics = parsedMetrics.filter(m =>
+        m.aggregateFields[0].yAxes[0].includes('avg')
+      );
+      const p95Metrics = parsedMetrics.filter(m =>
+        m.aggregateFields[0].yAxes[0].includes('p95')
+      );
+      expect(avgMetrics).toHaveLength(2);
+      expect(p95Metrics).toHaveLength(2);
+    });
+
+    it('applies different conditions to each query', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Different Conditions',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Success',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: 'http.status_code:200',
+            orderby: '',
+            fieldAliases: [],
+          },
+          {
+            name: 'Errors',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: 'http.status_code:500',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      // Should have 2 metric queries (1 aggregate × 2 queries)
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      expect(metrics).toHaveLength(2);
+
+      const parsedMetrics = metrics.map(metric => JSON.parse(metric as string));
+      expect(parsedMetrics[0].query).toContain('http.status_code:200');
+      expect(parsedMetrics[1].query).toContain('http.status_code:500');
+    });
+  });
+
+  describe('display type mapping', () => {
+    it('maps LINE display type to LINE chart type', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Line Chart',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateFields[0].chartType).toBe(ChartType.LINE);
+    });
+
+    it('maps BAR display type to BAR chart type', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Bar Chart',
+        displayType: DisplayType.BAR,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['count(value,duration,d,-)'],
+            columns: [],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateFields[0].chartType).toBe(ChartType.BAR);
+    });
+
+    it('maps AREA display type to AREA chart type', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Area Chart',
+        displayType: DisplayType.AREA,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['sum(value,duration,d,-)'],
+            columns: [],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateFields[0].chartType).toBe(ChartType.AREA);
+    });
+  });
+
+  it('handles empty query conditions', () => {
+    const widget: Widget = {
+      id: '1',
+      title: 'Empty Conditions',
+      displayType: DisplayType.LINE,
+      interval: '5m',
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        {
+          name: 'Query 1',
+          fields: [],
+          aggregates: ['avg(value,duration,d,-)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+          fieldAliases: [],
+        },
+      ],
+    };
+
+    const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+    const {params} = parseMetricsUrl(url);
+
+    expect(params.metric).toBeDefined();
+    const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+    const metricQuery = JSON.parse(metrics[0]!);
+    expect(metricQuery.query).toBe('');
+  });
+
+  describe('datetime selection', () => {
+    it('includes absolute datetime when start and end are provided', () => {
+      const absoluteSelection: PageFilters = {
+        datetime: {
+          start: '2024-01-01T00:00:00Z',
+          end: '2024-01-31T23:59:59Z',
+          period: null,
+          utc: true,
+        },
+        environments: [],
+        projects: [1],
+      };
+
+      const widget: Widget = {
+        id: '1',
+        title: 'Absolute Time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['avg(value,duration,d,-)'],
+            columns: [],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, absoluteSelection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      expect(params.start).toBe('2024-01-01T00:00:00Z');
+      expect(params.end).toBe('2024-01-31T23:59:59Z');
+      expect(params.utc).toBe('true');
+      expect(params.statsPeriod).toBeUndefined();
+    });
+  });
+});

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -14,6 +14,7 @@ import type {
 import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {getMetricsUrl, makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -43,11 +44,11 @@ export function getWidgetMetricsUrl(
     const defaultQuery = defaultMetricQuery();
 
     // Build aggregate fields (visualizations + group bys)
-    const aggregateFields = [
+    const aggregateFields: AggregateField[] = [
       // Convert aggregates to VisualizeFunction objects
       ...query.aggregates.map(agg => new VisualizeFunction(agg, {chartType})),
-      // Group by columns are added as-is (they're already strings)
-      ...query.columns.map(col => col),
+      // Convert columns to GroupBy objects
+      ...query.columns.map((col): GroupBy => ({groupBy: col})),
     ];
 
     // Parse sorts from orderby
@@ -68,7 +69,7 @@ export function getWidgetMetricsUrl(
         fields: defaultQuery.queryParams.fields,
         sortBys: defaultQuery.queryParams.sortBys,
         aggregateCursor: '',
-        aggregateFields: aggregateFields as readonly AggregateField[],
+        aggregateFields,
         aggregateSortBys,
       }),
     };

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -41,7 +41,8 @@ export function getWidgetMetricsUrl(
       // For each aggregate, create a metric query for each widget query
       return widget.queries.map(query => {
         const queryString =
-          applyDashboardFilters(query.conditions, dashboardFilters) ?? '';
+          applyDashboardFilters(query.conditions, dashboardFilters, widget.widgetType) ??
+          '';
 
         const groupByFields: GroupBy[] = query.columns.map(
           (col): GroupBy => ({groupBy: col})

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -1,0 +1,128 @@
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {parseFunction} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {applyDashboardFilters} from 'sentry/views/dashboards/utils';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import type {
+  BaseMetricQuery,
+  TraceMetric,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {getMetricsUrl, makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+/**
+ * Converts a TRACEMETRICS dashboard widget to a metrics page URL
+ */
+export function getWidgetMetricsUrl(
+  widget: Widget,
+  dashboardFilters: DashboardFilters | undefined,
+  selection: PageFilters,
+  organization: Organization
+): string {
+  // Extract trace metric from the first query's first aggregate
+  const traceMetric = extractTraceMetricFromWidget(widget);
+
+  if (!traceMetric?.name) {
+    // If we can't extract a valid trace metric, return a basic metrics URL
+    return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
+  }
+
+  // Map widget display type to chart type
+  const chartType = getChartTypeFromDisplayType(widget.displayType);
+
+  // Build metric queries for each widget query
+  const metricQueries: BaseMetricQuery[] = widget.queries.map(query => {
+    const defaultQuery = defaultMetricQuery();
+
+    // Build aggregate fields (visualizations + group bys)
+    const aggregateFields = [
+      // Convert aggregates to VisualizeFunction objects
+      ...query.aggregates.map(agg => new VisualizeFunction(agg, {chartType})),
+      // Group by columns are added as-is (they're already strings)
+      ...query.columns.map(col => col),
+    ];
+
+    // Parse sorts from orderby
+    const aggregateSortBys: Sort[] = query.orderby
+      ? decodeSorts(query.orderby)
+      : [...defaultQuery.queryParams.aggregateSortBys];
+
+    // Apply dashboard filters to the query conditions
+    const queryString = applyDashboardFilters(query.conditions, dashboardFilters) ?? '';
+
+    return {
+      metric: traceMetric,
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: queryString,
+        cursor: '',
+        fields: defaultQuery.queryParams.fields,
+        sortBys: defaultQuery.queryParams.sortBys,
+        aggregateCursor: '',
+        aggregateFields: aggregateFields as readonly AggregateField[],
+        aggregateSortBys,
+      }),
+    };
+  });
+
+  // Generate the metrics URL using the shared utility
+  return getMetricsUrl({
+    organization,
+    selection,
+    metricQueries,
+    title: widget.title,
+    referrer: 'dashboards',
+  });
+}
+
+/**
+ * Extracts TraceMetric information from a TRACEMETRICS widget's aggregates
+ */
+function extractTraceMetricFromWidget(widget: Widget): TraceMetric | null {
+  const firstQuery = widget.queries[0];
+  if (!firstQuery?.aggregates || firstQuery.aggregates.length === 0) {
+    return null;
+  }
+
+  // Parse the first aggregate to extract metric name and type
+  // TRACEMETRICS aggregates are in format: avg(value,metric_name,metric_type,-)
+  const firstAggregate = firstQuery.aggregates[0] ?? '';
+  const parsedFunction = parseFunction(firstAggregate);
+
+  if (!parsedFunction?.arguments || parsedFunction.arguments.length < 3) {
+    return null;
+  }
+
+  // Arguments: [value, metric_name, metric_type, unit]
+  const name = parsedFunction.arguments[1] ?? '';
+  const type = parsedFunction.arguments[2] ?? '';
+
+  return {name, type};
+}
+
+/**
+ * Maps dashboard DisplayType to metrics ChartType
+ */
+function getChartTypeFromDisplayType(displayType: DisplayType): ChartType {
+  switch (displayType) {
+    case DisplayType.LINE:
+      return ChartType.LINE;
+    case DisplayType.AREA:
+      return ChartType.AREA;
+    case DisplayType.BAR:
+      return ChartType.BAR;
+    case DisplayType.TABLE:
+    case DisplayType.BIG_NUMBER:
+    default:
+      return ChartType.LINE;
+  }
+}

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -32,6 +32,7 @@ import {
   performanceScoreTooltip,
 } from 'sentry/views/dashboards/utils';
 import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -258,6 +259,20 @@ export function getMenuOptions(
         Mode.SAMPLES,
         getReferrer(widget.displayType)
       ),
+    });
+  }
+
+  if (widget.widgetType === WidgetType.TRACEMETRICS) {
+    menuOptions.push({
+      key: 'open-in-metrics',
+      label: t('Open in Metrics'),
+      to: getWidgetMetricsUrl(widget, dashboardFilters, selection, organization),
+      onAction: () => {
+        trackAnalytics('dashboards_views.open_in_metrics.opened', {
+          organization,
+          widget_type: widget.displayType,
+        });
+      },
     });
   }
 

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -79,7 +79,9 @@ type BaseGetMetricsUrlParams = {
 export function getMetricsUrl(
   params: BaseGetMetricsUrlParams & {organization: Organization}
 ): string;
-export function getMetricsUrl(params: BaseGetMetricsUrlParams & {organization: string}): string;
+export function getMetricsUrl(
+  params: BaseGetMetricsUrlParams & {organization: string}
+): string;
 export function getMetricsUrl({
   organization,
   selection,

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -76,11 +76,11 @@ type BaseGetMetricsUrlParams = {
   title?: string;
 };
 
-function getMetricsUrl(
+export function getMetricsUrl(
   params: BaseGetMetricsUrlParams & {organization: Organization}
 ): string;
-function getMetricsUrl(params: BaseGetMetricsUrlParams & {organization: string}): string;
-function getMetricsUrl({
+export function getMetricsUrl(params: BaseGetMetricsUrlParams & {organization: string}): string;
+export function getMetricsUrl({
   organization,
   selection,
   metricQueries,


### PR DESCRIPTION
Adds an "Open in Metrics" action to the widget context menu (i.e. the `...` menu) and the widget viewer.

This parses the widget queries and for every aggregate, creates a query that has one of the filters (essentially `aggregates X queries`). We have to do this because we do not currently support plotting multiple metrics on a chart in the metrics explorer yet.

This cross product functionality is also what technically happens behind the scenes when we create widgets with multiple yAxes and filters at the moment.