### PR TITLE
fix(preprod): Standardize error responses to use `detail` key in compare download endpoint (EME-718)

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_download.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_download.py
@@ -57,7 +57,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint(ProjectEndpoint)
         if not features.has(
             "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         logger.info(
             "preprod.size_analysis.compare.api.download",
@@ -81,14 +81,14 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint(ProjectEndpoint)
                     "base_size_metric_id": base_size_metric_id,
                 },
             )
-            return Response({"error": "Comparison not found."}, status=404)
+            return Response({"detail": "Comparison not found."}, status=404)
 
         if comparison_obj.file_id is None:
             logger.info(
                 "preprod.size_analysis.compare.api.download.no_file_id",
                 extra={"comparison_id": comparison_obj.id},
             )
-            return Response({"error": "Comparison not found."}, status=404)
+            return Response({"detail": "Comparison not found."}, status=404)
 
         try:
             file_obj = File.objects.get(id=comparison_obj.file_id)
@@ -97,7 +97,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint(ProjectEndpoint)
                 "preprod.size_analysis.compare.api.download.no_file",
                 extra={"comparison_id": comparison_obj.id},
             )
-            return Response({"error": "Comparison not found."}, status=404)
+            return Response({"detail": "Comparison not found."}, status=404)
 
         try:
             fp = file_obj.getfile()
@@ -106,7 +106,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint(ProjectEndpoint)
                 "preprod.size_analysis.compare.api.download.no_file_getfile",
                 extra={"comparison_id": comparison_obj.id},
             )
-            return Response({"error": "Failed to retrieve size analysis comparison."}, status=500)
+            return Response({"detail": "Failed to retrieve size analysis comparison."}, status=500)
 
         response = FileResponse(
             fp,

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_download.py
@@ -95,7 +95,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == 404
-        assert response.json()["error"] == "Comparison not found."
+        assert response.json()["detail"] == "Comparison not found."
 
     def test_download_size_analysis_comparison_no_file_id(self) -> None:
         # Create a comparison without a file_id
@@ -111,7 +111,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == 404
-        assert response.json()["error"] == "Comparison not found."
+        assert response.json()["detail"] == "Comparison not found."
 
     def test_download_size_analysis_comparison_file_not_found(self) -> None:
         # Create a comparison with a non-existent file_id
@@ -127,7 +127,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == 404
-        assert response.json()["error"] == "Comparison not found."
+        assert response.json()["detail"] == "Comparison not found."
 
     def test_download_size_analysis_comparison_file_retrieval_failure(self) -> None:
         failing_file = self.create_file(
@@ -148,7 +148,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == 404
-        assert response.json()["error"] == "Comparison not found."
+        assert response.json()["detail"] == "Comparison not found."
 
     def test_download_size_analysis_comparison_different_organization(self) -> None:
         other_user = self.create_user()
@@ -163,4 +163,4 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
 
         # Should still return 404 because the comparison doesn't exist for this organization
         assert response.status_code == 404
-        assert response.json()["error"] == "Comparison not found."
+        assert response.json()["detail"] == "Comparison not found."


### PR DESCRIPTION
## Summary

Fixes the size analysis compare download endpoint to use the `detail` key in error responses instead of `error` to follow up on #105529 (EME-699).

## Problem

The `parseApiError` utility function on the frontend only looks for the `detail` key in error responses. When the compare download endpoint returns errors with the `error` key, the frontend displays a generic "Unknown API Error" message instead of the specific error message from the API.

## Related

- Completes work from #105529 (EME-699)
- Linear: [EME-718](https://linear.app/getsentry/issue/EME-718)