### PR TITLE
feat(tracemetrics): Add Big Number visualization

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -216,7 +216,7 @@ function getEventsRequest(
       ...eventView.generateQueryStringObject(),
       ...params,
     },
-    // Tries events request up to 3 times on rate limit
+    // Tries events request up to 10 times on rate limit
     {
       retry: hasQueueFeature
         ? // The queue will handle retries, so we don't need to retry here

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -6,8 +6,13 @@ import type {ApiResult, Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import toArray from 'sentry/utils/array/toArray';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
+import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {parseFunction, type QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
+import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
@@ -22,11 +27,13 @@ import {
 import {
   getTableSortOptions,
   getTimeseriesSortOptions,
+  transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {combineBaseFieldsWithTags} from 'sentry/views/dashboards/datasetConfig/utils/combineBaseFieldsWithEapTags';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import {useHasTraceMetricsDashboards} from 'sentry/views/dashboards/hooks/useHasTraceMetricsDashboards';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
+import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
@@ -166,7 +173,10 @@ export function formatTraceMetricsFunction(
   return defaultValue;
 }
 
-export const TraceMetricsConfig: DatasetConfig<EventsTimeSeriesResponse, never> = {
+export const TraceMetricsConfig: DatasetConfig<
+  EventsTimeSeriesResponse,
+  EventsTableData
+> = {
   defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,
@@ -184,9 +194,40 @@ export const TraceMetricsConfig: DatasetConfig<EventsTimeSeriesResponse, never> 
       value: option.value,
     })),
   getGroupByFieldOptions,
-  supportedDisplayTypes: [DisplayType.AREA, DisplayType.BAR, DisplayType.LINE],
+  supportedDisplayTypes: [
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.LINE,
+    DisplayType.BIG_NUMBER,
+  ],
+  getTableRequest: (
+    api: Client,
+    _widget: Widget,
+    query: WidgetQuery,
+    organization: Organization,
+    pageFilters: PageFilters,
+    _onDemandControlContext?: OnDemandControlContext,
+    limit?: number,
+    cursor?: string,
+    referrer?: string,
+    _mepSetting?: MEPState | null,
+    samplingMode?: SamplingMode
+  ) => {
+    return getEventsRequest(
+      api,
+      query,
+      organization,
+      pageFilters,
+      limit,
+      cursor,
+      referrer,
+      undefined,
+      undefined,
+      samplingMode
+    );
+  },
   getSeriesRequest,
-  transformTable: () => ({data: []}),
+  transformTable: transformEventsResponseToTable,
   transformSeries: (data, _widgetQuery) =>
     data.timeSeries.map(timeSeries => {
       const func = parseFunction(timeSeries.yAxis);
@@ -201,6 +242,9 @@ export const TraceMetricsConfig: DatasetConfig<EventsTimeSeriesResponse, never> 
         seriesName: formatTimeSeriesLabel(timeSeries),
       };
     }),
+  getCustomFieldRenderer: (field, meta, _organization) => {
+    return getFieldRenderer(field, meta, false);
+  },
 };
 
 function getPrimaryFieldOptions(
@@ -276,6 +320,56 @@ function getSeriesRequest(
   return doEventsRequest<true>(api, requestData) as unknown as Promise<
     ApiResult<EventsTimeSeriesResponse>
   >;
+}
+
+function getEventsRequest(
+  api: Client,
+  query: WidgetQuery,
+  organization: Organization,
+  pageFilters: PageFilters,
+  limit?: number,
+  cursor?: string,
+  referrer?: string,
+  _mepSetting?: MEPState | null,
+  _queryExtras?: any,
+  samplingMode?: SamplingMode
+) {
+  const url = `/organizations/${organization.slug}/events/`;
+  const eventView = eventViewFromWidget('', query, pageFilters);
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const params: DiscoverQueryRequestParams = {
+    per_page: limit,
+    cursor,
+    referrer,
+    dataset: DiscoverDatasets.TRACEMETRICS,
+  };
+
+  if (query.orderby) {
+    params.sort = toArray(query.orderby);
+  }
+
+  return doDiscoverQuery<EventsTableData>(
+    api,
+    url,
+    {
+      ...eventView.generateQueryStringObject(),
+      ...params,
+      ...(samplingMode ? {sampling: samplingMode} : {}),
+    },
+    // Tries events request up to 10 times on rate limit
+    {
+      retry: hasQueueFeature
+        ? // The queue will handle retries, so we don't need to retry here
+          undefined
+        : {
+            statusCodes: [429],
+            tries: 10,
+          },
+    }
+  );
 }
 
 function filterSeriesSortOptions(columns: Set<string>) {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -7,6 +7,7 @@ import {
   type Widget,
   type WidgetQuery,
 } from 'sentry/views/dashboards/types';
+import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import {
   serializeSorts,
   type WidgetBuilderState,
@@ -25,7 +26,11 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
   const fieldAliases = state.fields?.map(field => field.alias ?? '');
   let aggregates: string[];
 
-  if (state.dataset === WidgetType.TRACEMETRICS) {
+  if (
+    state.dataset === WidgetType.TRACEMETRICS &&
+    (state.displayType !== DisplayType.BIG_NUMBER ||
+      isChartDisplayType(state.displayType))
+  ) {
     // HACK: Inject the trace metric name and type into the aggregate function
     // prior to making the request because the current types for y-axes do not support
     // the correct number of arguments required for trace metrics

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -28,7 +28,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
 
   if (
     state.dataset === WidgetType.TRACEMETRICS &&
-    (state.displayType !== DisplayType.BIG_NUMBER ||
+    (state.displayType === DisplayType.BIG_NUMBER ||
       isChartDisplayType(state.displayType))
   ) {
     // HACK: Inject the trace metric name and type into the aggregate function

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -24,22 +24,22 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
 
   const fieldAliases = state.fields?.map(field => field.alias ?? '');
   let aggregates: string[];
-  if (state.yAxis?.length) {
-    if (state.dataset === WidgetType.TRACEMETRICS) {
-      // HACK: Inject the trace metric name and type into the aggregate function
-      // prior to making the request because the current types for y-axes do not support
-      // the correct number of arguments required for trace metrics
-      aggregates =
-        state.yAxis?.map(axis => {
-          const traceMetric = state.traceMetric ?? {name: '', type: ''};
-          if (axis.kind === 'function') {
-            return generateMetricAggregate(traceMetric, axis);
-          }
-          return axis.field;
-        }) ?? [];
-    } else {
-      aggregates = state.yAxis?.map(generateFieldAsString) ?? [];
-    }
+
+  if (state.dataset === WidgetType.TRACEMETRICS) {
+    // HACK: Inject the trace metric name and type into the aggregate function
+    // prior to making the request because the current types for y-axes do not support
+    // the correct number of arguments required for trace metrics
+    const aggregateSource = state.yAxis?.length ? state.yAxis : state.fields;
+    aggregates =
+      aggregateSource?.map(axis => {
+        const traceMetric = state.traceMetric ?? {name: '', type: ''};
+        if (axis.kind === 'function') {
+          return generateMetricAggregate(traceMetric, axis);
+        }
+        return axis.field;
+      }) ?? [];
+  } else if (state.yAxis?.length) {
+    aggregates = state.yAxis?.map(generateFieldAsString) ?? [];
   } else {
     aggregates =
       state.fields
@@ -51,14 +51,25 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
         .map(generateFieldAsString)
         .filter(Boolean) ?? [];
   }
+
   const columns = state.fields
     ?.filter(field => field.kind === FieldValueKind.FIELD)
     .map(generateFieldAsString)
     .filter(Boolean);
 
   const fields =
-    state.displayType === DisplayType.TABLE || state.displayType === DisplayType.DETAILS
-      ? state.fields?.map(generateFieldAsString)
+    state.displayType === DisplayType.TABLE ||
+    state.displayType === DisplayType.DETAILS ||
+    state.displayType === DisplayType.BIG_NUMBER
+      ? state.dataset === WidgetType.TRACEMETRICS
+        ? state.fields?.map(field => {
+            const traceMetric = state.traceMetric ?? {name: '', type: ''};
+            if (field.kind === 'function') {
+              return generateMetricAggregate(traceMetric, field);
+            }
+            return generateFieldAsString(field);
+          })
+        : state.fields?.map(generateFieldAsString)
       : [...(columns ?? []), ...(aggregates ?? [])];
 
   // If there's no sort, use the first field as the default sort (this doesn't apply to release table widgets)

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -43,7 +43,14 @@ export function convertWidgetToBuilderStateParams(
   if (isChartDisplayType(widget.displayType)) {
     field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'columns') : [];
   } else {
-    field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'fields') : [];
+    // For TRACEMETRICS table/big_number widgets, use raw field strings directly
+    // because stringifyFields loses the 4th argument (unit: "-")
+    if (widget.widgetType === WidgetType.TRACEMETRICS && firstWidgetQuery?.fields) {
+      field = firstWidgetQuery.fields;
+    } else {
+      field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'fields') : [];
+    }
+
     yAxis = [];
     legendAlias = [];
   }

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -3,6 +3,7 @@ import {useCallback, useState} from 'react';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {Confidence} from 'sentry/types/organization';
+import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -21,7 +22,7 @@ import type {
 import GenericWidgetQueries from './genericWidgetQueries';
 
 type SeriesResult = EventsTimeSeriesResponse;
-type TableResult = never;
+type TableResult = EventsTableData;
 
 type TraceMetricsWidgetQueriesProps = {
   api: Client;


### PR DESCRIPTION
Adds the big number visualization type to metrics. This required us to fill out the table request stubs in the dataset config.

I also had to update the UI to hide the "Add Field" and "Add Equation" buttons for datasets that don't support equations. Adding fields for big numbers is only relevant for equations and if you don't support equations you don't need either. Likewise, the "Delete" button needs to be hidden in these cases because you can never add.

I also had to reapply some of the hacks we use to massage all of the trace metric data into the aggregate because now it has to apply for fields if it's not a chart. This might need to be updated to manage aggregates differently for tables but we do not currently support those