### PR TITLE
fix(arithmetic-equations): Resolve padding issues

### DIFF
--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -644,6 +644,7 @@ function InternalInput({
             ? 'arithmetic-builder-argument-input'
             : undefined
         }
+        parameterDefinition={parameterDefinition}
       >
         {keyItem =>
           itemIsSection(keyItem) ? (

--- a/static/app/components/core/input/useAutosizeInput.tsx
+++ b/static/app/components/core/input/useAutosizeInput.tsx
@@ -45,7 +45,7 @@ export function useAutosizeInput(
         sourceRef.current.style.width = `${size.width}px`;
       }
     }
-  }, [enabled]);
+  }, [enabled, options?.value]);
 
   const onInputChange = useCallback((event: Event) => {
     if (!sourceRef.current) return;

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -29,6 +29,7 @@ import {useAutosizeInput} from 'sentry/components/core/input/useAutosizeInput';
 import {Overlay} from 'sentry/components/overlay';
 import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
 import {defined} from 'sentry/utils';
+import type {AggregateParameter} from 'sentry/utils/fields';
 import useOverlay from 'sentry/utils/useOverlay';
 
 interface ComboBoxProps {
@@ -50,6 +51,7 @@ interface ComboBoxProps {
   onOpenChange?: (newOpenState: boolean) => void;
   onOptionSelected?: (option: SelectOptionWithKey<string>) => void;
   onPaste?: (e: ClipboardEvent<HTMLInputElement>) => void;
+  parameterDefinition?: AggregateParameter | undefined;
   placeholder?: string;
   ref?: Ref<HTMLInputElement>;
   /**
@@ -109,6 +111,7 @@ export function ComboBox({
   placeholder,
   tabIndex,
   ref,
+  parameterDefinition,
 }: ComboBoxProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listBoxRef = useRef<HTMLUListElement>(null);
@@ -307,7 +310,19 @@ export function ComboBox({
     return () => {};
   }, [isOpen]);
 
-  const autosizeInputRef = useAutosizeInput({value: inputValue});
+  const onResize = useCallback(
+    (sourceRef: HTMLInputElement, size: {height: number; width: number}) => {
+      if (parameterDefinition?.kind === 'column') {
+        const maxWidth = Math.min(size.width, 130);
+        sourceRef.style.width = `${maxWidth}px`;
+      } else {
+        sourceRef.style.width = `${size.width}px`;
+      }
+    },
+    [parameterDefinition]
+  );
+
+  const autosizeInputRef = useAutosizeInput({value: inputValue, onResize});
 
   return (
     <Wrapper>

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -311,7 +311,11 @@ export function ComboBox({
   }, [isOpen]);
 
   const onResize = useCallback(
-    (sourceRef: HTMLInputElement, size: {height: number; width: number}) => {
+    (
+      _event: Event | null,
+      sourceRef: HTMLInputElement,
+      size: {height: number; width: number}
+    ) => {
       if (parameterDefinition?.kind === 'column') {
         const maxWidth = Math.min(size.width, 130);
         sourceRef.style.width = `${maxWidth}px`;


### PR DESCRIPTION
This PR resolves some styling issues with the arithmetic query builder through limiting the width that can be applied by the autoresizer.

Ticket: EXP-690

Before:

<img width="352" height="206" alt="Screenshot 2026-01-05 at 09 40 21" src="https://github.com/user-attachments/assets/85cb0e1d-abbf-4fcb-9f5f-bd23cee53a71" />

After:

<img width="327" height="199" alt="Screenshot 2026-01-05 at 09 40 29" src="https://github.com/user-attachments/assets/711358dd-e37e-46b3-867f-d6da972d09f7" />