### PR TITLE
fix(grouping): Fix ignoring delete-and-discard bug

### DIFF
--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -94,9 +94,6 @@ class EventManagerGroupingTest(TestCase):
         with pytest.raises(HashDiscarded):
             save_new_event({"message": "Dogs are great!"}, self.project)
 
-    @pytest.mark.xfail(
-        reason="bug will be fixed in https://github.com/getsentry/sentry/pull/105709", strict=True
-    )
     def test_obeys_delete_and_discard_regardless_of_other_hashes(self) -> None:
         project = self.project
 


### PR DESCRIPTION
This fixes a bug which happens under the following conditions: 
- An event generates multiple hashes.
- `GroupHash` records have already been created for at least two of those hashes.
- One grouphash has an assigned group, while another has a tombstone (delete-and-discard) id.
- The hashes are prioritized such that the former is checked before the latter.

In that case, we see the grouphash with the assigned group and take it and run, never discovering that really we should be discarding the event.

This PR fixes that bug (which, to be fair, has long been noted in a TODO in the code) by removing the early-out in `find_grouphash_with_group`. Now if we find a hash with a group, we note it, but don't return from the function until we've checked all the hashes for a tombstone id. (Note that while this PR doesn't add any tests, this fix allows us to remove the xfail from the existing relevant test.)