### PR TITLE
feat(replay): Add pagination to Playlist view

### DIFF
--- a/static/app/components/replays/table/replayTable.tsx
+++ b/static/app/components/replays/table/replayTable.tsx
@@ -5,6 +5,7 @@ import type {Query} from 'history';
 import {Alert} from 'sentry/components/core/alert';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Pagination from 'sentry/components/pagination';
 import type {ReplayTableColumn} from 'sentry/components/replays/table/replayTableColumns';
 import ReplayTableHeader from 'sentry/components/replays/table/replayTableHeader';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -12,6 +13,7 @@ import {t} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
@@ -30,12 +32,14 @@ type Props = SortProps & {
   replays: ReplayListRecord[];
   showDropdownFilters: boolean;
   highlightedRowIndex?: number;
+  pageLinks?: string | null;
   query?: Query;
   ref?: RefObject<HTMLDivElement | null>;
   stickyHeader?: boolean;
 };
 
 export default function ReplayTable({
+  pageLinks,
   query,
   columns,
   error,
@@ -52,6 +56,7 @@ export default function ReplayTable({
   const gridTemplateColumns = columns.map(col => col.width ?? 'max-content').join(' ');
   const hasInteractiveColumn = columns.some(col => col.interactive);
   const organization = useOrganization();
+  const navigate = useNavigate();
 
   if (isPending) {
     return (
@@ -142,6 +147,17 @@ export default function ReplayTable({
           ))}
         </RowWithScrollIntoView>
       ))}
+      {pageLinks ? (
+        <StyledPagination
+          pageLinks={pageLinks}
+          onCursor={(cursor, path, searchQuery) => {
+            navigate({
+              pathname: path,
+              query: {...searchQuery, cursor},
+            });
+          }}
+        />
+      ) : null}
     </StyledSimpleTable>
   );
 }
@@ -174,6 +190,11 @@ const StyledSimpleTable = styled(SimpleTable)`
   [data-clickable='true'] {
     cursor: pointer;
   }
+`;
+
+const StyledPagination = styled(Pagination)`
+  margin: ${p => p.theme.space.md};
+  grid-column: 1 / -1;
 `;
 
 function getErrorMessage(fetchError: RequestError) {

--- a/static/app/components/replays/table/replayTable.tsx
+++ b/static/app/components/replays/table/replayTable.tsx
@@ -173,7 +173,7 @@ function RowWithScrollIntoView({
   const rowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (scrollIntoView) {
-      rowRef.current?.scrollIntoView();
+      rowRef.current?.scrollIntoView({block: 'center'});
     }
   }, [scrollIntoView]);
   return (

--- a/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
@@ -8,25 +8,32 @@ interface Props {
   currentReplay: ReplayListRecord | undefined;
   isLoading: boolean;
   replays: ReplayListRecord[];
+  pageLinks?: string | null;
 }
 
 const Context = createContext<{
   currentReplayIndex: number;
   isLoading: boolean;
+  pageLinks: string | null;
   replays: ReplayListRecord[];
-}>({currentReplayIndex: -1, replays: [], isLoading: false});
+}>({currentReplayIndex: -1, replays: [], isLoading: false, pageLinks: null});
 
 export function ReplayPlaylistProvider({
   children,
   currentReplay,
   isLoading,
+  pageLinks = null,
   replays,
 }: Props) {
   const currentReplayIndex = useMemo(
     () => replays?.findIndex(r => r.id === currentReplay?.id) ?? -1,
     [replays, currentReplay]
   );
-  return <Context value={{replays, currentReplayIndex, isLoading}}>{children}</Context>;
+  return (
+    <Context value={{replays, currentReplayIndex, isLoading, pageLinks}}>
+      {children}
+    </Context>
+  );
 }
 
 export function useReplayPlaylist() {

--- a/static/app/views/replays/detail/body/replayDetailsProviders.tsx
+++ b/static/app/views/replays/detail/body/replayDetailsProviders.tsx
@@ -81,13 +81,14 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
       ? (query.referrer as ReplayListQueryReferrer)
       : 'replayList',
   });
-  const {data, isLoading} = useApiQuery<{
+  const {data, isLoading, getResponseHeader} = useApiQuery<{
     data: ReplayListRecord[];
     enabled: boolean;
   }>(queryKey, {
     staleTime: 0,
     enabled: Boolean(playlistStart && playlistEnd),
   });
+  const pageLinks = getResponseHeader?.('Link') ?? null;
 
   const replays = useMemo(() => data?.data?.map(mapResponseToReplayRecord) ?? [], [data]);
 
@@ -109,6 +110,7 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
                   <ReplayPlaylistProvider
                     currentReplay={replayRecord}
                     isLoading={isLoading}
+                    pageLinks={pageLinks}
                     replays={replays}
                   >
                     {children}

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -58,18 +58,20 @@ export default function Playlist() {
             <Text>{t('This playlist is filtered by:')} </Text>
           </Alert>
         ) : null}
