### PR TITLE
feat(preprod): write build distribution data to EAP

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -333,6 +333,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-internal-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable writing preprod size metrics to EAP for querying
     manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable writing preprod build distribution data to EAP for querying
+    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables PR page
     manager.add("organizations:pr-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -116,10 +116,10 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
             # Update build distribution data in EAP with new download count
             try:
                 organization = project.organization
-                if features.has("organizations:preprod-size-metrics-eap-write", organization):
+                if features.has("organizations:preprod-build-distribution-eap-write", organization):
                     produce_preprod_build_distribution_to_eap(
                         artifact=preprod_artifact,
-                        organization_id=organization.id,
+                        organization_id=project.organization_id,
                         project_id=project.id,
                     )
             except Exception:
@@ -127,7 +127,7 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
                     "Failed to write preprod build distribution to EAP after download",
                     extra={
                         "preprod_artifact_id": preprod_artifact.id,
-                        "organization_id": organization.id,
+                        "organization_id": project.organization_id,
                         "project_id": project.id,
                     },
                 )

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
+import logging
+
 from django.db.models import F
 from django.http.response import FileResponse, HttpResponse, HttpResponseBase
 from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models.files.file import File
 from sentry.models.project import Project
+from sentry.preprod.eap.write import produce_preprod_build_distribution_to_eap
 from sentry.preprod.models import InstallablePreprodArtifact, PreprodArtifact
 from sentry.utils.http import absolute_uri
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
@@ -106,6 +112,26 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
             InstallablePreprodArtifact.objects.filter(pk=installable.pk).update(
                 download_count=F("download_count") + 1
             )
