### PR TITLE
feat(eap-resolver): support between operator

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -104,6 +104,9 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
 
     if operator == "between":
         value2 = args[4]
+
+        assert isinstance(value2, str), "Second value must be a String"
+
         # TODO: A bit of a hack here, the default arg is set to an empty string so it's not treated as a required argument.
         # We check against the default arg to determine if the second value is missing.
         if value2 == "":

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -103,9 +103,11 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     attr_value = resolve_attribute_value(key, value)
 
     if operator == "between":
-        value2 = args[
-            4
-        ]  # This is already be validated to be a number in the `BaseArgumentDefinition.validator`
+        value2 = args[4]
+        # TODO: A bit of a hack here, the default arg is set to an empty string so it's not treated as a required argument.
+        # We check against the default arg to determine if the second value is missing.
+        if value2 == "":
+            raise InvalidSearchQuery("between operator requires two values")
 
         if float(value2) <= float(value):
             raise InvalidSearchQuery(f"Invalid parameter {value2}. Must be greater than {value}")
@@ -273,7 +275,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
             ),
             ValueArgumentDefinition(argument_types={"string"}),
             ValueArgumentDefinition(
-                argument_types={"string"}, default_arg="0.0", validator=number_validator
+                argument_types={"string"}, default_arg="", validator=number_validator
             ),  # Second value is only for between, so it must be a number
         ],
         aggregate_resolver=resolve_key_eq_value_filter,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -109,8 +109,13 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
         if value2 == "":
             raise InvalidSearchQuery("between operator requires two values")
 
-        if float(value2) <= float(value):
-            raise InvalidSearchQuery(f"Invalid parameter {value2}. Must be greater than {value}")
+        try:
+            if float(value2) <= float(value):
+                raise InvalidSearchQuery(
+                    f"Invalid parameter {value2}. Must be greater than {value}"
+                )
+        except ValueError:
+            raise InvalidSearchQuery("between operator requires two numbers")
 
         attr_value2 = resolve_attribute_value(key, value2)
         trace_filter = TraceItemFilter(

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6312,7 +6312,10 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             }
         )
         assert response.status_code == 400, response.content
-        assert "Invalid Parameter " in response.data["detail"].title()
+        assert (
+            "Fourth Parameter 299 Must Be Greater Than Third Parameter 300"
+            in response.data["detail"].title()
+        )
 
     def test_count_if_numeric_raises_invalid_search_query_with_bad_value(self) -> None:
         response = self.do_request(
@@ -6326,7 +6329,10 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         )
 
         assert response.status_code == 400, response.content
-        assert "Invalid Parameter " in response.data["detail"].title()
+        assert (
+            "Invalid Third Parameter Three. Must Be Of Type Number"
+            in response.data["detail"].title()
+        )
 
     def test_count_if_integer(self) -> None:
         self.store_spans(

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6288,7 +6288,20 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         ]
         assert meta["dataset"] == "spans"
 
-    def test_count_if_numeric_between_raises_with_second_value_less_than_first(self) -> None:
+    def test_count_if_between_raises_with_second_value_missing(self) -> None:
+        response = self.do_request(
+            {
+                "field": ["count_if(span.duration,between,300)"],
+                "query": "",
+                "orderby": "count_if(span.duration,between,300)",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert "between operator requires two values" in response.data["detail"]
+
+    def test_count_if_between_raises_with_second_value_less_than_first(self) -> None:
         response = self.do_request(
             {
                 "field": ["count_if(span.duration,between,300,299)"],


### PR DESCRIPTION
Add support for inclusive `between` operator in `count_if`. 

This can eventually be expanded to other functions, but for now we need this to create percentage http response status codes in dashboards via formulas.
i.e `count_if(status_code,between,300,399) / count(span.duration)`