### PR TITLE
Remapping `translucentBorder` to new border tokens

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -223,7 +223,7 @@ const BreadcrumbItem = styled(Timeline.Item)`
     border-image: linear-gradient(
         to right,
         transparent 20px,
-        ${p => p.theme.translucentInnerBorder} 20px
+        ${p => p.theme.tokens.border.secondary} 20px
       )
       100% 1;
   }

--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -57,7 +57,7 @@ export const EventNavigator = styled('div')`
   background: ${p => p.theme.tokens.background.primary};
   z-index: 2; /* Just above EventStickyControls */
   min-height: ${MIN_NAV_HEIGHT}px;
-  box-shadow: ${p => p.theme.translucentBorder} 0 1px;
+  box-shadow: ${p => p.theme.tokens.border.primary} 0 1px;
 `;
 
 export const EventStickyControls = styled('div')`

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -166,7 +166,7 @@ const Container = styled('div')`
     width: 1px;
     top: 0;
     bottom: 0;
-    background: ${p => p.theme.border};
+    background: ${p => p.theme.tokens.border.transparent.neutral.muted};
   }
 `;
 

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -145,7 +145,7 @@ const Text = styled('div')`
 const Data = styled('div')`
   border-radius: ${space(0.5)};
   padding: ${space(0.25)} ${space(0.75)};
-  border: 1px solid ${p => p.theme.translucentInnerBorder};
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
   margin: ${space(0.75)} 0 0 -${space(0.75)};
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -124,7 +124,7 @@ const TagPanel = styled('div')`
   flex-direction: column;
   gap: ${space(0.5)};
   border-radius: ${p => p.theme.radius.md};
-  border: 1px solid ${p => p.theme.border};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
   padding: ${space(1)};
 `;
 
@@ -166,7 +166,7 @@ const TagBarPlaceholder = styled('div')`
   height: ${space(1)};
   width: 100%;
   border-radius: 3px;
-  box-shadow: inset 0 0 0 1px ${p => p.theme.translucentBorder};
+  box-shadow: inset 0 0 0 1px ${p => p.theme.tokens.border.transparent.neutral.muted};
   background: ${p => Color(p.theme.colors.gray400).alpha(0.1).toString()};
   overflow: hidden;
 `;

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -84,7 +84,7 @@ const FloatingEventNavigation = styled(EventTitle)`
 
 const GroupContent = styled('div')`
   position: relative;
-  border: 1px solid ${p => p.theme.translucentBorder};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
   background: ${p => p.theme.tokens.background.primary};
   border-radius: ${p => p.theme.radius.md};
 `;

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -269,7 +269,7 @@ const DetailsContainer = styled('div')<{
   padding-top: ${p => p.theme.space.lg};
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    border-right: 1px solid ${p => p.theme.translucentBorder};
+    border-right: 1px solid ${p => p.theme.tokens.border.primary};
   }
 `;
 
@@ -284,7 +284,7 @@ const GraphSection = styled('div')`
   & > * {
     background: ${p => p.theme.tokens.background.primary};
     border-radius: ${p => p.theme.radius.md};
-    border: 1px solid ${p => p.theme.translucentBorder};
+    border: 1px solid ${p => p.theme.tokens.border.primary};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -210,7 +210,7 @@ const EventInfoJumpToWrapper = styled('div')<{hasProcessingError: boolean}>`
   align-items: center;
   padding: 0 ${p => p.theme.space.lg};
   min-height: ${MIN_NAV_HEIGHT}px;
-  border-bottom: 1px solid ${p => p.theme.translucentBorder};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
 
   @media (max-width: ${p =>
       p.hasProcessingError ? p.theme.breakpoints.lg : p.theme.breakpoints.sm}) {

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -115,10 +115,10 @@ const GroupContent = styled('section')`
   display: flex;
   flex-direction: column;
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    border-right: 1px solid ${p => p.theme.translucentBorder};
+    border-right: 1px solid ${p => p.theme.tokens.border.primary};
   }
   @media (max-width: ${p => p.theme.breakpoints.lg}) {
-    border-bottom-width: 1px solid ${p => p.theme.translucentBorder};
+    border-bottom-width: 1px solid ${p => p.theme.tokens.border.primary};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -352,7 +352,7 @@ const ActionBar = styled('div')<{isComplete: boolean}>`
   gap: ${space(1)};
   flex-wrap: wrap;
   padding: ${space(1)} 24px;
-  border-bottom: 1px solid ${p => p.theme.translucentBorder};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
   position: relative;
   transition: background 0.3s ease-in-out;
   background: ${p => (p.isComplete ? 'transparent' : p.theme.tokens.background.primary)};
@@ -375,7 +375,7 @@ const ActionBar = styled('div')<{isComplete: boolean}>`
     left: 24px;
     bottom: unset;
     height: 1px;
-    background: ${p => p.theme.translucentBorder};
+    background: ${p => p.theme.tokens.border.primary};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -366,7 +366,7 @@ const TagBarSegment = styled('div')`
   position: absolute;
   top: 0;
   min-width: ${p => p.theme.space['2xs']};
-  border-right: 1px solid ${p => p.theme.translucentBorder};
+  border-right: 1px solid ${p => p.theme.tokens.border.transparent.neutral.muted};
 
   &:last-child {
     border-right: none;


### PR DESCRIPTION
## Problem
The Issue Details page currently relies on the aliases `translucentBorder` or `translucentInnerBorder` which were recently mapped to a new scraps token `tokens.border.transparent.neutral.muted`. UI2 stylistically went in a different direction when it came to painting border colors in dark mode, which meant that when this mapping landed, the issue details page was stylistically inconsistent. See Screenshot below.

<img width="2880" height="1801" alt="CleanShot 2026-01-05 at 11 13 23@2x" src="https://github.com/user-attachments/assets/0123462c-3fca-46cc-9b52-26ab23c333d6" />

## Solution
### Dark mode
<img width="2880" height="1801" alt="CleanShot 2026-01-05 at 11 17 59@2x" src="https://github.com/user-attachments/assets/5ef0533c-0074-4270-a31e-d60925f40d9c" />

### Light mode
<img width="2880" height="2042" alt="CleanShot 2026-01-05 at 11 18 28@2x" src="https://github.com/user-attachments/assets/fb39c490-eae9-4042-aa59-d00d37573f37" />

## Extra Goodies
The new scraps tokens allow us to still use transparent borders, but just under a new syntax. So with that, I decided to modify a few extra components to demonstrate this.

### Breadcrumbs Vertical Line
The vertical lines are trying to visually communicate a relationship based on order of events. To make that stand out, this seems like a good candidate for our `neutral` borders. 

#### Before
<img width="2880" height="1801" alt="CleanShot 2026-01-05 at 11 23 08@2x" src="https://github.com/user-attachments/assets/1374b00d-4263-4e22-9257-70c762f271c8" />

#### After
<img width="2880" height="1801" alt="CleanShot 2026-01-05 at 11 23 56@2x" src="https://github.com/user-attachments/assets/a182ac7a-b56e-4276-b184-977948f572f4" />