### PR TITLE
nit(aci): handle NaN aggregation value in subscription processor

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -255,7 +255,7 @@ class SubscriptionProcessor:
             comparison_delta = self.get_comparison_delta(self.detector)
             aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
 
-            if aggregation_value is None:
+            if aggregation_value is None or str(aggregation_value) == "nan":
                 metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
                 # We have an invalid aggregate, but we _did_ process the update, so we store
                 # last_update to reflect that and avoid reprocessing.

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime, timedelta
 from typing import Literal, TypedDict, TypeVar
 
@@ -255,7 +256,7 @@ class SubscriptionProcessor:
             comparison_delta = self.get_comparison_delta(self.detector)
             aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
 
-            if aggregation_value is None or str(aggregation_value) == "nan":
+            if aggregation_value is None or math.isnan(aggregation_value):
                 metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
                 # We have an invalid aggregate, but we _did_ process the update, so we store
                 # last_update to reflect that and avoid reprocessing.

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -1,4 +1,5 @@
 import copy
+import math
 from datetime import timedelta
 from functools import cached_property
 from unittest.mock import MagicMock, call, patch
@@ -80,7 +81,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_invalid_aggregation_value(self, mock_metrics: MagicMock) -> None:
-        self.send_update("not a number")
+        self.send_update(math.nan)
         assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
         mock_metrics.incr.assert_has_calls(
             [

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -80,7 +80,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_invalid_aggregation_value(self, mock_metrics: MagicMock) -> None:
-        self.send_update("nan")
+        self.send_update("not a number")
         assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
         mock_metrics.incr.assert_has_calls(
             [

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -79,6 +79,16 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             )
 
     @patch("sentry.incidents.subscription_processor.metrics")
+    def test_invalid_aggregation_value(self, mock_metrics: MagicMock) -> None:
+        self.send_update("nan")
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+        mock_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
+        )
+
+    @patch("sentry.incidents.subscription_processor.metrics")
     def test_has_downgraded_on_demand(self, mock_metrics: MagicMock) -> None:
         snuba_query = self.get_snuba_query(self.detector)
         snuba_query.update(time_window=15 * 60, dataset=Dataset.PerformanceMetrics.value)


### PR DESCRIPTION
Since we know before data condition evaluation that this is the case, skip processing and return early.