### PR TITLE
feat(aci): Add ability to filter workflows by connected detectors

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -128,9 +128,6 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                 raise ValidationError({"detector": ["Invalid detector ID format"]})
             queryset = queryset.filter(detectorworkflow__detector_id__in=detector_ids).distinct()
 
-            # If detector IDs are provided, skip query and project filtering
-            return queryset
-
         if raw_query := request.GET.get("query"):
             for filter in parse_workflow_query(raw_query):
                 assert isinstance(filter, SearchFilter)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -121,6 +121,16 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
             # If specific IDs are provided, skip query and project filtering
             return queryset
 
+        if raw_detectorlist := request.GET.getlist("detector"):
+            try:
+                detector_ids = [int(id) for id in raw_detectorlist]
+            except ValueError:
+                raise ValidationError({"detector": ["Invalid detector ID format"]})
+            queryset = queryset.filter(detectorworkflow__detector_id__in=detector_ids).distinct()
+
+            # If detector IDs are provided, skip query and project filtering
+            return queryset
+
         if raw_query := request.GET.get("query"):
             for filter in parse_workflow_query(raw_query):
                 assert isinstance(filter, SearchFilter)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -65,6 +65,20 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         hits = int(response["X-Hits"])
         assert hits == 3
 
+    def test_only_returns_workflows_from_organization(self) -> None:
+        other_org = self.create_organization()
+        self.create_workflow(organization_id=other_org.id, name="Other Org Workflow")
+
+        response = self.get_success_response(self.organization.slug)
+        assert len(response.data) == 3
+        workflow_names = {w["name"] for w in response.data}
+        assert "Other Org Workflow" not in workflow_names
+        assert workflow_names == {
+            self.workflow.name,
+            self.workflow_two.name,
+            self.workflow_three.name,
+        }
+
     def test_empty_result(self) -> None:
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "aaaaaaaaaaaaa"}


### PR DESCRIPTION
Adds the ability to do `/organizations/org-slug/workflows/?detector=1&detector=2` which will return workflows connected to either of those two detectors.