+
+            # Update build distribution data in EAP with new download count
+            try:
+                organization = project.organization
+                if features.has("organizations:preprod-size-metrics-eap-write", organization):
+                    produce_preprod_build_distribution_to_eap(
+                        artifact=preprod_artifact,
+                        organization_id=organization.id,
+                        project_id=project.id,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to write preprod build distribution to EAP after download",
+                    extra={
+                        "preprod_artifact_id": preprod_artifact.id,
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                    },
+                )
+
             fp = file_obj.getfile()
             filename = preprod_artifact.app_id or "app"
             if preprod_artifact.build_version:

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -13,7 +13,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem as EAPTraceItem
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.preprod.eap.constants import PREPROD_NAMESPACE
-from sentry.preprod.models import PreprodArtifactSizeMetrics
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.search.eap.rpc_utils import anyvalue
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
@@ -105,6 +105,104 @@ def produce_preprod_size_metric_to_eap(
         trace_id=trace_id,
         received=received,
         retention_days=90,  # Default retention for preprod data
+        attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},
+        client_sample_rate=1.0,
+        server_sample_rate=1.0,
+    )
+
+    topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
+    payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
+    _eap_producer.produce(ArroyoTopic(topic), payload)
+
+
+def produce_preprod_build_distribution_to_eap(
+    artifact: PreprodArtifact,
+    organization_id: int,
+    project_id: int,
+) -> None:
+    """
+    Write PreprodArtifact build distribution data to EAP as a TRACE_ITEM_TYPE_PREPROD trace item.
+
+    Extracts distribution metadata from artifact.extras (codesigning, profile info, etc.) and includes
+    data from any associated InstallablePreprodArtifact (download count, expiration, etc.).
+
+    NOTE: One build distribution record per artifact (many size metrics can relate to one build).
+    EAP is append-only with ReplacingMergeTree deduplication support.
+    """
+    proto_timestamp = Timestamp()
+    proto_timestamp.FromDatetime(artifact.date_added)
+
+    received = Timestamp()
+    received.FromDatetime(artifact.date_added)
+
+    # Generate trace_id for this preprod artifact - same as size metrics to enable grouping.
+    # This allows queries to join build distribution data with size metrics via trace_id.
+    trace_id = uuid.uuid5(PREPROD_NAMESPACE, str(artifact.id)).hex
+
+    # Generate deterministic item_id based on artifact.id.
+    # Unlike size metrics (one per size_metric.id), build distribution has one record per artifact.
+    # This enables ReplacingMergeTree deduplication when reprocessing the same artifact.
+    item_id_str = f"build_distribution_{artifact.id}"
+    item_id = int(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex, 16).to_bytes(16, "little")
+
+    attributes: dict[str, Any] = {
+        "preprod_artifact_id": artifact.id,
+        "sub_item_type": "build_distribution",
+        "artifact_state": artifact.state,
+        "artifact_type": artifact.artifact_type,
+        "app_id": artifact.app_id,
+        "app_name": artifact.app_name,
+        "build_version": artifact.build_version,
+        "build_number": artifact.build_number,
+        "main_binary_identifier": artifact.main_binary_identifier,
+        "artifact_date_built": (
+            int(artifact.date_built.timestamp()) if artifact.date_built else None
+        ),
+        "build_configuration_name": (
+            artifact.build_configuration.name if artifact.build_configuration else None
+        ),
+    }
+
+    if artifact.extras:
+        # Apple-specific distribution fields
+        attributes["codesigning_type"] = artifact.extras.get("codesigning_type")
+        attributes["profile_name"] = artifact.extras.get("profile_name")
+        attributes["profile_expiration_date"] = artifact.extras.get("profile_expiration_date")
+        attributes["certificate_expiration_date"] = artifact.extras.get(
+            "certificate_expiration_date"
+        )
+        attributes["is_code_signature_valid"] = artifact.extras.get("is_code_signature_valid")
+        attributes["is_simulator"] = artifact.extras.get("is_simulator")
+        attributes["has_missing_dsym_binaries"] = artifact.extras.get("has_missing_dsym_binaries")
+        # Android-specific fields
+        attributes["has_proguard_mapping"] = artifact.extras.get("has_proguard_mapping")
+
+    attributes["has_installable_file"] = artifact.installable_app_file_id is not None
+
+    if artifact.commit_comparison is not None:
+        commit_comparison = artifact.commit_comparison
+        attributes.update(
+            {
+                "git_head_sha": commit_comparison.head_sha,
+                "git_base_sha": commit_comparison.base_sha,
+                "git_provider": commit_comparison.provider,
+                "git_head_repo_name": commit_comparison.head_repo_name,
+                "git_base_repo_name": commit_comparison.base_repo_name,
+                "git_head_ref": commit_comparison.head_ref,
+                "git_base_ref": commit_comparison.base_ref,
+                "git_pr_number": commit_comparison.pr_number,
+            }
+        )
+
+    trace_item = EAPTraceItem(
+        organization_id=organization_id,
+        project_id=project_id,
+        item_id=item_id,
+        item_type=TraceItemType.TRACE_ITEM_TYPE_PREPROD,
+        timestamp=proto_timestamp,
+        trace_id=trace_id,
+        received=received,
+        retention_days=90,
         attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},
         client_sample_rate=1.0,
         server_sample_rate=1.0,

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -13,7 +13,11 @@ from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem as EAPTraceItem
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.preprod.eap.constants import PREPROD_NAMESPACE
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.models import (
+    InstallablePreprodArtifact,
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+)
 from sentry.search.eap.rpc_utils import anyvalue
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
@@ -178,6 +182,9 @@ def produce_preprod_build_distribution_to_eap(
         attributes["has_proguard_mapping"] = artifact.extras.get("has_proguard_mapping")
 
     attributes["has_installable_file"] = artifact.installable_app_file_id is not None
+
+    installable = InstallablePreprodArtifact.objects.filter(preprod_artifact=artifact).first()
+    attributes["download_count"] = installable.download_count if installable else 0
 
     if artifact.commit_comparison is not None:
         commit_comparison = artifact.commit_comparison

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -708,7 +708,7 @@ def _assemble_preprod_artifact_installable_app(
 
     try:
         organization = preprod_artifact.project.organization
-        if features.has("organizations:preprod-size-metrics-eap-write", organization):
+        if features.has("organizations:preprod-build-distribution-eap-write", organization):
             produce_preprod_build_distribution_to_eap(
                 artifact=preprod_artifact,
                 organization_id=org_id,

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -238,6 +238,7 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
         assert attrs["build_version"].string_value == "1.2.3"
         assert attrs["build_number"].int_value == 100
         assert attrs["main_binary_identifier"].string_value == "com.example.MainBinary"
+        assert artifact.date_built is not None
         assert attrs["artifact_date_built"].int_value == int(artifact.date_built.timestamp())
         assert attrs["build_configuration_name"].string_value == "Release"
 

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -11,6 +11,7 @@ from sentry.preprod.eap.write import (
     produce_preprod_size_metric_to_eap,
 )
 from sentry.preprod.models import (
+    InstallablePreprodArtifact,
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
@@ -201,6 +202,12 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
             },
         )
 
+        InstallablePreprodArtifact.objects.create(
+            preprod_artifact=artifact,
+            url_path="test-url-path",
+            download_count=42,
+        )
+
         produce_preprod_build_distribution_to_eap(
             artifact=artifact,
             organization_id=self.organization.id,
@@ -244,6 +251,7 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
         assert attrs["has_proguard_mapping"].bool_value is False
 
         assert attrs["has_installable_file"].bool_value is True
+        assert attrs["download_count"].int_value == 42
 
         assert attrs["git_head_sha"].string_value == "abc123"
         assert attrs["git_base_sha"].string_value == "def456"
@@ -280,6 +288,7 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
 
         assert attrs["sub_item_type"].string_value == "build_distribution"
         assert attrs["has_installable_file"].bool_value is False
+        assert attrs["download_count"].int_value == 0
 
         assert "codesigning_type" not in attrs
         assert "profile_name" not in attrs

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -6,7 +6,10 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.models.commitcomparison import CommitComparison
-from sentry.preprod.eap.write import produce_preprod_size_metric_to_eap
+from sentry.preprod.eap.write import (
+    produce_preprod_build_distribution_to_eap,
+    produce_preprod_size_metric_to_eap,
+)
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
@@ -150,5 +153,135 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
         assert "identifier" not in attrs
         assert "min_install_size" not in attrs
         assert "max_install_size" not in attrs
+        assert "build_configuration_name" not in attrs
+        assert "git_head_sha" not in attrs
+
+
+class WritePreprodBuildDistributionToEAPTest(TestCase):
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
+    def test_write_preprod_build_distribution_encodes_all_fields_correctly(self, mock_produce):
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="abc123",
+            base_sha="def456",
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        build_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="Release"
+        )
+
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            app_name="Example App",
+            build_version="1.2.3",
+            build_number=100,
+            main_binary_identifier="com.example.MainBinary",
+            commit_comparison=commit_comparison,
+            build_configuration=build_config,
+            date_built=datetime(2024, 1, 1, 10, 0, 0, tzinfo=dt_timezone.utc),
+            installable_app_file_id=456,
+            extras={
+                "codesigning_type": "AdHoc",
+                "profile_name": "Development Profile",
+                "profile_expiration_date": "2025-12-31",
+                "certificate_expiration_date": "2025-12-31",
+                "is_code_signature_valid": True,
+                "is_simulator": False,
+                "has_missing_dsym_binaries": True,
+                "has_proguard_mapping": False,
+            },
+        )
+
+        produce_preprod_build_distribution_to_eap(
+            artifact=artifact,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+        mock_produce.assert_called_once()
+        topic, payload = mock_produce.call_args[0]
+
+        assert topic.name == "snuba-items"
+
+        codec = get_topic_codec(Topic.SNUBA_ITEMS)
+        trace_item = codec.decode(payload.value)
+
+        assert trace_item.organization_id == self.organization.id
+        assert trace_item.project_id == self.project.id
+        assert trace_item.item_type == TraceItemType.TRACE_ITEM_TYPE_PREPROD
+        assert trace_item.retention_days == 90
+
+        attrs = trace_item.attributes
+
+        assert attrs["preprod_artifact_id"].int_value == artifact.id
+        assert attrs["sub_item_type"].string_value == "build_distribution"
+        assert attrs["artifact_state"].int_value == PreprodArtifact.ArtifactState.PROCESSED
+        assert attrs["artifact_type"].int_value == PreprodArtifact.ArtifactType.XCARCHIVE
+        assert attrs["app_id"].string_value == "com.example.app"
+        assert attrs["app_name"].string_value == "Example App"
+        assert attrs["build_version"].string_value == "1.2.3"
+        assert attrs["build_number"].int_value == 100
+        assert attrs["main_binary_identifier"].string_value == "com.example.MainBinary"
+        assert attrs["artifact_date_built"].int_value == int(artifact.date_built.timestamp())
+        assert attrs["build_configuration_name"].string_value == "Release"
+
+        assert attrs["codesigning_type"].string_value == "AdHoc"
+        assert attrs["profile_name"].string_value == "Development Profile"
+        assert attrs["profile_expiration_date"].string_value == "2025-12-31"
+        assert attrs["certificate_expiration_date"].string_value == "2025-12-31"
+        assert attrs["is_code_signature_valid"].bool_value is True
+        assert attrs["is_simulator"].bool_value is False
+        assert attrs["has_missing_dsym_binaries"].bool_value is True
+        assert attrs["has_proguard_mapping"].bool_value is False
+
+        assert attrs["has_installable_file"].bool_value is True
+
+        assert attrs["git_head_sha"].string_value == "abc123"
+        assert attrs["git_base_sha"].string_value == "def456"
+        assert attrs["git_provider"].string_value == "github"
+        assert attrs["git_head_repo_name"].string_value == "owner/repo"
+        assert attrs["git_base_repo_name"].string_value == "owner/repo"
+        assert attrs["git_head_ref"].string_value == "feature/test"
+        assert attrs["git_base_ref"].string_value == "main"
+        assert attrs["git_pr_number"].int_value == 42
+
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
+    def test_write_preprod_build_distribution_handles_optional_fields(self, mock_produce):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        produce_preprod_build_distribution_to_eap(
+            artifact=artifact,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+        mock_produce.assert_called_once()
+        topic, payload = mock_produce.call_args[0]
+
+        codec = get_topic_codec(Topic.SNUBA_ITEMS)
+        trace_item = codec.decode(payload.value)
+
+        assert trace_item.organization_id == self.organization.id
+        assert trace_item.item_type == TraceItemType.TRACE_ITEM_TYPE_PREPROD
+
+        attrs = trace_item.attributes
+
+        assert attrs["sub_item_type"].string_value == "build_distribution"
+        assert attrs["has_installable_file"].bool_value is False
+
+        assert "codesigning_type" not in attrs
+        assert "profile_name" not in attrs
         assert "build_configuration_name" not in attrs
         assert "git_head_sha" not in attrs

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -202,10 +202,16 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
             },
         )
 
+        # Create multiple installables to test summing
         InstallablePreprodArtifact.objects.create(
             preprod_artifact=artifact,
-            url_path="test-url-path",
+            url_path="test-url-path-1",
             download_count=42,
+        )
+        InstallablePreprodArtifact.objects.create(
+            preprod_artifact=artifact,
+            url_path="test-url-path-2",
+            download_count=10,
         )
 
         produce_preprod_build_distribution_to_eap(
@@ -252,7 +258,7 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
         assert attrs["has_proguard_mapping"].bool_value is False
 
         assert attrs["has_installable_file"].bool_value is True
-        assert attrs["download_count"].int_value == 42
+        assert attrs["download_count"].int_value == 52  # 42 + 10 from both installables
 
         assert attrs["git_head_sha"].string_value == "abc123"
         assert attrs["git_base_sha"].string_value == "def456"


### PR DESCRIPTION
This writes our build distribution data to EAP using a new `"sub_item_type": "build_distribution"`. I created a new flag to gate the writes just in case. Notably, this attempts to update the data whenever a new download is triggered and waits for EAP to dedup. Will test how well this works in practice.

The reading/querying code can come later when we decide how to use it.