### PR TITLE
(fix): Add org check to data_condition_group

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -60,7 +60,6 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer):
             raise serializers.ValidationError(f"Condition group with id {instance.id} not found.")
 
         remove_items_by_api_input(validated_data.get("conditions", []), instance.conditions, "id")
-
         conditions = validated_data.pop("conditions", None)
         if conditions:
             for condition_data in conditions:

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -23,15 +23,23 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer):
 
         return conditions
 
-    def update_or_create_condition(self, condition_data: dict[str, Any]) -> DataCondition:
+    def update_or_create_condition(
+        self, condition_data: dict[str, Any], organization_id: int
+    ) -> DataCondition:
         validator = BaseDataConditionValidator()
         condition_id = condition_data.get("id")
 
         if condition_id:
             try:
-                condition = DataCondition.objects.get(id=condition_id)
-            except DataCondition.DoesNotExist:
-                raise serializers.ValidationError(f"Condition with id {condition_id} not found.")
+                # Validate that the condition belongs to this organization
+                condition = DataCondition.objects.get(
+                    id=condition_id,
+                    condition_group__organization_id=organization_id,
+                )
+            except DataCondition.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    f"Condition with id {condition_id} not found."
+                ) from exc
 
             condition = validator.update(condition, condition_data)
         else:
@@ -44,6 +52,13 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer):
         instance: DataConditionGroup,
         validated_data: dict[str, Any],
     ) -> DataConditionGroup:
+        # Require organization context to validate ownership of conditions
+        context_org = self.context.get("organization") if self.context else None
+        if not context_org:
+            raise serializers.ValidationError("Organization context is required.")
+        if instance.organization_id != context_org.id:
+            raise serializers.ValidationError(f"Condition group with id {instance.id} not found.")
+
         remove_items_by_api_input(validated_data.get("conditions", []), instance.conditions, "id")
 
         conditions = validated_data.pop("conditions", None)
@@ -51,8 +66,7 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer):
             for condition_data in conditions:
                 if not condition_data.get("condition_group_id"):
                     condition_data["condition_group_id"] = instance.id
-
-                self.update_or_create_condition(condition_data)
+                self.update_or_create_condition(condition_data, context_org.id)
 
         # update the condition group
         instance.update(**validated_data)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -146,7 +146,8 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 data_conditions: list[DataConditionType] = condition_group.get("conditions")
 
                 if data_conditions and instance.workflow_condition_group:
-                    group_validator = BaseDataConditionGroupValidator()
+                    # Pass context for organization validation of condition IDs
+                    group_validator = BaseDataConditionGroupValidator(context=self.context)
                     group_validator.update(instance.workflow_condition_group, condition_group)
 
             # Handle config field update

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
@@ -1,3 +1,6 @@
+import pytest
+from rest_framework import serializers
+
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseDataConditionGroupValidator
 from sentry.workflow_engine.models import Condition, DataConditionGroup
@@ -189,3 +192,117 @@ class TestBaseDataConditionGroupValidatorUpdate(TestBaseDataConditionGroupValida
         assert condition2.type == Condition.NOT_EQUAL
         assert condition2.comparison == 5
         assert condition2.condition_group == dcg
+
+    def test_update__rejects_cross_organization_condition_id(self) -> None:
+        """
+        Test that updating with a condition ID from another organization is rejected
+        """
+        # Create a condition group and condition for the current org
+        self.valid_data["conditions"] = [
+            {
+                "type": Condition.EQUAL,
+                "comparison": 1,
+                "conditionResult": True,
+            }
+        ]
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        dcg = validator.create(validator.validated_data)
+        assert dcg.conditions.count() == 1
+
+        # Create another organization with its own condition group and condition
+        other_org = self.create_organization()
+        other_dcg = self.create_data_condition_group(organization_id=other_org.id)
+        other_condition = self.create_data_condition(
+            condition_group=other_dcg,
+            type=Condition.GREATER,
+            comparison=100,
+            condition_result=True,
+        )
+
+        # Attempt to update using the other org's condition ID
+        self.valid_data["conditions"] = [
+            {
+                "id": other_condition.id,
+                "type": Condition.EQUAL,
+                "comparison": 999,
+                "conditionResult": True,
+            }
+        ]
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            validator.update(dcg, validator.validated_data)
+
+        assert f"Condition with id {other_condition.id} not found" in str(exc_info.value)
+
+        # Verify the other org's condition was not modified
+        other_condition.refresh_from_db()
+        assert other_condition.comparison == 100
+        assert other_condition.condition_group_id == other_dcg.id
+
+    def test_update__accepts_same_organization_condition_id(self) -> None:
+        """
+        Test that updating with a condition ID from the same organization works correctly.
+        """
+        # Create a condition group and condition for the current org
+        self.valid_data["conditions"] = [
+            {
+                "type": Condition.EQUAL,
+                "comparison": 1,
+                "conditionResult": True,
+            }
+        ]
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        dcg = validator.create(validator.validated_data)
+        condition = dcg.conditions.first()
+        assert condition is not None
+        assert condition.comparison == 1
+
+        # Update using the same org's condition ID - this should succeed
+        self.valid_data["conditions"] = [
+            {
+                "id": condition.id,
+                "type": Condition.EQUAL,
+                "comparison": 999,  # New value
+                "conditionResult": True,
+            }
+        ]
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        validator.update(dcg, validator.validated_data)
+
+        # Verify the condition was updated
+        condition.refresh_from_db()
+        assert condition.comparison == 999
+        assert condition.condition_group_id == dcg.id
+
+    def test_update__rejects_nonexistent_condition_id(self) -> None:
+        """
+        Test that updating with a non-existent condition ID is rejected.
+        """
+        # Create a condition group for the current org
+        self.valid_data["conditions"] = []
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        dcg = validator.create(validator.validated_data)
+
+        # Attempt to update using a non-existent condition ID
+        nonexistent_id = 999999999
+        self.valid_data["conditions"] = [
+            {
+                "id": nonexistent_id,
+                "type": Condition.EQUAL,
+                "comparison": 1,
+                "conditionResult": True,
+            }
+        ]
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            validator.update(dcg, validator.validated_data)
+
+        assert f"Condition with id {nonexistent_id} not found" in str(exc_info.value)


### PR DESCRIPTION
update_or_create_condition was not verifying that the the condition being modified was owned by the appropriate organization. Added some tests to verify.

The DataConditionGroup.DoesNotExist exception was also a small bug, should have been catching DataCondition.DoesNotExist.