### PR TITLE
feat(search-bar): Add/Update type hints

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -122,7 +122,7 @@ export function createItem(
     showDetailsInOverlay: true,
     details: () => <KeyDescription tag={tag} />,
     type: 'item',
-    trailingItems: (
+    trailingItems: () => (
       <TypeBadge
         kind={(fieldDefinition?.kind || tag?.kind) ?? undefined}
         valueType={fieldDefinition?.valueType ?? undefined}
@@ -143,7 +143,7 @@ export function createRawSearchItem(value: string): RawSearchItem {
     showDetailsInOverlay: true,
     details: null,
     type: 'raw-search',
-    trailingItems: <SearchItemLabel>{t('Raw Search')}</SearchItemLabel>,
+    trailingItems: () => <SearchItemLabel>{t('Raw Search')}</SearchItemLabel>,
   };
 }
 
@@ -292,7 +292,7 @@ export function createLogicFilterItem({
     textValue: value,
     hideCheck: true,
     showDetailsInOverlay: true,
-    trailingItems: <TypeBadge isLogicFilter />,
+    trailingItems: () => <TypeBadge isLogicFilter />,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -34,6 +34,7 @@ import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {FieldKind, prettifyTagKey, type FieldDefinition} from 'sentry/utils/fields';
 import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
 export const ALL_CATEGORY_VALUE = '__all';
 export const RECENT_SEARCH_CATEGORY_VALUE = '__recent_searches';
@@ -121,6 +122,12 @@ export function createItem(
     showDetailsInOverlay: true,
     details: () => <KeyDescription tag={tag} />,
     type: 'item',
+    trailingItems: (
+      <TypeBadge
+        kind={fieldDefinition?.kind ?? undefined}
+        valueType={fieldDefinition?.valueType ?? undefined}
+      />
+    ),
   };
 }
 
@@ -285,6 +292,7 @@ export function createLogicFilterItem({
     textValue: value,
     hideCheck: true,
     showDetailsInOverlay: true,
+    trailingItems: <TypeBadge isLogicFilter />,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -124,7 +124,7 @@ export function createItem(
     type: 'item',
     trailingItems: (
       <TypeBadge
-        kind={fieldDefinition?.kind ?? undefined}
+        kind={(fieldDefinition?.kind || tag?.kind) ?? undefined}
         valueType={fieldDefinition?.valueType ?? undefined}
       />
     ),

--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
-import {Tag as Badge} from 'sentry/components/core/badge/tag';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
@@ -14,12 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Tag} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {
-  FieldKind,
-  FieldValueType,
-  getFieldDefinition,
-  prettifyTagKey,
-} from 'sentry/utils/fields';
+import {FieldKind, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {SchemaHintsPageParams} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
@@ -28,6 +22,7 @@ import {
   formatHintName,
   parseTagKey,
 } from 'sentry/views/explore/components/schemaHints/schemaHintsList';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
 type SchemaHintsDrawerProps = SchemaHintsPageParams & {
   hints: Tag[];
@@ -153,15 +148,6 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
   function HintItem({hint, index}: {hint: Tag; index: number}) {
     const hintFieldDefinition = getFieldDefinition(hint.key, 'span', hint.kind);
 
-    const hintType =
-      hintFieldDefinition?.valueType === FieldValueType.BOOLEAN ? (
-        <Badge variant="muted">{t('boolean')}</Badge>
-      ) : hint.kind === FieldKind.MEASUREMENT || hint.kind === FieldKind.FUNCTION ? (
-        <Badge variant="success">{t('number')}</Badge>
-      ) : (
-        <Badge variant="info">{t('string')}</Badge>
-      );
-
     return (
       <div ref={virtualizer.measureElement} data-index={index}>
         <StyledMultipleCheckboxItem
@@ -173,7 +159,10 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
             <Tooltip title={formatHintName(hint)} showOnlyOnOverflow skipWrapper>
               <CheckboxLabel>{formatHintName(hint)}</CheckboxLabel>
             </Tooltip>
-            {hintType}
+            <TypeBadge
+              kind={hint.kind}
+              valueType={hintFieldDefinition?.valueType ?? undefined}
+            />
           </CheckboxLabelContainer>
         </StyledMultipleCheckboxItem>
       </div>

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -1,4 +1,5 @@
-import {Tag} from 'sentry/components/core/badge/tag';
+import {Text} from '@sentry/scraps/text';
+
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
@@ -13,59 +14,59 @@ interface TypeBadgeProps {
 
 export function TypeBadge({func, kind, valueType, isLogicFilter}: TypeBadgeProps) {
   if (defined(func) || kind === FieldKind.FUNCTION) {
-    return <Tag variant="success">{t('f(x)')}</Tag>;
+    return <Text variant="success">{t('f(x)')}</Text>;
   }
 
   if (valueType === FieldValueType.BOOLEAN) {
-    return <Tag variant="muted">{t('boolean')}</Tag>;
+    return <Text variant="promotion">{t('boolean')}</Text>;
   }
 
   if (valueType === FieldValueType.DATE) {
-    return <Tag variant="warning">{t('date')}</Tag>;
+    return <Text variant="danger">{t('date')}</Text>;
   }
 
   if (valueType === FieldValueType.DURATION) {
-    return <Tag variant="danger">{t('duration')}</Tag>;
+    return <Text variant="danger">{t('duration')}</Text>;
   }
 
   if (valueType === FieldValueType.INTEGER) {
-    return <Tag variant="info">{t('integer')}</Tag>;
+    return <Text variant="accent">{t('integer')}</Text>;
   }
 
   if (valueType === FieldValueType.PERCENTAGE) {
-    return <Tag variant="promotion">{t('percentage')}</Tag>;
+    return <Text variant="promotion">{t('percentage')}</Text>;
   }
 
   if (valueType === FieldValueType.SIZE) {
-    return <Tag variant="muted">{t('size')}</Tag>;
+    return <Text variant="success">{t('size')}</Text>;
   }
 
   if (valueType === FieldValueType.RATE) {
-    return <Tag variant="warning">{t('rate')}</Tag>;
+    return <Text variant="warning">{t('rate')}</Text>;
   }
 
   if (valueType === FieldValueType.PERCENT_CHANGE) {
-    return <Tag variant="danger">{t('percent change')}</Tag>;
+    return <Text variant="danger">{t('percent change')}</Text>;
   }
 
   if (valueType === FieldValueType.SCORE) {
-    return <Tag variant="info">{t('score')}</Tag>;
+    return <Text variant="accent">{t('score')}</Text>;
   }
 
   if (valueType === FieldValueType.CURRENCY) {
-    return <Tag variant="success">{t('currency')}</Tag>;
+    return <Text variant="success">{t('currency')}</Text>;
   }
 
   if (valueType === FieldValueType.NUMBER || kind === FieldKind.MEASUREMENT) {
-    return <Tag variant="info">{t('number')}</Tag>;
+    return <Text variant="warning">{t('number')}</Text>;
   }
 
   if (valueType === FieldValueType.STRING || kind === FieldKind.TAG) {
-    return <Tag variant="warning">{t('string')}</Tag>;
+    return <Text variant="accent">{t('string')}</Text>;
   }
 
   if (isLogicFilter) {
-    return <Tag variant="promotion">{t('logic')}</Tag>;
+    return <Text variant="promotion">{t('logic')}</Text>;
   }
 
   return null;

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -2,24 +2,70 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
-import {FieldKind} from 'sentry/utils/fields';
+import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 
 interface TypeBadgeProps {
   func?: ParsedFunction;
+  isLogicFilter?: boolean;
   kind?: FieldKind;
+  valueType?: FieldValueType;
 }
 
-export function TypeBadge({func, kind}: TypeBadgeProps) {
+export function TypeBadge({func, kind, valueType, isLogicFilter}: TypeBadgeProps) {
   if (defined(func) || kind === FieldKind.FUNCTION) {
     return <Tag variant="success">{t('f(x)')}</Tag>;
   }
 
-  if (kind === FieldKind.MEASUREMENT) {
+  if (valueType === FieldValueType.BOOLEAN) {
+    return <Tag variant="muted">{t('boolean')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.DATE) {
+    return <Tag variant="warning">{t('date')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.DURATION) {
+    return <Tag variant="danger">{t('duration')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.INTEGER) {
+    return <Tag variant="info">{t('integer')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.PERCENTAGE) {
+    return <Tag variant="promotion">{t('percentage')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.SIZE) {
+    return <Tag variant="muted">{t('size')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.RATE) {
+    return <Tag variant="warning">{t('rate')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.PERCENT_CHANGE) {
+    return <Tag variant="danger">{t('percent change')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.SCORE) {
+    return <Tag variant="info">{t('score')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.CURRENCY) {
+    return <Tag variant="success">{t('currency')}</Tag>;
+  }
+
+  if (valueType === FieldValueType.NUMBER || kind === FieldKind.MEASUREMENT) {
     return <Tag variant="info">{t('number')}</Tag>;
   }
 
-  if (kind === FieldKind.TAG) {
+  if (valueType === FieldValueType.STRING || kind === FieldKind.TAG) {
     return <Tag variant="warning">{t('string')}</Tag>;
+  }
+
+  if (isLogicFilter) {
+    return <Tag variant="promotion">{t('logic')}</Tag>;
   }
 
   return null;


### PR DESCRIPTION
This PR adds in type hints to the search query builder, while also updating the styles to be colored text as outlined in the tickets designs.

Ticket: EXP-685

Screenshots:
<img width="618" height="228" alt="Screenshot 2026-01-02 at 12 06 28" src="https://github.com/user-attachments/assets/d5400ea8-6752-4b54-a6f3-3bf5a0d4177e" />