### PR TITLE
feat(projects): warn about eventual removal of Project Details

### DIFF
--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,3 +1,4 @@
+import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
@@ -18,5 +19,9 @@ export default function ProjectDetailContainer() {
       : {}
   );
 
-  return <ProjectDetail />;
+  return (
+    <PageAlertProvider>
+      <ProjectDetail />;
+    </PageAlertProvider>
+  );
 }

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -21,7 +21,7 @@ export default function ProjectDetailContainer() {
 
   return (
     <PageAlertProvider>
-      <ProjectDetail />;
+      <ProjectDetail />
     </PageAlertProvider>
   );
 }

--- a/static/app/views/projectDetail/projectDetail.spec.tsx
+++ b/static/app/views/projectDetail/projectDetail.spec.tsx
@@ -14,6 +14,7 @@ import * as pageFilters from 'sentry/actionCreators/pageFilters';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 import ProjectDetail from './projectDetail';
+import ProjectDetailContainer from './';
 
 jest.mock('sentry/actionCreators/organization');
 
@@ -110,6 +111,18 @@ describe('ProjectDetail', () => {
 
     expect(await screen.findByText(/project details/i)).toBeInTheDocument();
     expect(screen.getByText(project.slug)).toBeInTheDocument();
+  });
+
+  it('Render deprecation dialog', async () => {
+    ProjectsStore.loadInitialData([project]);
+    setupMockResponses();
+
+    render(<ProjectDetailContainer />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    expect(await screen.findByText(/similar charts are available/i)).toBeInTheDocument();
   });
 
   it('Sync project with slug', async () => {

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -9,6 +9,7 @@ import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Link} from 'sentry/components/core/link';
 import CreateAlertButton from 'sentry/components/createAlertButton';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
@@ -21,9 +22,10 @@ import MissingProjectMembership from 'sentry/components/projects/missingProjectM
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import useApi from 'sentry/utils/useApi';
@@ -79,6 +81,31 @@ export default function ProjectDetail() {
     }
     return ['chart1'];
   }, [hasTransactions, hasSessions]);
+
+  const {setPageInfo, pageAlert} = usePageAlert();
+  const msg = useMemo(
+    () =>
+      tctCode(
+        'Project Details will be removed soon. Find this project’s settings under [settingsLink:Settings]. Similar charts are available on the [sessionHealth:Session Health] and [backendOverview:Backend Overview] dashboards.',
+        {
+          settingsLink: (
+            <Link to={`/settings/${params.orgId}/projects/${params.projectId}/`} />
+          ),
+          sessionHealth: (
+            <Link to={`/organizations/${params.orgId}/insights/frontend/sessions/`} />
+          ),
+          backendOverview: (
+            <Link to={`/organizations/${params.orgId}/insights/backend/`} />
+          ),
+        }
+      ),
+    [params]
+  );
+  useEffect(() => {
+    if (pageAlert?.message !== msg) {
+      setPageInfo(msg);
+    }
+  }, [msg, pageAlert, setPageInfo]);
 
   const onRetryProjects = useCallback(() => {
     fetchOrganizationDetails(api, params.orgId);
@@ -209,6 +236,7 @@ export default function ProjectDetail() {
 
             <Layout.Body noRowGap>
               <Layout.Main>
+                <PageAlert />
                 <ProjectFiltersWrapper>
                   <ProjectFilters
                     query={query}

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -83,24 +83,20 @@ export default function ProjectDetail() {
   }, [hasTransactions, hasSessions]);
 
   const {setPageInfo, pageAlert} = usePageAlert();
-  const {orgId, projectId} = params
+  const {orgId, projectId: projectSlug} = params;
   const msg = useMemo(
     () =>
       tctCode(
         'Project Details will be removed soon. Find this project’s settings under [settingsLink:Settings]. Similar charts are available on the [sessionHealth:Session Health] and [backendOverview:Backend Overview] dashboards.',
         {
-          settingsLink: (
-            <Link to={`/settings/${params.orgId}/projects/${projectId}/`} />
-          ),
+          settingsLink: <Link to={`/settings/${orgId}/projects/${projectSlug}/`} />,
           sessionHealth: (
             <Link to={`/organizations/${orgId}/insights/frontend/sessions/`} />
           ),
-          backendOverview: (
-            <Link to={`/organizations/${orgId}/insights/backend/`} />
-          ),
+          backendOverview: <Link to={`/organizations/${orgId}/insights/backend/`} />,
         }
       ),
-    [orgId, projectId]
+    [orgId, projectSlug]
   );
   useEffect(() => {
     if (pageAlert?.message !== msg) {

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -83,23 +83,24 @@ export default function ProjectDetail() {
   }, [hasTransactions, hasSessions]);
 
   const {setPageInfo, pageAlert} = usePageAlert();
+  const {orgId, projectId} = params
   const msg = useMemo(
     () =>
       tctCode(
         'Project Details will be removed soon. Find this project’s settings under [settingsLink:Settings]. Similar charts are available on the [sessionHealth:Session Health] and [backendOverview:Backend Overview] dashboards.',
         {
           settingsLink: (
-            <Link to={`/settings/${params.orgId}/projects/${params.projectId}/`} />
+            <Link to={`/settings/${params.orgId}/projects/${projectId}/`} />
           ),
           sessionHealth: (
-            <Link to={`/organizations/${params.orgId}/insights/frontend/sessions/`} />
+            <Link to={`/organizations/${orgId}/insights/frontend/sessions/`} />
           ),
           backendOverview: (
-            <Link to={`/organizations/${params.orgId}/insights/backend/`} />
+            <Link to={`/organizations/${orgId}/insights/backend/`} />
           ),
         }
       ),
-    [params]
+    [orgId, projectId]
   );
   useEffect(() => {
     if (pageAlert?.message !== msg) {


### PR DESCRIPTION
### Project Details

<img width="2324" height="702" alt="Screenshot 2026-01-02 at 5 26 42 PM" src="https://github.com/user-attachments/assets/dd7732e0-b435-49b9-8747-c624e96a04d7" />

### Project LIst

<img width="2328" height="572" alt="Screenshot 2026-01-05 at 10 27 06 AM" src="https://github.com/user-attachments/assets/321fcd48-9d67-4344-a1ef-329be9a10a22" />

We're considering removing the Project Pages. These pages serve a few purposes that are redundant:

1. They are a shortcut to the Project Settings page. This page is available both in Settings, and from the project selector drop down (we will be making this more obvious).
2. They are a shortcut to the Issues feed for the given project. Using the project selector on the issues page can replace this functionality.
3. They show session health statistics by default. This is replaced by the [session health](https://docs.sentry.io/product/insights/frontend/session-health/) Insights page.


---

TODO:

- [x] Write some tests.