### PR TITLE
fix(code-mappings): handle malformed source path

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -420,6 +420,9 @@ def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
     Returns a tuple containing the stack_root, and the source_root.
     If there is no overlap, raise an exception since this should not happen
     """
+    if not source_path:
+        raise UnexpectedPathException("Source path is empty")
+
     stack_path = frame_filename.raw_path
     stack_root = ""
     if stack_path[0] == "/" or stack_path[0] == "\\":

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -180,6 +180,13 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
         assert resp.status_code == 400, resp.content
         assert resp.data == {"sourceUrl": ["Enter a valid URL."]}
 
+    def test_malformed_source_url_empty_source_path(self) -> None:
+        source_url = "https://github.com/getsentry/sentry/tree/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {"detail": "Could not determine code mapping from provided paths"}
+
     def test_wrong_file(self) -> None:
         source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_releases.py"
         stack_path = "sentry/api/endpoints/project_stacktrace_link.py"

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -308,6 +308,13 @@ class TestDerivedCodeMappings(TestCase):
                 "nothing/something.js",
             )
 
+    def test_find_roots_empty_source_path(self) -> None:
+        with pytest.raises(UnexpectedPathException):
+            find_roots(
+                create_frame_info({"filename": "sentry/foo.py"}),
+                "",
+            )
+
     def test_find_roots_windows_path_with_spaces(self) -> None:
         stacktrace_root, source_path = find_roots(
             create_frame_info({"filename": "C:\\Program Files\\MyApp\\src\\file.py"}), "src/file.py"


### PR DESCRIPTION
Fixes SENTRY-47GS

Passing a malformed/empty `source_path` when creating a code mapping causes `source_path` to be `""`, which results in an error here (since `stack_path` always will end with `""`)
```
    elif stack_path.endswith(source_path):
        stack_prefix = stack_path.rpartition(source_path)[0]
```
Since the user can input invalid `source_path`s, we should handle this and return 400 instead of 500 