### PR TITLE
chore(api): deprecate `sentry-api-0-group-first-last-release` FE

### DIFF
--- a/static/app/components/feedback/getFeedbackItemQueryKey.tsx
+++ b/static/app/components/feedback/getFeedbackItemQueryKey.tsx
@@ -16,7 +16,7 @@ export default function getFeedbackItemQueryKey({feedbackId, organization}: Prop
           `/organizations/${organization.slug}/issues/${feedbackId}/`,
           {
             query: {
-              collapse: ['release', 'tags'],
+              collapse: ['tags'],
             },
           },
         ]

--- a/static/app/components/group/releaseStats.spec.tsx
+++ b/static/app/components/group/releaseStats.spec.tsx
@@ -12,13 +12,6 @@ describe('GroupReleaseStats', () => {
   const project = ProjectFixture();
   const group = GroupFixture();
 
-  beforeEach(() => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      body: {id: group.id, firstRelease: undefined, lastRelease: undefined},
-    });
-  });
-
   const createWrapper = (
     props: Partial<React.ComponentProps<typeof GroupReleaseStats>>
   ) =>

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -42,8 +42,8 @@ function GroupReleaseStats({
         ? environments[0]
         : undefined;
 
-  const firstRelease = group?.firstRelease;
-  const lastRelease = group?.lastRelease;
+  const firstRelease = group?.firstRelease ?? undefined;
+  const lastRelease = group?.lastRelease ?? undefined;
 
   const projectId = project.id;
   const projectSlug = project.slug;

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -13,9 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import type {CurrentRelease, Release} from 'sentry/types/release';
-import {defined} from 'sentry/utils';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import type {CurrentRelease} from 'sentry/types/release';
 
 type Props = {
   environments: string[];
@@ -24,11 +22,6 @@ type Props = {
   allEnvironments?: Group;
   currentRelease?: CurrentRelease;
   group?: Group;
-};
-
-type GroupRelease = {
-  firstRelease: Release;
-  lastRelease: Release;
 };
 
 function GroupReleaseStats({
@@ -49,20 +42,8 @@ function GroupReleaseStats({
         ? environments[0]
         : undefined;
 
-  const {data: groupReleaseData} = useApiQuery<GroupRelease>(
-    [
-      defined(group)
-        ? `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`
-        : '',
-    ],
-    {
-      staleTime: 30000,
-      gcTime: 30000,
-    }
-  );
-
-  const firstRelease = groupReleaseData?.firstRelease;
-  const lastRelease = groupReleaseData?.lastRelease;
+  const firstRelease = group?.firstRelease;
+  const lastRelease = group?.lastRelease;
 
   const projectId = project.id;
   const projectSlug = project.slug;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -17,6 +17,7 @@ import type {
 } from './integrations';
 import type {Team} from './organization';
 import type {AvatarProject, PlatformKey, Project} from './project';
+import type {Release} from './release';
 import type {AvatarUser, User} from './user';
 
 export type EntryData = Record<string, any | any[]>;
@@ -970,8 +971,11 @@ export interface BaseGroup {
   title: string;
   type: EventOrGroupType;
   userReportCount: number;
+  // Only present when 'release' is not in the collapse array
+  firstRelease?: Release | null;
   inbox?: InboxDetails | null | false;
   integrationIssues?: ExternalIssue[];
+  lastRelease?: Release | null;
   latestEvent?: Event;
   latestEventHasAttachments?: boolean;
   owners?: SuggestedOwner[] | null;

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -120,10 +120,6 @@ describe('groupDetails', () => {
       body: [project],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/first-last-release/`,
-      method: 'GET',
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/events/`,
       statusCode: 200,
       body: {

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -234,7 +234,7 @@ describe('groupDetails', () => {
         expect.anything(),
         expect.objectContaining({
           query: {
-            collapse: ['release', 'tags'],
+            collapse: ['tags'],
             environment: ['staging'],
             expand: ['inbox', 'owners'],
           },

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -306,10 +306,6 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-    method: 'GET',
-  });
-  MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events/`,
     body: {
       data: [],

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -82,10 +82,6 @@ describe('GroupSidebar', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      method: 'GET',
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -57,9 +57,6 @@ describe('GroupDetailsLayout', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
       body: [],
     });

--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import FirstLastSeenSection from 'sentry/views/issueDetails/streamline/sidebar/firstLastSeenSection';
@@ -11,44 +11,30 @@ import FirstLastSeenSection from 'sentry/views/issueDetails/streamline/sidebar/f
 describe('FirstLastSeenSection', () => {
   const organization = OrganizationFixture();
   const project = ProjectFixture();
-  const group = GroupFixture({
-    project,
-    firstSeen: '2024-01-06T10:00:00Z',
-    lastSeen: '2024-01-14T12:00:00Z',
-  });
 
   const firstRelease = ReleaseFixture({version: '1.0.0'});
   const lastRelease = ReleaseFixture({version: '1.1.0'});
 
-  let mockFirstLastRelease: jest.Mock;
-
   beforeEach(() => {
     jest.clearAllMocks();
-
     MockApiClient.clearMockResponses();
+  });
 
-    mockFirstLastRelease = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      method: 'GET',
-      body: {
-        id: group.id,
-        firstRelease,
-        lastRelease,
-      },
+  it('renders first and last seen information with release data', async () => {
+    const group = GroupFixture({
+      project,
+      firstSeen: '2024-01-06T10:00:00Z',
+      lastSeen: '2024-01-14T12:00:00Z',
+      firstRelease,
+      lastRelease,
     });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'GET',
-      body: GroupFixture({
-        id: group.id,
-        firstSeen: '2024-01-06T10:00:00Z',
-        lastSeen: '2024-01-14T12:00:00Z',
-      }),
+      body: group,
     });
-  });
 
-  it('renders first and last seen information with release data', async () => {
     render(<FirstLastSeenSection group={group} />, {
       organization,
       initialRouterConfig: {
@@ -58,17 +44,6 @@ describe('FirstLastSeenSection', () => {
         },
       },
     });
-
-    await waitFor(() => {
-      expect(mockFirstLastRelease).toHaveBeenCalled();
-    });
-
-    expect(mockFirstLastRelease).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      expect.objectContaining({
-        query: {},
-      })
-    );
 
     expect(await screen.findByText('First seen')).toBeInTheDocument();
     expect(screen.getByText('Last seen')).toBeInTheDocument();
@@ -81,42 +56,20 @@ describe('FirstLastSeenSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls API with environment parameters when environments are selected', async () => {
-    render(<FirstLastSeenSection group={group} />, {
-      organization,
-      initialRouterConfig: {
-        location: {
-          pathname: `/organizations/${organization.slug}/issues/${group.id}/`,
-          query: {environment: ['production', 'staging']},
-        },
-      },
+  it('shows same release for first and last seen', async () => {
+    const sameRelease = ReleaseFixture({version: '1.0.0'});
+    const group = GroupFixture({
+      project,
+      firstSeen: '2024-01-06T10:00:00Z',
+      lastSeen: '2024-01-14T12:00:00Z',
+      firstRelease: sameRelease,
+      lastRelease: sameRelease,
     });
 
-    await waitFor(() => {
-      expect(mockFirstLastRelease).toHaveBeenCalled();
-    });
-
-    expect(mockFirstLastRelease).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      expect.objectContaining({
-        query: {
-          environment: ['production', 'staging'],
-        },
-      })
-    );
-  });
-
-  it('shows environment-specific release information', async () => {
-    const productionRelease = ReleaseFixture({version: '1.0.0'});
-
-    mockFirstLastRelease = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'GET',
-      body: {
-        id: group.id,
-        firstRelease: productionRelease,
-        lastRelease: productionRelease,
-      },
+      body: group,
     });
 
     render(<FirstLastSeenSection group={group} />, {
@@ -124,7 +77,7 @@ describe('FirstLastSeenSection', () => {
       initialRouterConfig: {
         location: {
           pathname: `/organizations/${organization.slug}/issues/${group.id}/`,
-          query: {environment: ['production']},
+          query: {},
         },
       },
     });
@@ -136,14 +89,18 @@ describe('FirstLastSeenSection', () => {
   });
 
   it('handles missing release data gracefully', async () => {
-    mockFirstLastRelease = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
+    const group = GroupFixture({
+      project,
+      firstSeen: '2024-01-06T10:00:00Z',
+      lastSeen: '2024-01-14T12:00:00Z',
+      firstRelease: null,
+      lastRelease: null,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'GET',
-      body: {
-        id: group.id,
-        firstRelease: null,
-        lastRelease: null,
-      },
+      body: group,
     });
 
     render(<FirstLastSeenSection group={group} />, {

--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -9,16 +9,10 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {useFetchAllEnvsGroupData} from 'sentry/views/issueDetails/groupSidebar';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
-
-interface GroupRelease {
-  firstRelease: Release;
-  lastRelease: Release;
-}
 
 export default function FirstLastSeenSection({group}: {group: Group}) {
   const organization = useOrganization();
@@ -28,20 +22,6 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
   const environments = useEnvironmentsFromUrl();
 
   const {data: allEnvsGroupData} = useFetchAllEnvsGroupData(organization, group);
-  const {data: groupReleaseData} = useApiQuery<GroupRelease>(
-    [
-      `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      {
-        query: {
-          ...(environments.length > 0 ? {environment: environments} : {}),
-        },
-      },
-    ],
-    {
-      staleTime: 30000,
-      gcTime: 30000,
-    }
-  );
   const {data: openPeriods} = useOpenPeriods(
     {groupId: group.id},
     {enabled: issueTypeConfig.useOpenPeriodChecks}
@@ -77,7 +57,7 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
           />
         </Flex>
         {lastSeen && (
-          <ReleaseText project={group.project} release={groupReleaseData?.lastRelease} />
+          <ReleaseText project={group.project} release={group.lastRelease ?? undefined} />
         )}
       </div>
       <div>
@@ -93,7 +73,10 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
           />
         </Flex>
         {group.firstSeen && (
-          <ReleaseText project={group.project} release={groupReleaseData?.firstRelease} />
+          <ReleaseText
+            project={group.project}
+            release={group.firstRelease ?? undefined}
+          />
         )}
       </div>
     </Flex>

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -37,7 +37,6 @@ describe('StreamlinedSidebar', () => {
   });
   const event = EventFixture({group});
 
-  let mockFirstLastRelease: jest.Mock;
   let mockExternalIssues: jest.Mock;
 
   beforeEach(() => {
@@ -67,10 +66,6 @@ describe('StreamlinedSidebar', () => {
       body: {steps: []},
     });
 
-    mockFirstLastRelease = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-      method: 'GET',
-    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/1/external-issues/`,
       body: [],
@@ -110,7 +105,6 @@ describe('StreamlinedSidebar', () => {
 
     expect(await screen.findByText('First seen')).toBeInTheDocument();
     expect(screen.getByText('Last seen')).toBeInTheDocument();
-    expect(mockFirstLastRelease).toHaveBeenCalled();
 
     expect(await screen.findByText('Issue Tracking')).toBeInTheDocument();
     expect(

--- a/static/app/views/issueDetails/useGroup.tsx
+++ b/static/app/views/issueDetails/useGroup.tsx
@@ -21,7 +21,7 @@ export function makeFetchGroupQueryKey({
   const query: Record<string, string | string[]> = {
     ...(environments.length > 0 ? {environment: environments} : {}),
     expand: ['inbox', 'owners'],
-    collapse: ['release', 'tags'],
+    collapse: ['tags'],
   };
 
   return [`/organizations/${organizationSlug}/issues/${groupId}/`, {query}];


### PR DESCRIPTION
https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23?source=copy_link
