### PR TITLE
chore(sentry-apps): option to disable paranoia for backfill script

### DIFF
--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -32,7 +32,7 @@ class ParanoidManager(BaseManager[M]):
     Only exposes objects that have NOT been soft-deleted.
     """
 
-    def get_queryset(self) -> ParanoidQuerySet[M]:
+    def get_queryset(self) -> BaseQuerySet[M]:
         if options.get("sentry-apps.disable-paranoia"):
             return super().get_queryset()
 

--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -3,6 +3,7 @@ from typing import ClassVar, Self
 from django.db import models
 from django.utils import timezone
 
+from sentry import options
 from sentry.db.models import BaseModel, sane_repr
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
@@ -32,6 +33,9 @@ class ParanoidManager(BaseManager[M]):
     """
 
     def get_queryset(self) -> ParanoidQuerySet[M]:
+        if options.get("sentry-apps.disable-paranoia"):
+            return super().get_queryset()
+
         return ParanoidQuerySet(self.model, using=self._db).filter(date_deleted__isnull=True)
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3774,9 +3774,17 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Manual option for hard deleting sentry apps and installations.
+# Disable paranoia for sentry apps
 register(
     "sentry-apps.hard-delete",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Manual option for hard deleting sentry apps and installations
+register(
+    "sentry-apps.disable-paranoia",
     type=Bool,
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/sentry/sentry_apps/models/test_sentryapp.py
+++ b/tests/sentry/sentry_apps/models/test_sentryapp.py
@@ -4,6 +4,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.models.apiapplication import ApiApplication
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test, create_test_regions
 
 
@@ -31,6 +32,13 @@ class SentryAppTest(TestCase):
         self.sentry_app.delete()
         assert self.sentry_app.date_deleted is not None
         assert self.sentry_app not in SentryApp.objects.all()
+
+    @override_options({"sentry-apps.disable-paranoia": True})
+    def test_paranoid_disabled(self) -> None:
+        self.sentry_app.save()
+        self.sentry_app.delete()
+        assert self.sentry_app.date_deleted is None
+        assert self.sentry_app in SentryApp.objects.all()
 
     def test_date_updated(self) -> None:
         self.sentry_app.save()

--- a/tests/sentry/sentry_apps/models/test_sentryapp.py
+++ b/tests/sentry/sentry_apps/models/test_sentryapp.py
@@ -34,10 +34,10 @@ class SentryAppTest(TestCase):
         assert self.sentry_app not in SentryApp.objects.all()
 
     @override_options({"sentry-apps.disable-paranoia": True})
-    def test_paranoid_disabled(self) -> None:
+    def test_paranoid_querying_disabled(self) -> None:
         self.sentry_app.save()
         self.sentry_app.delete()
-        assert self.sentry_app.date_deleted is None
+        assert self.sentry_app.date_deleted is not None
         assert self.sentry_app in SentryApp.objects.all()
 
     def test_date_updated(self) -> None:

--- a/tests/sentry/sentry_apps/models/test_sentryappinstallation.py
+++ b/tests/sentry/sentry_apps/models/test_sentryappinstallation.py
@@ -5,6 +5,7 @@ from sentry.models.apiapplication import ApiApplication
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import get_region_for_organization
 
@@ -35,6 +36,13 @@ class SentryAppInstallationTest(TestCase):
         self.install.delete()
         assert self.install.date_deleted is not None
         assert self.install not in SentryAppInstallation.objects.all()
+
+    @override_options({"sentry-apps.disable-paranoia": True})
+    def test_paranoid_disabled(self) -> None:
+        self.install.save()
+        self.install.delete()
+        assert self.install.date_deleted is None
+        assert self.install in SentryAppInstallation.objects.all()
 
     def test_date_updated(self) -> None:
         self.install.save()

--- a/tests/sentry/sentry_apps/models/test_sentryappinstallation.py
+++ b/tests/sentry/sentry_apps/models/test_sentryappinstallation.py
@@ -38,10 +38,10 @@ class SentryAppInstallationTest(TestCase):
         assert self.install not in SentryAppInstallation.objects.all()
 
     @override_options({"sentry-apps.disable-paranoia": True})
-    def test_paranoid_disabled(self) -> None:
+    def test_paranoid_querying_disabled(self) -> None:
         self.install.save()
         self.install.delete()
-        assert self.install.date_deleted is None
+        assert self.install.date_deleted is not None
         assert self.install in SentryAppInstallation.objects.all()
 
     def test_date_updated(self) -> None:


### PR DESCRIPTION
Right before running the backfill script to hard delete soft deleted sentry apps and installs, we'll need to disable the paranoid model manager so the scheduled deletion logic can pick up the soft deleted objects.

Opting for an option here instead of completely remove the paranoid model manager, because then all the soft deleted objects would become visible until we merge code to remove all paranoid related logic.