### PR TITLE
fix(code-mappings): bad url parsing for Gitlab and Bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -42,6 +42,7 @@ from sentry.utils.http import absolute_uri
 from .client import BitbucketApiClient
 from .issues import BitbucketIssuesSpec
 from .repository import BitbucketRepositoryProvider
+from .utils import parse_bitbucket_src_url
 
 DESCRIPTION = """
 Connect your Sentry organization to Bitbucket, enabling the following features:
@@ -172,13 +173,15 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
         return f"https://bitbucket.org/{repo.name}/src/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/src/", "")
-        branch, _, _ = url.partition("/")
+        if not repo.url:
+            return ""
+        branch, _ = parse_bitbucket_src_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/src/", "")
-        _, _, source_path = url.partition("/")
+        if not repo.url:
+            return ""
+        _, source_path = parse_bitbucket_src_url(repo.url, url)
         return source_path
 
     # Bitbucket only methods

--- a/src/sentry/integrations/bitbucket/utils.py
+++ b/src/sentry/integrations/bitbucket/utils.py
@@ -1,0 +1,19 @@
+from urllib.parse import urlparse
+
+
+def parse_bitbucket_src_url(repo_url: str, source_url: str) -> tuple[str, str]:
+    """
+    Parse a Bitbucket src URL relative to a repository URL and return
+    a tuple of (branch, source_path). If parsing fails, returns ("", "").
+    """
+    repo_path = urlparse(repo_url).path.rstrip("/")
+    path = urlparse(source_url).path
+    if repo_path and path.startswith(repo_path):
+        path = path[len(repo_path) :]
+
+    _, _, after_src = path.partition("/src/")
+    if not after_src:
+        return "", ""
+
+    branch, _, remainder = after_src.partition("/")
+    return branch, remainder.lstrip("/")

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -49,6 +49,7 @@ from sentry.web.helpers import render_to_response
 from .client import GitLabApiClient, GitLabSetupApiClient
 from .issues import GitlabIssuesSpec
 from .repository import GitlabRepositoryProvider
+from .utils import parse_gitlab_blob_url
 
 logger = logging.getLogger("sentry.integrations.gitlab")
 
@@ -165,15 +166,15 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         return f"{base_url}/{repo_name}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/-/blob/", "")
-        url = url.replace(f"{repo.url}/blob/", "")
-        branch, _, _ = url.partition("/")
+        if not repo.url:
+            return ""
+        branch, _ = parse_gitlab_blob_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/-/blob/", "")
-        url = url.replace(f"{repo.url}/blob/", "")
-        _, _, source_path = url.partition("/")
+        if not repo.url:
+            return ""
+        _, source_path = parse_gitlab_blob_url(repo.url, url)
         return source_path
 
     # CommitContextIntegration methods

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -423,3 +423,18 @@ class ProjectStacktraceLinkGitlabTest(BaseStacktraceLinkTest):
         assert resp.status_code == 400, resp.content
 
         assert resp.data == {"sourceUrl": ["Could not find repo"]}
+
+    def test_strips_query_params_from_source_url(self) -> None:
+        source_url = "https://gitlab.com/getsentry/sentry/-/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py?ref_type=heads"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 200, resp.content
+
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repositoryId": self.repo.id,
+            "provider": "gitlab",
+            "stackRoot": "sentry/",
+            "sourceRoot": "src/sentry/",
+            "defaultBranch": "master",
+        }


### PR DESCRIPTION
(maybe) Fixes SENTRY-3Z81

When a user attempts to create a code mapping in GitLab or Bitbucket, sometimes they'll include URL params (common one is `?ref_type=heads`. When we extract the source path from the URL, these headers break our parsing, leading to the error. Refactor the URL extraction to be consistent with https://github.com/getsentry/sentry/pull/99309, which uses urlparse to remove these params.

While investigating this issue, I saw some other potential problems in the event data with GitLab specifically, but that'll be a follow-up PR if this issue regresses.