### PR TITLE
ref(strings): Add additional tags and metrics for span first

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -200,6 +200,9 @@ SHARED_TAG_STRINGS = {
     "cardinality.window": PREFIX + 278,
     "cardinality.limit": PREFIX + 279,
     "cardinality.scope": PREFIX + 280,
+    "has_transaction": PREFIX + 281,
+    "was_transaction": PREFIX + 282,
+    "is_segment": PREFIX + 283,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }
@@ -231,6 +234,7 @@ SPAN_METRICS_NAMES = {
     "g:spans/self_time_light@millisecond": PREFIX + 420,
     "g:spans/total_time@millisecond": PREFIX + 421,
     "c:spans/count_per_root_project@none": PREFIX + 422,
+    "c:spans/count_segments_per_root_project@none": PREFIX + 423,
     # Last possible index: 499
 }
 

--- a/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
+++ b/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 
 LOCKED_FILE = "src/sentry/sentry_metrics/indexer/strings.py"
-LOCKED_DIGEST = "a0395ac3cc5c59712f1875c69b107575a13a5c79b730a37508eea0aa4ab73675"
+LOCKED_DIGEST = "6d6b48cc1c24b0dd3788cb6d0bb9a69817cef3368febf27548041adf5e84b650"
 MESSAGE = f"""{LOCKED_FILE} is locked.
 
 * We have detected you made changes to this file.


### PR DESCRIPTION
Additional metric `c:spans/count_segments_per_root_project@none` to count segments span per root (not just spans).

- `has_transaction`/`was_transaction` tag to indicate whether the (segment) span was created from a transaction and the transaction still "exists". Added both because semantically it's not fully clear which one(s) we're going to need.
- `is_segment` to indicate whether a span (e.g. in the usage metric) is a segment


Usage has been checked:

```sql
SELECT string, count(*) 
FROM sentry_{perf,}stringindexer 
WHERE 1=1
    AND string IN (
        'c:spans/count_segments_per_root_project@none',
        'has_transaction',
        'was_transaction',
        'is_segment'
    ) 
GROUP BY string;
```

We need to modify `strings.py` as for DS we need to query the tags across orgs, which is not possible if the indexer chooses the values.

Refs: INGEST-689