### PR TITLE
chore(preprod): Adjust preprod search bar visibility

### DIFF
--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -100,7 +100,6 @@ export default function PreprodBuilds() {
   const pageLinks = getResponseHeader?.('Link') || null;
 
   const hasSearchQuery = !!urlSearchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
   const handleBuildRowClick = useCallback(
@@ -125,15 +124,14 @@ export default function PreprodBuilds() {
           projectSlug={projectSlug}
         />
         {buildsError && <LoadingError onRetry={refetch} />}
-        {shouldShowSearchBar && (
-          <Container paddingBottom="md">
-            <SearchBar
-              placeholder={t('Search by build, SHA, branch name, or pull request')}
-              onChange={handleSearch}
-              query={localSearchQuery}
-            />
-          </Container>
-        )}
+        <Container paddingBottom="md">
+          <SearchBar
+            placeholder={t('Search by build, SHA, branch name, or pull request')}
+            onChange={handleSearch}
+            query={localSearchQuery}
+            disabled={isLoadingBuilds}
+          />
+        </Container>
         {showOnboarding ? (
           <PreprodOnboarding
             organizationSlug={organization.slug}

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -87,18 +87,16 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
   const builds = buildsData?.builds ?? [];
   const pageLinks = getResponseHeader?.('Link') ?? undefined;
   const hasSearchQuery = !!searchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showProjectColumn = selectedProjectIds.length > 1;
 
   return (
     <Stack gap="xl">
-      {shouldShowSearchBar && (
-        <SearchBar
-          placeholder={t('Search by build, SHA, branch name, or pull request')}
-          onSearch={handleSearch}
-          query={searchQuery ?? undefined}
-        />
-      )}
+      <SearchBar
+        placeholder={t('Search by build, SHA, branch name, or pull request')}
+        onSearch={handleSearch}
+        query={searchQuery ?? undefined}
+        disabled={isLoadingBuilds}
+      />
 
       {buildsError && <LoadingError onRetry={refetch} />}
 


### PR DESCRIPTION
  - Always render the preprod search bar in release/mobile builds views
  - Disable the search input while builds are loading

Part of stack to add distribution table
- #105551
- #105552
- #105553
- #105554