### PR TITLE
fix(auth) Don't 500 on invalid op parameters

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.exceptions import BadRequest
 from django.forms.utils import ErrorList
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.http.response import HttpResponseBase
@@ -231,7 +232,8 @@ class AuthLoginView(BaseView):
                 request=request, organization=organization, **kwargs
             )
         else:
-            assert op == "login"
+            if op != "login":
+                raise BadRequest()
             return self.handle_login_form_submit(
                 request=request, organization=organization, **kwargs
             )

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -138,6 +138,17 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
             (f"/organizations/{org.slug}/issues/", 302),
         ]
 
+    def test_login_invalid_op(self) -> None:
+        # load it once for test cookie
+        self.client.get(self.path)
+
+        resp = self.client.post(
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "alert('hackerman')"},
+            follow=True,
+        )
+        assert resp.status_code == 400
+
     def test_login_valid_credentials_2fa_redirect(self) -> None:
         user = self.create_user("bar@example.com")
         RecoveryCodeInterface().enroll(user)


### PR DESCRIPTION
We get a non-zero number of requests with invalid `op` parameterts in production. We should return BadRequest on invalid data instead of failing with a 500.

Fixes SENTRY-3VFR