### PR TITLE
fix(preprod): Avoid text overflow on diff hover

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -206,8 +206,10 @@ export function SizeCompareItemDiffTable({
                 <Tooltip
                   title={
                     diffItem.path ? (
-                      <Flex align="start" gap="xs">
-                        <Text monospace>{diffItem.path}</Text>
+                      <Flex align="center" gap="xs">
+                        <Text wordBreak="break-all" monospace>
+                          {diffItem.path}
+                        </Text>
                         <CopyToClipboardButton
                           borderless
                           size="zero"


### PR DESCRIPTION
Fixes: EME-710

Before:
<img width="2784" height="270" alt="CleanShot 2026-01-05 at 15 01 13@2x" src="https://github.com/user-attachments/assets/871e15c5-64fd-4dea-a228-9dee606d4f13" />

After:
<img width="1814" height="372" alt="CleanShot 2026-01-05 at 15 09 37@2x" src="https://github.com/user-attachments/assets/3f013506-5249-4a4b-b4d0-53c92b76056a" />
<img width="2976" height="418" alt="CleanShot 2026-01-05 at 15 09 20@2x" src="https://github.com/user-attachments/assets/b3249cd1-aaa7-4b0f-858b-158b66eee94c" />



