### PR TITLE
chore(preprod): Refactor preprod builds table

### DIFF
--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -1,0 +1,121 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  formattedPrimaryMetricDownloadSize,
+  formattedPrimaryMetricInstallSize,
+  getLabels,
+} from 'sentry/views/preprod/utils/labelUtils';
+
+import {
+  FullRowLink,
+  PreprodBuildsCommonHeaderCells,
+  PreprodBuildsCommonRowCells,
+  PreprodBuildsCreatedHeaderCell,
+  PreprodBuildsCreatedRowCell,
+} from './preprodBuildsTableCommon';
+
+type PreprodBuildLabels = ReturnType<typeof getLabels>;
+
+interface PreprodBuildsSizeTableProps {
+  builds: BuildDetailsApiResponse[];
+  labels: PreprodBuildLabels;
+  organizationSlug: string;
+  showProjectColumn: boolean;
+  content?: ReactNode;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
+}
+
+function InstallSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
+  return (
+    <SimpleTable.HeaderCell>
+      {labels.installSizeLabelTooltip ? (
+        <Tooltip title={labels.installSizeLabelTooltip}>
+          <span>{labels.installSizeLabel}</span>
+        </Tooltip>
+      ) : (
+        labels.installSizeLabel
+      )}
+    </SimpleTable.HeaderCell>
+  );
+}
+
+function DownloadSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
+  return <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>;
+}
+
+function InstallSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+function DownloadSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+export function PreprodBuildsSizeTable({
+  builds,
+  content,
+  labels,
+  onRowClick,
+  organizationSlug,
+  showProjectColumn,
+}: PreprodBuildsSizeTableProps) {
+  const rows = builds.map(build => {
+    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
+    return (
+      <SimpleTable.Row key={build.id}>
+        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
+          <Fragment>
+            <PreprodBuildsCommonRowCells
+              build={build}
+              showInteraction
+              showProjectColumn={showProjectColumn}
+            />
+            <InstallSizeRowCell build={build} />
+            <DownloadSizeRowCell build={build} />
+            <PreprodBuildsCreatedRowCell build={build} />
+          </Fragment>
+        </FullRowLink>
+      </SimpleTable.Row>
+    );
+  });
+
+  return (
+    <BuildsSizeTable showProjectColumn={showProjectColumn}>
+      <SimpleTable.Header>
+        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <InstallSizeHeaderCell labels={labels} />
+        <DownloadSizeHeaderCell labels={labels} />
+        <PreprodBuildsCreatedHeaderCell />
+      </SimpleTable.Header>
+      {content ?? rows}
+    </BuildsSizeTable>
+  );
+}
+
+const sizeTableColumns = {
+  withProject: `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr)
+    minmax(100px, 1fr) minmax(100px, 1fr) minmax(80px, 120px)`,
+  withoutProject: `minmax(250px, 2fr) minmax(250px, 2fr) minmax(100px, 1fr)
+    minmax(100px, 1fr) minmax(80px, 120px)`,
+};
+
+const BuildsSizeTable = styled(SimpleTable)<{showProjectColumn?: boolean}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p =>
+    p.showProjectColumn ? sizeTableColumns.withProject : sizeTableColumns.withoutProject};
+`;

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -2,9 +2,12 @@ import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconQuestion} from 'sentry/icons';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -29,24 +32,6 @@ interface PreprodBuildsSizeTableProps {
   showProjectColumn: boolean;
   content?: ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
-}
-
-function InstallSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
-  return (
-    <SimpleTable.HeaderCell>
-      {labels.installSizeLabelTooltip ? (
-        <Tooltip title={labels.installSizeLabelTooltip}>
-          <span>{labels.installSizeLabel}</span>
-        </Tooltip>
-      ) : (
-        labels.installSizeLabel
-      )}
-    </SimpleTable.HeaderCell>
-  );
-}
-
-function DownloadSizeHeaderCell({labels}: {labels: PreprodBuildLabels}) {
-  return <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>;
 }
 
 function InstallSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
@@ -97,8 +82,21 @@ export function PreprodBuildsSizeTable({
     <BuildsSizeTable showProjectColumn={showProjectColumn}>
       <SimpleTable.Header>
         <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
-        <InstallSizeHeaderCell labels={labels} />
-        <DownloadSizeHeaderCell labels={labels} />
+        <SimpleTable.HeaderCell>
+          {labels.installSizeLabelTooltip ? (
+            <Tooltip title={labels.installSizeLabelTooltip}>
+              <Flex align="center" gap="xs">
+                <Text as="span" variant="muted">
+                  {labels.installSizeLabel}
+                </Text>
+                <IconQuestion size="xs" variant="muted" />
+              </Flex>
+            </Tooltip>
+          ) : (
+            labels.installSizeLabel
+          )}
+        </SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>
         <PreprodBuildsCreatedHeaderCell />
       </SimpleTable.Header>
       {content ?? rows}

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -12,42 +12,24 @@ import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDeta
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
-  getLabels,
+  type Labels,
 } from 'sentry/views/preprod/utils/labelUtils';
 
 import {
   FullRowLink,
-  PreprodBuildsCommonHeaderCells,
-  PreprodBuildsCommonRowCells,
   PreprodBuildsCreatedHeaderCell,
   PreprodBuildsCreatedRowCell,
+  PreprodBuildsHeaderCells,
+  PreprodBuildsRowCells,
 } from './preprodBuildsTableCommon';
-
-type PreprodBuildLabels = ReturnType<typeof getLabels>;
 
 interface PreprodBuildsSizeTableProps {
   builds: BuildDetailsApiResponse[];
-  labels: PreprodBuildLabels;
+  labels: Labels;
   organizationSlug: string;
   showProjectColumn: boolean;
   content?: ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
-}
-
-function InstallSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
-  return (
-    <SimpleTable.RowCell>
-      <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
-    </SimpleTable.RowCell>
-  );
-}
-
-function DownloadSizeRowCell({build}: {build: BuildDetailsApiResponse}) {
-  return (
-    <SimpleTable.RowCell>
-      <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
-    </SimpleTable.RowCell>
-  );
 }
 
 export function PreprodBuildsSizeTable({
@@ -64,13 +46,17 @@ export function PreprodBuildsSizeTable({
       <SimpleTable.Row key={build.id}>
         <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
           <Fragment>
-            <PreprodBuildsCommonRowCells
+            <PreprodBuildsRowCells
               build={build}
               showInteraction
               showProjectColumn={showProjectColumn}
             />
-            <InstallSizeRowCell build={build} />
-            <DownloadSizeRowCell build={build} />
+            <SimpleTable.RowCell>
+              <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
+            </SimpleTable.RowCell>
             <PreprodBuildsCreatedRowCell build={build} />
           </Fragment>
         </FullRowLink>
@@ -81,7 +67,7 @@ export function PreprodBuildsSizeTable({
   return (
     <BuildsSizeTable showProjectColumn={showProjectColumn}>
       <SimpleTable.Header>
-        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <PreprodBuildsHeaderCells showProjectColumn={showProjectColumn} />
         <SimpleTable.HeaderCell>
           {labels.installSizeLabelTooltip ? (
             <Tooltip title={labels.installSizeLabelTooltip}>

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -1,27 +1,15 @@
 import React, {Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
 
-import Feature from 'sentry/components/acl/feature';
-import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
-import {Container, Flex} from 'sentry/components/core/layout';
-import {ExternalLink, Link} from 'sentry/components/core/link';
+import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import TimeSince from 'sentry/components/timeSince';
-import {IconCheckmark, IconCommit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {
-  formattedPrimaryMetricDownloadSize,
-  formattedPrimaryMetricInstallSize,
-  getLabels,
-  getPlatformIconFromPlatform,
-} from 'sentry/views/preprod/utils/labelUtils';
+import {getLabels} from 'sentry/views/preprod/utils/labelUtils';
+
+import {PreprodBuildsSizeTable} from './preprodBuildsSizeTable';
 
 interface PreprodBuildsTableProps {
   builds: BuildDetailsApiResponse[];
@@ -54,149 +42,7 @@ export function PreprodBuildsTable({
     [builds, hasMultiplePlatforms]
   );
 
-  const header = (
-    <SimpleTable.Header>
-      <SimpleTable.HeaderCell>{t('App')}</SimpleTable.HeaderCell>
-      {showProjectColumn && (
-        <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
-      )}
-      <SimpleTable.HeaderCell>{t('Build')}</SimpleTable.HeaderCell>
-      <SimpleTable.HeaderCell>
-        {labels.installSizeLabelTooltip ? (
-          <Tooltip title={labels.installSizeLabelTooltip}>
-            <span>{labels.installSizeLabel}</span>
-          </Tooltip>
-        ) : (
-          labels.installSizeLabel
-        )}
-      </SimpleTable.HeaderCell>
-      <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>
-      <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
-    </SimpleTable.Header>
-  );
-
-  const renderBuildRow = (build: BuildDetailsApiResponse) => {
-    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
-
-    return (
-      <SimpleTable.Row key={build.id}>
-        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
-          <InteractionStateLayer />
-          <SimpleTable.RowCell justify="start">
-            {build.app_info?.name || build.app_info?.app_id ? (
-              <Flex direction="column" gap="xs">
-                <Flex align="center" gap="2xs">
-                  {build.app_info?.platform && (
-                    <PlatformIcon
-                      platform={getPlatformIconFromPlatform(build.app_info.platform)}
-                    />
-                  )}
-                  <Container paddingLeft="xs">
-                    <Text size="lg" bold>
-                      {build.app_info?.name || '--'}
-                    </Text>
-                  </Container>
-                  <Feature features="organizations:preprod-build-distribution">
-                    {build.app_info.is_installable && (
-                      <InstallAppButton
-                        projectId={build.project_slug}
-                        artifactId={build.id}
-                        platform={build.app_info.platform ?? null}
-                        source="builds_table"
-                        variant="icon"
-                      />
-                    )}
-                  </Feature>
-                </Flex>
-                <Flex align="center" gap="xs">
-                  <Text size="sm" variant="muted">
-                    {build.app_info?.app_id || '--'}
-                  </Text>
-                  {build.app_info?.build_configuration && (
-                    <React.Fragment>
-                      <Text size="sm" variant="muted">
-                        {' • '}
-                      </Text>
-                      <Tooltip title={t('Build configuration')}>
-                        <Text size="sm" variant="muted" monospace>
-                          {build.app_info.build_configuration}
-                        </Text>
-                      </Tooltip>
-                    </React.Fragment>
-                  )}
-                </Flex>
-              </Flex>
-            ) : null}
-          </SimpleTable.RowCell>
-
-          {showProjectColumn && (
-            <SimpleTable.RowCell justify="start">
-              <Text>{build.project_slug}</Text>
-            </SimpleTable.RowCell>
-          )}
-
-          <SimpleTable.RowCell justify="start">
-            <Flex direction="column" gap="xs">
-              <Flex align="center" gap="xs">
-                {build.app_info?.version !== null && (
-                  <Text size="lg" bold>
-                    {build.app_info?.version}
-                  </Text>
-                )}
-                {build.app_info?.build_number !== null && (
-                  <Text size="lg" variant="muted">
-                    ({build.app_info?.build_number})
-                  </Text>
-                )}
-                {build.state === 3 && <IconCheckmark size="sm" color="green300" />}
-              </Flex>
-              <Flex align="center" gap="xs">
-                <IconCommit size="xs" />
-                <Text size="sm" variant="muted" monospace>
-                  {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
-                </Text>
-                {build.vcs_info?.pr_number && (
-                  <React.Fragment>
-                    <Text size="sm" variant="muted">
-                      #{build.vcs_info?.pr_number}
-                    </Text>
-                  </React.Fragment>
-                )}
-                {build.vcs_info?.head_ref !== null && (
-                  <React.Fragment>
-                    <Text size="sm" variant="muted">
-                      –
-                    </Text>
-                    <Text size="sm" variant="muted">
-                      {build.vcs_info?.head_ref || '--'}
-                    </Text>
-                  </React.Fragment>
-                )}
-              </Flex>
-            </Flex>
-          </SimpleTable.RowCell>
-
-          <SimpleTable.RowCell>
-            <Text>{formattedPrimaryMetricInstallSize(build.size_info)}</Text>
-          </SimpleTable.RowCell>
-
-          <SimpleTable.RowCell>
-            <Text>{formattedPrimaryMetricDownloadSize(build.size_info)}</Text>
-          </SimpleTable.RowCell>
-
-          <SimpleTable.RowCell>
-            {build.app_info?.date_added ? (
-              <TimeSince date={build.app_info.date_added} unitStyle="short" />
-            ) : (
-              '-'
-            )}
-          </SimpleTable.RowCell>
-        </FullRowLink>
-      </SimpleTable.Row>
-    );
-  };
-
-  let tableContent = null;
+  let tableContent: React.ReactNode | undefined;
   if (isLoading) {
     tableContent = (
       <SimpleTable.Empty>
@@ -221,38 +67,19 @@ export function PreprodBuildsTable({
         </Text>
       </SimpleTable.Empty>
     );
-  } else {
-    tableContent = <Fragment>{builds.map(build => renderBuildRow(build))}</Fragment>;
   }
 
   return (
     <Fragment>
-      <SimpleTableWithColumns showProjectColumn={showProjectColumn}>
-        {header}
-        {tableContent}
-      </SimpleTableWithColumns>
+      <PreprodBuildsSizeTable
+        builds={builds}
+        content={tableContent}
+        labels={labels}
+        onRowClick={onRowClick}
+        organizationSlug={organizationSlug}
+        showProjectColumn={showProjectColumn}
+      />
       {pageLinks && <Pagination pageLinks={pageLinks} />}
     </Fragment>
   );
 }
-
-const SimpleTableWithColumns = styled(SimpleTable)<{showProjectColumn?: boolean}>`
-  overflow-x: auto;
-  overflow-y: auto;
-  grid-template-columns: ${p =>
-    p.showProjectColumn
-      ? `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr) minmax(100px, 1fr)
-    minmax(100px, 1fr) minmax(80px, 120px)`
-      : `minmax(250px, 2fr) minmax(250px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr)
-    minmax(80px, 120px)`};
-`;
-
-const FullRowLink = styled(Link)`
-  display: contents;
-  cursor: pointer;
-  color: inherit;
-
-  &:hover {
-    color: inherit;
-  }
-`;

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -16,7 +16,7 @@ import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getPlatformIconFromPlatform} from 'sentry/views/preprod/utils/labelUtils';
 
-export function PreprodBuildsCommonHeaderCells({
+export function PreprodBuildsHeaderCells({
   showProjectColumn,
 }: {
   showProjectColumn: boolean;
@@ -36,17 +36,17 @@ export function PreprodBuildsCreatedHeaderCell() {
   return <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>;
 }
 
-interface PreprodBuildsCommonRowCellsProps {
+interface PreprodBuildsRowCellsProps {
   build: BuildDetailsApiResponse;
   showInteraction: boolean;
   showProjectColumn: boolean;
 }
 
-export function PreprodBuildsCommonRowCells({
+export function PreprodBuildsRowCells({
   build,
   showInteraction,
   showProjectColumn,
-}: PreprodBuildsCommonRowCellsProps) {
+}: PreprodBuildsRowCellsProps) {
   return (
     <Fragment>
       {showInteraction && <InteractionStateLayer />}

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -1,0 +1,170 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import Feature from 'sentry/components/acl/feature';
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import TimeSince from 'sentry/components/timeSince';
+import {IconCheckmark, IconCommit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getPlatformIconFromPlatform} from 'sentry/views/preprod/utils/labelUtils';
+
+export function PreprodBuildsCommonHeaderCells({
+  showProjectColumn,
+}: {
+  showProjectColumn: boolean;
+}) {
+  return (
+    <Fragment>
+      <SimpleTable.HeaderCell>{t('App')}</SimpleTable.HeaderCell>
+      {showProjectColumn && (
+        <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
+      )}
+      <SimpleTable.HeaderCell>{t('Build')}</SimpleTable.HeaderCell>
+    </Fragment>
+  );
+}
+
+export function PreprodBuildsCreatedHeaderCell() {
+  return <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>;
+}
+
+interface PreprodBuildsCommonRowCellsProps {
+  build: BuildDetailsApiResponse;
+  showInteraction: boolean;
+  showProjectColumn: boolean;
+}
+
+export function PreprodBuildsCommonRowCells({
+  build,
+  showInteraction,
+  showProjectColumn,
+}: PreprodBuildsCommonRowCellsProps) {
+  return (
+    <Fragment>
+      {showInteraction && <InteractionStateLayer />}
+      <SimpleTable.RowCell justify="start">
+        {build.app_info?.name || build.app_info?.app_id ? (
+          <Flex direction="column" gap="xs">
+            <Flex align="center" gap="2xs">
+              {build.app_info?.platform && (
+                <PlatformIcon
+                  platform={getPlatformIconFromPlatform(build.app_info.platform)}
+                />
+              )}
+              <Container paddingLeft="xs">
+                <Text size="lg" bold>
+                  {build.app_info?.name || '--'}
+                </Text>
+              </Container>
+              <Feature features="organizations:preprod-build-distribution">
+                {build.app_info.is_installable && (
+                  <InstallAppButton
+                    projectId={build.project_slug}
+                    artifactId={build.id}
+                    platform={build.app_info.platform ?? null}
+                    source="builds_table"
+                    variant="icon"
+                  />
+                )}
+              </Feature>
+            </Flex>
+            <Flex align="center" gap="xs">
+              <Text size="sm" variant="muted">
+                {build.app_info?.app_id || '--'}
+              </Text>
+              {build.app_info?.build_configuration && (
+                <Fragment>
+                  <Text size="sm" variant="muted">
+                    {' • '}
+                  </Text>
+                  <Tooltip title={t('Build configuration')}>
+                    <Text size="sm" variant="muted" monospace>
+                      {build.app_info.build_configuration}
+                    </Text>
+                  </Tooltip>
+                </Fragment>
+              )}
+            </Flex>
+          </Flex>
+        ) : null}
+      </SimpleTable.RowCell>
+
+      {showProjectColumn && (
+        <SimpleTable.RowCell justify="start">
+          <Text>{build.project_slug}</Text>
+        </SimpleTable.RowCell>
+      )}
+
+      <SimpleTable.RowCell justify="start">
+        <Flex direction="column" gap="xs">
+          <Flex align="center" gap="xs">
+            {build.app_info?.version !== null && (
+              <Text size="lg" bold>
+                {build.app_info?.version}
+              </Text>
+            )}
+            {build.app_info?.build_number !== null && (
+              <Text size="lg" variant="muted">
+                ({build.app_info?.build_number})
+              </Text>
+            )}
+            {build.state === 3 && <IconCheckmark size="sm" color="green300" />}
+          </Flex>
+          <Flex align="center" gap="xs">
+            <IconCommit size="xs" />
+            <Text size="sm" variant="muted" monospace>
+              {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
+            </Text>
+            {build.vcs_info?.pr_number && (
+              <Fragment>
+                <Text size="sm" variant="muted">
+                  #{build.vcs_info?.pr_number}
+                </Text>
+              </Fragment>
+            )}
+            {build.vcs_info?.head_ref !== null && (
+              <Fragment>
+                <Text size="sm" variant="muted">
+                  –
+                </Text>
+                <Text size="sm" variant="muted">
+                  {build.vcs_info?.head_ref || '--'}
+                </Text>
+              </Fragment>
+            )}
+          </Flex>
+        </Flex>
+      </SimpleTable.RowCell>
+    </Fragment>
+  );
+}
+
+export function PreprodBuildsCreatedRowCell({build}: {build: BuildDetailsApiResponse}) {
+  return (
+    <SimpleTable.RowCell>
+      {build.app_info?.date_added ? (
+        <TimeSince date={build.app_info.date_added} unitStyle="short" />
+      ) : (
+        '-'
+      )}
+    </SimpleTable.RowCell>
+  );
+}
+
+export const FullRowLink = styled(Link)`
+  display: contents;
+  cursor: pointer;
+  color: inherit;
+
+  &:hover {
+    color: inherit;
+  }
+`;

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -62,7 +62,7 @@ export function getReadableArtifactTypeTooltip(
   }
 }
 
-interface Labels {
+export interface Labels {
   appId: string;
   buildConfiguration: string;
   downloadSizeDescription: string;

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -146,7 +146,7 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             onRowClick={handleBuildRowClick}
-            hasSearchQuery
+            hasSearchQuery={hasSearchQuery}
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -100,7 +100,6 @@ export default function PreprodBuilds() {
   const pageLinks = getResponseHeader?.('Link') || null;
 
   const hasSearchQuery = !!urlSearchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
   const handleBuildRowClick = useCallback(
@@ -125,15 +124,14 @@ export default function PreprodBuilds() {
           projectSlug={projectSlug}
         />
         {buildsError && <LoadingError onRetry={refetch} />}
-        {shouldShowSearchBar && (
-          <Container paddingBottom="md">
-            <SearchBar
-              placeholder={t('Search by build, SHA, branch name, or pull request')}
-              onChange={handleSearch}
-              query={localSearchQuery}
-            />
-          </Container>
-        )}
+        <Container paddingBottom="md">
+          <SearchBar
+            placeholder={t('Search by build, SHA, branch name, or pull request')}
+            onChange={handleSearch}
+            query={localSearchQuery}
+            disabled={isLoadingBuilds}
+          />
+        </Container>
         {showOnboarding ? (
           <PreprodOnboarding
             organizationSlug={organization.slug}

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -87,18 +87,16 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
   const builds = buildsData?.builds ?? [];
   const pageLinks = getResponseHeader?.('Link') ?? undefined;
   const hasSearchQuery = !!searchQuery?.trim();
-  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showProjectColumn = selectedProjectIds.length > 1;
 
   return (
     <Stack gap="xl">
-      {shouldShowSearchBar && (
-        <SearchBar
-          placeholder={t('Search by build, SHA, branch name, or pull request')}
-          onSearch={handleSearch}
-          query={searchQuery ?? undefined}
-        />
-      )}
+      <SearchBar
+        placeholder={t('Search by build, SHA, branch name, or pull request')}
+        onSearch={handleSearch}
+        query={searchQuery ?? undefined}
+        disabled={isLoadingBuilds}
+      />
 
       {buildsError && <LoadingError onRetry={refetch} />}
 


### PR DESCRIPTION
Eventually going to add in a similar `<DistributionTable>`, but isolating this change for just the size table
  - extract shared preprod builds table header/row rendering into reusable components
  - move size-table rendering into its own component
  - should be no behavioral changes

Part of stack to add distribution table
- #105551
- #105552
- #105553
- #105554