### PR TITLE
feat(tracemetrics): Handle sort resets for visualize changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/aggregateSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/aggregateSelector.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo} from 'react';
+import {useMemo} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {t} from 'sentry/locale';
@@ -39,44 +39,6 @@ export function AggregateSelector({
     () => OPTIONS_BY_TYPE[traceMetric?.type ?? ''] ?? [],
     [traceMetric?.type]
   );
-
-  // Ensure the aggregate is valid for the trace metric type
-  useEffect(() => {
-    if (field.kind !== 'function' || !field.function?.[0] || !traceMetric.type) {
-      return;
-    }
-
-    const aggregate = field.function[0];
-    if (
-      aggregate &&
-      !aggregateOptions.some(option => option.value === aggregate) &&
-      aggregateSource
-    ) {
-      const validAggregate = aggregateOptions[0]?.value;
-      dispatch({
-        type: actionType,
-        payload:
-          aggregateSource?.map((axis, i) =>
-            i === index
-              ? ({
-                  function: [validAggregate, 'value', undefined, undefined],
-                  alias: undefined,
-                  kind: 'function',
-                } as QueryFieldValue)
-              : axis
-          ) ?? [],
-      });
-    }
-  }, [
-    aggregateOptions,
-    dispatch,
-    index,
-    aggregateSource,
-    actionType,
-    field.kind,
-    field,
-    traceMetric.type,
-  ]);
 
   return (
     <AggregateCompactSelect

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -706,7 +706,14 @@ function useWidgetBuilderState(): {
             // any of the current fields
             if (
               sort &&
-              !checkTraceMetricSortUsed(sort, action.payload, updatedAggregates, fields)
+              !checkTraceMetricSortUsed(
+                sort,
+                action.payload,
+                // Depending on the display type, the updated aggregates can be either
+                // the yAxis or the fields
+                isChartDisplayType(displayType) ? updatedAggregates : yAxis,
+                isChartDisplayType(displayType) ? fields : updatedAggregates
+              )
             ) {
               if (updatedAggregates.length > 0) {
                 setSort(
@@ -923,11 +930,14 @@ function checkTraceMetricSortUsed(
   yAxis: Column[] = [],
   fields: Column[] = []
 ): boolean {
+  const sortValue = sort[0]?.field;
   const sortInFields = fields?.some(
-    field => generateFieldAsString(field) === sort[0]?.field
+    field =>
+      generateFieldAsString(field) === sortValue ||
+      generateMetricAggregate(traceMetric, field) === sortValue
   );
   const sortInYAxis = yAxis?.some(
-    field => generateMetricAggregate(traceMetric, field) === sort[0]?.field
+    field => generateMetricAggregate(traceMetric, field) === sortValue
   );
   return sortInFields || sortInYAxis;
 }

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -708,18 +708,22 @@ function useWidgetBuilderState(): {
               sort &&
               !checkTraceMetricSortUsed(sort, action.payload, updatedAggregates, fields)
             ) {
-              setSort(
-                [
-                  {
-                    field: generateMetricAggregate(
-                      action.payload,
-                      updatedAggregates?.[0]!
-                    ),
-                    kind: 'desc',
-                  },
-                ],
-                options
-              );
+              if (updatedAggregates.length > 0) {
+                setSort(
+                  [
+                    {
+                      field: generateMetricAggregate(
+                        action.payload,
+                        updatedAggregates[0]!
+                      ),
+                      kind: 'desc',
+                    },
+                  ],
+                  options
+                );
+              } else {
+                setSort([], options);
+              }
             }
           }
           break;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -706,6 +706,7 @@ function useWidgetBuilderState(): {
             // any of the current fields
             if (
               sort &&
+              sort.length > 0 &&
               !checkTraceMetricSortUsed(
                 sort,
                 action.payload,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -702,6 +702,8 @@ function useWidgetBuilderState(): {
               }
             }
 
+            // Update the sort if the current sort is not used in
+            // any of the current fields
             if (
               sort &&
               !checkTraceMetricSortUsed(sort, action.payload, updatedAggregates, fields)

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -572,29 +572,25 @@ function useWidgetBuilderState(): {
             }
           }
 
-          if (action.payload.length > 0 && fields?.length === 0) {
-            // Clear the sort if there is no grouping
+          // If there are yAxis fields but no groupings, clear the sort
+          if (action.payload.length > 0 && (!fields || fields.length === 0)) {
             setSort([], options);
-          }
-
-          if (
+          } else if (
+            action.payload.length > 0 &&
             dataset === WidgetType.TRACEMETRICS &&
             traceMetric &&
-            sort &&
-            sort.length > 0 &&
-            action.payload.length > 0
+            sort?.length &&
+            !checkTraceMetricSortUsed(sort, traceMetric, action.payload, fields)
           ) {
-            if (!checkTraceMetricSortUsed(sort, traceMetric, action.payload, fields)) {
-              setSort(
-                [
-                  {
-                    kind: 'desc',
-                    field: generateMetricAggregate(traceMetric, action.payload[0]!),
-                  },
-                ],
-                options
-              );
-            }
+            setSort(
+              [
+                {
+                  kind: 'desc',
+                  field: generateMetricAggregate(traceMetric, action.payload[0]!),
+                },
+              ],
+              options
+            );
           }
           break;
         case BuilderStateAction.SET_QUERY:


### PR DESCRIPTION
The orderby wasn't resetting properly when the tracemetric changed or when the aggregate changed and made the function invalid. This meant that the request to `events-timeseries` was sending an orderby for something that was unselected which threw an error.

I had to update the widget builder state hook to handle trace metrics. There are two selectors, one for the tracemetric and one for the aggregate. When the tracemetric is changed we need to check if the aggregate is valid, make it valid, and then the sort also needs to sync to choose something valid.

If the aggregate is changed, we only need to check and see if it's valid in the selection. If it isn't, choose the first to set it to.