### PR TITLE
fix(integrations): Disable uninstall button when integration is pending deletion

### DIFF
--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -123,6 +123,7 @@ export default class InstalledIntegration extends Component<Props> {
           const canConfigure =
             (hasAccess || superuser) && this.integrationStatus === 'active';
           const disableAction = !(hasAccess && this.integrationStatus === 'active');
+          const isPendingDeletion = this.integrationStatus === 'pending_deletion';
           return (
             <Fragment>
               <IntegrationItemBox>
@@ -174,11 +175,11 @@ export default class InstalledIntegration extends Component<Props> {
                   <Confirm
                     priority="danger"
                     onConfirming={this.handleUninstallClick}
-                    disabled={!hasAccess}
+                    disabled={!hasAccess || isPendingDeletion}
                     {...removeConfirmProps}
                   >
                     <StyledButton
-                      disabled={!hasAccess}
+                      disabled={!hasAccess || isPendingDeletion}
                       borderless
                       icon={<IconDelete />}
                       data-test-id="integration-remove-button"

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -157,6 +157,46 @@ describe('IntegrationDetailedView', () => {
     );
   });
 
+  it('disables uninstall button when integration is pending deletion', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'bitbucket', includeConfig: 0})],
+      body: [
+        {
+          accountType: null,
+          configData: {},
+          configOrganization: [],
+          domainName: 'bitbucket.org/%7Bfb715533-bbd7-4666-aa57-01dc93dd9cc0%7D',
+          icon: 'https://secure.gravatar.com/avatar/8b4cb68e40b74c90427d8262256bd1c8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNN-0.png',
+          id: '4',
+          name: '{fb715533-bbd7-4666-aa57-01dc93dd9cc0}',
+          provider: {
+            aspects: {},
+            canAdd: true,
+            canDisable: false,
+            features: ['commits', 'issue-basic'],
+            key: 'bitbucket',
+            name: 'Bitbucket',
+            slug: 'bitbucket',
+          },
+          status: 'active',
+          organizationIntegrationStatus: 'pending_deletion',
+        },
+      ],
+    });
+
+    render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('bitbucket', {tab: 'configurations'}),
+      organization,
+    });
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Uninstall'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
   it('allows members to configure github/gitlab', async () => {
     const lowerAccessOrganization = OrganizationFixture({access: ['org:read']});
     render(<IntegrationDetailedView />, {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -189,12 +189,12 @@ describe('IntegrationDetailedView', () => {
       initialRouterConfig: createRouterConfig('bitbucket', {tab: 'configurations'}),
       organization,
     });
-    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: 'Uninstall'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'Uninstall'})).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
   });
 
   it('allows members to configure github/gitlab', async () => {


### PR DESCRIPTION
## Summary
- Disables the "Uninstall" button on integration settings pages when the integration is already in `pending_deletion` status
- Previously, users could repeatedly click "Uninstall" on an integration that was already being deleted

## Test plan
- Navigate to `/settings/integrations/{provider}/`
- Click "Uninstall" on an integration
- Verify the button becomes disabled while the integration is in "pending deletion" state


NOTICE:

This PR was created with Claude Code using Opus-4.5 (Thinking) with the prompt:

> bug: if i hit "uninstall" on an integration on
/settings/integrations/cursor/, and then it goes into pending deletion, I
can still hit "uninstall" again. it seems like if its pending deletion
the uninstall buttons shouldn't show or be disabled?

I also had to prompt cc to add a test.

