### PR TITLE
ref(billing): Remove usage of `deprecatedRouteProps` for `UsageHistory` component

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -48,7 +48,6 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'usage/',
           name: 'Usage History',
           component: make(() => import('../views/subscriptionPage/usageHistory')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'receipts/',

--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {BillingHistoryFixture} from 'getsentry-test/fixtures/billingHistory';
@@ -69,7 +68,7 @@ describe('Subscription > UsageHistory', () => {
     const subscription = SubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(await screen.findByTestId('history-expand')).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', {name: /Usage History/i})
@@ -86,7 +85,7 @@ describe('Subscription > UsageHistory', () => {
     const subscription = SubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(
       await screen.findByRole('heading', {name: /Usage History/i})
     ).toBeInTheDocument();
@@ -107,7 +106,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(org.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization: org});
+    render(<UsageHistory />, {organization: org});
     expect(await screen.findByTestId('permission-denied')).toBeInTheDocument();
   });
 
@@ -125,7 +124,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(screen.queryByTestId('permission-denied')).not.toBeInTheDocument();
     expect(mockCall).toHaveBeenCalled();
   });
@@ -144,7 +143,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(mockCall).toHaveBeenCalled();
 
     // Expand button should be present.
@@ -176,7 +175,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(screen.queryByText('On-Demand Spend')).not.toBeInTheDocument();
     expect(mockCall).toHaveBeenCalled();
@@ -218,7 +217,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(await screen.findByText('>100%')).toBeInTheDocument();
     expect(screen.queryByText('Gifted')).not.toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '1 GB'})).toBeInTheDocument();
@@ -261,7 +260,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
     expect(await screen.findByText('Gifted')).toBeInTheDocument();
     expect(screen.queryByText('>100%')).not.toBeInTheDocument();
     expect(screen.queryByRole('cell', {name: '∞'})).not.toBeInTheDocument();
@@ -303,7 +302,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Shared On-demand should show up
     expect(await screen.findByText('On-Demand Spend (Shared)')).toBeInTheDocument();
@@ -355,7 +354,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Per-category On-demand should show up
     expect(await screen.findByText('On-Demand Spend (Per-Category)')).toBeInTheDocument();
@@ -389,7 +388,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(await screen.findByText('On-Demand Spend (Shared)')).toBeInTheDocument();
     expect(
@@ -432,7 +431,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Per-category Soft Cap On-demand should show up
     expect(await screen.findAllByText('Errors (On-Demand)')).toHaveLength(2);
@@ -475,7 +474,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Per-category Soft Cap True Forward should show up
     expect(await screen.findAllByText('Errors (True Forward)')).toHaveLength(2);
@@ -519,7 +518,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Per-category True Forward should show up
     expect(await screen.findAllByText('Errors (True Forward)')).toHaveLength(2);
@@ -561,7 +560,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -605,7 +604,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -629,7 +628,7 @@ describe('Subscription > UsageHistory', () => {
     const subscription = SubscriptionFixture({organization, plan: 'am2_f'});
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -650,7 +649,7 @@ describe('Subscription > UsageHistory', () => {
     const subscription = SubscriptionFixture({organization, plan: 'am1_f'});
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -691,7 +690,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -731,7 +730,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -774,7 +773,7 @@ describe('Subscription > UsageHistory', () => {
     const subscription = Am3DsEnterpriseSubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -817,7 +816,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     expect(
       await screen.findByRole('row', {
@@ -861,7 +860,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Should show 2% (100/6000 * 100)
     expect(await screen.findByText(/UI Profile Hours/i)).toBeInTheDocument();
@@ -896,7 +895,7 @@ describe('Subscription > UsageHistory', () => {
     });
     SubscriptionStore.set(organization.slug, subscription);
 
-    render(<UsageHistory {...RouteComponentPropsFixture()} />, {organization});
+    render(<UsageHistory />, {organization});
 
     // Should show >100% when usage exceeds prepaid limit
     expect(await screen.findByText(/UI Profile Hours/i)).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -19,7 +19,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconChevron, IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -52,7 +51,7 @@ import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/componen
 import {StripedTable} from './styles';
 import SubscriptionHeader from './subscriptionHeader';
 
-interface Props extends RouteComponentProps<unknown, unknown> {
+interface Props {
   subscription: Subscription;
 }
 


### PR DESCRIPTION
Migrates the `UsageHistory` route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7