### PR TITLE
feat(issue search): Enable fallback to truncation of group IDs for all Snuba queries

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3834,6 +3834,15 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Option to enable truncation of group IDs in Snuba query
+# when search filters are selective.
+register(
+    "snuba.search.truncate-group-ids-for-selective-filters-enabled",
+    type=Bool,
+    default=True,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Organization slug allowlist to enable Autopilot for specific organizations.
 register(
     "autopilot.organization-allowlist",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -961,12 +961,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # If we had too_many_candidates, fall back to truncation instead of
             # returning empty. This handles selective filters (like assigned_to)
             # where random sampling is unlikely to find matches.
-            truncation_allowlist = options.get(
-                "snuba.search.truncate-group-ids-for-selective-filters-project-allowlist"
-            )
-            is_truncation_enabled = any(pid in truncation_allowlist for pid in project_ids)
-
-            if too_many_candidates and original_group_ids and is_truncation_enabled:
+            if too_many_candidates and original_group_ids:
                 metrics.incr("snuba.search.hits_zero_fallback_to_truncation", skip_internal=False)
                 group_ids = original_group_ids[:max_candidates]
                 too_many_candidates = False

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -961,7 +961,10 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # If we had too_many_candidates, fall back to truncation instead of
             # returning empty. This handles selective filters (like assigned_to)
             # where random sampling is unlikely to find matches.
-            if too_many_candidates and original_group_ids:
+            is_truncation_enabled = options.get(
+                "snuba.search.truncate-group-ids-for-selective-filters-enabled"
+            )
+            if too_many_candidates and original_group_ids and is_truncation_enabled:
                 metrics.incr("snuba.search.hits_zero_fallback_to_truncation", skip_internal=False)
                 group_ids = original_group_ids[:max_candidates]
                 too_many_candidates = False

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1941,9 +1941,6 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         with self.options(
             {
                 "snuba.search.max-pre-snuba-candidates": 1,
-                "snuba.search.truncate-group-ids-for-selective-filters-project-allowlist": [
-                    self.project.id
-                ],
             }
         ):
             # Mock calculate_hits to return 0, simulating failed sampling


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/105204.

Enables fallback to truncation of group IDs for all Snuba queries (previously was relying on a project allowlist).