### PR TITLE
test(code-review): Improvements

### DIFF
--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -741,6 +741,16 @@ class IssueCommentEventWebhookTest(GitHubWebhookHelper):
             self.mock_api_client = mock_api_client
             yield
 
+    @pytest.fixture(autouse=True)
+    def mock_seer_request(self) -> Generator[None]:
+        """
+        Prevents real HTTP requests to Seer API across all tests.
+        Uses autouse fixture to apply mocking automatically without @patch decorators on each test.
+        """
+        with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
+            self.mock_seer = mock_seer
+            yield
+
     def _send_issue_comment_event(self, event_data: bytes | str) -> HttpResponseBase:
         return self._send_webhook_event(GithubWebhookType.ISSUE_COMMENT, event_data)
 
@@ -765,89 +775,159 @@ class IssueCommentEventWebhookTest(GitHubWebhookHelper):
         }
         return orjson.dumps(event)
 
-    @patch("sentry.seer.code_review.webhooks.task.schedule_task")
-    def test_skips_when_code_review_not_enabled(self, mock_schedule: MagicMock) -> None:
-        event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-        self._send_issue_comment_event(event)
-        mock_schedule.assert_not_called()
+    def test_skips_when_code_review_not_enabled(self) -> None:
+        """Test that processing is skipped when code review features are not enabled."""
+        with self.options({"github.webhook.issue-comment": False}):
+            event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
 
-    @patch("sentry.seer.code_review.webhooks.task.schedule_task")
-    @with_feature({"organizations:gen-ai-features", "organizations:code-review-beta"})
-    def test_skips_when_no_review_command(self, mock_schedule: MagicMock) -> None:
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
+
+        self.mock_seer.assert_not_called()
+
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_skips_when_no_review_command(self) -> None:
+        """Test that processing is skipped when comment doesn't contain review command."""
         self._enable_code_review()
-        event = self._build_issue_comment_event("This is a regular comment without the command")
-        self._send_issue_comment_event(event)
-        mock_schedule.assert_not_called()
+        with self.options({"github.webhook.issue-comment": False}):
+            event = self._build_issue_comment_event("This is a regular comment without the command")
 
-    @patch("sentry.seer.code_review.webhooks.task.schedule_task")
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
+
+        self.mock_seer.assert_not_called()
+
     @with_feature({"organizations:gen-ai-features"})
     def test_runs_when_code_review_beta_flag_disabled_but_pr_review_test_generation_enabled(
-        self, mock_schedule: MagicMock
+        self,
     ) -> None:
+        """Test that processing runs with gen-ai-features flag alone when org option is enabled."""
         with self.options(
             {"organizations:code-review-beta": False, "github.webhook.issue-comment": False}
         ):
             self.organization.update_option("sentry:enable_pr_review_test_generation", True)
             event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-            self._send_issue_comment_event(event)
-        mock_schedule.assert_called_once()
 
-    @patch("sentry.seer.code_review.webhooks.task.make_seer_request")
-    @patch("sentry.seer.code_review.utils.GitHubApiClient")
-    @patch("sentry.integrations.github.client.GitHubApiClient.create_comment_reaction")
-    @with_feature({"organizations:gen-ai-features", "organizations:code-review-beta"})
-    def test_adds_reaction_and_forwards_when_valid(
-        self, mock_create_reaction: MagicMock, mock_api_client: MagicMock, mock_seer: MagicMock
-    ) -> None:
-        # Mock the GitHub API client to return PR data with head SHA
-        mock_client_instance = MagicMock()
-        mock_client_instance.get_pull_request.return_value = {"head": {"sha": "abc123"}}
-        mock_api_client.return_value = mock_client_instance
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
 
+        self.mock_seer.assert_called_once()
+
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_adds_reaction_and_forwards_when_valid(self) -> None:
+        """Test successful PR review command processing with reaction and Seer request."""
         self._enable_code_review()
         with self.options({"github.webhook.issue-comment": False}):
             event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
 
             with self.tasks():
-                self._send_issue_comment_event(event)
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
 
-        mock_create_reaction.assert_called_once()
-        mock_seer.assert_called_once()
+        self.mock_reaction.assert_called_once_with("owner/repo", "123456789", GitHubReaction.EYES)
+        self.mock_seer.assert_called_once()
 
-    @patch("sentry.seer.code_review.utils.GitHubApiClient")
+        call_args = self.mock_seer.call_args
+        assert call_args[1]["path"] == "/v1/automation/overwatch-request"
+        payload = call_args[1]["payload"]
+        assert payload["request_type"] == "pr-review"
+        assert payload["data"]["repo"]["base_commit_sha"] == "abc123"
+
     @patch("sentry.seer.code_review.webhooks.issue_comment._add_eyes_reaction_to_comment")
