### PR TITLE
(fix): add user-scoped project filtering for org code mappings

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -176,16 +176,13 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
 
         integration_id = request.GET.get("integrationId")
 
-        queryset = RepositoryProjectPathConfig.objects.all()
+        # Always filter by projects the user can access
+        projects = self.get_projects(request, organization)
+        queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects)
 
         if integration_id:
-            # get_organization_integration will raise a 404 if no org_integration is found
             org_integration = self.get_organization_integration(organization, integration_id)
             queryset = queryset.filter(organization_integration_id=org_integration.id)
-        else:
-            # Filter by project
-            projects = self.get_projects(request, organization)
-            queryset = queryset.filter(project__in=projects)
 
         return self.paginate(
             request=request,

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -379,3 +379,32 @@ class OrganizationCodeMappingsTest(APITestCase):
         response = self.make_post({"defaultBranch": "prod/deploy-branch/"})
         assert response.status_code == 400
         assert response.data == {"defaultBranch": [BRANCH_NAME_ERROR_MESSAGE]}
+
+    def test_get_with_integrationId_enforces_project_access(self) -> None:
+        """GET with integrationId only returns mappings for projects user can access."""
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # user2 is only on team2, which has access to project2 but not project1
+        self.login_as(user=self.user2)
+
+        self.create_code_mapping(
+            project=self.project1,
+            repo=self.repo1,
+            stack_root="inaccessible/path",
+            source_root="source/root",
+        )
+        accessible_mapping = self.create_code_mapping(
+            project=self.project2,
+            repo=self.repo1,
+            stack_root="accessible/path",
+            source_root="source/root",
+        )
+
+        url_path = f"{self.url}?integrationId={self.integration.id}"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(accessible_mapping.id)
+        assert response.data[0]["projectId"] == str(self.project2.id)


### PR DESCRIPTION
Code mappings GET lacked project-level filtering so all projects for a specific integrationId would be returned regardless of a user's project access, unlike the GET without an integrationId that performed this. This fixes that authentication bypass.