### PR TITLE
feat(dashboards): support http spans in details component

### DIFF
--- a/static/app/views/dashboards/layoutUtils.tsx
+++ b/static/app/views/dashboards/layoutUtils.tsx
@@ -52,7 +52,7 @@ export function getMobileLayout(desktopLayout: Layout[], widgets: Widget[]) {
     x: 0,
     y: index * 2,
     w: 2,
-    h: widget.displayType === DisplayType.BIG_NUMBER ? 1 : 2,
+    h: getDefaultWidgetHeight(widget.displayType),
   }));
 
   return mobileLayout;
@@ -80,7 +80,10 @@ export function pickDefinedStoreKeys(layout: Layout): WidgetLayout {
 }
 
 export function getDefaultWidgetHeight(displayType: DisplayType): number {
-  return displayType === DisplayType.BIG_NUMBER ? 1 : 2;
+  if (displayType === DisplayType.BIG_NUMBER || displayType === DisplayType.DETAILS) {
+    return 1;
+  }
+  return 2;
 }
 
 export function getInitialColumnDepths() {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -16,6 +16,22 @@ import {SpanFields} from 'sentry/views/insights/types';
 
 const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
 
+const DOMAIN_WIDGET: Widget = {
+  id: 'domain-widget',
+  title: t('Domain'),
+  displayType: DisplayType.DETAILS,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  queries: [],
+  layout: {
+    x: 0,
+    y: 0,
+    minH: 1,
+    h: 1,
+    w: 6,
+  },
+};
+
 const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
   [
     {
@@ -121,7 +137,7 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       ],
     },
   ],
-  0,
+  1,
   {h: 1, minH: 1}
 );
 
@@ -195,7 +211,7 @@ const CHART_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       ],
     },
   ],
-  1
+  2
 );
 
 const TRANSACTIONS_TABLE: Widget = {
@@ -231,7 +247,7 @@ const TRANSACTIONS_TABLE: Widget = {
   ],
   layout: {
     x: 0,
-    y: 3,
+    y: 4,
     minH: 2,
     h: 5,
     w: 6,
@@ -255,5 +271,10 @@ export const HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       },
     ],
   },
-  widgets: [...BIG_NUMBER_ROW_WIDGETS, ...CHART_ROW_WIDGETS, TRANSACTIONS_TABLE],
+  widgets: [
+    DOMAIN_WIDGET,
+    ...BIG_NUMBER_ROW_WIDGETS,
+    ...CHART_ROW_WIDGETS,
+    TRANSACTIONS_TABLE,
+  ],
 };

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.spec.tsx
@@ -23,6 +23,25 @@ describe('DetailsWidgetVisualization', () => {
           },
         ],
       },
+      match: [MockApiClient.matchQuery({referrer: 'api.insights.span-description'})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            project: project.slug,
+            span_id: '123',
+            'span.domain': 'sentry.io',
+          },
+        ],
+      },
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.dashboards.details-widget.domain-status',
+        }),
+      ],
     });
   });
 
@@ -59,5 +78,23 @@ describe('DetailsWidgetVisualization', () => {
     const queryCodeSnippet = await screen.findByText(/select \* from users/i);
     expect(queryCodeSnippet).toBeInTheDocument();
     expect(queryCodeSnippet).toHaveClass('language-sql');
+  });
+
+  it('renders an http domain status link', async () => {
+    const span = {
+      id: '123',
+      ['span.op']: 'http',
+      ['span.description']: 'GET /users',
+      ['span.group']: 'span_group',
+      ['span.category']: 'http',
+    };
+    render(<DetailsWidgetVisualization span={span} />);
+
+    const httpSpan = await screen.findByRole('link', {name: 'Status'});
+    expect(httpSpan).toBeInTheDocument();
+    expect(httpSpan).toHaveAttribute('href', 'https://status.sentry.io/');
+    expect(httpSpan).toHaveTextContent('Status');
+
+    expect(screen.getByText('sentry.io')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
@@ -40,8 +40,8 @@ export function DetailsWidgetVisualization(props: DetailsWidgetVisualizationProp
     return (
       <HttpSpanVisualization
         spanId={span[SpanFields.ID]}
-        spanOp={span[SpanFields.SPAN_OP]}
-        spanDescription={span[SpanFields.SPAN_DESCRIPTION]}
+        spanOp={spanOp}
+        spanDescription={spanDescription}
       />
     );
   }

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
@@ -93,10 +93,11 @@ function Wrapper({children}: any) {
 }
 
 const HttpSpanVisualizationWrapper = styled('div')`
-  padding: ${p => p.theme.space.xl};
   display: flex;
   align-items: center;
-  gap: ${p => p.theme.space.sm};
+  gap: ${p => p.theme.space.md};
+  height: 100%;
+  padding: ${p => p.theme.space.xl};
 `;
 
 // Takes up 100% of the parent. If within flex context, grows to fill.


### PR DESCRIPTION
1. If an http span is detected in the details component, it now renders out the domain preview
2. The details widget now support a height of 1, this makes it much cleaner with http spans.
<img width="1234" height="396" alt="image" src="https://github.com/user-attachments/assets/9a029fd9-1ce7-444d-b06c-9d9c0c364cb2" />
