### PR TITLE
ref(billing): Remove usage of `deprecatedRouteProps` for `PaymentHistory` component

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -54,7 +54,6 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'receipts/',
           name: 'Receipts',
           component: make(() => import('../views/subscriptionPage/paymentHistory')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'notifications/',

--- a/static/gsApp/views/subscriptionPage/paymentHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {InvoiceFixture} from 'getsentry-test/fixtures/invoice';
@@ -74,10 +73,7 @@ describe('Subscription > PaymentHistory', () => {
       body: [basicInvoice],
     });
 
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     expect(await screen.findByTestId('payment-list')).toBeInTheDocument();
     expect(screen.getByText('Sep 20, 2021')).toBeInTheDocument();
@@ -96,10 +92,7 @@ describe('Subscription > PaymentHistory', () => {
       body: [],
     });
 
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     await screen.findByTestId('payment-list');
     expect(screen.getByText('No receipts found')).toBeInTheDocument();
@@ -121,10 +114,7 @@ describe('Subscription > PaymentHistory', () => {
       body: [],
     });
 
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
     expect(await screen.findByTestId('permission-denied')).toBeInTheDocument();
     expect(screen.queryByTestId('payment-list')).not.toBeInTheDocument();
   });
@@ -148,10 +138,7 @@ describe('Subscription > PaymentHistory', () => {
       body: [InvoiceFixture({isClosed: true, isPaid: false})],
     });
 
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     expect(await screen.findByTestId('payment-list')).toBeInTheDocument();
     expect(screen.getByText('Closed')).toBeInTheDocument();
@@ -171,10 +158,7 @@ describe('Subscription > PaymentHistory', () => {
       body: [InvoiceFixture({isClosed: false, isPaid: false})],
     });
 
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     expect(await screen.findByTestId('payment-list')).toBeInTheDocument();
     expect(screen.getByText('Awaiting payment')).toBeInTheDocument();
@@ -193,10 +177,7 @@ describe('Subscription > PaymentHistory', () => {
       method: 'GET',
       body: [InvoiceFixture({isClosed: true, isPaid: true})],
     });
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     expect(await screen.findByTestId('payment-list')).toBeInTheDocument();
     expect(screen.getByText('Paid')).toBeInTheDocument();
@@ -216,10 +197,7 @@ describe('Subscription > PaymentHistory', () => {
       method: 'GET',
       body: [InvoiceFixture({isClosed: true, isPaid: true})],
     });
-    render(
-      <PaymentHistory {...RouteComponentPropsFixture()} organization={organization} />,
-      {organization}
-    );
+    render(<PaymentHistory />, {organization});
 
     await screen.findByText('Receipts');
     expect(screen.getByTestId('payment-list')).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -19,13 +19,12 @@ import {
   IconWarning,
 } from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {capitalize} from 'sentry/utils/string/capitalize';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import withSubscription from 'getsentry/components/withSubscription';
@@ -38,9 +37,8 @@ import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/componen
 import SubscriptionHeader from './subscriptionHeader';
 
 type Props = {
-  organization: Organization;
   subscription: Subscription;
-} & RouteComponentProps<unknown, unknown>;
+};
 
 enum ReceiptStatus {
   PAID = 'paid',
@@ -52,7 +50,8 @@ enum ReceiptStatus {
 /**
  * Invoice/Payment list view.
  */
-function PaymentHistory({organization, subscription}: Props) {
+function PaymentHistory({subscription}: Props) {
+  const organization = useOrganization();
   const isNewBillingUI = hasNewBillingUI(organization);
   const location = useLocation();
 
@@ -256,4 +255,4 @@ function ReceiptGrid({
   );
 }
 
-export default withOrganization(withSubscription(PaymentHistory));
+export default withSubscription(PaymentHistory);


### PR DESCRIPTION
Migrates the `PaymentHistory` route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7