### PR TITLE
fix(dashboards): prebuilt domain summary not loading

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -22,7 +22,31 @@ const DOMAIN_WIDGET: Widget = {
   displayType: DisplayType.DETAILS,
   widgetType: WidgetType.SPANS,
   interval: '5m',
-  queries: [],
+  queries: [
+    {
+      name: '',
+      fields: [
+        SpanFields.ID,
+        SpanFields.SPAN_OP,
+        SpanFields.SPAN_GROUP,
+        SpanFields.SPAN_DESCRIPTION,
+        SpanFields.SPAN_CATEGORY,
+      ],
+      aggregates: [],
+      columns: [
+        SpanFields.ID,
+        SpanFields.SPAN_OP,
+        SpanFields.SPAN_GROUP,
+        SpanFields.SPAN_DESCRIPTION,
+        SpanFields.SPAN_CATEGORY,
+      ],
+      fieldAliases: [],
+      conditions: FILTER_STRING,
+      orderby: SpanFields.ID,
+      onDemand: [],
+      linkedDashboards: [],
+    },
+  ],
   layout: {
     x: 0,
     y: 0,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -11,6 +11,7 @@ import {
   THROUGHPUT_TEXT,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/http/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -31,7 +32,7 @@ const DOMAIN_WIDGET: Widget = {
         SpanFields.SPAN_GROUP,
         SpanFields.SPAN_DESCRIPTION,
         SpanFields.SPAN_CATEGORY,
-      ],
+      ] satisfies DefaultDetailWidgetFields[],
       aggregates: [],
       columns: [
         SpanFields.ID,
@@ -39,7 +40,7 @@ const DOMAIN_WIDGET: Widget = {
         SpanFields.SPAN_GROUP,
         SpanFields.SPAN_DESCRIPTION,
         SpanFields.SPAN_CATEGORY,
-      ],
+      ] satisfies DefaultDetailWidgetFields[],
       fieldAliases: [],
       conditions: FILTER_STRING,
       orderby: SpanFields.ID,


### PR DESCRIPTION
Forgot to add a `query` to this widget so it knows which fields to fetch. This also resulted in the dashboard not loading at all and a `TypeError: Cannot read properties of undefined (reading 'columns')` error