### PR TITLE
chore(checkout): Clean up some styling

### DIFF
--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -315,7 +315,13 @@ function Receipt({
   return (
     <div data-test-id="receipt">
       <ReceiptSlot />
-      <ReceiptPaperContainer>
+      <Container
+        position="relative"
+        left="62px"
+        top="-7px"
+        width="320px"
+        overflow="hidden"
+      >
         <ReceiptPaperShadow />
         <motion.div
           animate={{y: [-600, -575, -400, -380, -360, -340, -7]}}
@@ -325,7 +331,7 @@ function Receipt({
             times: [0.1, 0.2, 0.3, 0.34, 0.36, 0.37, 1],
           }}
         >
-          <ReceiptPaper background="primary" border="primary">
+          <Container background="primary" borderLeft="primary" borderRight="primary">
             <Flex direction="column" gap="xl" padding="xl" align="center">
               <img src={SentryLogo} alt={t('Sentry logo')} />
               <Grid columns="1fr 2fr 1fr" align="center" gap="sm">
@@ -489,9 +495,9 @@ function Receipt({
               <img src={Barcode} alt={t('Barcode')} />
             </Flex>
             <ZigZagEdge />
-          </ReceiptPaper>
+          </Container>
         </motion.div>
-      </ReceiptPaperContainer>
+      </Container>
     </div>
   );
 }
@@ -584,13 +590,13 @@ function CheckoutSuccess({
       direction={{sm: 'column', md: 'row'}}
     >
       <Flex direction="column" align={{sm: 'center', md: 'start'}} maxWidth="500px">
-        <Title size="2xl" as="h1" align="left">
+        <Heading size="2xl" as="h1" align={{'2xs': 'center', md: 'left'}}>
           {contentTitle}
-        </Title>
+        </Heading>
         <Flex gap="2xl" direction="column" align={{sm: 'center', md: 'start'}}>
-          <Description variant="muted" size="lg" align="left">
+          <Text variant="muted" size="lg" align={{'2xs': 'center', md: 'left'}}>
             {contentDescription}
-          </Description>
+          </Text>
           <Flex gap="sm">
             <LinkButton
               priority="primary"
@@ -641,18 +647,6 @@ function CheckoutSuccess({
 
 export default CheckoutSuccess;
 
-const Title = styled(Heading)`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    text-align: center;
-  }
-`;
-
-const Description = styled(Text)`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    text-align: center;
-  }
-`;
-
 const StyledGrid = styled(Grid)`
   & > :last-child {
     justify-self: end;
@@ -668,14 +662,6 @@ const ReceiptSlot = styled('div')`
     ${p => Color(p.theme.black).lighten(0.08).alpha(0.15).toString()} inset;
 `;
 
-const ReceiptPaperContainer = styled('div')`
-  position: relative;
-  left: 62px;
-  top: -7px;
-  width: 320px;
-  overflow: hidden;
-`;
-
 const ReceiptPaperShadow = styled('div')`
   position: relative;
   z-index: 1000;
@@ -684,11 +670,6 @@ const ReceiptPaperShadow = styled('div')`
   height: 7px;
   box-shadow: inset 0 10px 6px -6px
     ${p => Color(p.theme.black).lighten(0.05).alpha(0.15).toString()};
-`;
-
-const ReceiptPaper = styled(Container)`
-  border-top: none;
-  border-bottom: none;
 `;
 
 const DateSeparator = styled('div')`

--- a/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
@@ -4,7 +4,6 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {IconCheckmark} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 type Props = {
   color?: string;
@@ -24,7 +23,7 @@ function MoreFeaturesLink({color, legacySize}: Props) {
 const MoreLink = styled(ExternalLink)<{color?: string}>`
   display: grid;
   grid-template-columns: max-content auto;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   align-items: center;
   align-content: center;
   color: ${p => p.color ?? p.theme.subText};

--- a/static/gsApp/views/amCheckout/components/unitTypeItem.tsx
+++ b/static/gsApp/views/amCheckout/components/unitTypeItem.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 
+import {Container, Grid} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
 import PanelItem from 'sentry/components/panels/panelItem';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 type UnitTypeProps = {
   description: React.ReactNode;
@@ -10,16 +12,32 @@ type UnitTypeProps = {
   weight: string;
 };
 
+function UnitColumn({children}: {children: React.ReactNode}) {
+  return (
+    <Grid columns="auto max-content" justify="between" align="center" gap="3xl">
+      {children}
+    </Grid>
+  );
+}
+
 export default function UnitTypeItem({unitName, description, weight}: UnitTypeProps) {
   return (
     <UnitTypeContainer>
       <UnitColumn>
-        <UnitName>{unitName}</UnitName>
-        <UnitTitle>{t('Unit')}</UnitTitle>
+        <Text size="lg" bold>
+          {unitName}
+        </Text>
+        <Text size="sm" bold uppercase variant="muted">
+          {t('Unit')}
+        </Text>
       </UnitColumn>
       <UnitColumn>
-        <Description>{description}</Description>
-        <Weight>{weight}</Weight>
+        <Text variant="muted">{description}</Text>
+        <Container alignSelf="start">
+          <Text size="xl" bold variant="muted">
+            {weight}
+          </Text>
+        </Container>
       </UnitColumn>
     </UnitTypeContainer>
   );
@@ -28,38 +46,5 @@ export default function UnitTypeItem({unitName, description, weight}: UnitTypePr
 const UnitTypeContainer = styled(PanelItem)`
   display: grid;
   grid-auto-flow: row;
-  gap: ${space(0.5)};
-`;
-
-const UnitColumn = styled('div')`
-  display: grid;
-  grid-template-columns: auto max-content;
-  justify-content: space-between;
-  align-items: center;
-  gap: 40px;
-`;
-
-const UnitName = styled('div')`
-  font-weight: 600;
-  font-size: ${p => p.theme.fontSize.lg};
-`;
-
-const Description = styled('p')`
-  font-size: ${p => p.theme.fontSize.md};
-  margin-bottom: 0px;
-  font-weight: normal;
-  color: ${p => p.theme.subText};
-`;
-
-const UnitTitle = styled('div')`
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSize.sm};
-  text-transform: uppercase;
-  font-weight: 600;
-`;
-
-const Weight = styled('div')`
-  font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.gray500};
-  align-self: start;
+  gap: ${p => p.theme.space.xs};
 `;

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/core/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Flex, Grid} from 'sentry/components/core/layout';
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
 import {Body, Header, Hovercard} from 'sentry/components/hovercard';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -151,26 +153,24 @@ function VolumeSliders({
                     <div>{getPlanCategoryName({plan: activePlan, category})}</div>
                   </Title>
                   {eventBucket.price !== 0 && (
-                    <Description>
-                      <div>
-                        {tct('[unitPrice]/[category]', {
-                          category:
-                            category ===
-                            DATA_CATEGORY_INFO[DataCategoryExact.ATTACHMENT].plural
-                              ? 'GB'
-                              : getSingularCategoryName({
-                                  plan: activePlan,
-                                  category,
-                                  capitalize: false,
-                                }),
-                          unitPrice,
-                        })}
-                      </div>
-                    </Description>
+                    <Text variant="muted" size="sm">
+                      {tct('[unitPrice]/[category]', {
+                        category:
+                          category ===
+                          DATA_CATEGORY_INFO[DataCategoryExact.ATTACHMENT].plural
+                            ? 'GB'
+                            : getSingularCategoryName({
+                                plan: activePlan,
+                                category,
+                                capitalize: false,
+                              }),
+                        unitPrice,
+                      })}
+                    </Text>
                   )}
                 </Flex>
                 <div>
-                  <SpaceBetweenGrid>
+                  <Grid columns="repeat(2, auto)" justify="between">
                     <VolumeAmount>
                       {formatReservedWithUnits(
                         formData.reserved[category] ?? null,
@@ -188,7 +188,7 @@ function VolumeSliders({
                         <BillingInterval>/{billingInterval}</BillingInterval>
                       )}
                     </div>
-                  </SpaceBetweenGrid>
+                  </Grid>
                   <RangeSlider
                     showLabel={false}
                     name={category}
@@ -212,18 +212,18 @@ function VolumeSliders({
                         : undefined
                     }
                   />
-                  <MinMax>
-                    <div>
+                  <Grid columns="repeat(2, auto)" justify="between">
+                    <Text variant="muted" size="sm">
                       {tct('[min] included', {
                         min: formatReservedWithUnits(min, category),
                       })}
-                    </div>
-                    <div>
+                    </Text>
+                    <Text variant="muted" size="sm">
                       {formatReservedWithUnits(max, category, {
                         isAbbreviated: !isByteCategory(category),
                       })}
-                    </div>
-                  </MinMax>
+                    </Text>
+                  </Grid>
                 </div>
                 {showTransactionsDisclaimer && (
                   <span>
@@ -267,21 +267,6 @@ const Title = styled('label')`
   margin-bottom: 0px;
   font-weight: ${p => p.theme.fontWeight.bold};
   font-size: ${p => p.theme.fontSize.md};
-`;
-
-const SpaceBetweenGrid = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  justify-content: space-between;
-`;
-
-const Description = styled(SpaceBetweenGrid)`
-  font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.subText};
-`;
-
-const MinMax = styled(Description)`
-  font-size: ${p => p.theme.fontSize.sm};
 `;
 
 const BaseRow = styled('div')`

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -10,7 +10,7 @@ import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {Flex, Grid, Stack} from 'sentry/components/core/layout';
+import {Container, Flex, Grid, Stack} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import LoadingError from 'sentry/components/loadingError';
@@ -664,14 +664,27 @@ class AMCheckout extends Component<Props, State> {
 
     const renderCheckoutContent = () => (
       <Fragment>
-        <CheckoutBody>
+        <Flex
+          padding="0 2xl 3xl 2xl"
+          width="100%"
+          direction="column"
+          align="start"
+          maxWidth={{'2xs': undefined, md: '47.5rem'}}
+          paddingTop={{'2xs': '0', md: 'md'}}
+        >
           {this.renderPartnerAlert()}
           <CheckoutStepsContainer data-test-id="checkout-steps">
             {this.renderSteps()}
           </CheckoutStepsContainer>
-        </CheckoutBody>
+        </Flex>
         <SidePanel>
-          <OverviewContainer>
+          <Flex
+            flex={1}
+            direction="column"
+            gap="xl"
+            padding={{'2xs': '2xl 0', md: '0'}}
+            position="relative"
+          >
             <Cart
               {...overviewProps}
               referrer={this.referrer}
@@ -721,7 +734,7 @@ class AMCheckout extends Component<Props, State> {
                 </Text>
               )}
             </Stack>
-          </OverviewContainer>
+          </Flex>
         </SidePanel>
       </Fragment>
     );
@@ -771,8 +784,11 @@ class AMCheckout extends Component<Props, State> {
             >
               {t('Manage Subscription')}
             </LinkButton>
-
-            <OrgSlug>{organization.slug.toUpperCase()}</OrgSlug>
+            <Container flexGrow={1}>
+              <Text monospace variant="muted" ellipsis textWrap="nowrap" align="right">
+                {organization.slug.toUpperCase()}
+              </Text>
+            </Container>
           </Flex>
         </CheckoutHeader>
 
@@ -806,28 +822,6 @@ const CheckoutHeader = styled('header')`
   gap: ${p => p.theme.space.md};
 `;
 
-const OrgSlug = styled('div')`
-  font-family: ${p => p.theme.text.familyMono};
-  color: ${p => p.theme.subText};
-  text-overflow: ellipsis;
-  text-wrap: nowrap;
-  flex: 1;
-  text-align: right;
-`;
-
-const CheckoutBody = styled('div')`
-  padding: 0 ${p => p.theme.space['2xl']} ${p => p.theme.space['3xl']}
-    ${p => p.theme.space['2xl']};
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    max-width: 47.5rem;
-    padding-top: ${p => p.theme.space.md};
-  }
-`;
-
 const SidePanel = styled('aside')`
   width: 100%;
   border-top: 1px solid ${p => p.theme.border};
@@ -845,24 +839,6 @@ const SidePanel = styled('aside')`
     padding-left: ${p => p.theme.space['3xl']};
     background-color: ${p => p.theme.tokens.background.primary};
     padding-bottom: ${p => p.theme.space['3xl']};
-  }
-`;
-
-/**
- * Hide overview at smaller screen sizes in old checkout
- * Bring overview to bottom at smaller screen sizes in new checkout
- * Cancel subscription button is always visible
- */
-const OverviewContainer = styled('div')`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  gap: ${p => p.theme.space.xl};
-  padding: ${p => p.theme.space['2xl']} 0;
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    padding: 0;
   }
 `;
 


### PR DESCRIPTION
In `/amCheckout/`:
- Removes all uses of deprecated `space` function 
- Replaces uses of custom styled components with scraps