### PR TITLE
fix(user-feedback): Remove link to trace when it wasn't sampled

### DIFF
--- a/static/app/components/events/contexts/knownContext/trace.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/trace.spec.tsx
@@ -163,4 +163,21 @@ describe('TraceContext', () => {
     expect(screen.getByText('Origin')).toBeInTheDocument();
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
   });
+
+  it('returns trace_id with tooltip when trace is not sampled', () => {
+    const result = getTraceContextData({
+      data: {trace_id: TRACE_ID, sampled: false},
+      event: EventFixture(),
+      organization,
+      location,
+    });
+
+    const traceItem = result.find(item => item.key === 'trace_id');
+    expect(traceItem).toMatchObject({
+      key: 'trace_id',
+      subject: 'Trace ID',
+    });
+    // When not sampled, value is a React element (Tooltip) not a string
+    expect(traceItem?.action).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR removes the link from the Trace ID when trace wasn't sampled so it doesn't exist.

Ticket: REPLAY-857