### PR TITLE
chore(preprod): Set default data EAP retention to 13 months

### DIFF
--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -23,6 +23,8 @@ from sentry.search.eap.rpc_utils import anyvalue
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
 
+THIRTEEN_MONTHS = 396  # 13 months in days
+
 
 def produce_preprod_size_metric_to_eap(
     size_metric: PreprodArtifactSizeMetrics,
@@ -109,7 +111,7 @@ def produce_preprod_size_metric_to_eap(
         timestamp=proto_timestamp,
         trace_id=trace_id,
         received=received,
-        retention_days=90,  # Default retention for preprod data
+        retention_days=THIRTEEN_MONTHS,  # Default retention for preprod data
         attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},
         client_sample_rate=1.0,
         server_sample_rate=1.0,
@@ -217,7 +219,7 @@ def produce_preprod_build_distribution_to_eap(
         timestamp=proto_timestamp,
         trace_id=trace_id,
         received=received,
-        retention_days=90,
+        retention_days=THIRTEEN_MONTHS,
         attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},
         client_sample_rate=1.0,
         server_sample_rate=1.0,

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -7,6 +7,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.eap.write import (
+    THIRTEEN_MONTHS,
     produce_preprod_build_distribution_to_eap,
     produce_preprod_size_metric_to_eap,
 )
@@ -82,7 +83,7 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
         assert trace_item.organization_id == self.organization.id
         assert trace_item.project_id == self.project.id
         assert trace_item.item_type == TraceItemType.TRACE_ITEM_TYPE_PREPROD
-        assert trace_item.retention_days == 90
+        assert trace_item.retention_days == THIRTEEN_MONTHS
 
         attrs = trace_item.attributes
 
@@ -231,7 +232,7 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
         assert trace_item.organization_id == self.organization.id
         assert trace_item.project_id == self.project.id
         assert trace_item.item_type == TraceItemType.TRACE_ITEM_TYPE_PREPROD
-        assert trace_item.retention_days == 90
+        assert trace_item.retention_days == THIRTEEN_MONTHS
 
         attrs = trace_item.attributes
 


### PR DESCRIPTION
While we wait for the billing code to be implemented so we can have proper retention values set based off the plan type, we should use the default max retention so that enterprise customers don't start losing size data when they shouldn't have

better to trim down retention later than the opposite