### PR TITLE
test(ui): Migrate route error off deprecatedRouterMocks

### DIFF
--- a/static/app/views/routeError.spec.tsx
+++ b/static/app/views/routeError.spec.tsx
@@ -1,28 +1,24 @@
 import * as Sentry from '@sentry/react';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {useRoutes} from 'sentry/utils/useRoutes';
 import RouteError from 'sentry/views/routeError';
 
-describe('RouteError', () => {
-  const {router} = initializeOrg({
-    router: {
-      routes: [
-        {path: '/'},
-        {path: '/:orgId/'},
-        {name: 'this should be skipped'},
-        {path: '/organizations/:orgId/'},
-        {path: 'api-keys/', name: 'API Key'},
-      ],
-    },
-  });
+jest.mock('sentry/utils/useRoutes');
 
+jest
+  .mocked(useRoutes)
+  .mockReturnValue([
+    {path: '/'},
+    {path: '/:orgId/'},
+    {path: '/organizations/:orgId/'},
+    {path: 'api-keys/'},
+  ]);
+
+describe('RouteError', () => {
   it('captures errors with sentry', async () => {
-    render(<RouteError error={new Error('Big Bad Error')} />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    render(<RouteError error={new Error('Big Bad Error')} />);
 
     await waitFor(() =>
       expect(Sentry.captureException).toHaveBeenCalledWith(


### PR DESCRIPTION
migrate to in-memory test router. We don't have a great way of defining a tree of test routes so mocking the routes is the best option.
