### PR TITLE
docs(cloudflare): Change onboarding script for Cloudflare Workers

### DIFF
--- a/static/app/gettingStartedDocs/node-cloudflare-workers/logs.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/logs.tsx
@@ -9,7 +9,7 @@ export const logs = getNodeLogsOnboarding({
     code: `import * as Sentry from "${packageName}";
 
 export default Sentry.withSentry(
-  env => ({
+  (env: Env) => ({
     dsn: "${params.dsn.public}",
     integrations: [
       // send console.log, console.warn, and console.error calls as logs to Sentry

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
@@ -25,7 +25,7 @@ const getSdkSetupSnippet = (params: DocsParams) => `
 import * as Sentry from "@sentry/cloudflare";
 
 export default Sentry.withSentry(
-  env => ({
+  (env: Env) => ({
     dsn: "${params.dsn.public}",${
       params.isPerformanceSelected
         ? `


### PR DESCRIPTION
This adds the workaround until v11 is out. At the moment we have to explicitly set `(env: Env) => ...` in order to make the types work. This can be reverted (no must) when following is merged and released: https://github.com/getsentry/sentry-javascript/pull/18302

reference: https://github.com/getsentry/sentry-javascript/issues/18294#issuecomment-3710725391