### PR TITLE
feat(dashboards): convert user.geo.subregion from numeric to string version

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -41,6 +41,8 @@ function FilterSelectorTrigger({
   const filterValue = activeFilterValues[0] ?? '';
   const isDefaultOperator = operator === TermOperator.DEFAULT;
   const opLabel = isDefaultOperator ? ':' : OP_LABELS[operator];
+  const label =
+    options.find(option => option.value === filterValue)?.label || filterValue;
 
   return (
     <ButtonLabelWrapper gap="xs">
@@ -53,7 +55,7 @@ function FilterSelectorTrigger({
           {isAllSelected ? (
             t('All')
           ) : (
-            <FilterValueTruncated>{filterValue}</FilterValueTruncated>
+            <FilterValueTruncated>{label}</FilterValueTruncated>
           )}
         </span>
       )}


### PR DESCRIPTION
user.geo.subregion is a code, this Pr converts the code to a readable string in the global filter (the same way we already do in insights). Eventually this can done in other areas of our app.

Additionally, to make this work the global filter has been updated to display it's current selected label instead of value, although normally they are the same, it makes sense to use the label as that is what we display in the select dropdown so it will guarantee that the currently selected options match what's in the dropdown.

<img width="369" height="300" alt="image" src="https://github.com/user-attachments/assets/ba69f2ab-7464-44ca-9635-93f4d3121df2" />

