### PR TITLE
fix(dashboards): add `/trace` route to dashboards

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1381,6 +1381,7 @@ function buildRoutes(): RouteObject[] {
           index: true,
           component: make(() => import('sentry/views/dashboards/manage')),
         },
+        traceView,
       ],
       deprecatedRouteProps: true,
     },


### PR DESCRIPTION
Adds the `/trace` route as a child to the `/organizations/:orgId/dashboards/` route, currently it is only a child on `/dashboards/` route. This aims to solve the problem where clicking on a trace end up at a 404 in self hosted instances of dashboards (https://github.com/getsentry/sentry/issues/105609)

This doesn't affect SAAS because we use subdomains and not the org paths.