### PR TITLE
fix(grouping): Handle case where all exceptions are groups

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -811,6 +811,13 @@ def filter_exceptions_for_exception_groups(
         # If there's no root exception, return the original list
         return exceptions
 
+    # It's possible to end up with no top-level exceptions, for example if all exceptions in the
+    # chain are marked as exception groups and therefore all get excluded, or if the exception tree
+    # contains a cycle. (Ideally SDKs should never mark the data this way, but we've run into this
+    # before.) In that case, return the list as is.
+    if not top_level_exceptions:
+        return exceptions
+
     # Figure out the distinct top-level exceptions, grouping by the hash of the grouping component values.
     distinct_top_level_exceptions = [
         next(group)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -717,6 +717,12 @@ def filter_exceptions_for_exception_groups(
     exception_components: dict[int, dict[str, ExceptionGroupingComponent]],
     event: Event,
 ) -> list[SingleException]:
+    """
+    Attempt to filter exceptions in exception groups in order to deduplicate sibling exceptions, and
+    in order to ignore wrapper aggregate exceptions if all they do is add a level to the chain.
+
+    If the data is malformed in any way, return the list of exceptions as is.
+    """
     # This function only filters exceptions if there are at least two exceptions.
     if len(exceptions) <= 1:
         return exceptions

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -20,13 +20,19 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "93b26686d00504b4e5aa1cb0244d8b37"
+    contributing component: chained_exception
     hint: None
     root_component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained_exception*
+          exception*
+            type*
+              "InnerException"
+            value*
+              "Nope"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -3,7 +3,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 ---
 hash_basis: message
 hashing_metadata: {
-  "message_parameterized": false,
+  "message_parameterized": true,
   "message_source": "exception"
 }
 ---
@@ -13,20 +13,31 @@ metrics with tags: {
     "is_hybrid_fingerprint": "False"
   },
   "grouping.grouphashmetadata.event_hashing_metadata.message": {
-    "message_parameterized": "False",
+    "message_parameterized": "True",
     "message_source": "exception"
   }
 }
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
+    contributing component: chained_exception
     hint: None
     root_component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained_exception*
+          exception*
+            type*
+              "System.Exception"
+            value*
+              "Some Inner Exception"
+          exception*
+            type*
+              "MyApp.Exception"
+            value* (stripped event-specific values)
+              "Test <int>"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -20,13 +20,19 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "93b26686d00504b4e5aa1cb0244d8b37"
+    contributing component: chained_exception
     hint: None
     root_component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained_exception*
+          exception*
+            type*
+              "InnerException"
+            value*
+              "Nope"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
@@ -3,7 +3,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 ---
 hash_basis: message
 hashing_metadata: {
-  "message_parameterized": false,
+  "message_parameterized": true,
   "message_source": "exception"
 }
 ---
@@ -13,20 +13,31 @@ metrics with tags: {
     "is_hybrid_fingerprint": "False"
   },
   "grouping.grouphashmetadata.event_hashing_metadata.message": {
-    "message_parameterized": "False",
+    "message_parameterized": "True",
     "message_source": "exception"
   }
 }
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
+    contributing component: chained_exception
     hint: None
     root_component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained_exception*
+          exception*
+            type*
+              "System.Exception"
+            value*
+              "Some Inner Exception"
+          exception*
+            type*
+              "MyApp.Exception"
+            value* (stripped event-specific values)
+              "Test <int>"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2023-01-11",
   "variants": {
-    "app_exception_message": {
+    "app_chained_exception_message": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,43 +14,84 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "chained_exception",
+            "name": null,
             "values": [
               {
                 "contributes": true,
                 "hint": null,
-                "id": "type",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "System.AggregateException"
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "InnerException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Nope"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
                 "contributes": true,
                 "hint": null,
-                "id": "value",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "One or more errors occurred."
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.AggregateException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "One or more errors occurred."
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
-              },
-              {
-                "contributes": false,
-                "hint": null,
-                "id": "stacktrace",
-                "name": "stacktrace",
-                "values": []
               }
             ]
           }
         ]
       },
       "contributes": true,
-      "description": "exception message",
-      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "description": "chained exception messages",
+      "hash": "93b26686d00504b4e5aa1cb0244d8b37",
       "hint": null,
-      "key": "app_exception_message",
+      "key": "app_chained_exception_message",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2023-01-11",
   "variants": {
-    "app_exception_message": {
+    "app_chained_exception_message": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,43 +14,117 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "chained_exception",
+            "name": null,
             "values": [
               {
                 "contributes": true,
                 "hint": null,
-                "id": "type",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "System.AggregateException"
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.Exception"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Some Inner Exception"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
                 "contributes": true,
                 "hint": null,
-                "id": "value",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "One or more errors occurred."
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "MyApp.Exception"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "stripped event-specific values",
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Test <int>"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
-                "contributes": false,
+                "contributes": true,
                 "hint": null,
-                "id": "stacktrace",
-                "name": "stacktrace",
-                "values": []
+                "id": "exception",
+                "name": "exception",
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.AggregateException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "One or more errors occurred."
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
+                ]
               }
             ]
           }
         ]
       },
       "contributes": true,
