### PR TITLE
fix(stories): `type` -> `variant`

### DIFF
--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -26,7 +26,7 @@ export {documentation};
 To create a basic alert, wrap your message in an `<Alert>` component and specify the appropriate type.
 
 ```jsx
-<Alert type="info">This is an informational message</Alert>
+<Alert variant="info">This is an informational message</Alert>
 ```
 
 ## Props
@@ -90,7 +90,7 @@ By default, alerts display appropriate icons based on their type. You can hide i
   <Alert variant="warning" showIcon={false}>
     No icon
   </Alert>
-  <Alert type="success" icon={<IconAdd />}>
+  <Alert variant="success" icon={<IconAdd />}>
     Custom add icon
   </Alert>
 </Alert.Container>
@@ -172,7 +172,10 @@ Add interactive elements like buttons, links or badges to the right side of aler
 
 <Storybook.Demo>
   <Alert.Container>
-    <Alert variant="info" trailingItems={<Badge type="warning">Action Required</Badge>}>
+    <Alert
+      variant="info"
+      trailingItems={<Badge variant="warning">Action Required</Badge>}
+    >
       This alert has a trailing badge
     </Alert>
     <Alert
@@ -200,7 +203,7 @@ Add interactive elements like buttons, links or badges to the right side of aler
       }
       trailingItems={
         <Flex gap="sm">
-          <Badge type="warning">Action Required</Badge>
+          <Badge variant="warning">Action Required</Badge>
           <Alert.Button priority="transparent" icon={<IconEdit />}>
             Edit
           </Alert.Button>
@@ -251,7 +254,7 @@ Use `Alert.Container` to properly manage spacing between multiple alerts.
 ```jsx
 <Alert.Container>
   <Alert variant="info">First alert in a container</Alert>
-  <Alert type="warning">Second alert in a container</Alert>
+  <Alert variant="warning">Second alert in a container</Alert>
   <Alert variant="success">Third alert in a container</Alert>
 </Alert.Container>
 ```

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -100,11 +100,10 @@ Buttons are available in different sizes: `md` (default), `sm`, `xs`, and `zero`
 
 Buttons support an optional leading icon.
 
-<Alert type="info">
-  You do not typically need to set the `size` prop for the icon, the Button wraps the
-  rendered Icon in a `IcconDefaultsProvider` to provide an icon size proportional to the
-  button size.
-</Alert>
+> [!TIP]
+> You do not typically need to set the `size` prop for the icon, the LinkButton wraps the
+> rendered Icon in a `IcconDefaultsProvider` to provide an icon size proportional to the
+> button size.
 
 <Storybook.Demo>
   <Button icon={<IconAdd />} priority="primary">

--- a/static/app/components/core/button/linkButton.mdx
+++ b/static/app/components/core/button/linkButton.mdx
@@ -124,11 +124,10 @@ LinkButtons are available in the same sizes as regular buttons.
 
 LinkButtons support an optional leading icon, following the same patterns as regular buttons.
 
-<Alert type="info">
-  You do not typically need to set the `size` prop for the icon, the LinkButton wraps the
-  rendered Icon in a `IcconDefaultsProvider` to provide an icon size proportional to the
-  button size.
-</Alert>
+> [!TIP]
+> You do not typically need to set the `size` prop for the icon, the LinkButton wraps the
+> rendered Icon in a `IcconDefaultsProvider` to provide an icon size proportional to the
+> button size.
 
 <Storybook.Demo>
   <LinkButton icon={<IconOpen />} priority="primary" to="/dashboard">


### PR DESCRIPTION
Fixes a few places in docs that still referenced `type` rather than `variant`, causing these stories to not load properly.

Follow-up to #105504 and #105490.