### PR TITLE
ref(trace-waterfall): update scroll when query params change

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -24,7 +24,7 @@ function TraceAiSpans({traceSlug}: {traceSlug: string}) {
   const location = useLocation();
   const {nodes, isLoading, error} = useAITrace(traceSlug);
   const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(() => {
-    const path = getScrollToPath()?.path;
+    const path = getScrollToPath(location.search)?.path;
     const lastSpan = path?.findLast(item => item.startsWith('span-'));
     return lastSpan?.replace('span-', '') ?? null;
   });

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 import * as qs from 'query-string';
 
 import {useLocation} from 'sentry/utils/useLocation';
@@ -22,8 +22,8 @@ type UseTraceScrollToPath =
   | null
   | undefined;
 
-export function getScrollToPath(): UseTraceScrollToPath {
-  const queryParams = qs.parse(location.search);
+export function getScrollToPath(queryString: string): UseTraceScrollToPath {
+  const queryParams = qs.parse(queryString);
   const scrollToNode = {
     eventId: (queryParams.eventId ?? queryParams.targetId) as string | undefined,
     path: decodeScrollQueue(queryParams.node) as TraceTree.NodePath[] | undefined,
@@ -44,20 +44,22 @@ export function useTraceScrollToPath({
 }: {
   traceSlug: string;
 }): React.MutableRefObject<UseTraceScrollToPath> {
-  const location = useLocation();
-  const queryParams = qs.parse(location.search);
-
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
-  useEffect(() => {
-    scrollQueueRef.current = getScrollToPath();
+  const location = useLocation();
+  const scrollPath = useMemo(() => {
+    return getScrollToPath(location.search);
+  }, [location.search]);
 
-    // Only re-run this effect when the traceSlug changes, not on every render since we manage
+  useEffect(() => {
+    scrollQueueRef.current = scrollPath;
+
+    // Only re-run this effect when the path or traceSlug changes, not on every render since we manage
     // scroll internally in the traceWaterfall component, and only update the url for state consistency across
     // subsequent loads
-  }, [traceSlug, queryParams.node, queryParams.eventId, queryParams.targetId]);
+  }, [traceSlug, scrollPath]);
 
   return scrollQueueRef;
 }

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,6 +1,8 @@
 import {useEffect, useRef} from 'react';
 import * as qs from 'query-string';
 
+import {useLocation} from 'sentry/utils/useLocation';
+
 import type {TraceTree} from './traceModels/traceTree';
 
 function decodeScrollQueue(maybePath: unknown): TraceTree.NodePath[] | null {
@@ -42,6 +44,9 @@ export function useTraceScrollToPath({
 }: {
   traceSlug: string;
 }): React.MutableRefObject<UseTraceScrollToPath> {
+  const location = useLocation();
+  const queryParams = qs.parse(location.search);
+
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
@@ -52,7 +57,7 @@ export function useTraceScrollToPath({
     // Only re-run this effect when the traceSlug changes, not on every render since we manage
     // scroll internally in the traceWaterfall component, and only update the url for state consistency across
     // subsequent loads
-  }, [traceSlug]);
+  }, [traceSlug, queryParams.node, queryParams.eventId, queryParams.targetId]);
 
   return scrollQueueRef;
 }


### PR DESCRIPTION
Seer explorer panel outputs links to specific spans within a trace. When using it, I noticed clicking a link to a new span when already on the waterfall page doesn't update the page. I think this useEffect should also depend on the current query params