### PR TITLE
chore(trace explorer): Use agentic search endpoint

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -249,6 +249,8 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             query={item?.query}
             groupBys={item?.groupBys}
             statsPeriod={item?.statsPeriod}
+            start={item?.start}
+            end={item?.end}
             visualizations={item?.visualizations}
           />
         </Item>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -6,11 +6,59 @@ import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/forma
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
 
+function formatDateRange(start: string, end: string): string {
+  // Treat UTC dates as local dates by removing the 'Z' suffix
+  // This ensures "2025-12-06T00:00:00Z" displays as Dec 6th in the user's timezone
+  const startLocal = start.endsWith('Z') ? start.slice(0, -1) : start;
+  const endLocal = end.endsWith('Z') ? end.slice(0, -1) : end;
+
+  const startDate = new Date(startLocal);
+  const endDate = new Date(endLocal);
+
+  // Check if times are at midnight (date-only range)
+  const startIsMidnight =
+    startDate.getHours() === 0 &&
+    startDate.getMinutes() === 0 &&
+    startDate.getSeconds() === 0;
+  const endIsMidnight =
+    endDate.getHours() === 0 && endDate.getMinutes() === 0 && endDate.getSeconds() === 0;
+  const endIsEndOfDay =
+    endDate.getHours() === 23 &&
+    endDate.getMinutes() === 59 &&
+    endDate.getSeconds() === 59;
+
+  // Use date-only format if both are midnight or end of day
+  const useDateOnly = startIsMidnight && (endIsMidnight || endIsEndOfDay);
+
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  };
+
+  const dateTimeOptions: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  };
+
+  const formatOptions = useDateOnly ? dateOptions : dateTimeOptions;
+
+  const startFormatted = startDate.toLocaleString('en-US', formatOptions);
+  const endFormatted = endDate.toLocaleString('en-US', formatOptions);
+
+  return `${startFormatted} - ${endFormatted}`;
+}
+
 function QueryTokens({
   groupBys,
   query,
   sort,
   statsPeriod,
+  start,
+  end,
   visualizations,
 }: QueryTokensProps) {
   const tokens = [];
@@ -55,7 +103,15 @@ function QueryTokens({
     );
   }
 
-  if (statsPeriod && statsPeriod.length > 0) {
+  // Display absolute date range if start and end are provided
+  if (start && end) {
+    tokens.push(
+      <Token key="timeRange">
+        <ExploreParamTitle>{t('Time Range')}</ExploreParamTitle>
+        <ExploreGroupBys>{formatDateRange(start, end)}</ExploreGroupBys>
+      </Token>
+    );
+  } else if (statsPeriod && statsPeriod.length > 0) {
     tokens.push(
       <Token key="timeRange">
         <ExploreParamTitle>{t('Time Range')}</ExploreParamTitle>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -1,43 +1,11 @@
 import styled from '@emotion/styled';
-import moment from 'moment-timezone';
 
 import type {QueryTokensProps} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {formatDateRange} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
-
-function formatDateRange(start: string, end: string): string {
-  // Parse as UTC but display the UTC values directly (without timezone conversion)
-  // The endpoint returns times in UTC format, but the values represent what the user
-  // intended in their local context. E.g., if user asks for "9pm", endpoint returns
-  // "T21:00:00Z" - we want to display "9:00 PM", not convert to local timezone.
-  const startMoment = moment.utc(start);
-  const endMoment = moment.utc(end);
-
-  // Check if times are at midnight (date-only range)
-  const startIsMidnight =
-    startMoment.hours() === 0 &&
-    startMoment.minutes() === 0 &&
-    startMoment.seconds() === 0;
-  const endIsMidnight =
-    endMoment.hours() === 0 && endMoment.minutes() === 0 && endMoment.seconds() === 0;
-  const endIsEndOfDay =
-    endMoment.hours() === 23 && endMoment.minutes() === 59 && endMoment.seconds() === 59;
-
-  // Use date-only format if both are midnight or end of day
-  const useDateOnly = startIsMidnight && (endIsMidnight || endIsEndOfDay);
-
-  const dateFormat = 'MMM D, YYYY';
-  const dateTimeFormat = 'MMM D, YYYY h:mm A';
-
-  const formatStr = useDateOnly ? dateFormat : dateTimeFormat;
-
-  const startFormatted = startMoment.format(formatStr);
-  const endFormatted = endMoment.format(formatStr);
-
-  return `${startFormatted} - ${endFormatted}`;
-}
 
 function QueryTokens({
   groupBys,
@@ -95,7 +63,7 @@ function QueryTokens({
     tokens.push(
       <Token key="timeRange">
         <ExploreParamTitle>{t('Time Range')}</ExploreParamTitle>
-        <ExploreGroupBys>{formatDateRange(start, end)}</ExploreGroupBys>
+        <ExploreGroupBys>{formatDateRange(start, end, ' - ')}</ExploreGroupBys>
       </Token>
     );
   } else if (statsPeriod && statsPeriod.length > 0) {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -12,9 +12,11 @@ interface AskSeerSearchItem<S extends string> {
 export type AskSeerSearchItems<T> = (AskSeerSearchItem<string> & T) | NoneOfTheseItem;
 
 export interface QueryTokensProps {
+  end?: string | null;
   groupBys?: string[];
   query?: string;
   sort?: string;
+  start?: string | null;
   statsPeriod?: string;
   visualizations?: Array<{chartType: ChartType; yAxes: string[]}>;
 }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -1,3 +1,5 @@
+import moment from 'moment-timezone';
+
 import type {
   AskSeerSearchItems,
   NoneOfTheseItem,
@@ -79,48 +81,40 @@ export function formatQueryToNaturalLanguage(query: string): string {
   return `${formattedQuery} `;
 }
 
-function formatDateRangeForText(start: string, end: string): string {
-  // Treat UTC dates as local dates by removing the 'Z' suffix
-  const startLocal = start.endsWith('Z') ? start.slice(0, -1) : start;
-  const endLocal = end.endsWith('Z') ? end.slice(0, -1) : end;
-
-  const startDate = new Date(startLocal);
-  const endDate = new Date(endLocal);
+/**
+ * Formats a date range for display.
+ *
+ * The endpoint returns times in UTC format, but the values represent what the user
+ * intended in their local context. E.g., if user asks for "9pm", endpoint returns
+ * "T21:00:00Z" - we want to display "9:00 PM", not convert to local timezone.
+ */
+export function formatDateRange(start: string, end: string, separator = ' to '): string {
+  // Parse as UTC but display the UTC values directly (without timezone conversion)
+  const startMoment = moment.utc(start);
+  const endMoment = moment.utc(end);
 
   // Check if times are at midnight (date-only range)
   const startIsMidnight =
-    startDate.getHours() === 0 &&
-    startDate.getMinutes() === 0 &&
-    startDate.getSeconds() === 0;
+    startMoment.hours() === 0 &&
+    startMoment.minutes() === 0 &&
+    startMoment.seconds() === 0;
   const endIsMidnight =
-    endDate.getHours() === 0 && endDate.getMinutes() === 0 && endDate.getSeconds() === 0;
+    endMoment.hours() === 0 && endMoment.minutes() === 0 && endMoment.seconds() === 0;
   const endIsEndOfDay =
-    endDate.getHours() === 23 &&
-    endDate.getMinutes() === 59 &&
-    endDate.getSeconds() === 59;
+    endMoment.hours() === 23 && endMoment.minutes() === 59 && endMoment.seconds() === 59;
 
+  // Use date-only format if both are midnight or end of day
   const useDateOnly = startIsMidnight && (endIsMidnight || endIsEndOfDay);
 
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  };
+  const dateFormat = 'MMM D, YYYY';
+  const dateTimeFormat = 'MMM D, YYYY h:mm A';
 
-  const dateTimeOptions: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  };
+  const formatStr = useDateOnly ? dateFormat : dateTimeFormat;
 
-  const formatOptions = useDateOnly ? dateOptions : dateTimeOptions;
+  const startFormatted = startMoment.format(formatStr);
+  const endFormatted = endMoment.format(formatStr);
 
-  const startFormatted = startDate.toLocaleString('en-US', formatOptions);
-  const endFormatted = endDate.toLocaleString('en-US', formatOptions);
-
-  return `${startFormatted} to ${endFormatted}`;
+  return `${startFormatted}${separator}${endFormatted}`;
 }
 
 export function generateQueryTokensString(args: QueryTokensProps): string {
@@ -149,7 +143,7 @@ export function generateQueryTokensString(args: QueryTokensProps): string {
 
   // Prefer absolute date range over statsPeriod
   if (args?.start && args?.end) {
-    parts.push(`time range is '${formatDateRangeForText(args.start, args.end)}'`);
+    parts.push(`time range is '${formatDateRange(args.start, args.end)}'`);
   } else if (args?.statsPeriod && args.statsPeriod.length > 0) {
     parts.push(`time range is '${args?.statsPeriod}'`);
   }

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -80,11 +80,9 @@ export function SpansTabSeerComboBox() {
     enableAISearch,
   } = useSearchQueryBuilder();
 
-  // Check if the new translation endpoint should be used (internal testing)
-  // const useTranslateEndpoint = organization.features.includes(
-  //   'gen-ai-explore-traces-translate'
-  // );
-  const useTranslateEndpoint = true; // TODO: Testing
+  const useTranslateEndpoint = organization.features.includes(
+    'gen-ai-explore-traces-translate'
+  );
 
   let initialSeerQuery = '';
   const queryDetails = useMemo(() => {
@@ -125,7 +123,6 @@ export function SpansTabSeerComboBox() {
           ? pageFilters.selection.projects
           : projects.filter(p => p.isMember).map(p => p.id);
 
-      // Use new translation endpoint if feature flag is enabled
       if (useTranslateEndpoint) {
         const data = await fetchMutation<TraceAskSeerTranslateResponse>({
           url: `/organizations/${organization.slug}/search-agent/translate/`,
@@ -136,7 +133,6 @@ export function SpansTabSeerComboBox() {
           },
         });
 
-        // Convert responses array to the expected format
         return {
           status: 'ok',
           unsupported_reason: data.responses[0]?.unsupported_reason ?? null,
@@ -157,7 +153,6 @@ export function SpansTabSeerComboBox() {
         };
       }
 
-      // Use the original endpoint
       const data = await fetchMutation<TraceAskSeerSearchResponse>({
         url: `/organizations/${organization.slug}/trace-explorer-ai/query/`,
         method: 'POST',
@@ -202,23 +197,18 @@ export function SpansTabSeerComboBox() {
         end: resultEnd,
       } = result;
 
-      // Use start/end from result if provided, otherwise fall back to page filters
       let start: DateString = null;
       let end: DateString = null;
 
       if (resultStart && resultEnd) {
-        // Treat UTC dates as local dates by removing the 'Z' suffix
-        // This ensures "2025-12-06T00:00:00Z" is interpreted as Dec 6th midnight local time
+        // Strip 'Z' suffix to treat UTC dates as local time
         const startLocal = resultStart.endsWith('Z')
           ? resultStart.slice(0, -1)
           : resultStart;
         const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-
-        // Convert to ISO string format expected by the page filters
         start = new Date(startLocal).toISOString();
         end = new Date(endLocal).toISOString();
       } else {
-        // Fall back to page filters directly - DateString type is compatible
         start = pageFilters.selection.datetime.start;
         end = pageFilters.selection.datetime.end;
       }
@@ -229,7 +219,6 @@ export function SpansTabSeerComboBox() {
           start,
           end,
           utc: pageFilters.selection.datetime.utc,
-          // Only use statsPeriod if we don't have explicit start/end from result
           period:
             resultStart && resultEnd
               ? null
@@ -284,7 +273,6 @@ export function SpansTabSeerComboBox() {
     !organization?.hideAiFeatures &&
     organization.features.includes('gen-ai-features');
 
-  // Skip setup call when using the translation endpoint (it doesn't require setup)
   useTraceExploreAiQuerySetup({
     enableAISearch: areAiFeaturesAllowed && !useTranslateEndpoint,
   });

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -5,6 +5,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {Token} from 'sentry/components/searchSyntax/parser';
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+import type {DateString} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFieldDefinition} from 'sentry/utils/fields';
 import {fetchMutation, mutationOptions} from 'sentry/utils/queryClient';
@@ -202,8 +203,8 @@ export function SpansTabSeerComboBox() {
       } = result;
 
       // Use start/end from result if provided, otherwise fall back to page filters
-      let start: string | null | undefined;
-      let end: string | null | undefined;
+      let start: DateString = null;
+      let end: DateString = null;
 
       if (resultStart && resultEnd) {
         // Treat UTC dates as local dates by removing the 'Z' suffix
@@ -217,16 +218,9 @@ export function SpansTabSeerComboBox() {
         start = new Date(startLocal).toISOString();
         end = new Date(endLocal).toISOString();
       } else {
-        // Fall back to page filters
-        const startFilter = pageFilters.selection.datetime.start?.valueOf();
-        start = startFilter
-          ? new Date(startFilter).toISOString()
-          : pageFilters.selection.datetime.start;
-
-        const endFilter = pageFilters.selection.datetime.end?.valueOf();
-        end = endFilter
-          ? new Date(endFilter).toISOString()
-          : pageFilters.selection.datetime.end;
+        // Fall back to page filters directly - DateString type is compatible
+        start = pageFilters.selection.datetime.start;
+        end = pageFilters.selection.datetime.end;
       }
 
       const selection = {

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -81,7 +81,7 @@ export function SpansTabSeerComboBox() {
   } = useSearchQueryBuilder();
 
   const useTranslateEndpoint = organization.features.includes(
-    'gen-ai-explore-traces-translate'
+    'gen-ai-search-agent-translate'
   );
 
   let initialSeerQuery = '';

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -23,10 +23,12 @@ interface Visualization {
 }
 
 interface AskSeerSearchQuery {
+  end: string | null;
   groupBys: string[];
   mode: string;
   query: string;
   sort: string;
+  start: string | null;
   statsPeriod: string;
   visualizations: Visualization[];
 }
@@ -48,8 +50,20 @@ interface TraceAskSeerSearchResponse {
 }
 
 interface TraceAskSeerTranslateResponse {
-  query: string;
-  status: string;
+  responses: Array<{
+    end: string | null;
+    group_by: string[];
+    mode: string;
+    query: string;
+    sort: string;
+    start: string | null;
+    stats_period: string;
+    unsupported_reason: string | null;
+    visualization: Array<{
+      chart_type: number;
+      y_axes: string[];
+    }>;
+  }>;
 }
 
 export function SpansTabSeerComboBox() {
@@ -66,9 +80,10 @@ export function SpansTabSeerComboBox() {
   } = useSearchQueryBuilder();
 
   // Check if the new translation endpoint should be used (internal testing)
-  const useTranslateEndpoint = organization.features.includes(
-    'gen-ai-explore-traces-translate'
-  );
+  // const useTranslateEndpoint = organization.features.includes(
+  //   'gen-ai-explore-traces-translate'
+  // );
+  const useTranslateEndpoint = true; // TODO: Testing
 
   let initialSeerQuery = '';
   const queryDetails = useMemo(() => {
@@ -120,20 +135,24 @@ export function SpansTabSeerComboBox() {
           },
         });
 
-        // Convert single query response to the expected format
+        // Convert responses array to the expected format
         return {
-          status: data.status,
-          unsupported_reason: null,
-          queries: [
-            {
-              visualizations: [],
-              query: data.query,
-              sort: '',
-              groupBys: [],
-              statsPeriod: '',
-              mode: 'spans',
-            },
-          ],
+          status: 'ok',
+          unsupported_reason: data.responses[0]?.unsupported_reason ?? null,
+          queries: data.responses.map(r => ({
+            visualizations:
+              r?.visualization?.map(v => ({
+                chartType: v?.chart_type,
+                yAxes: v?.y_axes,
+              })) ?? [],
+            query: r?.query ?? '',
+            sort: r?.sort ?? '',
+            groupBys: r?.group_by ?? [],
+            statsPeriod: r?.stats_period ?? '',
+            start: r?.start ?? null,
+            end: r?.end ?? null,
+            mode: r?.mode ?? 'spans',
+          })),
         };
       }
 
@@ -161,6 +180,8 @@ export function SpansTabSeerComboBox() {
           sort: q?.sort ?? '',
           groupBys: q?.group_by ?? [],
           statsPeriod: q?.stats_period ?? '',
+          start: null,
+          end: null,
           mode: q?.mode ?? 'spans',
         })),
       };
@@ -170,17 +191,43 @@ export function SpansTabSeerComboBox() {
   const applySeerSearchQuery = useCallback(
     (result: AskSeerSearchQuery) => {
       if (!result) return;
-      const {query: queryToUse, visualizations, groupBys, sort, statsPeriod} = result;
+      const {
+        query: queryToUse,
+        visualizations,
+        groupBys,
+        sort,
+        statsPeriod,
+        start: resultStart,
+        end: resultEnd,
+      } = result;
 
-      const startFilter = pageFilters.selection.datetime.start?.valueOf();
-      const start = startFilter
-        ? new Date(startFilter).toISOString()
-        : pageFilters.selection.datetime.start;
+      // Use start/end from result if provided, otherwise fall back to page filters
+      let start: string | null | undefined;
+      let end: string | null | undefined;
 
-      const endFilter = pageFilters.selection.datetime.end?.valueOf();
-      const end = endFilter
-        ? new Date(endFilter).toISOString()
-        : pageFilters.selection.datetime.end;
+      if (resultStart && resultEnd) {
+        // Treat UTC dates as local dates by removing the 'Z' suffix
+        // This ensures "2025-12-06T00:00:00Z" is interpreted as Dec 6th midnight local time
+        const startLocal = resultStart.endsWith('Z')
+          ? resultStart.slice(0, -1)
+          : resultStart;
+        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
+
+        // Convert to ISO string format expected by the page filters
+        start = new Date(startLocal).toISOString();
+        end = new Date(endLocal).toISOString();
+      } else {
+        // Fall back to page filters
+        const startFilter = pageFilters.selection.datetime.start?.valueOf();
+        start = startFilter
+          ? new Date(startFilter).toISOString()
+          : pageFilters.selection.datetime.start;
+
+        const endFilter = pageFilters.selection.datetime.end?.valueOf();
+        end = endFilter
+          ? new Date(endFilter).toISOString()
+          : pageFilters.selection.datetime.end;
+      }
 
       const selection = {
         ...pageFilters.selection,
@@ -188,7 +235,11 @@ export function SpansTabSeerComboBox() {
           start,
           end,
           utc: pageFilters.selection.datetime.utc,
-          period: statsPeriod || pageFilters.selection.datetime.period,
+          // Only use statsPeriod if we don't have explicit start/end from result
+          period:
+            resultStart && resultEnd
+              ? null
+              : statsPeriod || pageFilters.selection.datetime.period,
         },
       };
 

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -59,12 +59,12 @@ interface TraceAskSeerTranslateResponse {
     sort: string;
     start: string | null;
     stats_period: string;
-    unsupported_reason: string | null;
     visualization: Array<{
       chart_type: number;
       y_axes: string[];
     }>;
   }>;
+  unsupported_reason: string | null;
 }
 
 export function SpansTabSeerComboBox() {
@@ -83,7 +83,6 @@ export function SpansTabSeerComboBox() {
   const useTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
-
   let initialSeerQuery = '';
   const queryDetails = useMemo(() => {
     const queryToUse = committedQuery.length > 0 ? committedQuery : query;
@@ -135,7 +134,7 @@ export function SpansTabSeerComboBox() {
 
         return {
           status: 'ok',
-          unsupported_reason: data.responses[0]?.unsupported_reason ?? null,
+          unsupported_reason: data.unsupported_reason,
           queries: data.responses.map(r => ({
             visualizations:
               r?.visualization?.map(v => ({


### PR DESCRIPTION
- Use agentic search endpoint for translation for internal use instead of the one shot workflow
- Update to support start/end
	- Don't show time if beginning to end of day
<img width="2483" height="709" alt="Screenshot 2026-01-02 at 12 52 02 PM" src="https://github.com/user-attachments/assets/413c6e0f-9149-4f00-94eb-965cef38e554" />
<img width="1892" height="577" alt="Screenshot 2026-01-02 at 12 52 06 PM" src="https://github.com/user-attachments/assets/ec6408d2-68dc-45d0-b710-7b4b97071eb9" />
<img width="1848" height="531" alt="Screenshot 2026-01-02 at 12 52 13 PM" src="https://github.com/user-attachments/assets/6413fec0-8c3d-412d-b9ee-fbbe5471547f" />
<img width="1746" height="256" alt="Screenshot 2026-01-02 at 12 52 39 PM" src="https://github.com/user-attachments/assets/e4c6e080-52c0-4997-936f-49e2162d4adf" />
<img width="1251" height="547" alt="Screenshot 2026-01-02 at 12 52 45 PM" src="https://github.com/user-attachments/assets/d75c2945-48a2-477f-82ee-fc0040981890" />
