### PR TITLE
fix(seer onboarding): remove on_command_phrase CR trigger from settings forms

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -63,7 +63,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
                 name: 'codeReviewTriggers',
                 label: t('Code Review Triggers'),
                 help: tct(
-                  'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                  'Reviews can run whenever a PR is opened, or after each commit is pushed to a PR. Reviews can always be triggered on demand by calling [code:@sentry review].',
                   {code: <code />}
                 ),
                 type: 'choice',

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -22,7 +22,8 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
     repoWithSettings?.settings?.codeReviewTriggers ??
     organization.defaultCodeReviewTriggers ??
     DEFAULT_CODE_REVIEW_TRIGGERS;
-  const modifiableTriggers = initialTriggers.filter(
+
+  const modifiableInitialTriggers = initialTriggers.filter(
     trigger => trigger !== 'on_command_phrase'
   );
 
@@ -38,7 +39,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
             repoWithSettings?.settings?.enabledCodeReview ??
             organization.autoEnableCodeReview ??
             true,
-          codeReviewTriggers: modifiableTriggers,
+          codeReviewTriggers: modifiableInitialTriggers,
           repositoryIds: [repoWithSettings.id],
         } satisfies RepositorySettings
       }

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -64,7 +64,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
                 name: 'codeReviewTriggers',
                 label: t('Code Review Triggers'),
                 help: tct(
-                  'Reviews can run whenever a PR is opened, or after each commit is pushed to a PR. Reviews can always be triggered on demand by calling [code:@sentry review].',
+                  'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
                   {code: <code />}
                 ),
                 type: 'choice',

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -18,15 +18,6 @@ interface Props {
 export default function RepoDetailsForm({organization, repoWithSettings}: Props) {
   const canWrite = useCanWriteSettings();
 
-  const initialTriggers =
-    repoWithSettings?.settings?.codeReviewTriggers ??
-    organization.defaultCodeReviewTriggers ??
-    DEFAULT_CODE_REVIEW_TRIGGERS;
-
-  const modifiableInitialTriggers = initialTriggers.filter(
-    trigger => trigger !== 'on_command_phrase'
-  );
-
   return (
     <Form
       allowUndo
@@ -39,7 +30,10 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
             repoWithSettings?.settings?.enabledCodeReview ??
             organization.autoEnableCodeReview ??
             true,
-          codeReviewTriggers: modifiableInitialTriggers,
+          codeReviewTriggers:
+            repoWithSettings?.settings?.codeReviewTriggers ??
+            organization.defaultCodeReviewTriggers ??
+            DEFAULT_CODE_REVIEW_TRIGGERS,
           repositoryIds: [repoWithSettings.id],
         } satisfies RepositorySettings
       }

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,6 +1,6 @@
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {
   DEFAULT_CODE_REVIEW_TRIGGERS,
   type RepositoryWithSettings,
@@ -18,6 +18,14 @@ interface Props {
 export default function RepoDetailsForm({organization, repoWithSettings}: Props) {
   const canWrite = useCanWriteSettings();
 
+  const initialTriggers =
+    repoWithSettings?.settings?.codeReviewTriggers ??
+    organization.defaultCodeReviewTriggers ??
+    DEFAULT_CODE_REVIEW_TRIGGERS;
+  const modifiableTriggers = initialTriggers.filter(
+    trigger => trigger !== 'on_command_phrase'
+  );
+
   return (
     <Form
       allowUndo
@@ -30,10 +38,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
             repoWithSettings?.settings?.enabledCodeReview ??
             organization.autoEnableCodeReview ??
             true,
-          codeReviewTriggers:
-            repoWithSettings?.settings?.codeReviewTriggers ??
-            organization.defaultCodeReviewTriggers ??
-            DEFAULT_CODE_REVIEW_TRIGGERS,
+          codeReviewTriggers: modifiableTriggers,
           repositoryIds: [repoWithSettings.id],
         } satisfies RepositorySettings
       }
@@ -57,13 +62,13 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
               {
                 name: 'codeReviewTriggers',
                 label: t('Code Review Triggers'),
-                help: t(
-                  'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
+                help: tct(
+                  'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                  {code: <code />}
                 ),
                 type: 'choice',
                 multiple: true,
                 choices: [
-                  ['on_command_phrase', t('On Command Phrase')],
                   ['on_ready_for_review', t('On Ready for Review')],
                   ['on_new_commit', t('On New Commit')],
                 ],

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -98,13 +98,13 @@ export default function SeerAutomationSettings() {
                 {
                   name: 'defaultCodeReviewTriggers',
                   label: t('Code Review Triggers'),
-                  help: t(
-                    'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
+                  help: tct(
+                    'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                    {code: <code />}
                   ),
                   type: 'choice',
                   multiple: true,
                   choices: [
-                    ['on_command_phrase', t('On Command Phrase')],
                     ['on_ready_for_review', t('On Ready for Review')],
                     ['on_new_commit', t('On New Commit')],
                   ],


### PR DESCRIPTION
relates to ENG-6194

depends on https://github.com/codecov/overwatch/pull/622

Since we are not charging by review, let's make sure the `on_command_phrase` trigger is always turned on and immutable in `RepositorySettings`. We remove it from the form options and update the help text to specify the command phrase.

Before
<img width="1398" height="207" alt="Screenshot 2026-01-06 at 12 03 10 PM" src="https://github.com/user-attachments/assets/8fc2a159-9bb3-4b20-9df3-1f4a5d046cbf" />
<img width="1396" height="204" alt="Screenshot 2026-01-06 at 1 33 22 PM" src="https://github.com/user-attachments/assets/0236e0a4-d676-45dd-a55f-cdc199d5ad53" />
After
<img width="1396" height="218" alt="Screenshot 2026-01-06 at 1 25 07 PM" src="https://github.com/user-attachments/assets/b793d527-4f59-465a-a8a0-f001329bde00" />
<img width="1396" height="218" alt="Screenshot 2026-01-06 at 1 33 04 PM" src="https://github.com/user-attachments/assets/874fe826-fd99-4846-81ce-6a522232cedc" />

