### PR TITLE
chore(aci): parse metric issue assignee from detector.owner

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -214,9 +214,8 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
             )
 
         try:
-            assignee = parse_and_validate_actor(
-                str(self.detector.created_by_id), self.detector.project.organization_id
-            )
+            owner = self.detector.owner.identifier if self.detector.owner else None
+            assignee = parse_and_validate_actor(owner, self.detector.project.organization_id)
         except Exception:
             logger.exception("Failed to parse assignee for detector id %s", self.detector.id)
             assignee = None

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -218,6 +218,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
                 str(self.detector.created_by_id), self.detector.project.organization_id
             )
         except Exception:
+            logger.exception("Failed to parse assignee for detector id %s", self.detector.id)
             assignee = None
 
         return (

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -93,7 +93,7 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         assert occurrence.level == "error"
         assert occurrence.priority == detector_trigger.condition_result
         assert occurrence.assignee
-        assert occurrence.assignee.id == self.detector.created_by_id
+        assert occurrence.assignee.id == self.detector.owner_user_id
 
     def test_metric_issue_occurrence(self) -> None:
         value = self.critical_detector_trigger.comparison + 1

--- a/tests/sentry/incidents/utils/test_metric_issue_base.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_base.py
@@ -27,6 +27,7 @@ class BaseMetricIssueTest(TestCase):
             workflow_condition_group=self.create_data_condition_group(),
             type=MetricIssue.slug,
             created_by_id=self.user.id,
+            owner_user_id=self.user.id,
         )
         self.critical_detector_trigger = self.create_data_condition(
             type=Condition.GREATER,


### PR DESCRIPTION
<img width="205" height="76" alt="Screenshot 2026-01-02 at 10 11 33" src="https://github.com/user-attachments/assets/c72b953e-c96f-4bb8-83ca-266a36659410" />

`detector.owner` corresponds to this UI component in which issues emitted from the monitor should be assigned to that user/team. Currently we use the `created_by_id` which is incorrect.

Additionally, we expect parsing the assignee from the detector to work, and we should know when it doesn't. When it doesn't, the owner assignment will happen in post process which can be confusing for users because it might be different from the detector owner. So add a log so we can see when this fails.