### PR TITLE
fix(ui): Avoid loading invalid prism files

### DIFF
--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -7,7 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {loadPrismLanguage} from 'sentry/utils/prism';
+import {getPrismLanguage, loadPrismLanguage} from 'sentry/utils/prism';
 // eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
 
@@ -110,7 +110,8 @@ export function CodeBlock({
       return;
     }
 
-    if (!language) {
+    // Skip if no language or if language is not a valid Prism language (e.g. "text")
+    if (!language || !getPrismLanguage(language)) {
       return;
     }
 


### PR DESCRIPTION
there's a few places where we do things like `<CodeBlock language="text"` and there isn't a syntax to load for this. Check the mapping before attempting to load the syntax file. Silences big warnings in tests.

example warning https://github.com/getsentry/sentry/actions/runs/20756980249/job/59601628632?pr=105724#step:8:2004 via test static/app/views/prevent/tests/onboarding.spec.tsx
