### PR TITLE
chore: cleanup `secret-scanning.github.notifications.email-allowlist`

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3471,13 +3471,6 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Secret Scanning. Email allowlist for notifications.
-register(
-    "secret-scanning.github.notifications.email-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Rate limiting for the occurrence consumer
 register(


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry-options-automator/pull/6020