### PR TITLE
fix(uptime): Include headers and body in detector form payload

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -190,6 +190,8 @@ interface UpdateUptimeDataSourcePayload {
   timeoutMs: number;
   traceSampling: boolean;
   url: string;
+  body?: string | null;
+  headers?: Array<[string, string]>;
 }
 
 export interface BaseDetectorUpdatePayload {

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -43,6 +43,8 @@ export function uptimeFormDataToEndpointPayload(
         timeoutMs: data.timeoutMs,
         traceSampling: data.traceSampling,
         url: data.url,
+        headers: data.headers,
+        body: data.body || null,
       },
     ],
     config: {

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -775,6 +775,20 @@ describe('DetectorEdit', () => {
         'https://uptime.example.com'
       );
 
+      // Change method to POST
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Method'}), 'POST');
+
+      // Add headers
+      const headerNameInput = screen.getByRole('textbox', {name: 'Name of header 1'});
+      await userEvent.type(headerNameInput, 'X-API-Key');
+      const headerValueInput = screen.getByRole('textbox', {name: 'Value of X-API-Key'});
+      await userEvent.type(headerValueInput, 'secret-key-123');
+
+      // Add body
+      const bodyInput = screen.getByRole('textbox', {name: 'Body'});
+      await userEvent.click(bodyInput);
+      await userEvent.paste('{"test": "data"}');
+
       await selectEvent.select(screen.getByLabelText('Select Environment'), 'production');
 
       await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
@@ -796,10 +810,12 @@ describe('DetectorEdit', () => {
             dataSources: [
               {
                 intervalSeconds: 60,
-                method: 'GET',
+                method: 'POST',
                 timeoutMs: 5000,
                 traceSampling: undefined,
                 url: 'https://uptime.example.com',
+                headers: [['X-API-Key', 'secret-key-123']],
+                body: '{"test": "data"}',
               },
             ],
             name: 'Uptime Monitor',
@@ -865,6 +881,8 @@ describe('DetectorEdit', () => {
                 timeoutMs: 5000,
                 traceSampling: undefined,
                 url: 'https://uptime-custom.example.com',
+                headers: [],
+                body: null,
               },
             ],
             name: 'Uptime check for uptime-custom.example.com',


### PR DESCRIPTION
The uptime detector form was collecting headers and body fields but not
sending them to the backend. Updated uptimeFormDataToEndpointPayload to
include these fields in the dataSources payload.

Also added test coverage to verify headers and body are properly included
in the API request.

Fixed [NEW-671](https://linear.app/getsentry/issue/NEW-671)