-    @patch("sentry.seer.code_review.webhooks.task.schedule_task")
-    @with_feature({"organizations:gen-ai-features", "organizations:code-review-beta"})
-    def test_skips_reaction_when_no_comment_id(
-        self, mock_schedule: MagicMock, mock_reaction: MagicMock, mock_api_client: MagicMock
-    ) -> None:
-        # Mock the GitHub API client to return PR data with head SHA
-        mock_client_instance = MagicMock()
-        mock_client_instance.get_pull_request.return_value = {"head": {"sha": "abc123"}}
-        mock_api_client.return_value = mock_client_instance
-
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_skips_reaction_when_no_comment_id(self, mock_reaction: MagicMock) -> None:
+        """Test that reaction is skipped when comment has no ID, but processing continues."""
         self._enable_code_review()
         with self.options({"github.webhook.issue-comment": False}):
             event = self._build_issue_comment_event(SENTRY_REVIEW_COMMAND, comment_id=None)
-            self._send_issue_comment_event(event)
+
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
 
         mock_reaction.assert_not_called()
-        mock_schedule.assert_called_once()
+        self.mock_seer.assert_called_once()
 
     @patch("sentry.seer.code_review.webhooks.issue_comment._add_eyes_reaction_to_comment")
-    @patch("sentry.seer.code_review.webhooks.task.schedule_task")
-    @with_feature({"organizations:gen-ai-features", "organizations:code-review-beta"})
-    def test_skips_processing_when_option_is_true(
-        self, mock_schedule: MagicMock, mock_reaction: MagicMock
-    ) -> None:
-        """Test that when github.webhook.issue-comment option is True (default), no processing occurs."""
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_skips_processing_when_option_is_true(self, mock_reaction: MagicMock) -> None:
+        """Test that when github.webhook.issue-comment option is True (kill switch), no processing occurs."""
         self._enable_code_review()
         with self.options({"github.webhook.issue-comment": True}):
             event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-            self._send_issue_comment_event(event)
+
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
 
         mock_reaction.assert_not_called()
-        mock_schedule.assert_not_called()
+        self.mock_seer.assert_not_called()
+
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_skips_when_comment_on_non_pr_issue(self) -> None:
+        """Test that comments on regular issues (not PRs) are skipped gracefully."""
+        self._enable_code_review()
+        with self.options({"github.webhook.issue-comment": False}):
+            event = {
+                "action": "created",
+                "comment": {
+                    "body": f"Please {SENTRY_REVIEW_COMMAND} this",
+                    "id": 123456789,
+                },
+                "issue": {
+                    "number": 42,
+                },
+                "repository": {
+                    "id": 12345,
+                    "full_name": "owner/repo",
+                    "html_url": "https://github.com/owner/repo",
+                },
+            }
+
+            with self.tasks():
+                response = self._send_issue_comment_event(orjson.dumps(event))
+                assert response.status_code == 204
+
+        self.mock_seer.assert_not_called()
+
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_processes_review_command_in_middle_of_comment(self) -> None:
+        """Test that review command is detected anywhere in the comment body."""
+        self._enable_code_review()
+        with self.options({"github.webhook.issue-comment": False}):
+            event = self._build_issue_comment_event(
+                f"I found a bug. {SENTRY_REVIEW_COMMAND} this change please. Thanks!"
+            )
+
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
+
+        self.mock_seer.assert_called_once()
+
+    @with_feature(CODE_REVIEW_FEATURES)
+    def test_validates_seer_request_contains_trigger_metadata(self) -> None:
+        """Test that Seer request includes trigger metadata from the comment."""
+        self._enable_code_review()
+        with self.options({"github.webhook.issue-comment": False}):
+            event_dict = orjson.loads(
+                self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
+            )
+            event_dict["comment"]["user"] = {"login": "test-user"}
+            event = orjson.dumps(event_dict)
+
+            with self.tasks():
+                response = self._send_issue_comment_event(event)
+                assert response.status_code == 204
+
+        self.mock_seer.assert_called_once()
+        payload = self.mock_seer.call_args[1]["payload"]
+        assert payload["data"]["config"]["trigger_user"] == "test-user"
+        assert payload["data"]["config"]["trigger_comment_id"] == 123456789
+        assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
 
 
 class AddEyesReactionTest(TestCase):

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Collection, Generator, Mapping
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -45,9 +45,11 @@ class GitHubWebhookHelper(GitHubWebhookTestCase):
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
     @contextmanager
-    def code_review_setup(self, features: set[str] | dict[str, Any] = CODE_REVIEW_FEATURES):
+    def code_review_setup(
+        self, features: Collection[str] | Mapping[str, Any] = CODE_REVIEW_FEATURES
+    ) -> Generator[None]:
         """Helper to set up code review test context."""
-        self._enable_code_review()
+        self.organization.update_option("sentry:enable_pr_review_test_generation", True)
         with (
             self.feature(features),
             self.options({"github.webhook.issue-comment": False}),


### PR DESCRIPTION
This is a follow-up to #105632 and #105560.

Changes included:
* Added assertion to verify that the webhook endpoint returns 204 (No Content)
* Added `mock_seer_request` autouse fixture
* Simplified tests thanks to autouse fixtures
* Patch Seer call instead of task scheduling (deeper integration testing)