### PR TITLE
Modified Scraps Graphics Token Values

### DIFF
--- a/static/app/utils/theme/compat.tsx
+++ b/static/app/utils/theme/compat.tsx
@@ -93,7 +93,7 @@ export interface LegacyTokens {
      */
     danger: string;
     /**
-     * @deprecated Use `graphics.neutral.moderate` instead
+     * @deprecated Use `graphics.neutral.vibrant` for the same color, or access `.muted`, `.moderate`, or `.vibrant` variants
      */
     muted: string;
     /**

--- a/static/app/utils/theme/compat.tsx
+++ b/static/app/utils/theme/compat.tsx
@@ -135,8 +135,8 @@ export function withLegacyTokens<T extends Record<string, any>>(
   } satisfies LegacyTokens['content'];
   const graphics = {
     ...tokens.graphics,
-    muted: tokens.graphics.neutral.moderate,
     // Apply compatability Proxy to deprecated tokens
+    muted: createBackwardsCompatibleToken(tokens.graphics.neutral),
     accent: createBackwardsCompatibleToken(tokens.graphics.accent),
     promotion: createBackwardsCompatibleToken(tokens.graphics.promotion),
     danger: createBackwardsCompatibleToken(tokens.graphics.danger),

--- a/static/app/utils/theme/scraps/theme/dark.tsx
+++ b/static/app/utils/theme/scraps/theme/dark.tsx
@@ -1048,12 +1048,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0ZGMDAxNSIvPgogIDwvc3ZnPg==)
      *
-     * `danger.vibrant` `#F55C58`
+     * `danger.vibrant` `#FE726E`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.red.dark.opaque1000,
+    vibrant: color.red.dark.opaque1100,
   },
   warning: {
     /**

--- a/static/app/utils/theme/scraps/theme/dark.tsx
+++ b/static/app/utils/theme/scraps/theme/dark.tsx
@@ -951,12 +951,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0I2QjBCRSIvPgogIDwvc3ZnPg==)
      *
-     * `neutral.vibrant` `#B6B0BE`
+     * `neutral.vibrant` `#A49EAF`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.neutral.dark.opaque1200,
+    vibrant: color.neutral.dark.opaque1100,
   },
   accent: {
     /**
@@ -983,12 +983,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iIzdCNTJGRiIvPgogIDwvc3ZnPg==)
      *
-     * `accent.vibrant` `#7B52FF`
+     * `accent.vibrant` `#9A94F9`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.blue.dark.opaque900,
+    vibrant: color.blue.dark.opaque1100,
   },
   promotion: {
     /**
@@ -1016,12 +1016,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0ZGMjZBQiIvPgogIDwvc3ZnPg==)
      *
-     * `promotion.vibrant` `#FF26AB`
+     * `promotion.vibrant` `#ED77AA`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.pink.dark.opaque1000,
+    vibrant: color.pink.dark.opaque1100,
   },
   danger: {
     /**
@@ -1048,12 +1048,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0ZGMDAxNSIvPgogIDwvc3ZnPg==)
      *
-     * `danger.vibrant` `#FF0015`
+     * `danger.vibrant` `#F55C58`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.red.dark.opaque900,
+    vibrant: color.red.dark.opaque1000,
   },
   warning: {
     /**
@@ -1112,12 +1112,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iIzAwRjc0NiIvPgogIDwvc3ZnPg==)
      *
-     * `success.vibrant` `#00F746`
+     * `success.vibrant` `#00D267`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.green.dark.opaque1100,
+    vibrant: color.green.dark.opaque1200,
   },
 };
 

--- a/static/app/utils/theme/scraps/theme/light.tsx
+++ b/static/app/utils/theme/scraps/theme/light.tsx
@@ -951,12 +951,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0E0OUVBQyIvPgogIDwvc3ZnPg==)
      *
-     * `neutral.vibrant` `#A49EAC`
+     * `neutral.vibrant` `#787583`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.neutral.light.opaque800,
+    vibrant: color.neutral.light.opaque1000,
   },
   accent: {
     /**
@@ -1016,12 +1016,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0ZGNjRDMCIvPgogIDwvc3ZnPg==)
      *
-     * `promotion.vibrant` `#FF64C0`
+     * `promotion.vibrant` `#ED008F`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.pink.light.opaque700,
+    vibrant: color.pink.light.opaque1000,
   },
   danger: {
     /**
@@ -1080,12 +1080,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iI0ZGQ0MwMCIvPgogIDwvc3ZnPg==)
      *
-     * `warning.vibrant` `#FFCC00`
+     * `warning.vibrant` `#E19300`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.yellow.light.opaque600,
+    vibrant: color.yellow.light.opaque800,
   },
   success: {
     /**
@@ -1112,12 +1112,12 @@ const graphics = {
      *
      * ![color visualization](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTQiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCAyOTQgODAiPgogICAgPHJlY3Qgd2lkdGg9IjI5NCIgaGVpZ2h0PSI4MCIgZmlsbD0iIzAwRjc0NiIvPgogIDwvc3ZnPg==)
      *
-     * `success.vibrant` `#00F746`
+     * `success.vibrant` `#009C00`
      *
      * Used situationally, but its primary purpose is to emphasize shapes in
      * data visualisations. This is the most intense token of its family.
      */
-    vibrant: color.green.light.opaque800,
+    vibrant: color.green.light.opaque1000,
   },
 };
 


### PR DESCRIPTION
- **Modified: Scraps token values for `vibrant` graphics group**
- **Modified: Const `content` to include `createBackwardsComaptibleToken` for `muted`**

## Screenshots
### Before Light
<img width="2880" height="1801" alt="CleanShot 2026-01-02 at 15 16 51@2x" src="https://github.com/user-attachments/assets/af4487cc-8a76-4ba7-a2b9-d91105ed3175" />

### Before Dark
<img width="2880" height="1801" alt="CleanShot 2026-01-02 at 15 17 24@2x" src="https://github.com/user-attachments/assets/5bc43e51-1385-479c-a814-d1aed2816a1e" />

### After Light
<img width="2880" height="1801" alt="CleanShot 2026-01-02 at 15 17 40@2x" src="https://github.com/user-attachments/assets/b7819254-1b02-47ba-8573-e60f7a7a3e67" />

### After Dark
<img width="2880" height="1801" alt="CleanShot 2026-01-02 at 15 18 02@2x" src="https://github.com/user-attachments/assets/014296ef-1d53-4d6a-9b99-c0dba3a5fd4c" />
