### PR TITLE
feat(preprod): Display version and build number in build comparison list (EME-489)

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -20,6 +20,7 @@ import {
   IconDownload,
   IconMobile,
   IconSearch,
+  IconTag,
 } from 'sentry/icons';
 import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
@@ -213,6 +214,29 @@ export function SizeCompareSelectionContent({
   );
 }
 
+/**
+ * Formats version and build number into a combined string.
+ * Examples: "v1.2.3 (456)", "v1.2.3", "(456)", or null
+ */
+function formatVersionInfo(
+  version?: string | null,
+  buildNumber?: string | null
+): string | null {
+  if (!version && !buildNumber) {
+    return null;
+  }
+
+  if (version && buildNumber) {
+    return `v${version} (${buildNumber})`;
+  }
+
+  if (version) {
+    return `v${version}`;
+  }
+
+  return `(${buildNumber})`;
+}
+
 interface BuildItemProps {
   build: BuildDetailsApiResponse;
   isSelected: boolean;
@@ -225,6 +249,8 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
   const branchName = build.vcs_info?.head_ref;
   const dateAdded = build.app_info?.date_added;
   const sizeInfo = build.size_info;
+  const version = build.app_info?.version;
+  const buildNumber = build.app_info?.build_number;
 
   const hasGitInfo = prNumber || branchName || commitHash;
 
@@ -251,6 +277,12 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
               <Flex align="center" gap="sm">
                 <IconCommit size="xs" color="gray300" />
                 <Text>{commitHash}</Text>
+              </Flex>
+            )}
+            {formatVersionInfo(version, buildNumber) && (
+              <Flex align="center" gap="sm">
+                <IconTag size="xs" color="gray300" />
+                <Text>{formatVersionInfo(version, buildNumber)}</Text>
               </Flex>
             )}
           </Flex>

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -252,7 +252,8 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
   const version = build.app_info?.version;
   const buildNumber = build.app_info?.build_number;
 
-  const hasGitInfo = prNumber || branchName || commitHash;
+  const hasGitInfo = Boolean(prNumber || branchName || commitHash);
+  const versionInfo = formatVersionInfo(version, buildNumber);
 
   return (
     <BuildItemContainer
@@ -262,7 +263,7 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
       gap="md"
     >
       <Flex direction="column" gap="sm" flex={1}>
-        {hasGitInfo && (
+        {(hasGitInfo || versionInfo) && (
           <Flex align="center" gap="md">
             {(prNumber || branchName) && <IconBranch size="xs" color="gray300" />}
             {prNumber && (
@@ -279,10 +280,10 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
                 <Text>{commitHash}</Text>
               </Flex>
             )}
-            {formatVersionInfo(version, buildNumber) && (
+            {versionInfo && (
               <Flex align="center" gap="sm">
                 <IconTag size="xs" color="gray300" />
-                <Text>{formatVersionInfo(version, buildNumber)}</Text>
+                <Text>{versionInfo}</Text>
               </Flex>
             )}
           </Flex>


### PR DESCRIPTION
Fixes EME-489

## Summary

Adds version and build number display to the build comparison selection list. When selecting a build to compare, users can now see the version (e.g., "1.2.3") and build number (e.g., "456") displayed as "v1.2.3 (456)" in the first row of each build item.

Here's an image of the version numbers added to the list. (A lot of the uploads on my local machine didn't have version numbers so ignore those)
<img width="1132" height="754" alt="image" src="https://github.com/user-attachments/assets/3b74c204-342b-4f8c-b054-a9e5983a57d7" />
