### PR TITLE
fix(checkout): Success screen buttons should have same height

### DIFF
--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -616,6 +616,7 @@ function CheckoutSuccess({
                   ['feedback.owner']: 'billing',
                 },
               }}
+              size="md"
             />
           </Flex>
         </Flex>


### PR DESCRIPTION
# before 
<img width="531" height="196" alt="image" src="https://github.com/user-attachments/assets/6e292ed8-f183-4123-bc95-e675ede8d5c0" />

# after

<img width="525" height="173" alt="Screenshot 2026-01-02 at 12 22 46 PM" src="https://github.com/user-attachments/assets/d448063e-8466-4ce8-8e6b-d3962cfe2455" />
