### PR TITLE
icons: remap warning variant color value

### DIFF
--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -43,9 +43,13 @@ export function SvgIcon(props: SVGIconProps) {
       viewBox="0 0 16 16"
       {...rest}
       fill={
-        iconProps.variant
-          ? theme.tokens.content[iconProps.variant]
-          : resolveIconColor(theme, iconProps)
+        // Exception for warning icon variant. Design enginering needs to figure out what
+        // to align this color to, as content.warning looks too dark in this context.
+        iconProps.variant === 'warning'
+          ? theme.tokens.graphics.warning.vibrant
+          : iconProps.variant
+            ? theme.tokens.content[iconProps.variant]
+            : resolveIconColor(theme, iconProps)
       }
       height={size}
       width={size}


### PR DESCRIPTION
Temporary change so that we can get rid of the ColorOrAlias type in our icons.

Before
<img width="434" height="73" alt="CleanShot 2026-01-06 at 09 58 56" src="https://github.com/user-attachments/assets/a26e670c-6385-4956-a65b-0e28b18c9270" />

After
<img width="440" height="61" alt="CleanShot 2026-01-06 at 09 58 34" src="https://github.com/user-attachments/assets/e6f1dfb2-909c-48f4-a769-190e73cd9ab2" />
