### PR TITLE
feat(grouping): Add test input where all exceptions are groups

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/exception-groups-bad-all-exceptions-marked-as-groups.json
+++ b/tests/sentry/grouping/grouping_inputs/exception-groups-bad-all-exceptions-marked-as-groups.json
@@ -1,0 +1,27 @@
+{
+  "exception": {
+    "values": [
+      {
+        "type": "InnerException",
+        "value": "Nope",
+        "mechanism": {
+          "type": "chained",
+          "handled": false,
+          "is_exception_group": true,
+          "exception_id": 1,
+          "parent_id": 0
+        }
+      },
+      {
+        "type": "System.AggregateException",
+        "value": "One or more errors occurred.",
+        "mechanism": {
+          "type": "AppDomain.UnhandledException",
+          "handled": false,
+          "is_exception_group": true,
+          "exception_id": 0
+        }
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,32 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "0809098f9f613b63467605dd1739cc9b"
+    contributing component: exception
+    hint: None
+    root_component:
+      app*
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,32 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "0809098f9f613b63467605dd1739cc9b"
+    contributing component: exception
+    hint: None
+    root_component:
+      app*
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,57 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_exception_message": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "System.AggregateException"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "value",
+                "name": null,
+                "values": [
+                  "One or more errors occurred."
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": []
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "exception message",
+      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "hint": null,
+      "key": "app_exception_message",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,57 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2025-11-21",
+  "variants": {
+    "app_exception_message": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "System.AggregateException"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "value",
+                "name": null,
+                "values": [
+                  "One or more errors occurred."
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": []
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "exception message",
+      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "hint": null,
+      "key": "app_exception_message",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,14 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: "0809098f9f613b63467605dd1739cc9b"
+  contributing component: exception
+  hint: None
+  root_component:
+    app*
+      exception*
+        type*
+          "System.AggregateException"
+        value*
+          "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -1,0 +1,14 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: "0809098f9f613b63467605dd1739cc9b"
+  contributing component: exception
+  hint: None
+  root_component:
+    app*
+      exception*
+        type*
+          "System.AggregateException"
+        value*
+          "One or more errors occurred."


### PR DESCRIPTION
This adds a new grouping input to our tests, illustrating the case in which all exceptions in a chain are marked as exception groups. Though this shouldn't happen, it does, and we don't handle it gracefully. A fix will be included in an upcoming PR; the input is added here separately so the effects of that fix will be clearer.