### PR TITLE
deprecate(code_review): Do not forward events to Overwatch

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -979,28 +979,6 @@ class PullRequestEventWebhook(GitHubWebhook):
         )
 
 
-class PullRequestReviewEventWebhook(GitHubWebhook):
-    """
-    Handles GitHub pull_request_review webhook events.
-    https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review
-    """
-
-    EVENT_TYPE = IntegrationWebhookEventType.MERGE_REQUEST_REVIEW
-    # XXX: Once we port the Overwatch feature, we can add the processor here.
-    WEBHOOK_EVENT_PROCESSORS = ()
-
-
-class PullRequestReviewCommentEventWebhook(GitHubWebhook):
-    """
-    Handles GitHub pull_request_review_comment webhook events.
-    https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review_comment
-    """
-
-    EVENT_TYPE = IntegrationWebhookEventType.MERGE_REQUEST_REVIEW_COMMENT
-    # XXX: Once we port the Overwatch feature, we can add the processor here.
-    WEBHOOK_EVENT_PROCESSORS = ()
-
-
 class CheckRunEventWebhook(GitHubWebhook):
     """
     Handles GitHub check_run webhook events.
@@ -1042,8 +1020,6 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
         GithubWebhookType.ISSUE: IssuesEventWebhook,
         GithubWebhookType.ISSUE_COMMENT: IssueCommentEventWebhook,
         GithubWebhookType.PULL_REQUEST: PullRequestEventWebhook,
-        GithubWebhookType.PULL_REQUEST_REVIEW: PullRequestReviewEventWebhook,
-        GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT: PullRequestReviewCommentEventWebhook,
         GithubWebhookType.PUSH: PushEventWebhook,
     }
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -693,8 +693,6 @@ register("overwatch.forward-webhooks.verbose", default=False, flags=FLAG_AUTOMAT
 # Control forwarding of specific GitHub webhook types to overwatch (True) or seer (False)
 register("github.webhook.issue-comment", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("github.webhook.pr-review-comment", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("github.webhook.pr-review", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -4,6 +4,4 @@ from sentry.integrations.github.webhook_types import GithubWebhookType
 WEBHOOK_TYPE_TO_OPTION_KEY = {
     GithubWebhookType.ISSUE_COMMENT: "github.webhook.issue-comment",
     GithubWebhookType.PULL_REQUEST: "github.webhook.pr",
-    GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT: "github.webhook.pr-review-comment",
-    GithubWebhookType.PULL_REQUEST_REVIEW: "github.webhook.pr-review",
 }

--- a/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
+++ b/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
@@ -428,28 +428,17 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
         """Test that default events should always be forwarded."""
         events = get_github_events_to_forward_overwatch()
         assert GithubWebhookType.PULL_REQUEST in events
-        assert GithubWebhookType.PULL_REQUEST_REVIEW in events
-        assert GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT in events
         assert GithubWebhookType.ISSUE_COMMENT in events
         # These are always forwarded
         assert GithubWebhookType.INSTALLATION in events
         assert GithubWebhookType.INSTALLATION_REPOSITORIES in events
 
-    @override_options(
-        {
-            "github.webhook.issue-comment": False,
-            "github.webhook.pr": False,
-            "github.webhook.pr-review": False,
-            "github.webhook.pr-review-comment": False,
-        }
-    )
+    @override_options({"github.webhook.issue-comment": False, "github.webhook.pr": False})
     def test_disabling_options_excludes_events(self):
         """Test that disabling options excludes events from forwarding."""
         events = get_github_events_to_forward_overwatch()
         assert GithubWebhookType.ISSUE_COMMENT not in events
         assert GithubWebhookType.PULL_REQUEST not in events
-        assert GithubWebhookType.PULL_REQUEST_REVIEW not in events
-        assert GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT not in events
         # These are always forwarded
         assert GithubWebhookType.INSTALLATION in events
         assert GithubWebhookType.INSTALLATION_REPOSITORIES in events


### PR DESCRIPTION
`pull_request_review` and `pull_request_review_comment` have stopped working a while ago. This change stops the forwarding to Overwatch.