### PR TITLE
ref(replay): Move live/refresh logic into hooks

### DIFF
--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
@@ -15,18 +15,14 @@ import {
   getReplayExpiresAtMs,
   LIVE_TOOLTIP_MESSAGE,
   LiveIndicator,
+  useLiveRefresh,
 } from 'sentry/components/replays/replayLiveIndicator';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {useQueryClient} from 'sentry/utils/queryClient';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
-import usePollReplayRecord from 'sentry/utils/replays/hooks/usePollReplayRecord';
-import {useReplayProjectSlug} from 'sentry/utils/replays/hooks/useReplayProjectSlug';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useReplaySummaryContext} from 'sentry/views/replays/detail/ai/replaySummaryContext';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 interface Props {
@@ -36,11 +32,7 @@ interface Props {
 export default function ReplayDetailsUserBadge({readerResult}: Props) {
   const organization = useOrganization();
   const replayRecord = readerResult.replayRecord;
-
-  const {slug: orgSlug} = organization;
-  const replayId = readerResult.replayId;
-
-  const queryClient = useQueryClient();
+  const {shouldShowRefreshButton, doRefresh} = useLiveRefresh({replay: replayRecord});
 
   // Generate search query based on available user data
   const getUserSearchQuery = () => {
@@ -61,39 +53,9 @@ export default function ReplayDetailsUserBadge({readerResult}: Props) {
 
   const searchQuery = getUserSearchQuery();
   const userDisplayName = replayRecord?.user.display_name || t('Anonymous User');
-  const projectSlug = useReplayProjectSlug({replayRecord});
-
-  const {startSummaryRequest} = useReplaySummaryContext();
-
-  const handleRefresh = async () => {
-    trackAnalytics('replay.details-refresh-clicked', {organization});
-    await queryClient.refetchQueries({
-      queryKey: [`/organizations/${orgSlug}/replays/${replayId}/`],
-      exact: true,
-      type: 'all',
-    });
-    await queryClient.invalidateQueries({
-      queryKey: [
-        `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/recording-segments/`,
-      ],
-      type: 'all',
-    });
-    startSummaryRequest();
-  };
 
   const isReplayExpired =
     Date.now() > getReplayExpiresAtMs(replayRecord?.started_at ?? null);
-
-  const polledReplayRecord = usePollReplayRecord({
-    enabled: !isReplayExpired,
-    replayId,
-    orgSlug,
-  });
-
-  const polledCountSegments = polledReplayRecord?.count_segments ?? 0;
-  const prevSegments = replayRecord?.count_segments ?? 0;
-
-  const showRefreshButton = polledCountSegments > prevSegments;
 
   const showLiveIndicator =
     !isReplayExpired && replayRecord && getLiveDurationMs(replayRecord.finished_at) > 0;
@@ -148,8 +110,8 @@ export default function ReplayDetailsUserBadge({readerResult}: Props) {
                 title={t('Replay is outdated. Refresh for latest activity.')}
                 data-test-id="refresh-button"
                 size="xs"
-                onClick={handleRefresh}
-                style={{visibility: showRefreshButton ? 'visible' : 'hidden'}}
+                onClick={doRefresh}
+                style={{visibility: shouldShowRefreshButton ? 'visible' : 'hidden'}}
               >
                 <IconRefresh />
               </Button>

--- a/static/app/views/replays/details.spec.tsx
+++ b/static/app/views/replays/details.spec.tsx
@@ -25,7 +25,9 @@ mockUseLoadReplayReader.mockReturnValue({
   projectSlug: ProjectFixture().slug,
   replay: null,
   replayId: 'test-replay-id',
-  replayRecord: ReplayRecordFixture(),
+  replayRecord: ReplayRecordFixture({
+    id: 'test-replay-id',
+  }),
   status: 'success' as const,
 });
 


### PR DESCRIPTION
This moves our replay "live" and "refresh" logic into two hooks: `useLiveBadge` and `useLiveRefresh` so that the logic is not tied to broader components
