### PR TITLE
Cursor issue resolution

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -218,4 +218,37 @@ const IconNode = styled('button')<{
 const TooltipWrapper = styled('div')`
   max-height: 80vh;
   overflow: auto;
+
+  /* Override breadcrumb item styling for timeline tooltip context */
+  /* Reduce padding and remove backgrounds from breadcrumb items */
+  > div {
+    padding: ${space(0.25)} ${space(0.5)} !important;
+    margin: 0 !important;
+    background: transparent !important;
+
+    &:hover {
+      background: transparent !important;
+
+      /* Keep icon wrapper background transparent on hover */
+      .timeline-icon-wrapper {
+        background: transparent !important;
+      }
+    }
+
+    /* Remove connecting lines between items in tooltip */
+    &::before {
+      display: none !important;
+    }
+
+    /* Reduce title font size - target grid column 2 which contains the title */
+    /* Timeline.Item uses a grid with 3 columns: icon | content | timestamp */
+    > div:nth-child(2) {
+      font-size: ${p => p.theme.fontSize.sm} !important;
+
+      /* The title div inside the Flex component */
+      > div:first-child {
+        font-size: ${p => p.theme.fontSize.sm} !important;
+      }
+    }
+  }
 `;


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes rendering issues for breadcrumb items displayed within the replay timeline tooltip.

Previously, breadcrumb items in the timeline tooltip used full-size styling, leading to:
- A dark background on hover.
- An excessively large font size.
- Excessive padding.
- Unnecessary connecting lines between items.

This PR overrides the default styling to make the breadcrumb items more compact and appropriate for the tooltip context.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C03USURCFBJ/p1767648995370069?thread_ts=1767648995.370069&cid=C03USURCFBJ)

<a href="https://cursor.com/background-agent?bcId=bc-39c53d40-c0e6-4450-a5b4-c44cb5b57c50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39c53d40-c0e6-4450-a5b4-c44cb5b57c50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

