### PR TITLE
fix(ui): Avoid logging sentry console banner in tests

### DIFF
--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -63,7 +63,7 @@ export function ThemeAndStyleProvider({children}: Props) {
   const theme = config.theme === 'dark' ? darkTheme : lightTheme;
 
   const didPrintBanner = useRef(false);
-  if (!didPrintBanner.current && NODE_ENV !== 'development') {
+  if (!didPrintBanner.current && NODE_ENV !== 'development' && NODE_ENV !== 'test') {
     didPrintBanner.current = true;
     printConsoleBanner(theme.tokens.content.accent, theme.font.family.mono);
   }


### PR DESCRIPTION
a few tests are outputting the console banner like `static/app/bootstrap/processInitQueue.spec.tsx`