-      "description": "exception message",
-      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "description": "chained exception messages",
+      "hash": "e2bf1e0628b7b1824a9b63dec7a079a3",
       "hint": null,
-      "key": "app_exception_message",
+      "key": "app_chained_exception_message",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2025-11-21",
   "variants": {
-    "app_exception_message": {
+    "app_chained_exception_message": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,43 +14,84 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "chained_exception",
+            "name": null,
             "values": [
               {
                 "contributes": true,
                 "hint": null,
-                "id": "type",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "System.AggregateException"
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "InnerException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Nope"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
                 "contributes": true,
                 "hint": null,
-                "id": "value",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "One or more errors occurred."
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.AggregateException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "One or more errors occurred."
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
-              },
-              {
-                "contributes": false,
-                "hint": null,
-                "id": "stacktrace",
-                "name": "stacktrace",
-                "values": []
               }
             ]
           }
         ]
       },
       "contributes": true,
-      "description": "exception message",
-      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "description": "chained exception messages",
+      "hash": "93b26686d00504b4e5aa1cb0244d8b37",
       "hint": null,
-      "key": "app_exception_message",
+      "key": "app_chained_exception_message",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2025-11-21",
   "variants": {
-    "app_exception_message": {
+    "app_chained_exception_message": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,43 +14,117 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "chained_exception",
+            "name": null,
             "values": [
               {
                 "contributes": true,
                 "hint": null,
-                "id": "type",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "System.AggregateException"
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.Exception"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Some Inner Exception"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
                 "contributes": true,
                 "hint": null,
-                "id": "value",
-                "name": null,
+                "id": "exception",
+                "name": "exception",
                 "values": [
-                  "One or more errors occurred."
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "MyApp.Exception"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "stripped event-specific values",
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "Test <int>"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
                 ]
               },
               {
-                "contributes": false,
+                "contributes": true,
                 "hint": null,
-                "id": "stacktrace",
-                "name": "stacktrace",
-                "values": []
+                "id": "exception",
+                "name": "exception",
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "type",
+                    "name": null,
+                    "values": [
+                      "System.AggregateException"
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "value",
+                    "name": null,
+                    "values": [
+                      "One or more errors occurred."
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "stacktrace",
+                    "name": "stacktrace",
+                    "values": []
+                  }
+                ]
               }
             ]
           }
         ]
       },
       "contributes": true,
-      "description": "exception message",
-      "hash": "0809098f9f613b63467605dd1739cc9b",
+      "description": "chained exception messages",
+      "hash": "e2bf1e0628b7b1824a9b63dec7a079a3",
       "hint": null,
-      "key": "app_exception_message",
+      "key": "app_chained_exception_message",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -2,13 +2,19 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "93b26686d00504b4e5aa1cb0244d8b37"
+  contributing component: chained_exception
   hint: None
   root_component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained_exception*
+        exception*
+          type*
+            "InnerException"
+          value*
+            "Nope"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -2,13 +2,24 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
+  contributing component: chained_exception
   hint: None
   root_component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained_exception*
+        exception*
+          type*
+            "System.Exception"
+          value*
+            "Some Inner Exception"
+        exception*
+          type*
+            "MyApp.Exception"
+          value* (stripped event-specific values)
+            "Test <int>"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_all_exceptions_marked_as_groups.pysnap
@@ -2,13 +2,19 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "93b26686d00504b4e5aa1cb0244d8b37"
+  contributing component: chained_exception
   hint: None
   root_component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained_exception*
+        exception*
+          type*
+            "InnerException"
+          value*
+            "Nope"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_bad_with_cycle.pysnap
@@ -2,13 +2,24 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
+  contributing component: chained_exception
   hint: None
   root_component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained_exception*
+        exception*
+          type*
+            "System.Exception"
+          value*
+            "Some Inner Exception"
+        exception*
+          type*
+            "MyApp.Exception"
+          value* (stripped event-specific values)
+            "Test <int>"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."


### PR DESCRIPTION
When given a chained or aggregate exception, in theory the exception tree should contain no cycles and the there should be at least one non-group exception somewhere in the tree. In practice, this isn't always the case. When we hit such a case, we end up ignoring all but the root exception, when in fact we should be using the data as is (which is what we do in other cases where we get weird chaining).

This PR fixes that, and adds a docstring to the filter function to make it clearer what should be happening.