### PR TITLE
fix(core-ui): Bump grid sticket z-index

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -13,7 +13,7 @@ const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
  * Local z-index stacking context
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
  */
-const Z_INDEX_STICKY_HEADER = 1;
+const Z_INDEX_STICKY_HEADER = 2;
 
 // Parent context is GridHeadCell
 const Z_INDEX_GRID_RESIZER = 1;


### PR DESCRIPTION
Not sure this is the ideal approach, but attempting to resolve some conflicting z-index from the grid header, and button styles. The core ui button has a z-index of 1 being applied, which clashes with the sticky header of the grid header.

Before:
<img width="1326" height="122" alt="Screenshot 2026-01-05 at 15 35 52" src="https://github.com/user-attachments/assets/f19ded45-1598-49dc-927f-dcf6e446801f" />

After:
<img width="1334" height="128" alt="Screenshot 2026-01-05 at 15 35 38" src="https://github.com/user-attachments/assets/9edeae15-a6fc-4171-8e0e-45ca89b707c7" />