### PR TITLE
feat(objectstore): enable token generator in objectstore client

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -9,6 +9,7 @@ from objectstore_client import (
     MetricsBackend,
     Session,
     TimeToLive,
+    TokenGenerator,
     Usecase,
     parse_accept_encoding,
 )
@@ -56,6 +57,16 @@ def create_client() -> Client:
     from sentry import options as options_store
 
     options = options_store.get("objectstore.config")
+
+    # Initialize the `TokenGenerator` if key parameters are found.
+    token_generator = None
+    if signing_key_options := options.get("token_generator"):
+        # We require the `kid` and `secret_key` keys be set, other options are optional
+        if signing_key_options.get("kid") and signing_key_options.get("secret_key"):
+            token_generator = TokenGenerator(
+                **signing_key_options,
+            )
+
     return Client(
         options["base_url"],
         metrics_backend=SentryMetricsBackend(),
@@ -67,6 +78,7 @@ def create_client() -> Client:
             # Workaround for 0.0.14's default read timeout. Can be removed with 0.0.15
             {"timeout": urllib3.Timeout(connect=0.1)},
         ),
+        token=token_generator,
     )
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -405,6 +405,7 @@ register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR
 #  - retries: int | None = None,
 #  - timeout_ms: float | None = None,
 #  - connection_kwargs: Mapping[str, Any] | None = None,
+#  - token_generator: Mapping[str, Any] | None = None,
 #
 # For an always up-to-date list, see:
 # https://getsentry.github.io/objectstore/python/objectstore_client.html#objectstore_client.Client


### PR DESCRIPTION
Closes FS-228.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
