### PR TITLE
fix: auto-correct Slack channel names from IDs

### DIFF
--- a/src/sentry/integrations/slack/actions/form.py
+++ b/src/sentry/integrations/slack/actions/form.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.utils.channel import (
     get_channel_id,
+    is_input_a_user_id,
     strip_channel_name,
     validate_slack_entity_id,
 )
@@ -137,6 +138,11 @@ class SlackNotifyServiceForm(forms.Form):
         # Use the actual name from Slack API if available (auto-correction for channel ID as name)
         if actual_slack_name:
             channel = actual_slack_name
+            # If we auto-corrected, we need to ensure the prefix is correct based on the ID type
+            if is_input_a_user_id(channel_id):
+                channel_prefix = "@"
+            else:
+                channel_prefix = "#"
         else:
             channel = strip_channel_name(channel)
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -255,6 +255,28 @@ class SlackNotifyActionTest(RuleTestCase):
             form = rule.get_form_instance()
             assert form.is_valid()
 
+    def test_channel_id_as_channel_name_auto_corrected(self) -> None:
+        """
+        Test that when a user provides a channel ID as the channel name,
+        the form auto-corrects it to the actual channel name from Slack.
+        This is for issue #105478.
+        """
+        # User mistakenly puts the channel ID in the channel name field
+        channel = {"name": "public", "id": "C013TMFDEAV"}
+        with self.mock_conversations_info(channel):
+            rule = self.get_rule(
+                data={
+                    "workspace": self.integration.id,
+                    "channel": "#C013TMFDEAV",
+                    "input_channel_id": "C013TMFDEAV",
+                    "tags": "",
+                }
+            )
+
+            form = rule.get_form_instance()
+            # Form should be valid and auto-correct the channel name
+            self.assert_form_valid(form, "C013TMFDEAV", "#public")
+
     def test_invalid_channel_id_provided_sdk(self) -> None:
         with patch(
             "slack_sdk.web.client.WebClient.conversations_info",
@@ -273,23 +295,26 @@ class SlackNotifyActionTest(RuleTestCase):
             assert not form.is_valid()
             assert "Channel not found. Invalid ID provided." in str(form.errors.values())
 
-    def test_invalid_channel_name_provided_sdk(self) -> None:
+    def test_mismatched_channel_name_auto_corrected(self) -> None:
+        """
+        Test that when the user-provided channel name doesn't match the actual name from Slack,
+        the form auto-corrects it to the actual channel name (instead of raising an error).
+        This is part of the fix for issue #105478.
+        """
         channel = {"name": "my-channel", "id": "C2349874"}
         with self.mock_conversations_info(channel):
             rule = self.get_rule(
                 data={
                     "workspace": self.integration.id,
-                    "channel": "#my-chanel",
-                    "input_channel_id": "C1234567",
+                    "channel": "#my-chanel",  # User typed wrong name
+                    "input_channel_id": "C2349874",
                     "tags": "",
                 }
             )
 
             form = rule.get_form_instance()
-            assert not form.is_valid()
-            assert "Slack: Slack channel name from ID does not match input channel name." in str(
-                form.errors.values()
-            )
+            # Form should be valid and auto-correct the channel name
+            self.assert_form_valid(form, "C2349874", "#my-channel")
 
     def test_invalid_workspace(self) -> None:
         # the workspace _should_ be the integration id

--- a/tests/sentry/integrations/slack/utils/test_channel.py
+++ b/tests/sentry/integrations/slack/utils/test_channel.py
@@ -386,19 +386,24 @@ class ValidateUserIdTest(TestCase):
                 )
             assert mock_client_call.call_count == 1
 
-    def test_no_matches_from_slack(self) -> None:
+    def test_username_auto_corrected_from_slack(self) -> None:
+        """
+        When user provides a username that doesn't match what Slack returns,
+        the function should return the actual username from Slack (auto-correction).
+        This is part of the fix for issue #105478.
+        """
         with patch(
             "slack_sdk.web.client.WebClient.users_info",
             return_value=create_user_response(user=self.slack_user),
         ) as mock_client_call:
-            with pytest.raises(
-                ValidationError, match="Slack username from ID does not match input username."
-            ):
-                validate_user_id(
-                    input_name="waldo",
-                    input_user_id=self.input_id,
-                    integration_id=self.integration.id,
-                )
+            # Instead of raising ValidationError, it should return the actual username
+            result = validate_user_id(
+                input_name="waldo",
+                input_user_id=self.input_id,
+                integration_id=self.integration.id,
+            )
+            # Should return the actual username from Slack
+            assert result == "carmen.sandiego"
             assert mock_client_call.call_count == 1
 
     def test_happy_path_does_not_raise(self) -> None:


### PR DESCRIPTION
### Summary

Fixes an issue where Slack alert actions incorrectly saved manually entered **channel IDs** (e.g., `C01234`) as display names (e.g., `C01234`).
The system now validates the ID against the Slack API and automatically replaces it with the correct **human-readable channel name** (e.g., `#general`).

### Changes

* **`src/sentry/integrations/slack/utils/channel.py`**

  * Updated `validate_slack_entity_id`, `validate_user_id`, and `validate_channel_id` to return the resolved name from the Slack API.
* **`src/sentry/integrations/slack/actions/form.py`**

  * Updated `SlackNotifyServiceForm.clean` to use the resolved channel name for auto-correction instead of the user input.
  * Fixed a variable scoping bug that caused the `#` prefix to be dropped.
* **`src/sentry/incidents/serializers/alert_rule_trigger_action.py`**

  * Updated metric alert serializers to support the same auto-correction logic.

### Testing

* **New test**

  * `test_channel_id_as_channel_name_auto_corrected` in `test_notify_action.py` to verify ID → name auto-correction.
* **Updated tests**

  * Updated tests in `test_channel.py` and `test_organization_alert_rule_details.py` to assert correct auto-correction behavior instead of validation errors.

### Verification

* Verified locally using the full devservices stack (Redis, Snuba, Postgres).

closes #105478

