### PR TITLE
feat(timeseries): Add ratelimits to the timeseries endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features, options
+from sentry import analytics, features
 from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -78,7 +78,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    enforce_rate_limit = options.get("visibility.events-timeseries.rate-limit")
+    enforce_rate_limit = True
 
     rate_limits = RateLimitConfig(
         limit_overrides={

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -15,8 +15,8 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_stats import SENTRY_BACKEND_REFERRERS
 from sentry.api.endpoints.timeseries import (
     EMPTY_STATS_RESPONSE,
-    INGESTION_DELAY_MESSAGE,
     INGESTION_DELAY,
+    INGESTION_DELAY_MESSAGE,
     Row,
     SeriesMeta,
     StatsMeta,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -15,6 +15,8 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_stats import SENTRY_BACKEND_REFERRERS
 from sentry.api.endpoints.timeseries import (
     EMPTY_STATS_RESPONSE,
+    INGESTION_DELAY_MESSAGE,
+    INGESTION_DELAY,
     Row,
     SeriesMeta,
     StatsMeta,
@@ -24,6 +26,7 @@ from sentry.api.endpoints.timeseries import (
 from sentry.api.utils import handle_query_errors
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.eap.trace_metrics.config import (
     TraceMetricsSearchResolverConfig,
     get_trace_metric_from_request,
@@ -45,6 +48,7 @@ from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.snuba import SnubaTSResult
 
 TOP_EVENTS_DATASETS = {
@@ -60,10 +64,6 @@ TOP_EVENTS_DATASETS = {
     transactions,
 }
 
-# Assumed ingestion delay for timeseries, this is a static number for now just to match how the frontend was doing it
-INGESTION_DELAY = 90
-INGESTION_DELAY_MESSAGE = "INCOMPLETE_BUCKET"
-
 
 def null_zero(value: float) -> float | None:
     if value == 0:
@@ -77,6 +77,18 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
+
+    enforce_rate_limit = options.get("visibility.events-timeseries.rate-limit")
+
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=30, window=1, concurrent_limit=15),
+                RateLimitCategory.USER: RateLimit(limit=30, window=1, concurrent_limit=15),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=30, window=1, concurrent_limit=15),
+            }
+        }
+    )
 
     def get_features(
         self, organization: Organization, request: Request

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -1,5 +1,9 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
+# Assumed ingestion delay for timeseries, this is a static number for now just to match how the frontend was doing it
+INGESTION_DELAY = 90
+INGESTION_DELAY_MESSAGE = "INCOMPLETE_BUCKET"
+
 
 class StatsMeta(TypedDict):
     dataset: str

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3534,6 +3534,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# enable rate limiting on the timeseries endpoint
+register(
+    "visibility.events-timeseries.rate-limit",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "performance.event-tracker.sample-rate.transactions",
     default=0.0,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3534,14 +3534,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# enable rate limiting on the timeseries endpoint
-register(
-    "visibility.events-timeseries.rate-limit",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "performance.event-tracker.sample-rate.transactions",
     default=0.0,

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 from django.urls import reverse
 
-from sentry.api.endpoints.organization_events_timeseries import INGESTION_DELAY_MESSAGE
+from sentry.api.endpoints.timeseries import INGESTION_DELAY_MESSAGE
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.samples import load_data


### PR DESCRIPTION
- These rate limits are copied directly from the /events endpoint
- Can't use options so just enabling as is, timeseries gets 1% the traffic /events does so should be fine
- Want to get this in before adding public docs for the endpoint