### PR TITLE
feat(preprod): Add preprod distribution display table

### DIFF
--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -10,10 +10,10 @@ import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDeta
 
 import {
   FullRowLink,
-  PreprodBuildsCommonHeaderCells,
-  PreprodBuildsCommonRowCells,
   PreprodBuildsCreatedHeaderCell,
   PreprodBuildsCreatedRowCell,
+  PreprodBuildsHeaderCells,
+  PreprodBuildsRowCells,
 } from './preprodBuildsTableCommon';
 
 interface PreprodBuildsDistributionTableProps {
@@ -38,7 +38,7 @@ export function PreprodBuildsDistributionTable({
     const downloadCount = build.distribution_info?.download_count ?? 0;
     const rowContent = (
       <Fragment>
-        <PreprodBuildsCommonRowCells
+        <PreprodBuildsRowCells
           build={build}
           showInteraction={!isRowDisabled}
           showInstallabilityIndicator
@@ -69,7 +69,7 @@ export function PreprodBuildsDistributionTable({
   return (
     <BuildsDistributionTable showProjectColumn={showProjectColumn}>
       <SimpleTable.Header>
-        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <PreprodBuildsHeaderCells showProjectColumn={showProjectColumn} />
         <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>
         <PreprodBuildsCreatedHeaderCell />
       </SimpleTable.Header>

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -24,19 +24,6 @@ interface PreprodBuildsDistributionTableProps {
   onRowClick?: (build: BuildDetailsApiResponse) => void;
 }
 
-function DownloadCountHeaderCell() {
-  return <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>;
-}
-
-function DownloadCountRowCell({build}: {build: BuildDetailsApiResponse}) {
-  const downloadCount = build.distribution_info?.download_count ?? 0;
-  return (
-    <SimpleTable.RowCell>
-      <Text>{formatNumberWithDynamicDecimalPoints(downloadCount, 0)}</Text>
-    </SimpleTable.RowCell>
-  );
-}
-
 export function PreprodBuildsDistributionTable({
   builds,
   content,
@@ -48,6 +35,7 @@ export function PreprodBuildsDistributionTable({
     const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`;
     const isInstallable = build.distribution_info?.is_installable ?? false;
     const isRowDisabled = !isInstallable;
+    const downloadCount = build.distribution_info?.download_count ?? 0;
     const rowContent = (
       <Fragment>
         <PreprodBuildsCommonRowCells
@@ -56,7 +44,9 @@ export function PreprodBuildsDistributionTable({
           showInstallabilityIndicator
           showProjectColumn={showProjectColumn}
         />
-        <DownloadCountRowCell build={build} />
+        <SimpleTable.RowCell>
+          <Text>{formatNumberWithDynamicDecimalPoints(downloadCount, 0)}</Text>
+        </SimpleTable.RowCell>
         <PreprodBuildsCreatedRowCell build={build} />
       </Fragment>
     );
@@ -80,7 +70,7 @@ export function PreprodBuildsDistributionTable({
     <BuildsDistributionTable showProjectColumn={showProjectColumn}>
       <SimpleTable.Header>
         <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
-        <DownloadCountHeaderCell />
+        <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>
         <PreprodBuildsCreatedHeaderCell />
       </SimpleTable.Header>
       {content ?? rows}

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -1,0 +1,120 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t} from 'sentry/locale';
+import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import {
+  FullRowLink,
+  PreprodBuildsCommonHeaderCells,
+  PreprodBuildsCommonRowCells,
+  PreprodBuildsCreatedHeaderCell,
+  PreprodBuildsCreatedRowCell,
+} from './preprodBuildsTableCommon';
+
+interface PreprodBuildsDistributionTableProps {
+  builds: BuildDetailsApiResponse[];
+  organizationSlug: string;
+  showProjectColumn: boolean;
+  content?: ReactNode;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
+}
+
+function DownloadCountHeaderCell() {
+  return <SimpleTable.HeaderCell>{t('Download Count')}</SimpleTable.HeaderCell>;
+}
+
+function DownloadCountRowCell({build}: {build: BuildDetailsApiResponse}) {
+  const downloadCount = build.distribution_info?.download_count ?? 0;
+  return (
+    <SimpleTable.RowCell>
+      <Text>{formatNumberWithDynamicDecimalPoints(downloadCount, 0)}</Text>
+    </SimpleTable.RowCell>
+  );
+}
+
+export function PreprodBuildsDistributionTable({
+  builds,
+  content,
+  onRowClick,
+  organizationSlug,
+  showProjectColumn,
+}: PreprodBuildsDistributionTableProps) {
+  const rows = builds.map(build => {
+    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`;
+    const isInstallable = build.distribution_info?.is_installable ?? false;
+    const isRowDisabled = !isInstallable;
+    const rowContent = (
+      <Fragment>
+        <PreprodBuildsCommonRowCells
+          build={build}
+          showInteraction={!isRowDisabled}
+          showProjectColumn={showProjectColumn}
+        />
+        <DownloadCountRowCell build={build} />
+        <PreprodBuildsCreatedRowCell build={build} />
+      </Fragment>
+    );
+
+    const RowComponent = isRowDisabled ? DisabledRow : SimpleTable.Row;
+
+    return (
+      <RowComponent key={build.id} variant={isRowDisabled ? 'faded' : 'default'}>
+        {isRowDisabled ? (
+          <Tooltip title={t('Not Installable')} containerDisplayMode="contents">
+            <DisabledRowContent>{rowContent}</DisabledRowContent>
+          </Tooltip>
+        ) : (
+          <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
+            {rowContent}
+          </FullRowLink>
+        )}
+      </RowComponent>
+    );
+  });
+
+  return (
+    <BuildsDistributionTable showProjectColumn={showProjectColumn}>
+      <SimpleTable.Header>
+        <PreprodBuildsCommonHeaderCells showProjectColumn={showProjectColumn} />
+        <DownloadCountHeaderCell />
+        <PreprodBuildsCreatedHeaderCell />
+      </SimpleTable.Header>
+      {content ?? rows}
+    </BuildsDistributionTable>
+  );
+}
+
+const distributionTableColumns = {
+  withProject: `minmax(250px, 2fr) minmax(120px, 1fr) minmax(250px, 2fr)
+    minmax(120px, 1fr) minmax(80px, 120px)`,
+  withoutProject: `minmax(250px, 2fr) minmax(250px, 2fr) minmax(120px, 1fr)
+    minmax(80px, 120px)`,
+};
+
+const BuildsDistributionTable = styled(SimpleTable)<{showProjectColumn?: boolean}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p =>
+    p.showProjectColumn
+      ? distributionTableColumns.withProject
+      : distributionTableColumns.withoutProject};
+`;
+
+const DisabledRowContent = styled('div')`
+  display: contents;
+  color: inherit;
+`;
+
+const DisabledRow = styled(SimpleTable.Row)`
+  [role='cell'] {
+    color: ${p => p.theme.subText};
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+`;

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Text} from 'sentry/components/core/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
@@ -66,9 +65,7 @@ export function PreprodBuildsDistributionTable({
     return (
       <RowComponent key={build.id} variant={isRowDisabled ? 'faded' : 'default'}>
         {isRowDisabled ? (
-          <Tooltip title={t('Not Installable')} containerDisplayMode="contents">
-            <DisabledRowContent>{rowContent}</DisabledRowContent>
-          </Tooltip>
+          rowContent
         ) : (
           <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
             {rowContent}
@@ -104,11 +101,6 @@ const BuildsDistributionTable = styled(SimpleTable)<{showProjectColumn?: boolean
     p.showProjectColumn
       ? distributionTableColumns.withProject
       : distributionTableColumns.withoutProject};
-`;
-
-const DisabledRowContent = styled('div')`
-  display: contents;
-  color: inherit;
 `;
 
 const DisabledRow = styled(SimpleTable.Row)`

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -53,6 +53,7 @@ export function PreprodBuildsDistributionTable({
         <PreprodBuildsCommonRowCells
           build={build}
           showInteraction={!isRowDisabled}
+          showInstallabilityIndicator
           showProjectColumn={showProjectColumn}
         />
         <DownloadCountRowCell build={build} />
@@ -107,6 +108,6 @@ const DisabledRow = styled(SimpleTable.Row)`
   [role='cell'] {
     color: ${p => p.theme.subText};
     cursor: not-allowed;
-    opacity: 0.4;
+    opacity: 0.5;
   }
 `;

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -1,0 +1,92 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
+import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
+import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+
+const organization = OrganizationFixture({
+  features: ['preprod-build-distribution'],
+});
+
+const baseBuild = {
+  id: 'build-1',
+  project_id: 1,
+  project_slug: 'project-1',
+  state: BuildDetailsState.UPLOADED,
+  app_info: {
+    app_id: 'com.example.app',
+    name: 'Example App',
+    platform: 'ios' as Platform,
+    build_number: '1',
+    version: '1.0.0',
+    date_added: '2024-01-01T00:00:00Z',
+  },
+  distribution_info: {
+    is_installable: true,
+    download_count: 1234,
+    release_notes: null,
+  },
+  vcs_info: {
+    head_sha: 'abcdef1',
+  },
+};
+
+describe('PreprodBuildsTable', () => {
+  it('renders size columns by default', () => {
+    render(
+      <PreprodBuildsTable
+        builds={[baseBuild]}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Install Size')).toBeInTheDocument();
+    expect(screen.getByText('Download Size')).toBeInTheDocument();
+    expect(screen.queryByText('Download Count')).not.toBeInTheDocument();
+  });
+
+  it('renders distribution columns and keeps non-installable rows visible but not linked', () => {
+    const nonInstallableBuild = {
+      ...baseBuild,
+      id: 'build-2',
+      app_info: {
+        ...baseBuild.app_info,
+        name: 'Non Installable App',
+      },
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        is_installable: false,
+        download_count: 99,
+      },
+    };
+
+    render(
+      <PreprodBuildsTable
+        builds={[baseBuild, nonInstallableBuild]}
+        display={PreprodBuildsDisplay.DISTRIBUTION}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Download Count')).toBeInTheDocument();
+    expect(screen.queryByText('Download Size')).not.toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('Non Installable App')).toBeInTheDocument();
+
+    const rowLink = screen.getByRole('link', {name: /Example App/});
+    expect(rowLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/preprod/1/build-1/install/`
+    );
+    expect(
+      screen.queryByRole('link', {name: /Non Installable App/})
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -2,6 +2,8 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {Button} from '@sentry/scraps/button';
+
 import Feature from 'sentry/components/acl/feature';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Container, Flex} from 'sentry/components/core/layout';
@@ -79,12 +81,16 @@ export function PreprodBuildsRowCells({
                         variant="icon"
                       />
                     ) : (
-                      <Tooltip title={t('Not installable')}>
-                        <IconNot
-                          aria-label={t('Not installable')}
-                          color="red300"
-                          size="xs"
-                        />
+                      <Tooltip title={t('Not installable')} skipWrapper>
+                        <span>
+                          <Button
+                            aria-label={t('Not installable')}
+                            icon={<IconNot color="red300" size="xs" />}
+                            priority="transparent"
+                            size="zero"
+                            disabled
+                          />
+                        </span>
                       </Tooltip>
                     )}
                   </Flex>

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -10,7 +10,7 @@ import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TimeSince from 'sentry/components/timeSince';
-import {IconCheckmark, IconCommit} from 'sentry/icons';
+import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -40,12 +40,14 @@ interface PreprodBuildsRowCellsProps {
   build: BuildDetailsApiResponse;
   showInteraction: boolean;
   showProjectColumn: boolean;
+  showInstallabilityIndicator?: boolean;
 }
 
 export function PreprodBuildsRowCells({
   build,
   showInteraction,
   showProjectColumn,
+  showInstallabilityIndicator = false,
 }: PreprodBuildsRowCellsProps) {
   return (
     <Fragment>
@@ -65,14 +67,27 @@ export function PreprodBuildsRowCells({
                 </Text>
               </Container>
               <Feature features="organizations:preprod-build-distribution">
-                {build.distribution_info?.is_installable && (
-                  <InstallAppButton
-                    projectId={build.project_slug}
-                    artifactId={build.id}
-                    platform={build.app_info.platform ?? null}
-                    source="builds_table"
-                    variant="icon"
-                  />
+                {(build.distribution_info?.is_installable ||
+                  showInstallabilityIndicator) && (
+                  <Flex align="center">
+                    {build.distribution_info?.is_installable ? (
+                      <InstallAppButton
+                        projectId={build.project_slug}
+                        artifactId={build.id}
+                        platform={build.app_info.platform ?? null}
+                        source="builds_table"
+                        variant="icon"
+                      />
+                    ) : (
+                      <Tooltip title={t('Not installable')}>
+                        <IconNot
+                          aria-label={t('Not installable')}
+                          color="red300"
+                          size="xs"
+                        />
+                      </Tooltip>
+                    )}
+                  </Flex>
                 )}
               </Feature>
             </Flex>

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -65,7 +65,7 @@ export function PreprodBuildsRowCells({
                 </Text>
               </Container>
               <Feature features="organizations:preprod-build-distribution">
-                {build.app_info.is_installable && (
+                {build.distribution_info?.is_installable && (
                   <InstallAppButton
                     projectId={build.project_slug}
                     artifactId={build.id}

--- a/static/app/views/preprod/components/preprodBuildsSearchBar.tsx
+++ b/static/app/views/preprod/components/preprodBuildsSearchBar.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 
 const displaySelectOptions: Array<SelectOption<PreprodBuildsDisplay>> = [
   {value: PreprodBuildsDisplay.SIZE, label: t('Size')},
-  {value: PreprodBuildsDisplay.DISTRIBUTION, label: t('Distribution'), disabled: true},
+  {value: PreprodBuildsDisplay.DISTRIBUTION, label: t('Distribution')},
 ];
 
 type DisplayOptionsProps = {

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -11,6 +11,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {ReleasesSortOption} from 'sentry/constants/releases';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -553,7 +554,7 @@ describe('ReleasesList', () => {
     );
   });
 
-  it('shows distribution display as disabled in the mobile-builds tab', async () => {
+  it('toggles display mode in the mobile-builds tab', async () => {
     const organizationWithDistribution = OrganizationFixture({
       slug: organization.slug,
       features: [...organization.features, 'preprod-build-distribution'],
@@ -617,11 +618,10 @@ describe('ReleasesList', () => {
     await userEvent.click(displayTrigger);
 
     const distributionOption = screen.getByRole('option', {name: 'Distribution'});
-    expect(distributionOption).toHaveAttribute('aria-disabled', 'true');
     await userEvent.click(distributionOption);
 
-    expect(router.location.query.display).toBe('users');
-    expect(router.location.query.cursor).toBe('123');
+    expect(router.location.query.display).toBe(PreprodBuildsDisplay.DISTRIBUTION);
+    expect(router.location.query.cursor).toBeUndefined();
   });
 
   it('allows searching within the mobile-builds tab', async () => {


### PR DESCRIPTION
  - add distribution-mode table with download count column and install routing
  - Distribution table is separate bc imo its cleaner and we'll also re-use it on the install pages

https://github.com/user-attachments/assets/284c0541-0cd8-4526-bd82-44b4701f4106

Part of stack to add distribution table
- #105551
- #105552
- #105553
- #105554