-        <Flex direction="column" gap="md">
-          <ReplayTable
-            columns={columns}
-            error={null}
-            highlightedRowIndex={currentReplayIndex}
-            // we prefer isLoading since isPending is true even if not enabled
-            isPending={isLoading}
-            query={location.query}
-            replays={replays}
-            showDropdownFilters={false}
-            stickyHeader
-          />
+        <Flex direction="column" gap="md" height="100%">
+          <Flex height="100%" overflow="auto">
+            <ReplayTable
+              columns={columns}
+              error={null}
+              highlightedRowIndex={currentReplayIndex}
+              // we prefer isLoading since isPending is true even if not enabled
+              isPending={isLoading}
+              query={location.query}
+              replays={replays}
+              showDropdownFilters={false}
+              stickyHeader
+            />
+          </Flex>
           <Pagination
             pageLinks={pageLinks}
             onCursor={(cursor, path, searchQuery) => {

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -4,6 +4,7 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Alert} from 'sentry/components/core/alert';
+import Pagination from 'sentry/components/pagination';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
   ReplayBrowserColumn,
@@ -16,6 +17,7 @@ import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/forma
 import {t} from 'sentry/locale';
 import {useReplayPlaylist} from 'sentry/utils/replays/playback/providers/replayPlaylistProvider';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useAllMobileProj from 'sentry/views/replays/detail/useAllMobileProj';
 
 const VISIBLE_COLUMNS = [
@@ -34,8 +36,9 @@ const MOBILE_COLUMNS = [
 ];
 
 export default function Playlist() {
-  const {replays, currentReplayIndex, isLoading} = useReplayPlaylist();
+  const {replays, currentReplayIndex, isLoading, pageLinks} = useReplayPlaylist();
   const location = useLocation();
+  const navigate = useNavigate();
   const [query] = useQueryState('query', parseAsString.withDefault(''));
 
   const {allMobileProj} = useAllMobileProj({});
@@ -55,17 +58,28 @@ export default function Playlist() {
             <Text>{t('This playlist is filtered by:')} </Text>
           </Alert>
         ) : null}
-        <ReplayTable
-          columns={columns}
-          error={null}
-          highlightedRowIndex={currentReplayIndex}
-          // we prefer isLoading since isPending is true even if not enabled
-          isPending={isLoading}
-          query={location.query}
-          replays={replays}
-          showDropdownFilters={false}
-          stickyHeader
-        />
+        <Flex direction="column" gap="md">
+          <ReplayTable
+            columns={columns}
+            error={null}
+            highlightedRowIndex={currentReplayIndex}
+            // we prefer isLoading since isPending is true even if not enabled
+            isPending={isLoading}
+            query={location.query}
+            replays={replays}
+            showDropdownFilters={false}
+            stickyHeader
+          />
+          <Pagination
+            pageLinks={pageLinks}
+            onCursor={(cursor, path, searchQuery) => {
+              navigate({
+                pathname: path,
+                query: {...searchQuery, cursor},
+              });
+            }}
+          />
+        </Flex>
       </Grid>
     </Flex>
   );

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -46,13 +46,11 @@ export default function Playlist() {
     <Flex height="100%" overflow="auto">
       <Grid gap="md" rows={rows} height="100%" width="100%">
         {query ? (
-          <Alert
-            variant="info"
-            showIcon
-            defaultExpanded
-            expand={<ProvidedFormattedQuery query={query} />}
-          >
-            <Text>{t('This playlist is filtered by:')} </Text>
+          <Alert variant="info" showIcon>
+            <Flex wrap="wrap" align="center">
+              <Text>{t('This playlist is filtered by')} </Text>
+              <ProvidedFormattedQuery query={query} />
+            </Flex>
           </Alert>
         ) : null}
         <ReplayTable

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -4,7 +4,6 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Alert} from 'sentry/components/core/alert';
-import Pagination from 'sentry/components/pagination';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
   ReplayBrowserColumn,
@@ -17,7 +16,6 @@ import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/forma
 import {t} from 'sentry/locale';
 import {useReplayPlaylist} from 'sentry/utils/replays/playback/providers/replayPlaylistProvider';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useAllMobileProj from 'sentry/views/replays/detail/useAllMobileProj';
 
 const VISIBLE_COLUMNS = [
@@ -38,7 +36,6 @@ const MOBILE_COLUMNS = [
 export default function Playlist() {
   const {replays, currentReplayIndex, isLoading, pageLinks} = useReplayPlaylist();
   const location = useLocation();
-  const navigate = useNavigate();
   const [query] = useQueryState('query', parseAsString.withDefault(''));
 
   const {allMobileProj} = useAllMobileProj({});
@@ -58,30 +55,18 @@ export default function Playlist() {
             <Text>{t('This playlist is filtered by:')} </Text>
           </Alert>
         ) : null}
-        <Flex direction="column" gap="md" height="100%">
-          <Flex height="100%" overflow="auto">
-            <ReplayTable
-              columns={columns}
-              error={null}
-              highlightedRowIndex={currentReplayIndex}
-              // we prefer isLoading since isPending is true even if not enabled
-              isPending={isLoading}
-              query={location.query}
-              replays={replays}
-              showDropdownFilters={false}
-              stickyHeader
-            />
-          </Flex>
-          <Pagination
-            pageLinks={pageLinks}
-            onCursor={(cursor, path, searchQuery) => {
-              navigate({
-                pathname: path,
-                query: {...searchQuery, cursor},
-              });
-            }}
-          />
-        </Flex>
+        <ReplayTable
+          columns={columns}
+          error={null}
+          highlightedRowIndex={currentReplayIndex}
+          // we prefer isLoading since isPending is true even if not enabled
+          isPending={isLoading}
+          query={location.query}
+          replays={replays}
+          showDropdownFilters={false}
+          pageLinks={pageLinks}
+          stickyHeader
+        />
       </Grid>
     </Flex>
   );


### PR DESCRIPTION
This adds our normal pagination at the end of the replays table in the Playlist view

<img width="768" height="883" alt="image" src="https://github.com/user-attachments/assets/8fe34957-416a-485f-9899-040250f9e5cf" />
