### PR TITLE
dev(agents): Do not use direnv allow

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -49,20 +49,37 @@ sentry/
 
 ## Command Execution Requirements
 
-**CRITICAL**: Before running ANY Python commands (pytest, mypy, pre-commit, etc.), you MUST activate the virtual environment:
+**CRITICAL**: When running Python commands (pytest, mypy, pre-commit, etc.), you MUST use the virtual environment.
+
+### For AI Agents (automated commands)
+
+Use the full relative path to virtualenv executables:
 
 ```bash
-direnv allow
+cd /path/to/sentry && .venv/bin/pytest tests/...
+cd /path/to/sentry && .venv/bin/python -m mypy ...
 ```
 
-This ensures you're using the correct Python interpreter and dependencies from `.venv`. Commands will fail or use the wrong Python environment without this step.
+Or source the activate script in your command:
 
-**When to run `direnv allow`:**
+```bash
+cd /path/to/sentry && source .venv/bin/activate && pytest tests/...
+```
 
-- Before running tests (`pytest`)
-- Before running type checks (`mypy`)
-- Before running any Python scripts
-- At the start of any new terminal session
+**Important for AI agents:**
+
+- Always use `required_permissions: ['all']` when running Python commands to avoid sandbox permission issues
+- The `.venv/bin/` prefix ensures you're using the correct Python interpreter and dependencies
+
+### For Human Developers (interactive shells)
+
+Run `direnv allow` once to trust the `.envrc` file. After that, direnv will automatically activate the virtual environment when you cd into the directory.
+
+```bash
+cd /path/to/sentry
+direnv allow  # Only needed once, or after .envrc changes
+# Now pytest, python, etc. will automatically use .venv
+```
 
 ## Security Guidelines
 


### PR DESCRIPTION
Switching to activating the virtualenv directly works while `direnv allow` does not work.

## Why `direnv allow` doesn't work in Cursor IDE agents

`direnv` is a shell integration tool that requires **persistent shell sessions** to function. Here's the issue:

### How direnv normally works
1. `direnv allow` grants permission to execute `.envrc`
2. Direnv hooks into the shell's `cd` command and prompt
3. When entering the directory, direnv automatically loads the environment

### Why it fails for AI agents
- Each Shell tool call creates a **fresh, independent shell session**
- `direnv allow` only sets permission—it doesn't activate the environment
- The activation requires the shell to remain open and display a prompt
- Subsequent commands start in new shells where direnv hasn't triggered

### The fix
Instead of relying on direnv's automatic activation, agents should:
- Use direct virtualenv paths: `.venv/bin/pytest tests/...`
- Or source activate in the same command: `source .venv/bin/activate && pytest tests/...`

This approach bypasses direnv entirely and works reliably in ephemeral shell sessions.