### PR TITLE
feat(api) Add a proxy header in the apigateway and access logging

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -22,6 +22,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.silo.util import (
+    PROXY_APIGATEWAY_HEADER,
     PROXY_DIRECT_LOCATION_HEADER,
     clean_outbound_headers,
     clean_proxy_headers,
@@ -191,6 +192,7 @@ def proxy_region_request(
     """Take a django request object and proxy it to a region silo"""
     target_url = urljoin(region.address, request.path)
     header_dict = clean_proxy_headers(request.headers)
+    header_dict[PROXY_APIGATEWAY_HEADER] = "true"
 
     # TODO: use requests session for connection pooling capabilities
     assert request.method is not None

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -12,6 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth.services.auth import AuthenticatedToken
+from sentry.silo.util import PROXY_APIGATEWAY_HEADER
 from sentry.types.ratelimit import RateLimitMeta, SnubaRateLimitMeta
 from sentry.utils import metrics
 
@@ -129,6 +130,7 @@ def _create_api_access_log(
             rate_limited=getattr(request, "will_be_rate_limited", False),
             rate_limit_category=getattr(request, "rate_limit_category", None),
             request_duration_seconds=access_log_metadata.get_request_duration(),
+            gateway_proxy=request.headers.get(PROXY_APIGATEWAY_HEADER, None),
             **_get_rate_limit_stats_dict(request),
         )
         auth = get_authorization_header(request).split()

--- a/src/sentry/silo/util.py
+++ b/src/sentry/silo/util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hmac
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from hashlib import sha256
 from wsgiref.util import is_hop_by_hop
 
@@ -14,6 +14,7 @@ PROXY_SIGNATURE_HEADER = "X-Sentry-Subnet-Signature"
 PROXY_PATH = "X-Sentry-Subnet-Path"
 PROXY_KEYID_HEADER = "X-Sentry-Subnet-Keyid"
 PROXY_DIRECT_LOCATION_HEADER = "X-Sentry-Proxy-URL"
+PROXY_APIGATEWAY_HEADER = "X-Apigateway"
 
 INVALID_PROXY_HEADERS = {"Host", "X-Forwarded-Proto", "Content-Length", "Content-Encoding"}
 INVALID_OUTBOUND_HEADERS = INVALID_PROXY_HEADERS | {
@@ -34,7 +35,7 @@ def trim_leading_slashes(path: str) -> str:
 
 def clean_headers(
     headers: Mapping[str, str] | None, invalid_headers: Iterable[str]
-) -> Mapping[str, str]:
+) -> MutableMapping[str, str]:
     if not headers:
         headers = {}
     normalized_invalid = {h.lower() for h in invalid_headers}
@@ -46,11 +47,11 @@ def clean_headers(
     return modified_headers
 
 
-def clean_proxy_headers(headers: Mapping[str, str] | None) -> Mapping[str, str]:
+def clean_proxy_headers(headers: Mapping[str, str] | None) -> MutableMapping[str, str]:
     return clean_headers(headers, invalid_headers=INVALID_PROXY_HEADERS)
 
 
-def clean_outbound_headers(headers: Mapping[str, str] | None) -> Mapping[str, str]:
+def clean_outbound_headers(headers: Mapping[str, str] | None) -> MutableMapping[str, str]:
     return clean_headers(headers, invalid_headers=INVALID_OUTBOUND_HEADERS)
 
 

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -290,11 +290,11 @@ class TestAccessLogSuccess(LogCaptureAPITestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
         self.login_as(user=self.create_user())
+        upper_gateway_header = PROXY_APIGATEWAY_HEADER.upper().replace("-", "_")
         self.get_success_response(
             extra_headers={
                 "HTTP_AUTHORIZATION": f"Bearer {token.token}",
-                "HTTP_BUTTS": "butts",
-                f"HTTP_{PROXY_APIGATEWAY_HEADER}": "true",
+                f"HTTP_{upper_gateway_header}": "true",
             }
         )
         self.assert_access_log_recorded()


### PR DESCRIPTION
It is currently not simple to understand if a request has gone through the control silo API gateway, or is a direct request to the region scoped webservers. Add a header to proxied requests and logging the presence of that header will provide the necessary context.