### PR TITLE
Add org code mapping 404 test 

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -181,6 +181,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects)
 
         if integration_id:
+            # get_organization_integration will raise a 404 if no org_integration is found
             org_integration = self.get_organization_integration(organization, integration_id)
             queryset = queryset.filter(organization_integration_id=org_integration.id)
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -380,6 +380,20 @@ class OrganizationCodeMappingsTest(APITestCase):
         assert response.status_code == 400
         assert response.data == {"defaultBranch": [BRANCH_NAME_ERROR_MESSAGE]}
 
+    def test_get_with_integration_from_another_org_returns_404(self) -> None:
+        """GET with integrationId from another organization returns 404."""
+        other_org = self.create_organization(name="other-org")
+        other_integration = self.create_integration(
+            organization=other_org,
+            external_id="other-external-id",
+            provider="github",
+        )
+
+        url_path = f"{self.url}?integrationId={other_integration.id}"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 404, response.content
+
     def test_get_with_integrationId_enforces_project_access(self) -> None:
         """GET with integrationId only returns mappings for projects user can access."""
         self.organization.flags.allow_joinleave = False


### PR DESCRIPTION
Forgot the negative assertion test, integration should 404 if you don't have permissions

