### PR TITLE
fix(preprod): Fix error response handling in size analysis download endpoint and frontend (EME-718)

### DIFF
--- a/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_size_analysis_download.py
+++ b/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_size_analysis_download.py
@@ -52,7 +52,7 @@ class OrganizationPullRequestSizeAnalysisDownloadEndpoint(OrganizationEndpoint):
         )
 
         if not features.has("organizations:pr-page", organization, actor=request.user):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         try:
             artifact = PreprodArtifact.objects.get(

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
@@ -60,7 +60,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpoint(PreprodArtifactEndpoint
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         all_size_metrics = list(head_artifact.get_size_metrics())
 

--- a/src/sentry/preprod/size_analysis/download.py
+++ b/src/sentry/preprod/size_analysis/download.py
@@ -136,4 +136,4 @@ def get_size_analysis_response(
 
 
 def get_size_analysis_error_response(error: SizeAnalysisError) -> Response:
-    return Response({"error": error.message}, status=error.status_code)
+    return Response({"detail": error.message}, status=error.status_code)

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -234,6 +234,22 @@ export function SizeCompareMainContent() {
     );
   }
 
+  if (comparisonDataQuery.isError || !comparisonDataQuery.data) {
+    const errorMessage = comparisonDataQuery.error
+      ? parseApiError(comparisonDataQuery.error)
+      : 'Unknown API Error';
+    return (
+      <BuildError
+        title={t('Failed to load comparison details')}
+        message={
+          errorMessage === 'Unknown API Error'
+            ? t('Could not retrieve detailed comparison results')
+            : errorMessage
+        }
+      />
+    );
+  }
+
   return (
     <Flex direction="column" gap="2xl">
       <SizeCompareSelectedBuilds

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -188,14 +188,17 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     );
   }
 
-  // TODO(EME-302): Currently we don't set the size metrics
-  // error_{code,message} correctly so we often see this.
   if (isAppSizeError) {
+    const errorMessage = appSizeError ? parseApiError(appSizeError) : 'Unknown API Error';
     return (
       <Flex width="100%" justify="center" align="center" minHeight="60vh">
         <BuildError
           title={t('Size analysis failed')}
-          message={appSizeError?.message ?? t('The treemap data could not be loaded')}
+          message={
+            errorMessage === 'Unknown API Error'
+              ? t('The treemap data could not be loaded')
+              : errorMessage
+          }
         >
           <Button
             priority="primary"

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -12,6 +12,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconClose, IconGrid, IconRefresh, IconSearch} from 'sentry/icons';
 import {IconGraphCircle} from 'sentry/icons/iconGraphCircle';
 import {t} from 'sentry/locale';
+import parseApiError from 'sentry/utils/parseApiError';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_size_analysis_download.py
@@ -57,7 +57,7 @@ class OrganizationPullRequestSizeAnalysisDownloadEndpointTest(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == 403
-        assert response.json()["error"] == "Feature not enabled"
+        assert response.json()["detail"] == "Feature not enabled"
 
     def test_size_analysis_download_artifact_not_found(self) -> None:
         with self.feature("organizations:pr-page"):
@@ -108,7 +108,7 @@ class OrganizationPullRequestSizeAnalysisDownloadEndpointTest(TestCase):
 
             assert response.status_code == 404
             assert (
-                response.json()["error"] == "Size analysis results not available for this artifact"
+                response.json()["detail"] == "Size analysis results not available for this artifact"
             )
 
     def test_size_analysis_download_multiple_size_metrics_same_file(self) -> None:
@@ -146,7 +146,8 @@ class OrganizationPullRequestSizeAnalysisDownloadEndpointTest(TestCase):
 
             assert response.status_code == 409
             assert (
-                response.json()["error"] == "Multiple size analysis results found for this artifact"
+                response.json()["detail"]
+                == "Multiple size analysis results found for this artifact"
             )
 
     def test_size_analysis_download_no_analysis_file(self) -> None:
@@ -168,4 +169,6 @@ class OrganizationPullRequestSizeAnalysisDownloadEndpointTest(TestCase):
             response = self.client.get(url)
 
             assert response.status_code == 500
-            assert response.json()["error"] == "Size analysis completed but results are unavailable"
+            assert (
+                response.json()["detail"] == "Size analysis completed but results are unavailable"
+            )

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
@@ -30,7 +30,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         """When no size metrics exist, should return 404"""
         response = self.get_response(self.organization.slug, self.project.slug, self.artifact.id)
         assert response.status_code == 404
-        assert response.data["error"] == "Size analysis results not available for this artifact"
+        assert response.data["detail"] == "Size analysis results not available for this artifact"
 
     def test_pending_state_returns_200(self):
         """When size metrics exist but are in PENDING state, should return 200 with state info"""
@@ -86,7 +86,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
 
         response = self.get_response(self.organization.slug, self.project.slug, self.artifact.id)
         assert response.status_code == 500
-        assert response.data["error"] == "Size analysis completed but results are unavailable"
+        assert response.data["detail"] == "Size analysis completed but results are unavailable"
 
     def test_completed_with_missing_file_returns_404(self):
         """When size metrics is COMPLETED but the File object was deleted, should return 404"""
@@ -101,7 +101,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
 
         response = self.get_response(self.organization.slug, self.project.slug, self.artifact.id)
         assert response.status_code == 404
-        assert response.data["error"] == "Analysis file not found"
+        assert response.data["detail"] == "Analysis file not found"
 
     def test_completed_with_file_returns_200(self):
         """When size metrics is COMPLETED with a file, should return 200 with file content"""


### PR DESCRIPTION
## Summary

Fixes error response handling in the size analysis download endpoint (single artifact) and frontend components. This addresses two related problems:

1. **Backend**: The download endpoint returns errors using the `error` key instead of `detail`
2. **Frontend**: Missing/incorrect error handling causes blank pages or generic error messages

## Problems

### Backend
The `project_preprod_size_analysis_download.py` endpoint and the `download.py` utility function return errors with the `error` key. Since `parseApiError` only looks for `detail`, users see "Unknown API Error" instead of specific error messages.

### Frontend

**sizeCompareMainContent.tsx**: No error handling for `comparisonDataQuery` (the download endpoint call). When the download endpoint returns an error:
- Loading spinner disappears
- No error message displays
- UI attempts to render undefined data
- Result: Blank or broken page

**buildDetailsMainContent.tsx**: Uses `appSizeError?.message` which returns the JavaScript Error message (e.g., "GET /projects/...") instead of the API response. Users see the generic fallback "The treemap data could not be loaded" instead of specific API error messages.

## Related

- Completes work from #105529 (EME-699) and #105623
- Linear: [EME-718](https://linear.app/getsentry/issue/EME-718)