### PR TITLE
feat(explorer): Create new conduit channel for explorer to use streaming

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -194,6 +194,8 @@ class SeerExplorerClient:
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
         metadata: dict[str, Any] | None = None,
+        conduit_channel_id: str | None = None,
+        conduit_url: str | None = None,
     ) -> int:
         """
         Start a new Seer Explorer session.
@@ -204,6 +206,8 @@ class SeerExplorerClient:
             artifact_key: Optional key to identify this artifact (required if artifact_schema is provided)
             artifact_schema: Optional Pydantic model to generate a structured artifact
             metadata: Optional metadata to store with the run (e.g., stopping_point, group_id)
+            conduit_channel_id: Optional Conduit channel ID for streaming
+            conduit_url: Optional Conduit URL for streaming
 
         Returns:
             int: The run ID that can be used to fetch results or continue the conversation
@@ -251,6 +255,11 @@ class SeerExplorerClient:
         if metadata:
             payload["metadata"] = metadata
 
+        # Add conduit params for streaming if provided
+        if conduit_channel_id and conduit_url:
+            payload["conduit_channel_id"] = conduit_channel_id
+            payload["conduit_url"] = conduit_url
+
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
         response = requests.post(
@@ -274,6 +283,8 @@ class SeerExplorerClient:
         on_page_context: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
+        conduit_channel_id: str | None = None,
+        conduit_url: str | None = None,
     ) -> int:
         """
         Continue an existing Seer Explorer session. This allows you to add follow-up queries to an ongoing conversation.
@@ -285,6 +296,8 @@ class SeerExplorerClient:
             on_page_context: Optional context from the user's screen
             artifact_key: Optional key for a new artifact to generate in this step
             artifact_schema: Optional Pydantic model for the new artifact (required if artifact_key is provided)
+            conduit_channel_id: Optional Conduit channel ID for streaming
+            conduit_url: Optional Conduit URL for streaming
 
         Returns:
             int: The run ID (same as input)
@@ -312,6 +325,11 @@ class SeerExplorerClient:
         if artifact_key and artifact_schema:
             payload["artifact_key"] = artifact_key
             payload["artifact_schema"] = artifact_schema.schema()
+
+        # Add conduit params for streaming if provided
+        if conduit_channel_id and conduit_url:
+            payload["conduit_channel_id"] = conduit_channel_id
+            payload["conduit_url"] = conduit_url
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -1,11 +1,23 @@
+import base64
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
+
+from django.test.utils import override_settings
 
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import collect_user_org_context
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from tests.sentry.utils.test_jwt import RS256_KEY
+
+RS256_KEY_B64 = base64.b64encode(RS256_KEY.encode()).decode()
+CONDUIT_SETTINGS = {
+    "CONDUIT_GATEWAY_PRIVATE_KEY": RS256_KEY_B64,
+    "CONDUIT_GATEWAY_JWT_ISSUER": "sentry",
+    "CONDUIT_GATEWAY_JWT_AUDIENCE": "conduit",
+    "CONDUIT_GATEWAY_URL": "https://conduit.example.com",
+}
 
 
 @with_feature("organizations:seer-explorer")
@@ -57,6 +69,36 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 400
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
+    def test_post_without_streaming_flag_no_conduit(self, mock_client_class: MagicMock):
+        mock_client_class.return_value.start_run.return_value = 123
+
+        response = self.client.post(self.url, {"query": "test"}, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {"run_id": 123}
+        assert "conduit" not in response.data
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature("organizations:seer-explorer-streaming")
+    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
+    def test_post_with_streaming_flag_includes_conduit(self, mock_client_class: MagicMock):
+        mock_client_class.return_value.start_run.return_value = 123
+
+        response = self.client.post(self.url, {"query": "test"}, format="json")
+
+        assert response.status_code == 200
+        assert response.data["run_id"] == 123
+        assert "conduit" in response.data
+        assert "token" in response.data["conduit"]
+        assert "channel_id" in response.data["conduit"]
+        assert "url" in response.data["conduit"]
+        # Verify conduit params passed to client
+        mock_client_class.return_value.start_run.assert_called_once()
+        call_kwargs = mock_client_class.return_value.start_run.call_args.kwargs
+        assert call_kwargs["conduit_channel_id"] is not None
+        assert call_kwargs["conduit_url"] is not None
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
     def test_post_new_conversation_calls_client(self, mock_client_class: MagicMock):
         mock_client = MagicMock()
         mock_client.start_run.return_value = 456
@@ -73,7 +115,10 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             self.organization, ANY, is_interactive=True, enable_coding=True
         )
         mock_client.start_run.assert_called_once_with(
-            prompt="What is this error about?", on_page_context=None
+            prompt="What is this error about?",
+            on_page_context=None,
+            conduit_channel_id=None,
+            conduit_url=None,
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -96,7 +141,12 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             self.organization, ANY, is_interactive=True, enable_coding=True
         )
         mock_client.continue_run.assert_called_once_with(
-            run_id=789, prompt="Follow up question", insert_index=2, on_page_context=None
+            run_id=789,
+            prompt="Follow up question",
+            insert_index=2,
+            on_page_context=None,
+            conduit_channel_id=None,
+            conduit_url=None,
         )
 
 


### PR DESCRIPTION
## PR Details
+ This PR create a new conduit channel whenever a new explorer chat is started.
+ The conduit channel details are passed to the frontend and Seer but currently neither will do anything with them and the channel will expire after 5 minute TTL
+ This would be phase 1 of the rollout plan - https://www.notion.so/sentry/Streaming-Rollout-for-Seer-Explorer-2da8b10e4b5d80f59f30da1ec6e8ad6e