### PR TITLE
fix(dashboards): dashboard link should include project

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -118,6 +118,7 @@ export type RenderFunctionBaggage = {
   disableLazyLoad?: boolean;
   eventView?: EventView;
   projectSlug?: string;
+  projects?: Project[];
   /**
    * The trace item meta data for the trace item, which includes information needed to render annotated tooltip (eg. scrubbing reasons)
    */
@@ -1410,16 +1411,7 @@ function wrapFieldRendererInDashboardLink(
   dashboardFilters: DashboardFilters | undefined = undefined
 ): FieldFormatterRenderFunctionPartial {
   return function (data, baggage) {
-    const {organization, location} = baggage;
-    const value = data[field];
-    const dashboardUrl = getDashboardUrl(
-      field,
-      value,
-      organization,
-      location,
-      widget,
-      dashboardFilters
-    );
+    const dashboardUrl = getDashboardUrl(data, field, baggage, widget, dashboardFilters);
     if (dashboardUrl) {
       return <Link to={dashboardUrl}>{renderer(data, baggage)}</Link>;
     }
@@ -1428,13 +1420,13 @@ function wrapFieldRendererInDashboardLink(
 }
 
 function getDashboardUrl(
+  data: EventData,
   field: string,
-  value: any,
-  organization: Organization,
-  location: Location,
+  baggage: RenderFunctionBaggage,
   widget: Widget | undefined = undefined,
   dashboardFilters: DashboardFilters | undefined = undefined
 ) {
+  const {organization, location, projects} = baggage;
   if (widget?.widgetType && dashboardFilters) {
     // Table widget only has one query
     const dashboardLink = widget.queries[0]?.linkedDashboards?.find(
@@ -1451,7 +1443,8 @@ function getDashboardUrl(
 
       // Format the value as a proper filter condition string
       const mutableSearch = new MutableSearch('');
-      const formattedValue = mutableSearch.addFilterValueList(field, [value]).toString();
+      mutableSearch.addFilterValueList(field, [data[field]]);
+      const formattedValue = mutableSearch.toString();
 
       newTemporaryFilters.push({
         dataset: widget.widgetType,
@@ -1470,14 +1463,22 @@ function getDashboardUrl(
         'end',
       ]);
 
+      if ('project' in data) {
+        const projectId = projects?.find(project => project.slug === data.project)?.id;
+        if (projectId) {
+          filterParams.project = projectId;
+        }
+      }
+
       const url = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/?${qs.stringify(
         {
-          ...filterParams,
           [DashboardFilterKeys.GLOBAL_FILTER]: newTemporaryFilters.map(filter =>
             JSON.stringify(filter)
           ),
+          ...filterParams,
         }
       )}`;
+
       return url;
     }
   }

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1443,8 +1443,9 @@ function getDashboardUrl(
 
       // Format the value as a proper filter condition string
       const mutableSearch = new MutableSearch('');
-      mutableSearch.addFilterValueList(field, [data[field]]);
-      const formattedValue = mutableSearch.toString();
+      const formattedValue = mutableSearch
+        .addFilterValueList(field, [data[field]])
+        .toString();
 
       newTemporaryFilters.push({
         dataset: widget.widgetType,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -58,6 +58,7 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {useTrackAnalyticsOnSpanMigrationError} from 'sentry/views/dashboards/hooks/useTrackAnalyticsOnSpanMigrationError';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -522,7 +523,7 @@ function TableComponent({
   const location = useLocation();
   const navigate = useNavigate();
   const theme = useTheme();
-
+  const {projects} = useProjects();
   if (loading || !tableResults?.[0]) {
     // Align height to other charts.
     return <LoadingPlaceholder />;
@@ -606,6 +607,7 @@ function TableComponent({
             return {
               location,
               organization,
+              projects,
               theme,
               unit,
               eventView,

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -21,6 +21,7 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   TabularColumn,
@@ -156,6 +157,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
   const theme = useTheme();
   const location = useLocation();
   const organization = useOrganization();
+  const {projects} = useProjects();
   const navigate = useNavigate();
 
   const getGenericRenderer: FieldRendererGetter = (field, _dataRow, meta) => {
@@ -175,6 +177,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
       theme,
       location,
       unit,
+      projects,
     };
   };
 


### PR DESCRIPTION
Updates the dashboard link to also include project as a filter when it's a column.

This is needed for http module, for example, if a user has all projects selected, but clicks on `*.sentry.io`
<img width="702" height="257" alt="image" src="https://github.com/user-attachments/assets/744b72dd-86c8-4e2c-aae4-70a649f450e0" />

the next page should filter by `project = javascript`
<img width="644" height="291" alt="image" src="https://github.com/user-attachments/assets/4a869de1-336a-4eae-8be3-f2d056880f10" />

