### PR TITLE
fix(aci): prevent error detector creation in the API

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -1,11 +1,11 @@
 from django.db import router, transaction
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from sentry import audit_log
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
-from sentry.shared_integrations.exceptions import ApiForbiddenError
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.models.detector import Detector
@@ -57,7 +57,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
         return value
 
     def create(self, validated_data):
-        raise ApiForbiddenError("Creating error detectors is not supported")
+        raise PermissionDenied("Creating error detectors is not supported")
 
     def update(self, instance, validated_data):
         with transaction.atomic(router.db_for_write(Detector)):

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -83,8 +83,11 @@ class TestErrorDetectorValidator(TestCase):
         ]
 
     def test_update_existing_with_valid_data(self) -> None:
+        user = self.create_user()
+        self.create_member(organization=self.project.organization, user=user)
+        data = {**self.valid_data, "owner": user.id, "enabled": False}
         validator = ErrorDetectorValidator(
-            data=self.valid_data, context=self.context, instance=self.existing_error_detector
+            data=data, context=self.context, instance=self.existing_error_detector
         )
         assert validator.is_valid()
         with self.tasks():
@@ -93,6 +96,8 @@ class TestErrorDetectorValidator(TestCase):
         assert detector.type == "error"
         assert detector.project_id == self.project.id
         assert detector.workflow_condition_group is None
+        assert detector.owner.identifier == f"user:{user.id}"
+        assert detector.enabled is False
 
     def test_update_with_name_change(self) -> None:
         data = {**self.valid_data, "name": "Updated Detector"}

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -1,8 +1,7 @@
 import pytest
-from rest_framework.exceptions import ErrorDetail
+from rest_framework.exceptions import ErrorDetail, PermissionDenied
 
 from sentry.models.environment import Environment
-from sentry.shared_integrations.exceptions import ApiForbiddenError
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
 from sentry.workflow_engine.models.detector import Detector
@@ -34,7 +33,7 @@ class TestErrorDetectorValidator(TestCase):
     def test_create(self) -> None:
         validator = ErrorDetectorValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid()
-        with pytest.raises(ApiForbiddenError):
+        with pytest.raises(PermissionDenied):
             validator.save()
 
     def test_invalid_detector_type(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -29,7 +29,12 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    DEFAULT_DOWNTIME_THRESHOLD,
+    DEFAULT_RECOVERY_THRESHOLD,
+    UptimeMonitorMode,
+)
 from sentry.workflow_engine.endpoints.organization_detector_index import convert_assignee_values
 from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
@@ -1148,12 +1153,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         mock_get_limit.return_value = 1
 
         # Create a not-metric detector
-        self.create_detector(
-            project=self.project,
-            name="Error Detector",
-            type=ErrorGroupType.slug,
-            status=ObjectStatus.ACTIVE,
-        )
+        self.create_uptime_detector()
 
         # Create 1 metric detector, it should succeed
         response = self.get_success_response(
@@ -1173,16 +1173,33 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert response.status_code == 400
 
         # Create another not-metric detector, it should succeed
+        data = {
+            "name": "Test Uptime Monitor",
+            "type": UptimeDomainCheckFailure.slug,
+            "enabled": True,
+            "config": {
+                "mode": UptimeMonitorMode.MANUAL.value,
+                "environment": None,
+                "recovery_threshold": DEFAULT_RECOVERY_THRESHOLD,
+                "downtime_threshold": DEFAULT_DOWNTIME_THRESHOLD,
+            },
+            "dataSources": [
+                {
+                    "url": "https://sentry.io",
+                    "intervalSeconds": 60,
+                    "timeoutMs": 1000,
+                }
+            ],
+        }
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
                 projectId=self.project.id,
-                name="Error Detector",
-                type=ErrorGroupType.slug,
+                **data,
                 status_code=201,
             )
         detector = Detector.objects.get(id=response.data["id"])
-        assert detector.type == ErrorGroupType.slug
+        assert detector.type == UptimeDomainCheckFailure.slug
 
 
 @region_silo_test


### PR DESCRIPTION
I noticed this happening from a user messing with our APIs. We shouldn't allow users to create error detectors.

Also added preventing the detector name from being modified