### PR TITLE
Add functional org filter to GroupEventJsonView

### DIFF
--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -15,7 +15,7 @@ class GroupEventJsonView(OrganizationView):
         try:
             # TODO(tkaemming): This should *actually* redirect, see similar
             # comment in ``GroupEndpoint.convert_args``.
-            group, _ = get_group_with_redirect(group_id)
+            group, _ = get_group_with_redirect(group_id, organization=organization)
         except Group.DoesNotExist:
             raise Http404
 

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -21,3 +21,45 @@ class GroupEventJsonTest(TestCase):
         assert resp["Content-Type"] == "application/json"
         data = json.loads(resp.content.decode("utf-8"))
         assert data["event_id"] == self.event.event_id
+
+    def test_cross_organization_access_denied(self) -> None:
+        """Ensures users cannot access event data from other organizations."""
+        victim_org = self.create_organization(name="victim-org")
+        victim_project = self.create_project(organization=victim_org)
+        min_ago = before_now(minutes=1).isoformat()
+        victim_event = self.store_event(
+            data={"fingerprint": ["victim-group"], "timestamp": min_ago},
+            project_id=victim_project.id,
+        )
+
+        attacker_org = self.create_organization(name="attacker-org")
+        attacker_user = self.create_user()
+        self.create_member(user=attacker_user, organization=attacker_org, role="member")
+
+        self.login_as(attacker_user)
+        path = f"/organizations/{attacker_org.slug}/issues/{victim_event.group_id}/events/{victim_event.event_id}/json/"
+        resp = self.client.get(path)
+
+        assert resp.status_code == 404
+
+    def test_cross_organization_access_denied_latest_event(self) -> None:
+        """Ensures cross-org access is denied for 'latest' event specifier."""
+        victim_org = self.create_organization(name="victim-org")
+        victim_project = self.create_project(organization=victim_org)
+        min_ago = before_now(minutes=1).isoformat()
+        victim_event = self.store_event(
+            data={"fingerprint": ["victim-group"], "timestamp": min_ago},
+            project_id=victim_project.id,
+        )
+
+        attacker_org = self.create_organization(name="attacker-org")
+        attacker_user = self.create_user()
+        self.create_member(user=attacker_user, organization=attacker_org, role="member")
+
+        self.login_as(attacker_user)
+        path = (
+            f"/organizations/{attacker_org.slug}/issues/{victim_event.group_id}/events/latest/json/"
+        )
+        resp = self.client.get(path)
+
+        assert resp.status_code == 404


### PR DESCRIPTION
GroupEventJsonView wasn't passing organization to its get_group_with_redirect call so organization-level permission checks weren't being applied correctly
