### PR TITLE
feat(preprod): add distribution view to mobile builds

### DIFF
--- a/static/app/components/preprod/preprodBuildsDisplay.ts
+++ b/static/app/components/preprod/preprodBuildsDisplay.ts
@@ -1,0 +1,25 @@
+export enum PreprodBuildsDisplay {
+  SIZE = 'size',
+  DISTRIBUTION = 'distribution',
+}
+
+export function getPreprodBuildsDisplay(
+  display: string | string[] | undefined,
+  isDistributionEnabled: boolean
+): PreprodBuildsDisplay {
+  if (!isDistributionEnabled) {
+    return PreprodBuildsDisplay.SIZE;
+  }
+
+  if (typeof display !== 'string') {
+    return PreprodBuildsDisplay.SIZE;
+  }
+
+  switch (display) {
+    case PreprodBuildsDisplay.DISTRIBUTION:
+      return PreprodBuildsDisplay.DISTRIBUTION;
+    case PreprodBuildsDisplay.SIZE:
+    default:
+      return PreprodBuildsDisplay.SIZE;
+  }
+}

--- a/static/app/components/preprod/preprodBuildsDisplay.ts
+++ b/static/app/components/preprod/preprodBuildsDisplay.ts
@@ -4,7 +4,7 @@ export enum PreprodBuildsDisplay {
 }
 
 export function getPreprodBuildsDisplay(
-  display: string | string[] | undefined,
+  display: string | string[] | null | undefined,
   isDistributionEnabled: boolean
 ): PreprodBuildsDisplay {
   if (!isDistributionEnabled) {

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -1,0 +1,120 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t} from 'sentry/locale';
+import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import {
+  FullRowLink,
+  PreprodBuildsCommonHeaderCells,
+  PreprodBuildsCommonRowCells,
+  PreprodBuildsCreatedHeaderCell,
+  PreprodBuildsCreatedRowCell,
+} from './preprodBuildsTableCommon';
+
+interface PreprodBuildsDistributionTableProps {
+  builds: BuildDetailsApiResponse[];
+  organizationSlug: string;
+  showProjectColumn: boolean;
+  content?: ReactNode;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
+}
+
+function DownloadCountHeaderCell() {
+  return <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>;
+}
+
+function DownloadCountRowCell({build}: {build: BuildDetailsApiResponse}) {
+  const downloadCount = build.distribution_info?.download_count ?? 0;
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formatNumberWithDynamicDecimalPoints(downloadCount, 0)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+export function PreprodBuildsDistributionTable({
+  builds,
+  content,
+  onRowClick,
+  organizationSlug,
+  showProjectColumn,
+}: PreprodBuildsDistributionTableProps) {
+  const rows = builds.map(build => {
+    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`;
+    const isInstallable = build.distribution_info?.is_installable ?? false;
+    const isRowDisabled = !isInstallable;
+    const rowContent = (
+      <Fragment>
+        <PreprodBuildsCommonRowCells
+          build={build}
+          showInteraction={!isRowDisabled}
+          showProjectColumn={showProjectColumn}
+        />
+        <DownloadCountRowCell build={build} />
+        <PreprodBuildsCreatedRowCell build={build} />
+      </Fragment>
+    );
+
+    const RowComponent = isRowDisabled ? DisabledRow : SimpleTable.Row;
+
+    return (
+      <RowComponent key={build.id} variant={isRowDisabled ? 'faded' : 'default'}>
+        {isRowDisabled ? (
+          <Tooltip title={t('Not Installable')} containerDisplayMode="contents">
+            <DisabledRowContent>{rowContent}</DisabledRowContent>
+          </Tooltip>
+        ) : (
+          <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
+            {rowContent}
+          </FullRowLink>
+        )}
+      </RowComponent>
+    );
+  });
+
+  return (
+    <BuildsDistributionTable showProjectColumn={showProjectColumn}>
+      <SimpleTable.Header>
+        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <DownloadCountHeaderCell />
+        <PreprodBuildsCreatedHeaderCell />
+      </SimpleTable.Header>
+      {content ?? rows}
+    </BuildsDistributionTable>
+  );
+}
+
+const distributionTableColumns = {
+  withProject: `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr)
+    minmax(120px, 1fr) minmax(80px, 120px)`,
+  withoutProject: `minmax(250px, 2fr) minmax(250px, 2fr) minmax(120px, 1fr)
+    minmax(80px, 120px)`,
+};
+
+const BuildsDistributionTable = styled(SimpleTable)<{showProjectColumn?: boolean}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p =>
+    p.showProjectColumn
+      ? distributionTableColumns.withProject
+      : distributionTableColumns.withoutProject};
+`;
+
+const DisabledRowContent = styled('div')`
+  display: contents;
+  color: inherit;
+`;
+
+const DisabledRow = styled(SimpleTable.Row)`
+  [role='cell'] {
+    color: ${p => p.theme.subText};
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+`;

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -1,0 +1,121 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  formattedPrimaryMetricDownloadSize,
+  formattedPrimaryMetricInstallSize,
+  getLabels,
+} from 'sentry/views/preprod/utils/labelUtils';
+
+import {
+  FullRowLink,
+  PreprodBuildsCommonHeaderCells,
+  PreprodBuildsCommonRowCells,
+  PreprodBuildsCreatedHeaderCell,
+  PreprodBuildsCreatedRowCell,
+} from './preprodBuildsTableCommon';
+
+type PreprodBuildLabels = ReturnType<typeof getLabels>;
+
+interface PreprodBuildsSizeTableProps {
+  builds: BuildDetailsApiResponse[];
+  labels: PreprodBuildLabels;
+  organizationSlug: string;
+  showProjectColumn: boolean;
+  content?: ReactNode;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
+}
+
+function InstallSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
+  return (
+    <SimpleTable.HeaderCell>
+      {labels.installSizeLabelTooltip ? (
+        <Tooltip title={labels.installSizeLabelTooltip}>
+          <span>{labels.installSizeLabel}</span>
+        </Tooltip>
+      ) : (
+        labels.installSizeLabel
+      )}
+    </SimpleTable.HeaderCell>
+  );
+}
+
+function DownloadSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
+  return <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>;
+}
+
+function InstallSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+function DownloadSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+export function PreprodBuildsSizeTable({
+  builds,
+  content,
+  labels,
+  onRowClick,
+  organizationSlug,
+  showProjectColumn,
+}: PreprodBuildsSizeTableProps) {
+  const rows = builds.map(build => {
+    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
+    return (
+      <SimpleTable.Row key={build.id}>
+        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
+          <Fragment>
+            <PreprodBuildsCommonRowCells
+              build={build}
+              showInteraction
+              showProjectColumn={showProjectColumn}
+            />
+            <InstallSizeRowCell build={build} />
+            <DownloadSizeRowCell build={build} />
+            <PreprodBuildsCreatedRowCell build={build} />
+          </Fragment>
+        </FullRowLink>
+      </SimpleTable.Row>
+    );
+  });
+
+  return (
+    <BuildsSizeTable showProjectColumn={showProjectColumn}>
+      <SimpleTable.Header>
+        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <InstallSizeHeaderCell labels={labels} />
+        <DownloadSizeHeaderCell labels={labels} />
+        <PreprodBuildsCreatedHeaderCell />
+      </SimpleTable.Header>
+      {content ?? rows}
+    </BuildsSizeTable>
+  );
+}
+
+const sizeTableColumns = {
+  withProject: `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr)
+    minmax(100px, 1fr) minmax(100px, 1fr) minmax(80px, 120px)`,
+  withoutProject: `minmax(250px, 2fr) minmax(250px, 2fr) minmax(100px, 1fr)
+    minmax(100px, 1fr) minmax(80px, 120px)`,
+};
+
+const BuildsSizeTable = styled(SimpleTable)<{showProjectColumn?: boolean}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p =>
+    p.showProjectColumn ? sizeTableColumns.withProject : sizeTableColumns.withoutProject};
+`;

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -1,0 +1,88 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
+import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
+import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+const organization = OrganizationFixture({
+  features: ['preprod-build-distribution'],
+});
+
+const baseBuild = {
+  id: 'build-1',
+  project_id: 1,
+  project_slug: 'project-1',
+  state: BuildDetailsState.UPLOADED,
+  app_info: {
+    app_id: 'com.example.app',
+    name: 'Example App',
+    platform: 'ios',
+    build_number: '1',
+    version: '1.0.0',
+    date_added: '2024-01-01T00:00:00Z',
+  },
+  distribution_info: {
+    is_installable: true,
+    download_count: 1234,
+    release_notes: null,
+  },
+  vcs_info: {
+    head_sha: 'abcdef1',
+  },
+};
+
+describe('PreprodBuildsTable', () => {
+  it('renders size columns by default', () => {
+    render(
+      <PreprodBuildsTable
+        builds={[baseBuild]}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Install Size')).toBeInTheDocument();
+    expect(screen.getByText('Download Size')).toBeInTheDocument();
+    expect(screen.queryByText('Download Count')).not.toBeInTheDocument();
+  });
+
+  it('renders distribution columns and filters non-installable builds', () => {
+    const nonInstallableBuild = {
+      ...baseBuild,
+      id: 'build-2',
+      app_info: {
+        ...baseBuild.app_info,
+        name: 'Non Installable App',
+      },
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        is_installable: false,
+        download_count: 99,
+      },
+    };
+
+    render(
+      <PreprodBuildsTable
+        builds={[baseBuild, nonInstallableBuild]}
+        display={PreprodBuildsDisplay.DISTRIBUTION}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Download Count')).toBeInTheDocument();
+    expect(screen.queryByText('Download Size')).not.toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.queryByText('Non Installable App')).not.toBeInTheDocument();
+
+    const rowLink = screen.getByRole('link', {name: /Example App/});
+    expect(rowLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/preprod/1/build-1/install/`
+    );
+  });
+});

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 
 const organization = OrganizationFixture({
   features: ['preprod-build-distribution'],
@@ -18,7 +19,7 @@ const baseBuild = {
   app_info: {
     app_id: 'com.example.app',
     name: 'Example App',
-    platform: 'ios',
+    platform: 'ios' as Platform,
     build_number: '1',
     version: '1.0.0',
     date_added: '2024-01-01T00:00:00Z',
@@ -49,7 +50,7 @@ describe('PreprodBuildsTable', () => {
     expect(screen.queryByText('Download Count')).not.toBeInTheDocument();
   });
 
-  it('renders distribution columns and filters non-installable builds', () => {
+  it('renders distribution columns and disables non-installable rows', () => {
     const nonInstallableBuild = {
       ...baseBuild,
       id: 'build-2',
@@ -77,12 +78,15 @@ describe('PreprodBuildsTable', () => {
     expect(screen.getByText('Download Count')).toBeInTheDocument();
     expect(screen.queryByText('Download Size')).not.toBeInTheDocument();
     expect(screen.getByText('1,234')).toBeInTheDocument();
-    expect(screen.queryByText('Non Installable App')).not.toBeInTheDocument();
+    expect(screen.getByText('Non Installable App')).toBeInTheDocument();
 
     const rowLink = screen.getByRole('link', {name: /Example App/});
     expect(rowLink).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/preprod/1/build-1/install/`
     );
+    expect(
+      screen.queryByRole('link', {name: /Non Installable App/})
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -1,30 +1,17 @@
 import React, {Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
 
-import Feature from 'sentry/components/acl/feature';
-import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
-import {Container, Flex} from 'sentry/components/core/layout';
-import {ExternalLink, Link} from 'sentry/components/core/link';
+import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import TimeSince from 'sentry/components/timeSince';
-import {IconCheckmark, IconCommit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
-import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {
-  formattedPrimaryMetricDownloadSize,
-  formattedPrimaryMetricInstallSize,
-  getLabels,
-  getPlatformIconFromPlatform,
-} from 'sentry/views/preprod/utils/labelUtils';
+import {getLabels} from 'sentry/views/preprod/utils/labelUtils';
 
 import {PreprodBuildsDisplay} from './preprodBuildsDisplay';
+import {PreprodBuildsDistributionTable} from './preprodBuildsDistributionTable';
+import {PreprodBuildsSizeTable} from './preprodBuildsSizeTable';
 
 interface PreprodBuildsTableProps {
   builds: BuildDetailsApiResponse[];
@@ -50,187 +37,20 @@ export function PreprodBuildsTable({
   showProjectColumn = false,
 }: PreprodBuildsTableProps) {
   const isDistributionDisplay = display === PreprodBuildsDisplay.DISTRIBUTION;
-  const visibleBuilds = useMemo(
-    () =>
-      isDistributionDisplay
-        ? builds.filter(build => build.distribution_info?.is_installable)
-        : builds,
-    [builds, isDistributionDisplay]
-  );
+  const emptyStateDocUrl = isDistributionDisplay
+    ? 'https://docs.sentry.io/product/build-distribution/'
+    : 'https://docs.sentry.io/product/size-analysis/';
 
   const hasMultiplePlatforms = useMemo(() => {
-    const platforms = new Set(
-      visibleBuilds.map(b => b.app_info?.platform).filter(Boolean)
-    );
+    const platforms = new Set(builds.map(b => b.app_info?.platform).filter(Boolean));
     return platforms.size > 1;
-  }, [visibleBuilds]);
+  }, [builds]);
 
   const labels = useMemo(
-    () =>
-      getLabels(visibleBuilds[0]?.app_info?.platform ?? undefined, hasMultiplePlatforms),
-    [visibleBuilds, hasMultiplePlatforms]
+    () => getLabels(builds[0]?.app_info?.platform ?? undefined, hasMultiplePlatforms),
+    [builds, hasMultiplePlatforms]
   );
-
-  const header = (
-    <SimpleTable.Header>
-      <SimpleTable.HeaderCell>{t('App')}</SimpleTable.HeaderCell>
-      {showProjectColumn && (
-        <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
-      )}
-      <SimpleTable.HeaderCell>{t('Build')}</SimpleTable.HeaderCell>
-      {isDistributionDisplay ? (
-        <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>
-      ) : (
-        <Fragment>
-          <SimpleTable.HeaderCell>
-            {labels.installSizeLabelTooltip ? (
-              <Tooltip title={labels.installSizeLabelTooltip}>
-                <span>{labels.installSizeLabel}</span>
-              </Tooltip>
-            ) : (
-              labels.installSizeLabel
-            )}
-          </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>
-        </Fragment>
-      )}
-      <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
-    </SimpleTable.Header>
-  );
-
-  const renderBuildRow = (build: BuildDetailsApiResponse) => {
-    const linkUrl = isDistributionDisplay
-      ? `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`
-      : `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
-    const downloadCount = build.distribution_info?.download_count ?? 0;
-
-    return (
-      <SimpleTable.Row key={build.id}>
-        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
-          <InteractionStateLayer />
-          <SimpleTable.RowCell justify="start">
-            {build.app_info?.name || build.app_info?.app_id ? (
-              <Flex direction="column" gap="xs">
-                <Flex align="center" gap="2xs">
-                  {build.app_info?.platform && (
-                    <PlatformIcon
-                      platform={getPlatformIconFromPlatform(build.app_info.platform)}
-                    />
-                  )}
-                  <Container paddingLeft="xs">
-                    <Text size="lg" bold>
-                      {build.app_info?.name || '--'}
-                    </Text>
-                  </Container>
-                  <Feature features="organizations:preprod-build-distribution">
-                    {build.distribution_info?.is_installable && (
-                      <InstallAppButton
-                        projectId={build.project_slug}
-                        artifactId={build.id}
-                        platform={build.app_info.platform ?? null}
-                        source="builds_table"
-                        variant="icon"
-                      />
-                    )}
-                  </Feature>
-                </Flex>
-                <Flex align="center" gap="xs">
-                  <Text size="sm" variant="muted">
-                    {build.app_info?.app_id || '--'}
-                  </Text>
-                  {build.app_info?.build_configuration && (
-                    <React.Fragment>
-                      <Text size="sm" variant="muted">
-                        {' • '}
-                      </Text>
-                      <Tooltip title={t('Build configuration')}>
-                        <Text size="sm" variant="muted" monospace>
-                          {build.app_info.build_configuration}
-                        </Text>
-                      </Tooltip>
-                    </React.Fragment>
-                  )}
-                </Flex>
-              </Flex>
-            ) : null}
-          </SimpleTable.RowCell>
-
-          {showProjectColumn && (
-            <SimpleTable.RowCell justify="start">
-              <Text>{build.project_slug}</Text>
-            </SimpleTable.RowCell>
-          )}
-
-          <SimpleTable.RowCell justify="start">
-            <Flex direction="column" gap="xs">
-              <Flex align="center" gap="xs">
-                {build.app_info?.version !== null && (
-                  <Text size="lg" bold>
-                    {build.app_info?.version}
-                  </Text>
-                )}
-                {build.app_info?.build_number !== null && (
-                  <Text size="lg" variant="muted">
-                    ({build.app_info?.build_number})
-                  </Text>
-                )}
-                {build.state === 3 && <IconCheckmark size="sm" color="green300" />}
-              </Flex>
-              <Flex align="center" gap="xs">
-                <IconCommit size="xs" />
-                <Text size="sm" variant="muted" monospace>
-                  {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
-                </Text>
-                {build.vcs_info?.pr_number && (
-                  <React.Fragment>
-                    <Text size="sm" variant="muted">
-                      #{build.vcs_info?.pr_number}
-                    </Text>
-                  </React.Fragment>
-                )}
-                {build.vcs_info?.head_ref !== null && (
-                  <React.Fragment>
-                    <Text size="sm" variant="muted">
-                      –
-                    </Text>
-                    <Text size="sm" variant="muted">
-                      {build.vcs_info?.head_ref || '--'}
-                    </Text>
-                  </React.Fragment>
-                )}
-              </Flex>
-            </Flex>
-          </SimpleTable.RowCell>
-
-          {isDistributionDisplay ? (
-            <SimpleTable.RowCell>
-              <Text>{formatNumberWithDynamicDecimalPoints(downloadCount, 0)}</Text>
-            </SimpleTable.RowCell>
-          ) : (
-            <Fragment>
-              <SimpleTable.RowCell>
-                <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
-              </SimpleTable.RowCell>
-
-              <SimpleTable.RowCell>
-                <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
-              </SimpleTable.RowCell>
-            </Fragment>
-          )}
-
-          <SimpleTable.RowCell>
-            {build.app_info?.date_added ? (
-              <TimeSince date={build.app_info.date_added} unitStyle="short" />
-            ) : (
-              '-'
-            )}
-          </SimpleTable.RowCell>
-        </FullRowLink>
-      </SimpleTable.Row>
-    );
-  };
-
-  let tableContent = null;
+  let tableContent: React.ReactNode | undefined;
   if (isLoading) {
     tableContent = (
       <SimpleTable.Empty>
@@ -239,7 +59,7 @@ export function PreprodBuildsTable({
     );
   } else if (error) {
     tableContent = <SimpleTable.Empty>{t('Error loading builds')}</SimpleTable.Empty>;
-  } else if (visibleBuilds.length === 0) {
+  } else if (builds.length === 0) {
     tableContent = (
       <SimpleTable.Empty>
         <Text as="p">
@@ -247,57 +67,35 @@ export function PreprodBuildsTable({
             ? t('No mobile builds found for your search')
             : tct('No mobile builds found, see our [link:documentation] for more info.', {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/product/size-analysis/">
-                    {t('Learn more')}
-                  </ExternalLink>
+                  <ExternalLink href={emptyStateDocUrl}>{t('Learn more')}</ExternalLink>
                 ),
               })}
         </Text>
       </SimpleTable.Empty>
     );
-  } else {
-    tableContent = (
-      <Fragment>{visibleBuilds.map(build => renderBuildRow(build))}</Fragment>
-    );
   }
 
   return (
     <Fragment>
-      <SimpleTableWithColumns showProjectColumn={showProjectColumn} display={display}>
-        {header}
-        {tableContent}
-      </SimpleTableWithColumns>
+      {isDistributionDisplay ? (
+        <PreprodBuildsDistributionTable
+          builds={builds}
+          content={tableContent}
+          onRowClick={onRowClick}
+          organizationSlug={organizationSlug}
+          showProjectColumn={showProjectColumn}
+        />
+      ) : (
+        <PreprodBuildsSizeTable
+          builds={builds}
+          content={tableContent}
+          labels={labels}
+          onRowClick={onRowClick}
+          organizationSlug={organizationSlug}
+          showProjectColumn={showProjectColumn}
+        />
+      )}
       {pageLinks && <Pagination pageLinks={pageLinks} />}
     </Fragment>
   );
 }
-
-const SimpleTableWithColumns = styled(SimpleTable)<{
-  display?: PreprodBuildsDisplay;
-  showProjectColumn?: boolean;
-}>`
-  overflow-x: auto;
-  overflow-y: auto;
-  grid-template-columns: ${p =>
-    p.showProjectColumn
-      ? p.display === PreprodBuildsDisplay.DISTRIBUTION
-        ? `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr) minmax(120px, 1fr)
-    minmax(80px, 120px)`
-        : `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr) minmax(100px, 1fr)
-    minmax(100px, 1fr) minmax(80px, 120px)`
-      : p.display === PreprodBuildsDisplay.DISTRIBUTION
-        ? `minmax(250px, 2fr) minmax(250px, 2fr) minmax(120px, 1fr)
-    minmax(80px, 120px)`
-        : `minmax(250px, 2fr) minmax(250px, 2fr) minmax(100px, 1fr)
-    minmax(100px, 1fr) minmax(80px, 120px)`};
-`;
-
-const FullRowLink = styled(Link)`
-  display: contents;
-  cursor: pointer;
-  color: inherit;
-
-  &:hover {
-    color: inherit;
-  }
-`;

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -1,0 +1,170 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import Feature from 'sentry/components/acl/feature';
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import TimeSince from 'sentry/components/timeSince';
+import {IconCheckmark, IconCommit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getPlatformIconFromPlatform} from 'sentry/views/preprod/utils/labelUtils';
+
+export function PreprodBuildsCommonHeaderCells({
+  showProjectColumn,
+}: {
+  showProjectColumn: boolean;
+}) {
+  return (
+    <Fragment>
+      <SimpleTable.HeaderCell>{t('App')}</SimpleTable.HeaderCell>
+      {showProjectColumn && (
+        <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
+      )}
+      <SimpleTable.HeaderCell>{t('Build')}</SimpleTable.HeaderCell>
+    </Fragment>
+  );
+}
+
+export function PreprodBuildsCreatedHeaderCell() {
+  return <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>;
+}
+
+interface PreprodBuildsCommonRowCellsProps {
+  build: BuildDetailsApiResponse;
+  showInteraction: boolean;
+  showProjectColumn: boolean;
+}
+
+export function PreprodBuildsCommonRowCells({
+  build,
+  showInteraction,
+  showProjectColumn,
+}: PreprodBuildsCommonRowCellsProps) {
+  return (
+    <Fragment>
+      {showInteraction && <InteractionStateLayer />}
+      <SimpleTable.RowCell justify="start">
+        {build.app_info?.name || build.app_info?.app_id ? (
+          <Flex direction="column" gap="xs">
+            <Flex align="center" gap="2xs">
+              {build.app_info?.platform && (
+                <PlatformIcon
+                  platform={getPlatformIconFromPlatform(build.app_info.platform)}
+                />
+              )}
+              <Container paddingLeft="xs">
+                <Text size="lg" bold>
+                  {build.app_info?.name || '--'}
+                </Text>
+              </Container>
+              <Feature features="organizations:preprod-build-distribution">
+                {build.distribution_info?.is_installable && (
+                  <InstallAppButton
+                    projectId={build.project_slug}
+                    artifactId={build.id}
+                    platform={build.app_info.platform ?? null}
+                    source="builds_table"
+                    variant="icon"
+                  />
+                )}
+              </Feature>
+            </Flex>
+            <Flex align="center" gap="xs">
+              <Text size="sm" variant="muted">
+                {build.app_info?.app_id || '--'}
+              </Text>
+              {build.app_info?.build_configuration && (
+                <Fragment>
+                  <Text size="sm" variant="muted">
+                    {' • '}
+                  </Text>
+                  <Tooltip title={t('Build configuration')}>
+                    <Text size="sm" variant="muted" monospace>
+                      {build.app_info.build_configuration}
+                    </Text>
+                  </Tooltip>
+                </Fragment>
+              )}
+            </Flex>
+          </Flex>
+        ) : null}
+      </SimpleTable.RowCell>
+
+      {showProjectColumn && (
+        <SimpleTable.RowCell justify="start">
+          <Text>{build.project_slug}</Text>
+        </SimpleTable.RowCell>
+      )}
+
+      <SimpleTable.RowCell justify="start">
+        <Flex direction="column" gap="xs">
+          <Flex align="center" gap="xs">
+            {build.app_info?.version !== null && (
+              <Text size="lg" bold>
+                {build.app_info?.version}
+              </Text>
+            )}
+            {build.app_info?.build_number !== null && (
+              <Text size="lg" variant="muted">
+                ({build.app_info?.build_number})
+              </Text>
+            )}
+            {build.state === 3 && <IconCheckmark size="sm" color="green300" />}
+          </Flex>
+          <Flex align="center" gap="xs">
+            <IconCommit size="xs" />
+            <Text size="sm" variant="muted" monospace>
+              {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
+            </Text>
+            {build.vcs_info?.pr_number && (
+              <Fragment>
+                <Text size="sm" variant="muted">
+                  #{build.vcs_info?.pr_number}
+                </Text>
+              </Fragment>
+            )}
+            {build.vcs_info?.head_ref !== null && (
+              <Fragment>
+                <Text size="sm" variant="muted">
+                  –
+                </Text>
+                <Text size="sm" variant="muted">
+                  {build.vcs_info?.head_ref || '--'}
+                </Text>
+              </Fragment>
+            )}
+          </Flex>
+        </Flex>
+      </SimpleTable.RowCell>
+    </Fragment>
+  );
+}
+
+export function PreprodBuildsCreatedRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      {build.app_info?.date_added ? (
+        <TimeSince date={build.app_info.date_added} unitStyle="short" />
+      ) : (
+        '-'
+      )}
+    </SimpleTable.RowCell>
+  );
+}
+
+export const FullRowLink = styled(Link)`
+  display: contents;
+  cursor: pointer;
+  color: inherit;
+
+  &:hover {
+    color: inherit;
+  }
+`;

--- a/static/app/components/searchBar/index.tsx
+++ b/static/app/components/searchBar/index.tsx
@@ -32,6 +32,7 @@ function SearchBar({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [query, setQuery] = useState(queryProp ?? defaultQuery);
+  const isDisabled = !!inputProps.disabled;
 
   // if query prop keeps changing we should treat this as
   // a controlled component and its internal state should be in sync
@@ -89,6 +90,7 @@ function SearchBar({
             <SearchBarTrailingButton
               size="zero"
               borderless
+              disabled={isDisabled}
               onClick={clearSearch}
               icon={<IconClose size="xs" />}
               aria-label={t('Clear')}

--- a/static/app/views/preprod/components/preprodBuildsDisplayOptions.tsx
+++ b/static/app/views/preprod/components/preprodBuildsDisplayOptions.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
+import {t} from 'sentry/locale';
+import ReleasesDropdown from 'sentry/views/releases/list/releasesDropdown';
+
+const displayOptions = {
+  [PreprodBuildsDisplay.SIZE]: {label: t('Size')},
+  [PreprodBuildsDisplay.DISTRIBUTION]: {label: t('Distribution')},
+};
+
+type Props = {
+  onSelect: (display: PreprodBuildsDisplay) => void;
+  selected: PreprodBuildsDisplay;
+};
+
+function PreprodBuildsDisplayOptions({selected, onSelect}: Props) {
+  return (
+    <StyledReleasesDropdown
+      label={t('Display')}
+      options={displayOptions}
+      selected={selected}
+      onSelect={key => onSelect(key as PreprodBuildsDisplay)}
+    />
+  );
+}
+
+export default PreprodBuildsDisplayOptions;
+
+const StyledReleasesDropdown = styled(ReleasesDropdown)`
+  z-index: 1;
+  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+    order: 3;
+  }
+`;

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -127,9 +127,8 @@ export default function PreprodBuilds() {
   const pageLinks = getResponseHeader?.('Link') || null;
 
   const hasSearchQuery = !!urlSearchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
-  const shouldShowFilters = shouldShowSearchBar || shouldShowDisplayToggle;
+  const shouldShowFilters = true;
 
   const handleBuildRowClick = useCallback(
     (build: BuildDetailsApiResponse) => {
@@ -161,15 +160,14 @@ export default function PreprodBuilds() {
               gap="md"
               wrap="wrap"
             >
-              {shouldShowSearchBar && (
-                <Container flex="1">
-                  <SearchBar
-                    placeholder={t('Search by build, SHA, branch name, or pull request')}
-                    onChange={handleSearch}
-                    query={localSearchQuery}
-                  />
-                </Container>
-              )}
+              <Container flex="1">
+                <SearchBar
+                  placeholder={t('Search by build, SHA, branch name, or pull request')}
+                  onChange={handleSearch}
+                  query={localSearchQuery}
+                  disabled={isLoadingBuilds}
+                />
+              </Container>
               {shouldShowDisplayToggle && (
                 <Container maxWidth="200px">
                   <PreprodBuildsDisplayOptions

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -11,6 +11,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {ReleasesSortOption} from 'sentry/constants/releases';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -551,6 +552,76 @@ describe('ReleasesList', () => {
         query: expect.objectContaining({per_page: 25, statsPeriod: '7d'}),
       })
     );
+  });
+
+  it('toggles display mode in the mobile-builds tab', async () => {
+    const organizationWithDistribution = OrganizationFixture({
+      slug: organization.slug,
+      features: [...organization.features, 'preprod-build-distribution'],
+    });
+    const mobileProject = ProjectFixture({
+      id: '15',
+      slug: 'mobile-project-4',
+      platform: 'android',
+      features: ['releases'],
+    });
+
+    ProjectsStore.loadInitialData([mobileProject]);
+    PageFiltersStore.updateProjects([Number(mobileProject.id)], null);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/preprodartifacts/list-builds/`,
+      body: {
+        builds: [
+          {
+            id: 'build-id',
+            project_id: 15,
+            project_slug: 'mobile-project-4',
+            state: 1,
+            app_info: {
+              app_id: 'com.example.app',
+              name: 'Example App',
+              platform: 'android',
+              build_number: '1',
+              version: '1.0.0',
+              date_added: '2024-01-01T00:00:00Z',
+            },
+            distribution_info: {
+              is_installable: true,
+              download_count: 12,
+              release_notes: null,
+            },
+            size_info: {},
+            vcs_info: {
+              head_sha: 'abcdef1',
+              pr_number: 123,
+              head_ref: 'main',
+            },
+          },
+        ],
+      },
+    });
+
+    const {router} = render(<ReleasesList />, {
+      organization: organizationWithDistribution,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/releases/`,
+          query: {tab: 'mobile-builds', cursor: '123', display: 'users'},
+        },
+      },
+    });
+
+    expect(await screen.findByText('Example App')).toBeInTheDocument();
+
+    const displayTrigger = screen.getByRole('button', {name: 'Display Size'});
+    await userEvent.click(displayTrigger);
+
+    const distributionOption = screen.getByText('Distribution');
+    await userEvent.click(distributionOption);
+
+    expect(router.location.query.display).toBe(PreprodBuildsDisplay.DISTRIBUTION);
+    expect(router.location.query.cursor).toBeUndefined();
   });
 
   it('allows searching within the mobile-builds tab', async () => {

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -111,9 +111,8 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
   const builds = buildsData?.builds ?? [];
   const pageLinks = getResponseHeader?.('Link') ?? undefined;
   const hasSearchQuery = !!searchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showProjectColumn = selectedProjectIds.length > 1;
-  const shouldShowFilters = shouldShowSearchBar || shouldShowDisplayToggle;
+  const shouldShowFilters = true;
 
   return (
     <Stack gap="xl">
@@ -124,15 +123,14 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
           gap="md"
           wrap="wrap"
         >
-          {shouldShowSearchBar && (
-            <Container flex="1">
-              <SearchBar
-                placeholder={t('Search by build, SHA, branch name, or pull request')}
-                onSearch={handleSearch}
-                query={searchQuery ?? undefined}
-              />
-            </Container>
-          )}
+          <Container flex="1">
+            <SearchBar
+              placeholder={t('Search by build, SHA, branch name, or pull request')}
+              onSearch={handleSearch}
+              query={searchQuery ?? undefined}
+              disabled={isLoadingBuilds}
+            />
+          </Container>
           {shouldShowDisplayToggle && (
             <Container maxWidth="200px">
               <PreprodBuildsDisplayOptions

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -1,11 +1,16 @@
 import {useCallback, useMemo} from 'react';
 import {parseAsString, useQueryState} from 'nuqs';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
+import {Container} from 'sentry/components/core/layout';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {
+  getPreprodBuildsDisplay,
+  PreprodBuildsDisplay,
+} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
@@ -14,6 +19,7 @@ import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import PreprodBuildsDisplayOptions from 'sentry/views/preprod/components/preprodBuildsDisplayOptions';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
 
 type Props = {
@@ -27,6 +33,14 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
 
   const [searchQuery] = useQueryState('query', parseAsString);
   const [cursor] = useQueryState('cursor', parseAsString);
+  const hasDistributionFeature = organization.features.includes(
+    'preprod-build-distribution'
+  );
+  const activeDisplay = useMemo(
+    () => getPreprodBuildsDisplay(location.query.display, hasDistributionFeature),
+    [hasDistributionFeature, location.query.display]
+  );
+  const shouldShowDisplayToggle = hasDistributionFeature;
 
   const buildsQueryParams = useMemo(() => {
     const query: Record<string, any> = {
@@ -80,6 +94,16 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
     [location, navigate]
   );
 
+  const handleDisplayChange = useCallback(
+    (display: PreprodBuildsDisplay) => {
+      navigate({
+        ...location,
+        query: {...location.query, cursor: undefined, display},
+      });
+    },
+    [location, navigate]
+  );
+
   if (selectedProjectIds.length === 0) {
     return <LoadingIndicator />;
   }
@@ -89,21 +113,42 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
   const hasSearchQuery = !!searchQuery?.trim();
   const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showProjectColumn = selectedProjectIds.length > 1;
+  const shouldShowFilters = shouldShowSearchBar || shouldShowDisplayToggle;
 
   return (
     <Stack gap="xl">
-      {shouldShowSearchBar && (
-        <SearchBar
-          placeholder={t('Search by build, SHA, branch name, or pull request')}
-          onSearch={handleSearch}
-          query={searchQuery ?? undefined}
-        />
+      {shouldShowFilters && (
+        <Flex
+          align={{xs: 'stretch', sm: 'center'}}
+          direction={{xs: 'column', sm: 'row'}}
+          gap="md"
+          wrap="wrap"
+        >
+          {shouldShowSearchBar && (
+            <Container flex="1">
+              <SearchBar
+                placeholder={t('Search by build, SHA, branch name, or pull request')}
+                onSearch={handleSearch}
+                query={searchQuery ?? undefined}
+              />
+            </Container>
+          )}
+          {shouldShowDisplayToggle && (
+            <Container maxWidth="200px">
+              <PreprodBuildsDisplayOptions
+                selected={activeDisplay}
+                onSelect={handleDisplayChange}
+              />
+            </Container>
+          )}
+        </Flex>
       )}
 
       {buildsError && <LoadingError onRetry={refetch} />}
 
       <PreprodBuildsTable
         builds={builds}
+        display={activeDisplay}
         isLoading={isLoadingBuilds}
         error={!!buildsError}
         pageLinks={pageLinks}


### PR DESCRIPTION
add toggle for distribution view under mobile builds
<img width="2990" height="1590" alt="CleanShot 2025-12-30 at 12 37 25@2x" src="https://github.com/user-attachments/assets/3e7b8079-079f-4948-8af3-9500ea8dd631" />
