### PR TITLE
chore(ui): Enforce getsentry import boundaries on dynamic imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ import globals from 'globals';
 import invariant from 'invariant';
 import typescript from 'typescript-eslint';
 
+// eslint-disable-next-line boundaries/element-types
 import * as sentryScrapsPlugin from './static/eslint/eslintPluginScraps/index.mjs';
 
 invariant(react.configs.flat, 'For typescript');
@@ -985,6 +986,9 @@ export default typescript.config([
       boundaries,
     },
     settings: {
+      // Analyze both static and dynamic imports for boundary checks
+      // https://www.jsboundaries.dev/docs/setup/settings/#boundariesdependency-nodes
+      'boundaries/dependency-nodes': ['import', 'dynamic-import'],
       // order matters here because of nested directories
       'boundaries/elements': [
         // --- stories ---
@@ -1100,7 +1104,7 @@ export default typescript.config([
       'boundaries/no-ignored': 'off',
       'boundaries/no-private': 'off',
       'boundaries/element-types': [
-        'warn',
+        'error',
         {
           default: 'disallow',
           message: '${file.type} is not allowed to import ${dependency.type}',

--- a/static/app/index.tsx
+++ b/static/app/index.tsx
@@ -85,7 +85,9 @@ async function app() {
   // We have split up the imports this way so that locale is initialized as
   // early as possible, (e.g. before `registerHooks` is imported otherwise the
   // imports in `registerHooks` will not be in the correct locale.
+  // eslint-disable-next-line boundaries/element-types -- getsentry entrypoint
   const registerHooksImport = import('getsentry/registerHooks');
+  // eslint-disable-next-line boundaries/element-types -- getsentry entrypoint
   const initalizeBundleMetricsImport = import('getsentry/initializeBundleMetrics');
 
   // getsentry augments Sentry's application through a 'hook' mechanism. Sentry

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -313,10 +313,12 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/stories/*',
       withOrgPath: true,
+      // eslint-disable-next-line boundaries/element-types -- storybook entrypoint
       component: make(() => import('sentry/stories/view/index')),
     },
     {
       path: '/debug/notifications/:notificationSource?/',
+      // eslint-disable-next-line boundaries/element-types -- debug tools entrypoint
       component: make(() => import('sentry/debug/notifications/views/index')),
       withOrgPath: true,
     },
@@ -1204,32 +1206,39 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'seer/',
       name: t('Seer'),
+      // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
       component: make(() => import('getsentry/views/seerAutomation/index')),
       children: [
         {
           path: 'trial/',
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/trial')),
         },
         {
           index: true,
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/seerAutomation')),
         },
         {
           path: 'projects/',
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/projects')),
         },
         {
           path: 'repos/',
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/repos')),
         },
         {
           path: 'repos/:repoId/',
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/repoDetails')),
         },
         {
           path: 'onboarding/',
           name: t('Setup Wizard'),
           component: make(
+            // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
             () => import('getsentry/views/seerAutomation/onboarding/onboarding')
           ),
         },

--- a/static/app/views/integrationPipeline/pipelineView.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.tsx
@@ -99,6 +99,7 @@ function PipelineView({pipelineName, ...props}: Props) {
     window.superUserCookieName = data.superUserCookieName;
     window.superUserCookieDomain = data.superUserCookieDomain ?? undefined;
 
+    // eslint-disable-next-line boundaries/element-types -- getsentry entrypoint
     const registerHooksImport = import('getsentry/registerHooks');
     const {default: registerHooks} = await registerHooksImport;
     registerHooks();


### PR DESCRIPTION
Rule was set to warning which we actually want an error. Adds some disables and a few todos that were violating the rules.
