### PR TITLE
chore(explore) Remove links to traces page from explore on old spans and traces

### DIFF
--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -139,7 +139,7 @@ describe('FieldRenderer tests', () => {
       );
       expect(await screen.findByRole('link')).toHaveAttribute(
         'href',
-        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h`
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&referrer=partial-trace&statsPeriod=24h`
       );
     });
   });
@@ -197,7 +197,7 @@ describe('FieldRenderer tests', () => {
       );
       expect(await screen.findByRole('link')).toHaveAttribute(
         'href',
-        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h`
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&referrer=partial-trace&statsPeriod=24h`
       );
     });
   });
@@ -255,7 +255,7 @@ describe('FieldRenderer tests', () => {
       );
       expect(await screen.findByRole('link')).toHaveAttribute(
         'href',
-        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h&table=trace`
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&referrer=partial-trace&statsPeriod=24h&table=trace`
       );
     });
   });

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -251,7 +251,7 @@ describe('FieldRenderer tests', () => {
       expect(await screen.findByText(/Trace is older than 30 days/)).toBeInTheDocument();
 
       const queryString = encodeURIComponent(
-        'is_transaction:true transaction:"GET /foo"'
+        'span.name:"HTTP GET /foo" span.description:"GET /foo"'
       );
       expect(await screen.findByRole('link')).toHaveAttribute(
         'href',

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -4,7 +4,7 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -22,6 +22,7 @@ const mockedEventData = {
   'transaction.span_id': 'transactionSpanId',
   'span.description': 'GET /foo',
   'span.name': 'HTTP GET /foo',
+  transaction: 'GET /foo',
 };
 
 function Wrapper({children}: {children: ReactNode}) {
@@ -49,7 +50,7 @@ describe('FieldRenderer tests', () => {
 
   const eventView = EventView.fromLocation(location);
 
-  beforeAll(() => {
+  beforeEach(() => {
     const mockTimestamp = new Date('2024-10-06T00:00:00').getTime();
     setMockDate(mockTimestamp);
 
@@ -64,7 +65,7 @@ describe('FieldRenderer tests', () => {
     ProjectsStore.loadInitialData(projects);
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.restoreAllMocks();
     resetMockDate();
     ProjectsStore.reset();
@@ -85,61 +86,178 @@ describe('FieldRenderer tests', () => {
     expect(screen.getByText('test_op')).toBeInTheDocument();
   });
 
-  it('renders span id link to traceview', () => {
-    render(
-      <Wrapper>
-        <FieldRenderer
-          column={eventView.getColumns()[0]}
-          data={mockedEventData}
-          meta={{}}
-        />
-      </Wrapper>,
-      {organization}
-    );
+  describe('span timestamp is less than 30 days', () => {
+    it('renders span id link to trace view', () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[0]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
 
-    expect(screen.getByText('spanId')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/explore/traces/trace/traceId/?node=span-spanId&node=txn-transactionSpanId&source=traces&statsPeriod=14d&targetId=transactionSpanId&timestamp=1727964900`
-    );
+      expect(screen.getByText('spanId')).toBeInTheDocument();
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/trace/traceId/?node=span-spanId&node=txn-transactionSpanId&source=traces&statsPeriod=14d&targetId=transactionSpanId&timestamp=1727964900`
+      );
+    });
   });
 
-  it('renders transaction id link to traceview', () => {
-    render(
-      <Wrapper>
-        <FieldRenderer
-          column={eventView.getColumns()[4]}
-          data={mockedEventData}
-          meta={{}}
-        />
-      </Wrapper>,
-      {organization}
-    );
+  describe('span timestamp is greater than 30 days', () => {
+    beforeEach(() => {
+      setMockDate(new Date('2025-10-06T00:00:00').getTime());
+    });
 
-    expect(screen.getByText('transactionId')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/explore/traces/trace/traceId/?source=traces&statsPeriod=14d&targetId=transactionSpanId&timestamp=1727964900`
-    );
+    afterEach(() => {
+      resetMockDate();
+    });
+
+    it('renders span id link to similar spans', async () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[0]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
+
+      expect(screen.getByText('spanId')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+      await userEvent.hover(screen.getByText('spanId'));
+      expect(await screen.findByText(/Span is older than 30 days/)).toBeInTheDocument();
+
+      const queryString = encodeURIComponent(
+        'span.name:"HTTP GET /foo" span.description:"GET /foo"'
+      );
+      expect(await screen.findByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h`
+      );
+    });
   });
 
-  it('renders trace id link to traceview', () => {
-    render(
-      <Wrapper>
-        <FieldRenderer
-          column={eventView.getColumns()[2]}
-          data={mockedEventData}
-          meta={{}}
-        />
-      </Wrapper>,
-      {organization}
-    );
+  describe('transaction timestamp is less than 30 days', () => {
+    it('renders transaction id link to trace view', () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[4]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
 
-    expect(screen.getByText('traceId')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/explore/traces/trace/traceId/?source=traces&statsPeriod=14d&timestamp=1727964900`
-    );
+      expect(screen.getByText('transactionId')).toBeInTheDocument();
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/trace/traceId/?source=traces&statsPeriod=14d&targetId=transactionSpanId&timestamp=1727964900`
+      );
+    });
+  });
+
+  describe('transaction timestamp is greater than 30 days', () => {
+    beforeEach(() => {
+      setMockDate(new Date('2025-10-06T00:00:00').getTime());
+    });
+
+    afterEach(() => {
+      resetMockDate();
+    });
+
+    it('renders transaction id link to similar transactions', async () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[4]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
+
+      expect(screen.getByText('transactionId')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+      await userEvent.hover(screen.getByText('transactionId'));
+      expect(await screen.findByText(/Span is older than 30 days/)).toBeInTheDocument();
+
+      const queryString = encodeURIComponent(
+        'is_transaction:true span.name:"HTTP GET /foo" span.description:"GET /foo"'
+      );
+      expect(await screen.findByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h`
+      );
+    });
+  });
+
+  describe('trace timestamp is less than 30 days', () => {
+    it('renders trace id link to trace view', () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[2]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
+
+      expect(screen.getByText('traceId')).toBeInTheDocument();
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/trace/traceId/?source=traces&statsPeriod=14d&timestamp=1727964900`
+      );
+    });
+  });
+
+  describe('trace timestamp is greater than 30 days', () => {
+    beforeEach(() => {
+      setMockDate(new Date('2025-10-06T00:00:00').getTime());
+    });
+
+    afterEach(() => {
+      resetMockDate();
+    });
+
+    it('renders trace id link to trace view', async () => {
+      render(
+        <Wrapper>
+          <FieldRenderer
+            column={eventView.getColumns()[2]}
+            data={mockedEventData}
+            meta={{}}
+          />
+        </Wrapper>,
+        {organization}
+      );
+
+      expect(screen.getByText('traceId')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+      await userEvent.hover(screen.getByText('traceId'));
+      expect(await screen.findByText(/Trace is older than 30 days/)).toBeInTheDocument();
+
+      const queryString = encodeURIComponent(
+        'is_transaction:true transaction:"GET /foo"'
+      );
+      expect(await screen.findByRole('link')).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h&table=trace`
+      );
+    });
   });
 
   it('renders timestamp', () => {

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -187,9 +187,8 @@ function BaseExploreFieldRenderer({
 
       return (
         <Tooltip
-          showUnderline
           isHoverable
-          disabled={!queryString}
+          showUnderline
           title={
             <Text>
               {tct('Trace is older than 30 days. [similarTraces] in the past 24 hours.', {
@@ -250,9 +249,8 @@ function BaseExploreFieldRenderer({
 
       return (
         <Tooltip
-          showUnderline
           isHoverable
-          disabled={!queryString}
+          showUnderline
           title={
             <Text>
               {tct('Span is older than 30 days. [similarSpans] in the past 24 hours.', {

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -170,7 +170,7 @@ function BaseExploreFieldRenderer({
       if (data?.['span.description']) {
         queryString.addFilterValue('span.description', data['span.description']);
       }
-      return (
+      rendered = (
         <ScrapsContainer maxWidth="fit-content">
           <Tooltip
             isHoverable
@@ -204,18 +204,18 @@ function BaseExploreFieldRenderer({
           </Tooltip>
         </ScrapsContainer>
       );
+    } else {
+      const target = getTraceDetailsUrl({
+        traceSlug: data.trace,
+        timestamp: data.timestamp,
+        organization,
+        dateSelection,
+        location,
+        source: TraceViewSources.TRACES,
+      });
+
+      rendered = <Link to={target}>{rendered}</Link>;
     }
-
-    const target = getTraceDetailsUrl({
-      traceSlug: data.trace,
-      timestamp: data.timestamp,
-      organization,
-      dateSelection,
-      location,
-      source: TraceViewSources.TRACES,
-    });
-
-    rendered = <Link to={target}>{rendered}</Link>;
   }
 
   if (['id', 'span_id', 'transaction.id'].includes(field)) {
@@ -236,7 +236,7 @@ function BaseExploreFieldRenderer({
         queryString.addFilterValue('span.description', data['span.description']);
       }
 
-      return (
+      rendered = (
         <ScrapsContainer maxWidth="fit-content">
           <Tooltip
             isHoverable
@@ -266,20 +266,20 @@ function BaseExploreFieldRenderer({
           </Tooltip>
         </ScrapsContainer>
       );
+    } else {
+      const target = generateLinkToEventInTraceView({
+        traceSlug: data.trace,
+        timestamp: data.timestamp,
+        targetId: data['transaction.span_id'],
+        eventId: undefined,
+        organization,
+        location,
+        spanId,
+        source: TraceViewSources.TRACES,
+      });
+
+      rendered = <Link to={target}>{rendered}</Link>;
     }
-
-    const target = generateLinkToEventInTraceView({
-      traceSlug: data.trace,
-      timestamp: data.timestamp,
-      targetId: data['transaction.span_id'],
-      eventId: undefined,
-      organization,
-      location,
-      spanId,
-      source: TraceViewSources.TRACES,
-    });
-
-    rendered = <Link to={target}>{rendered}</Link>;
 
     if (organization.features.includes('discover-cell-actions-v2') && field === 'id') {
       return rendered;

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -186,6 +186,7 @@ function BaseExploreFieldRenderer({
             : selection.projects,
           datetime: {start: null, end: null, utc: null, period: '24h'},
         },
+        referrer: 'partial-trace',
       });
 
       return (
@@ -248,6 +249,7 @@ function BaseExploreFieldRenderer({
             : selection.projects,
           datetime: {start: null, end: null, utc: null, period: '24h'},
         },
+        referrer: 'partial-trace',
       });
 
       return (

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Container as ScrapsContainer} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {ExternalLink, Link} from 'sentry/components/core/link';
@@ -170,33 +171,38 @@ function BaseExploreFieldRenderer({
         queryString.addFilterValue('span.description', data['span.description']);
       }
       return (
-        <Tooltip
-          isHoverable
-          showUnderline
-          title={
-            <Text>
-              {tct('Trace is older than 30 days. [similarTraces] in the past 24 hours.', {
-                similarTraces: (
-                  <Link
-                    to={getSimilarEventsUrl({
-                      queryString: queryString.formatString(),
-                      table: 'trace',
-                      organization,
-                      projectIds: defined(project?.id)
-                        ? [parseInt(project.id, 10)]
-                        : selection.projects,
-                      selection,
-                    })}
-                  >
-                    {t('View similar traces')}
-                  </Link>
-                ),
-              })}
-            </Text>
-          }
-        >
-          <Text variant="muted">{rendered}</Text>
-        </Tooltip>
+        <ScrapsContainer maxWidth="fit-content">
+          <Tooltip
+            isHoverable
+            showUnderline
+            title={
+              <Text>
+                {tct(
+                  'Trace is older than 30 days. [similarTraces] in the past 24 hours.',
+                  {
+                    similarTraces: (
+                      <Link
+                        to={getSimilarEventsUrl({
+                          queryString: queryString.formatString(),
+                          table: 'trace',
+                          organization,
+                          projectIds: defined(project?.id)
+                            ? [parseInt(project.id, 10)]
+                            : selection.projects,
+                          selection,
+                        })}
+                      >
+                        {t('View similar traces')}
+                      </Link>
+                    ),
+                  }
+                )}
+              </Text>
+            }
+          >
+            <Text variant="muted">{rendered}</Text>
+          </Tooltip>
+        </ScrapsContainer>
       );
     }
 
@@ -231,32 +237,34 @@ function BaseExploreFieldRenderer({
       }
 
       return (
-        <Tooltip
-          isHoverable
-          showUnderline
-          title={
-            <Text>
-              {tct('Span is older than 30 days. [similarSpans] in the past 24 hours.', {
-                similarSpans: (
-                  <Link
-                    to={getSimilarEventsUrl({
-                      queryString: queryString.formatString(),
-                      organization,
-                      projectIds: defined(project?.id)
-                        ? [parseInt(project.id, 10)]
-                        : selection.projects,
-                      selection,
-                    })}
-                  >
-                    {t('View similar spans')}
-                  </Link>
-                ),
-              })}
-            </Text>
-          }
-        >
-          <Text variant="muted">{rendered}</Text>
-        </Tooltip>
+        <ScrapsContainer maxWidth="fit-content">
+          <Tooltip
+            isHoverable
+            showUnderline
+            title={
+              <Text>
+                {tct('Span is older than 30 days. [similarSpans] in the past 24 hours.', {
+                  similarSpans: (
+                    <Link
+                      to={getSimilarEventsUrl({
+                        queryString: queryString.formatString(),
+                        organization,
+                        projectIds: defined(project?.id)
+                          ? [parseInt(project.id, 10)]
+                          : selection.projects,
+                        selection,
+                      })}
+                    >
+                      {t('View similar spans')}
+                    </Link>
+                  ),
+                })}
+              </Text>
+            }
+          >
+            <Text variant="muted">{rendered}</Text>
+          </Tooltip>
+        </ScrapsContainer>
       );
     }
 

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -164,10 +164,13 @@ function BaseExploreFieldRenderer({
   if (field === 'trace') {
     if (olderThan30Days) {
       const queryString = new MutableSearch('');
-      queryString.addFilterValue('is_transaction', 'true');
 
-      if (data?.transaction) {
-        queryString.addFilterValue('transaction', data.transaction);
+      if (data?.['span.name']) {
+        queryString.addFilterValue('span.name', data['span.name']);
+      }
+
+      if (data?.['span.description']) {
+        queryString.addFilterValue('span.description', data['span.description']);
       }
 
       const project = projectsMap[data.project];

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -137,7 +137,7 @@ function BaseExploreFieldRenderer({
   const olderThan30Days = useMemo(() => {
     const currentDate = moment();
     const timestampDate = moment(data.timestamp);
-    return currentDate.diff(timestampDate, 'days') >= 30;
+    return currentDate.diff(timestampDate, 'days') > 30;
   }, [data.timestamp]);
 
   if (!defined(column)) {

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -3,10 +3,8 @@ import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import {Container} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
-
-import {Stack} from '@sentry/scraps/layout';
 
 import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
 import {Link} from 'sentry/components/core/link';

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -558,6 +558,7 @@ export function TraceIdRenderer({
         projects: projectIds,
         datetime: {start: null, end: null, utc: null, period: '24h'},
       },
+      referrer: 'partial-trace',
     });
 
     return (

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -1,7 +1,11 @@
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
+import moment from 'moment-timezone';
+
+import {Container} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -13,18 +17,22 @@ import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import TimeSince from 'sentry/components/timeSince';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
 import Projects from 'sentry/utils/projects';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
 import {BREAKDOWN_SLICES} from 'sentry/views/explore/hooks/useTraces';
 import type {SpanResult} from 'sentry/views/explore/tables/tracesTable/types';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {SpanFields, SpanResponse} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
@@ -387,7 +395,10 @@ const BreakdownSlice = styled('div')<{
 `;
 
 interface SpanIdRendererProps {
+  spanDescription: string | null;
   spanId: string;
+  spanOp: string;
+  spanProject: string;
   timestamp: string;
   traceId: string;
   transactionId: string;
@@ -400,9 +411,71 @@ export function SpanIdRenderer({
   traceId,
   transactionId,
   onClick,
+  spanDescription,
+  spanOp,
+  spanProject,
 }: SpanIdRendererProps) {
   const location = useLocation();
   const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const shortSpanId = getShortEventId(spanId);
+
+  const olderThan30Days = useMemo(() => {
+    const currentDate = moment();
+    const timestampDate = moment(timestamp);
+    return currentDate.diff(timestampDate, 'days') >= 30;
+  }, [timestamp]);
+
+  const {projects} = useProjects({slugs: [spanProject]});
+  const projectIds = projects
+    .filter(project => defined(project.id))
+    .map(project => parseInt(project.id, 10));
+
+  const queryString = useMemo(() => {
+    if (!olderThan30Days) return undefined;
+
+    const search = new MutableSearch('');
+    if (spanOp) {
+      search.addFilterValue('span.op', spanOp);
+    }
+
+    if (spanDescription) {
+      search.addFilterValue('span.description', spanDescription);
+    }
+
+    return search.formatString();
+  }, [olderThan30Days, spanDescription, spanOp]);
+
+  if (olderThan30Days) {
+    const similarTraces = getExploreUrl({
+      organization,
+      mode: Mode.SAMPLES,
+      query: queryString,
+      selection: {
+        ...selection,
+        projects: projectIds,
+        datetime: {start: null, end: null, utc: null, period: '24h'},
+      },
+    });
+
+    return (
+      <Tooltip
+        showUnderline
+        isHoverable
+        disabled={!queryString}
+        title={
+          <Text>
+            {tct('Span is older than 30 days. [similarSpans] in the past 24 hours.', {
+              similarSpans: <Link to={similarTraces}>{t('View similar spans')}</Link>,
+            })}
+          </Text>
+        }
+      >
+        <Text variant="muted">{shortSpanId}</Text>
+      </Tooltip>
+    );
+  }
 
   const target = generateLinkToEventInTraceView({
     traceSlug: traceId,
@@ -416,15 +489,17 @@ export function SpanIdRenderer({
 
   return (
     <Link to={target} onClick={onClick}>
-      {getShortEventId(spanId)}
+      {shortSpanId}
     </Link>
   );
 }
 
 interface TraceIdRendererProps {
   location: Location;
+  projectSlugs: string[];
   timestamp: number; // in milliseconds
   traceId: string;
+  traceName: string | null;
   onClick?: React.ComponentProps<typeof Link>['onClick'];
   transactionId?: string;
 }
@@ -435,9 +510,73 @@ export function TraceIdRenderer({
   transactionId,
   location,
   onClick,
+  traceName,
+  projectSlugs,
 }: TraceIdRendererProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
+
+  const shortId = getShortEventId(traceId);
+
+  const olderThan30Days = useMemo(() => {
+    const currentDate = moment();
+    const timestampDate = moment(timestamp);
+    return currentDate.diff(timestampDate, 'days') >= 30;
+  }, [timestamp]);
+
+  const {projects} = useProjects({slugs: projectSlugs, orgId: organization.slug});
+  const projectIds = projects
+    .filter(project => defined(project.id))
+    .map(project => parseInt(project.id, 10));
+
+  const queryString = useMemo(() => {
+    if (!olderThan30Days) return undefined;
+
+    const search = new MutableSearch('');
+    search.addFilterValue('is_transaction', 'true');
+    if (traceName) {
+      search.addFilterValue('span.description', traceName);
+    }
+
+    return search.formatString();
+  }, [olderThan30Days, traceName]);
+
+  if (olderThan30Days) {
+    const similarTraces = getExploreUrl({
+      organization,
+      mode: Mode.SAMPLES,
+      table: 'trace',
+      query: queryString,
+      selection: {
+        ...selection,
+        projects: projectIds,
+        datetime: {start: null, end: null, utc: null, period: '24h'},
+      },
+    });
+
+    return (
+      <Tooltip
+        showUnderline
+        isHoverable
+        disabled={!queryString}
+        title={
+          <Text>
+            {tct('Event is older than 30 days. [similarTraces] in the past 24 hours.', {
+              similarTraces: <Link to={similarTraces}>{t('View similar traces')}</Link>,
+            })}
+          </Text>
+        }
+      >
+        <Container minWidth="66px">
+          {props => (
+            <Text variant="muted" aria-disabled="true" role="link" {...props}>
+              {shortId}
+            </Text>
+          )}
+        </Container>
+      </Tooltip>
+    );
+  }
 
   const target = getTraceDetailsUrl({
     organization,
@@ -454,9 +593,13 @@ export function TraceIdRenderer({
   });
 
   return (
-    <Link to={target} style={{minWidth: '66px', textAlign: 'right'}} onClick={onClick}>
-      {getShortEventId(traceId)}
-    </Link>
+    <Container minWidth="66px">
+      {props => (
+        <Link to={target} style={{textAlign: 'right'}} onClick={onClick} {...props}>
+          {shortId}
+        </Link>
+      )}
+    </Container>
   );
 }
 

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -561,7 +561,7 @@ export function TraceIdRenderer({
         disabled={!queryString}
         title={
           <Text>
-            {tct('Event is older than 30 days. [similarTraces] in the past 24 hours.', {
+            {tct('Trace is older than 30 days. [similarTraces] in the past 24 hours.', {
               similarTraces: <Link to={similarTraces}>{t('View similar traces')}</Link>,
             })}
           </Text>

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -457,6 +457,7 @@ export function SpanIdRenderer({
         projects: projectIds,
         datetime: {start: null, end: null, utc: null, period: '24h'},
       },
+      referrer: 'partial-trace',
     });
 
     return (

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -522,7 +522,7 @@ export function TraceIdRenderer({
       search.addOp('(');
       search.addFilterValue('transaction', traceName);
       search.addOp('OR');
-      search.addFilterValue('span.op', traceName);
+      search.addFilterValue('span.name', traceName);
       search.addOp('OR');
       search.addFilterValue('span.description', traceName);
       search.addOp(')');

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -533,9 +533,15 @@ export function TraceIdRenderer({
     if (!olderThan30Days) return undefined;
 
     const search = new MutableSearch('');
-    search.addFilterValue('is_transaction', 'true');
+
     if (traceName) {
+      search.addOp('(');
+      search.addFilterValue('transaction', traceName);
+      search.addOp('OR');
+      search.addFilterValue('span.op', traceName);
+      search.addOp('OR');
       search.addFilterValue('span.description', traceName);
+      search.addOp(')');
     }
 
     return search.formatString();

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -424,7 +424,7 @@ export function SpanIdRenderer({
   const olderThan30Days = useMemo(() => {
     const currentDate = moment();
     const timestampDate = moment(timestamp);
-    return currentDate.diff(timestampDate, 'days') >= 30;
+    return currentDate.diff(timestampDate, 'days') > 30;
   }, [timestamp]);
 
   const {projects} = useProjects({slugs: [spanProject]});
@@ -521,7 +521,7 @@ export function TraceIdRenderer({
   const olderThan30Days = useMemo(() => {
     const currentDate = moment();
     const timestampDate = moment(timestamp);
-    return currentDate.diff(timestampDate, 'days') >= 30;
+    return currentDate.diff(timestampDate, 'days') > 30;
   }, [timestamp]);
 
   const {projects} = useProjects({slugs: projectSlugs, orgId: organization.slug});

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -196,6 +196,9 @@ function TraceRow({
     return [...leadingProjects, ...trailingProjects];
   }, [selectedProjects, trace]);
 
+  const projectSlugs =
+    traceProjects.length > 0 ? traceProjects : trace.project ? [trace.project] : [];
+
   return (
     <Fragment>
       <StyledPanelItem align="center" center onClick={onClickExpand}>
@@ -214,7 +217,9 @@ function TraceRow({
           }
         />
         <TraceIdRenderer
+          projectSlugs={projectSlugs}
           traceId={trace.trace}
+          traceName={trace.name}
           timestamp={trace.end}
           onClick={event => {
             event.stopPropagation();
@@ -230,15 +235,7 @@ function TraceRow({
         <Tooltip title={trace.name} containerDisplayMode="block" showOnlyOnOverflow>
           <Description>
             <ProjectBadgeWrapper>
-              <ProjectsRenderer
-                projectSlugs={
-                  traceProjects.length > 0
-                    ? traceProjects
-                    : trace.project
-                      ? [trace.project]
-                      : []
-                }
-              />
+              <ProjectsRenderer projectSlugs={projectSlugs} />
             </ProjectBadgeWrapper>
             {trace.name ? (
               <WrappingText>{trace.name}</WrappingText>

--- a/static/app/views/explore/tables/tracesTable/spansTable.tsx
+++ b/static/app/views/explore/tables/tracesTable/spansTable.tsx
@@ -123,7 +123,6 @@ function SpanRow({
 }: {
   organization: Organization;
   span: SpanResult<Field>;
-
   trace: TraceResult;
 }) {
   const theme = useTheme();
@@ -134,6 +133,9 @@ function SpanRow({
           transactionId={span['transaction.id']}
           spanId={span.id}
           traceId={trace.trace}
+          spanDescription={span['span.description']}
+          spanOp={span['span.op']}
+          spanProject={span.project}
           timestamp={span.timestamp}
           onClick={() =>
             trackAnalytics('trace_explorer.open_trace_span', {

--- a/static/app/views/explore/tables/tracesTable/utils.tsx
+++ b/static/app/views/explore/tables/tracesTable/utils.tsx
@@ -1,4 +1,10 @@
+import moment from 'moment-timezone';
+
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 import type {SpanResult} from 'sentry/views/explore/tables/tracesTable/types';
+import {getExploreUrl, type GetExploreUrlArgs} from 'sentry/views/explore/utils';
 
 import type {Field} from './data';
 
@@ -27,4 +33,41 @@ export function getShortenedSdkName(sdkName: string | null) {
     return sdkName;
   }
   return sdkNameParts[sdkNameParts.length - 1];
+}
+
+export function isPartialSpanOrTraceData(timestamp: string | number) {
+  const now = moment();
+  const timestampDate = moment(timestamp);
+  return now.diff(timestampDate, 'days') > 30;
+}
+
+interface GetSimilarEventsUrlArgs {
+  organization: Organization;
+  projectIds: number[];
+  queryString: string;
+  selection: PageFilters;
+  mode?: Mode;
+  table?: GetExploreUrlArgs['table'];
+}
+
+export function getSimilarEventsUrl({
+  queryString,
+  mode,
+  table,
+  organization,
+  projectIds,
+  selection,
+}: GetSimilarEventsUrlArgs) {
+  return getExploreUrl({
+    organization,
+    mode: mode ?? Mode.SAMPLES,
+    query: queryString,
+    table,
+    selection: {
+      ...selection,
+      projects: projectIds,
+      datetime: {start: null, end: null, utc: null, period: '24h'},
+    },
+    referrer: 'partial-trace',
+  });
 }

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -83,7 +83,7 @@ export function getExploreUrl({
   referrer?: string;
   selection?: PageFilters;
   sort?: string;
-  table?: string;
+  table?: 'trace' | 'attribute_breakdowns';
   title?: string;
   visualize?: BaseVisualize[];
 }) {

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -54,6 +54,24 @@ import {isChartType} from 'sentry/views/insights/common/components/chart';
 import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
+export interface GetExploreUrlArgs {
+  organization: Organization;
+  aggregateField?: Array<GroupBy | BaseVisualize>;
+  caseInsensitive?: CaseInsensitive;
+  field?: string[];
+  groupBy?: string[];
+  id?: number;
+  interval?: string;
+  mode?: Mode;
+  query?: string;
+  referrer?: string;
+  selection?: PageFilters;
+  sort?: string;
+  table?: 'trace' | 'attribute_breakdowns';
+  title?: string;
+  visualize?: BaseVisualize[];
+}
+
 export function getExploreUrl({
   organization,
   selection,
@@ -70,23 +88,7 @@ export function getExploreUrl({
   title,
   referrer,
   caseInsensitive,
-}: {
-  organization: Organization;
-  aggregateField?: Array<GroupBy | BaseVisualize>;
-  caseInsensitive?: CaseInsensitive;
-  field?: string[];
-  groupBy?: string[];
-  id?: number;
-  interval?: string;
-  mode?: Mode;
-  query?: string;
-  referrer?: string;
-  selection?: PageFilters;
-  sort?: string;
-  table?: 'trace' | 'attribute_breakdowns';
-  title?: string;
-  visualize?: BaseVisualize[];
-}) {
+}: GetExploreUrlArgs) {
   const {start, end, period: statsPeriod, utc} = selection?.datetime ?? {};
   const {environments, projects} = selection ?? {};
   const queryParams = {


### PR DESCRIPTION
This PR updates the linking from the spans and traces table from the Explore -> Traces page. If the span or trace is older than 30 days we remove the link, and add a tooltip with a link to similar spans or traces.

Ticket: EXP-646