### PR TITLE
fix(stories): remove overflow

### DIFF
--- a/static/app/stories/layout.tsx
+++ b/static/app/stories/layout.tsx
@@ -40,6 +40,7 @@ export const SizingWindow = styled(NegativeSpaceContainer)<{display?: 'block' | 
 `;
 
 export const Section = styled('section')`
+  min-width: 0;
   padding-top: ${p => p.theme.space['3xl']};
   display: flex;
   flex-direction: column;

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -48,7 +48,7 @@ function StoryLayout() {
       {isMDXStory(story) ? <MDXStoryTitle story={story} /> : null}
       <StoryGrid>
         <StoryContainer>
-          <Flex flexGrow={1}>
+          <Flex flexGrow={1} minWidth={0}>
             <StoryTabPanels />
           </Flex>
           <ErrorBoundary>
@@ -265,6 +265,7 @@ function StoryModuleExports(props: {
 const StoryContainer = styled('div')`
   max-width: 580px;
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: ${p => p.theme.space['3xl']};

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -48,7 +48,7 @@ function StoryLayout() {
       {isMDXStory(story) ? <MDXStoryTitle story={story} /> : null}
       <StoryGrid>
         <StoryContainer>
-          <Flex flexGrow={1} minWidth={0}>
+          <Flex flexGrow={1} minWidth="0px">
             <StoryTabPanels />
           </Flex>
           <ErrorBoundary>


### PR DESCRIPTION
Fixes a regression in our Stories layout—classic `flex` issue with `min-width: 0;`.

**Before** (implicit `min-width: auto;`
<img width="1227" height="757" alt="before-overflow" src="https://github.com/user-attachments/assets/fb00762f-9404-494f-989b-3224d0b21668" />

**After** (explicit `min-width: 0;`)
<img width="1220" height="738" alt="after-fix" src="https://github.com/user-attachments/assets/25c0ad1d-d469-4acf-a68b-ce8f53a661df" />
