### PR TITLE
fix(code-review): Look up code review beta orgs dynamically

### DIFF
--- a/src/sentry/seer/code_review/permissions.py
+++ b/src/sentry/seer/code_review/permissions.py
@@ -23,4 +23,8 @@ def has_code_review_enabled(organization: Organization) -> bool:
     if not pr_review_test_generation_enabled:
         return False
 
-    return features.has("organizations:code-review-beta", organization)
+    # TODO: Remove the pr_review_test_generation_enabled check after the beta list is frozen
+    return (
+        features.has("organizations:code-review-beta", organization)
+        or pr_review_test_generation_enabled
+    )


### PR DESCRIPTION
Until we officially freeze the code review beta list, consider anyone with the feature toggle ON as part of the beta too.

Note that we'll replace this with the logic [here](https://github.com/getsentry/sentry/pull/105561) shortly, but wanted to unblock this.
