### PR TITLE
fix(sdk-integration-detector): Improve logs

### DIFF
--- a/src/sentry/autopilot/tasks.py
+++ b/src/sentry/autopilot/tasks.py
@@ -221,8 +221,12 @@ def run_missing_sdk_integration_detector_for_project(
 
     # Get docs URL from platform data
     platform_data = INTEGRATION_ID_TO_PLATFORM_DATA.get(project.platform or "", {})
-    docs_url = platform_data.get("link", "https://docs.sentry.io/platforms/")
-    integration_docs_url = f"{docs_url}configuration/integrations/"
+    docs_url = platform_data.get("link", None)
+    integration_docs_url = (
+        f"{docs_url}configuration/integrations/"
+        if docs_url
+        else "https://docs.sentry.io/platforms/"
+    )
 
     prompt = f"""Analyze the connected code repository for project "{project.slug}" to identify missing Sentry SDK integrations.
 


### PR DESCRIPTION
Remove verbose logging of `platform_data_lookup`.
Add project identifying info to `missing_sdk_integration_detector.integrations_found`.
Point docs url to the platforms integration page.