### PR TITLE
fix(stories): remove global css

### DIFF
--- a/static/app/stories/index.tsx
+++ b/static/app/stories/index.tsx
@@ -10,3 +10,4 @@ export {SizingWindow, Grid} from './layout';
 export {story} from './storybook';
 export {ThemeSwitcher, ThemeToggle} from './theme';
 export {TokenReference} from './tokenReference';
+export {StoryTable as Table} from './table';

--- a/static/app/stories/table.tsx
+++ b/static/app/stories/table.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+
+export const StoryTable = styled('table')`
+  min-width: 0;
+  flex-grow: 1;
+  margin: 1px;
+  padding: 0;
+  width: calc(100% - 2px);
+  table-layout: auto;
+  border: 0;
+  border-collapse: collapse;
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: 0 0 0 1px ${p => p.theme.tokens.border.primary};
+  margin-bottom: ${p => p.theme.space['3xl']};
+
+  & thead {
+    height: 36px;
+    border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
+    background: ${p => p.theme.tokens.background.tertiary};
+    border-bottom: 4px solid ${p => p.theme.tokens.border.primary};
+  }
+
+  & th {
+    padding-inline: ${p => p.theme.space.xl};
+    padding-block: ${p => p.theme.space.sm};
+
+    &:first-of-type {
+      border-radius: ${p => p.theme.radius.md} 0 0 0;
+    }
+    &:last-of-type {
+      border-radius: 0 ${p => p.theme.radius.md} 0 0;
+    }
+  }
+
+  tr:last-child td:first-of-type {
+    border-radius: 0 0 0 ${p => p.theme.radius.md};
+  }
+  tr:last-child td:last-of-type {
+    border-radius: 0 0 ${p => p.theme.radius.md} 0;
+  }
+
+  tbody {
+    background: ${p => p.theme.tokens.background.primary};
+    border-radius: 0 0 ${p => p.theme.radius.md} ${p => p.theme.radius.md};
+  }
+
+  tr {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.muted};
+    vertical-align: baseline;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  td:first-child {
+    white-space: nowrap;
+    word-break: break-all;
+    hyphens: none;
+  }
+
+  td {
+    padding-inline: ${p => p.theme.space.xl};
+    padding-block: ${p => p.theme.space.lg};
+  }
+`;

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -249,80 +249,6 @@ const StoryMainContainer = styled('main')`
   h5,
   h6 {
     scroll-margin-top: 80px;
-    margin: 0;
-  }
-
-  p,
-  pre {
-    margin: 0;
-  }
-
-  code:not([class]):not(pre > code) {
-    background: ${p => p.theme.tokens.background.secondary};
-    color: ${p => p.theme.tokens.content.primary};
-  }
-
-  table:not([class]) {
-    margin: 1px;
-    padding: 0;
-    width: calc(100% - 2px);
-    table-layout: auto;
-    border: 0;
-    border-collapse: collapse;
-    border-radius: ${p => p.theme.radius.md};
-    box-shadow: 0 0 0 1px ${p => p.theme.tokens.border.primary};
-    margin-bottom: ${p => p.theme.space['3xl']};
-
-    & thead {
-      height: 36px;
-      border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
-      background: ${p => p.theme.tokens.background.tertiary};
-      border-bottom: 4px solid ${p => p.theme.tokens.border.primary};
-    }
-
-    & th {
-      padding-inline: ${p => p.theme.space.xl};
-      padding-block: ${p => p.theme.space.sm};
-
-      &:first-of-type {
-        border-radius: ${p => p.theme.radius.md} 0 0 0;
-      }
-      &:last-of-type {
-        border-radius: 0 ${p => p.theme.radius.md} 0 0;
-      }
-    }
-
-    tr:last-child td:first-of-type {
-      border-radius: 0 0 0 ${p => p.theme.radius.md};
-    }
-    tr:last-child td:last-of-type {
-      border-radius: 0 0 ${p => p.theme.radius.md} 0;
-    }
-
-    tbody {
-      background: ${p => p.theme.tokens.background.primary};
-      border-radius: 0 0 ${p => p.theme.radius.md} ${p => p.theme.radius.md};
-    }
-
-    tr {
-      border-bottom: 1px solid ${p => p.theme.tokens.border.muted};
-      vertical-align: baseline;
-
-      &:last-child {
-        border-bottom: 0;
-      }
-    }
-
-    td:first-child {
-      white-space: nowrap;
-      word-break: break-all;
-      hyphens: none;
-    }
-
-    td {
-      padding-inline: ${p => p.theme.space.xl};
-      padding-block: ${p => p.theme.space.lg};
-    }
   }
 
   div + .expressive-code .frame {
@@ -333,9 +259,9 @@ const StoryMainContainer = styled('main')`
   }
 
   .expressive-code .frame {
-    margin-bottom: ${p => p.theme.space['3xl']};
+    margin: 0;
     box-shadow: none;
-    border: 1px solid #000000;
+    border: none;
     pre {
       background: hsla(254, 18%, 15%, 1);
       border: 0;

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -9,6 +9,7 @@ import {InlineCode} from 'sentry/components/core/code';
 import {Stack} from 'sentry/components/core/layout';
 import type {TextProps} from 'sentry/components/core/text/text';
 import {Text} from 'sentry/components/core/text/text';
+import * as Stories from 'sentry/stories';
 
 import {StoryHeading} from './storyHeading';
 
@@ -60,7 +61,8 @@ export const storyMdxComponents = {
     <Text as="p" size="md" density="comfortable" {...props} />
   ),
   ul: (props: Omit<HTMLProps<HTMLUListElement>, 'wrap'>) => (
-    <Stack {...props} as="ul" gap="lg" />
+    <Stack margin="0" {...props} as="ul" gap="lg" />
   ),
   blockquote: (props: QuoteProps) => <Quote {...props} />,
+  table: Stories.Table,
 };

--- a/static/app/stories/view/storyResources.tsx
+++ b/static/app/stories/view/storyResources.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import {Badge} from 'sentry/components/core/badge';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {IconGithub} from 'sentry/icons';
+import * as Stories from 'sentry/stories';
 import {
   isMDXStory,
   type StoryResources as Resources,
@@ -20,7 +21,7 @@ export function StoryResources() {
   const resources: Resources = story.exports.frontmatter?.resources ?? {};
 
   return (
-    <table style={{marginTop: theme.space['3xl']}}>
+    <Stories.Table style={{marginTop: theme.space['3xl']}}>
       <thead>
         <tr>
           <th>Type</th>
@@ -44,7 +45,7 @@ export function StoryResources() {
           }
         })}
       </tbody>
-    </table>
+    </Stories.Table>
   );
 }
 


### PR DESCRIPTION
Previously, Stories routes had some global style resets that were an attempt to remove our global margins. One side-effect of this was that components that rely on the default styles were being rendered incorrectly.

<img width="280" height="517" alt="composite-select-broken" src="https://github.com/user-attachments/assets/8a134f51-377a-4cda-800d-6de00852a4a3" />

With this PR, the global styles created by `StoryMainContainer` have been removed. `Stories.Table` is now exported as its own component, and `storyMdxComponents` have been updated to scope the style resets locally.

As a result, component rendering is now fixed.

<img width="259" height="572" alt="composite-select-fixed" src="https://github.com/user-attachments/assets/4c285abd-b8de-46c7-8865-5b4e5a45e753" />
