### PR TITLE
fix(errors): Add error.received to timestamp fields 

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -240,6 +240,7 @@ TIMESTAMP_FIELDS = {
     "timestamp",
     "timestamp.to_hour",
     "timestamp.to_day",
+    "error.received",
 }
 NON_FAILURE_STATUS = {"ok", "cancelled", "unknown"}
 HTTP_SERVER_ERROR_STATUS = {

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -42,6 +42,7 @@ from sentry.search.events.constants import (
     SEMVER_PACKAGE_ALIAS,
     SEMVER_WILDCARDS,
     TEAM_KEY_TRANSACTION_ALIAS,
+    TIMESTAMP_FIELDS,
     TRANSACTION_STATUS_ALIAS,
     USER_DISPLAY_ALIAS,
 )
@@ -578,13 +579,9 @@ def convert_search_filter_to_snuba_query(
     elif name in ARRAY_FIELDS and search_filter.value.raw_value == "":
         return [["notEmpty", [name]], "=", 1 if search_filter.operator == "!=" else 0]
     else:
-        # timestamp{,.to_{hour,day}} need a datetime string
+        # TIMESTAMP_FIELDS need a datetime string
         # last_seen needs an integer
-        if isinstance(value, datetime) and name not in {
-            "timestamp",
-            "timestamp.to_hour",
-            "timestamp.to_day",
-        }:
+        if isinstance(value, datetime) and name not in TIMESTAMP_FIELDS:
             value = int(value.timestamp()) * 1000
 
         if name in {"trace.span", "trace.parent_span"}:

--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from snuba_sdk import Entity, Join, Relationship
@@ -126,9 +126,10 @@ class ErrorsQueryBuilderTest(TestCase):
 
     def test_error_received_filter_uses_datetime(self) -> None:
         """Test that error.received filter uses datetime comparison, not epoch integer."""
-        start = datetime(2025, 12, 1, tzinfo=timezone.utc)
-        end = datetime(2025, 12, 31, tzinfo=timezone.utc)
-        filter_date = datetime(2025, 12, 17, tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(days=1)
+        end = now
+        filter_date = now - timedelta(hours=12)
 
         query = ErrorsQueryBuilder(
             dataset=Dataset.Events,


### PR DESCRIPTION
Worked with the AI's to resolve this issue, according to Opus the issue was:

>The `error.received` field is correctly recognized as a date field for parsing (it's in `date_keys` in `event_search.py`), but when the filter is built in `default_filter_converter`, it checks `TIMESTAMP_FIELDS` to decide whether to keep the datetime as a string or convert it to an epoch integer.
>
>Since `error.received` is not in this set, the datetime gets converted to epoch milliseconds `(int(value.timestamp()) * 1000)`, but the underlying snuba `received` column expects a DateTime string for comparison—not an epoch integer.
>
>This causes the filter to not work correctly because you're comparing a DateTime column against an integer value.

Ticket: EXP-632