### PR TITLE
chore(issue search): Remove enablement option for truncation of group IDs in Snuba queries

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3816,15 +3816,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Option to enable truncation of group IDs in Snuba query
-# when search filters are selective.
-register(
-    "snuba.search.truncate-group-ids-for-selective-filters-enabled",
-    type=Bool,
-    default=True,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Organization slug allowlist to enable Autopilot for specific organizations.
 register(
     "autopilot.organization-allowlist",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -920,10 +920,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # If we had too_many_candidates, fall back to truncation instead of
             # returning empty. This handles selective filters (like assigned_to)
             # where random sampling is unlikely to find matches.
-            is_truncation_enabled = options.get(
-                "snuba.search.truncate-group-ids-for-selective-filters-enabled"
-            )
-            if too_many_candidates and original_group_ids and is_truncation_enabled:
+            if too_many_candidates and original_group_ids:
                 metrics.incr("snuba.search.hits_zero_fallback_to_truncation", skip_internal=False)
                 group_ids = original_group_ids[:max_candidates]
                 too_many_candidates = False


### PR DESCRIPTION
This new truncation logic has been running successfully for all queries since Monday 1/5, so it's safe to remove this option.