### PR TITLE
fix(tracemetrics): Pass along response derived units

### DIFF
--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -4,7 +4,11 @@ import type {LegendComponentOption} from 'echarts';
 import type {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
-import type {AggregationOutputType, RateUnit} from 'sentry/utils/discover/fields';
+import type {
+  AggregationOutputType,
+  DataUnit,
+  RateUnit,
+} from 'sentry/utils/discover/fields';
 import {axisDuration} from 'sentry/utils/duration/axisDuration';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
@@ -18,12 +22,13 @@ import {categorizeDuration} from './categorizeDuration';
  */
 export function tooltipFormatter(
   value: number | null,
-  outputType: AggregationOutputType = 'number'
+  outputType: AggregationOutputType = 'number',
+  unit?: DataUnit
 ): string {
   if (!defined(value)) {
     return '\u2014';
   }
-  return tooltipFormatterUsingAggregateOutputType(value, outputType);
+  return tooltipFormatterUsingAggregateOutputType(value, outputType, unit);
 }
 
 /**
@@ -31,7 +36,8 @@ export function tooltipFormatter(
  */
 export function tooltipFormatterUsingAggregateOutputType(
   value: number | null,
-  type: string
+  type: string,
+  unit?: DataUnit
 ): string {
   if (!defined(value)) {
     return '\u2014';
@@ -46,6 +52,11 @@ export function tooltipFormatterUsingAggregateOutputType(
       return getDuration(value / 1000, 2, true);
     case 'size':
       return formatBytesBase2(value);
+    case 'rate':
+      if (unit) {
+        return formatRate(value, unit as RateUnit);
+      }
+      return formatRate(value);
     default:
       return value.toString();
   }

--- a/static/app/utils/timeSeries/transformLegacySeriesToPlottables.spec.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToPlottables.spec.tsx
@@ -12,8 +12,12 @@ describe('transformLegacySeriesToPlottables', () => {
   it('returns empty array for empty or undefined legacy series', () => {
     const widget = WidgetFixture({displayType: DisplayType.LINE});
 
-    expect(transformLegacySeriesToPlottables(undefined, undefined, widget)).toEqual([]);
-    expect(transformLegacySeriesToPlottables([], undefined, widget)).toEqual([]);
+    expect(
+      transformLegacySeriesToPlottables(undefined, undefined, undefined, widget)
+    ).toEqual([]);
+    expect(transformLegacySeriesToPlottables([], undefined, undefined, widget)).toEqual(
+      []
+    );
   });
 
   it('creates correct plottable instances for different display types', () => {
@@ -30,6 +34,7 @@ describe('transformLegacySeriesToPlottables', () => {
       transformLegacySeriesToPlottables(
         series,
         undefined,
+        undefined,
         WidgetFixture({displayType: DisplayType.LINE})
       )[0]
     ).toBeInstanceOf(Line);
@@ -37,6 +42,7 @@ describe('transformLegacySeriesToPlottables', () => {
     expect(
       transformLegacySeriesToPlottables(
         series,
+        undefined,
         undefined,
         WidgetFixture({displayType: DisplayType.AREA})
       )[0]
@@ -46,6 +52,7 @@ describe('transformLegacySeriesToPlottables', () => {
       transformLegacySeriesToPlottables(
         series,
         undefined,
+        undefined,
         WidgetFixture({displayType: DisplayType.BAR})
       )[0]
     ).toBeInstanceOf(Bars);
@@ -53,6 +60,7 @@ describe('transformLegacySeriesToPlottables', () => {
     expect(
       transformLegacySeriesToPlottables(
         series,
+        undefined,
         undefined,
         WidgetFixture({displayType: DisplayType.TABLE})
       )
@@ -72,6 +80,7 @@ describe('transformLegacySeriesToPlottables', () => {
 
     const plottables = transformLegacySeriesToPlottables(
       series,
+      undefined,
       undefined,
       WidgetFixture({displayType: DisplayType.LINE})
     ) as Line[];
@@ -102,6 +111,7 @@ describe('transformLegacySeriesToPlottables', () => {
     ];
     const sessionResult = transformLegacySeriesToPlottables(
       sessionSeries,
+      undefined,
       undefined,
       widget
     ) as ContinuousTimeSeries[];

--- a/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
@@ -35,19 +35,15 @@ export function transformLegacySeriesToPlottables(
       const fieldType =
         timeseriesResultsTypes?.[unaliasedSeriesName] ??
         aggregateOutputType(unaliasedSeriesName);
-      let valueType: AggregationOutputType;
-      let valueUnit: DataUnit | null;
-      if (timeseriesResultsUnits?.[series.seriesName]) {
-        valueType = timeseriesResultsTypes?.[series.seriesName] ?? fieldType;
-        valueUnit = timeseriesResultsUnits?.[series.seriesName] ?? null;
-      } else {
-        const mapped = mapAggregationTypeToValueTypeAndUnit(
-          fieldType,
-          unaliasedSeriesName
-        );
-        valueType = mapped.valueType as AggregationOutputType;
-        valueUnit = mapped.valueUnit;
-      }
+
+      // Prefer results types and units from the config if available
+      // Fallback to the default mapping logic if not available
+      const mapped = mapAggregationTypeToValueTypeAndUnit(fieldType, unaliasedSeriesName);
+      const valueType =
+        timeseriesResultsTypes?.[series.seriesName] ??
+        (mapped.valueType as AggregationOutputType);
+      const valueUnit = timeseriesResultsUnits?.[series.seriesName] ?? mapped.valueUnit;
+
       const timeSeries = convertEventsStatsToTimeSeriesData(
         series.seriesName,
         createEventsStatsFromSeries(series, valueType, valueUnit)

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -10,7 +10,11 @@ import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import type {AggregationOutputType, QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {
+  AggregationOutputType,
+  DataUnit,
+  QueryFieldValue,
+} from 'sentry/utils/discover/fields';
 import {isEquation} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {FieldKind} from 'sentry/utils/fields';
@@ -208,6 +212,13 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     data: SeriesResponse,
     widgetQuery: WidgetQuery
   ) => Record<string, AggregationOutputType>;
+  /**
+   * Get the result unit of the series. ie milliseconds, bytes, etc
+   */
+  getSeriesResultUnit?: (
+    data: SeriesResponse,
+    widgetQuery: WidgetQuery
+  ) => Record<string, DataUnit>;
   /**
    * Generate the request promises for fetching
    * tabular data.

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -123,6 +123,7 @@ type WidgetCardChartProps = Pick<GenericWidgetQueriesChildrenProps, 'timeseriesR
     showConfidenceWarning?: boolean;
     showLoadingText?: boolean;
     timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+    timeseriesResultsUnits?: Record<string, DataUnit>;
     windowWidth?: number;
   };
 
@@ -147,6 +148,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     onLegendSelectChanged,
     widgetLegendState,
     selection,
+    timeseriesResultsUnits,
   } = props;
 
   const chartRef = useRef<ReactEchartsRef>(null);
@@ -299,9 +301,14 @@ function WidgetCardChart(props: WidgetCardChartProps) {
       : seriesName;
     const aggregateName = decodedSeriesName?.split(':').pop()?.trim();
     if (aggregateName) {
-      return timeseriesResultsTypes
-        ? tooltipFormatter(value, timeseriesResultsTypes[aggregateName])
-        : tooltipFormatter(value, aggregateOutputType(aggregateName));
+      // Metrics widgets use the series name to fully differentiate types between aggregates
+      const type =
+        timeseriesResultsTypes?.[aggregateName] ??
+        timeseriesResultsTypes?.[decodedSeriesName ?? ''];
+      const unit =
+        timeseriesResultsUnits?.[aggregateName] ??
+        timeseriesResultsUnits?.[decodedSeriesName ?? ''];
+      return tooltipFormatter(value, type ?? aggregateOutputType(aggregateName), unit);
     }
     return tooltipFormatter(value, 'number');
   };

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -385,8 +385,9 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       });
     });
 
-    // Get series result type
-    // Only used by custom measurements in errorsAndTransactions at the moment
+    // Retrieve the config's series result types and units
+    // Since each query only differs in its query filter, we can use the first widget queries
+    // to derive the types and units since they share the same aggregations and fields
     const timeseriesResultsTypes = responses.reduce(
       (acc, response) => {
         acc = {...acc, ...config.getSeriesResultType?.(response[0], widget.queries[0]!)};

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -58,10 +58,17 @@ export function VisualizationWidget({
       onDataFetchStart={onDataFetchStart}
       tableItemLimit={tableItemLimit}
     >
-      {({timeseriesResults, timeseriesResultsTypes, errorMessage, loading}) => {
+      {({
+        timeseriesResults,
+        timeseriesResultsTypes,
+        timeseriesResultsUnits,
+        errorMessage,
+        loading,
+      }) => {
         const plottables = transformLegacySeriesToPlottables(
           timeseriesResults,
           timeseriesResultsTypes,
+          timeseriesResultsUnits,
           widget
         );
 

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -122,6 +122,7 @@ export function WidgetCardChartContainer({
         errorMessage,
         loading,
         timeseriesResultsTypes,
+        timeseriesResultsUnits,
         confidence,
         sampleCount,
         isSampled,
@@ -156,6 +157,7 @@ export function WidgetCardChartContainer({
               windowWidth={windowWidth}
               onZoom={onZoom}
               timeseriesResultsTypes={timeseriesResultsTypes}
+              timeseriesResultsUnits={timeseriesResultsUnits}
               noPadding={noPadding}
               chartGroup={chartGroup}
               shouldResize={shouldResize}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -4,7 +4,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
-import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -29,6 +29,7 @@ type Results = {
   tableResults?: TableDataWithTitle[];
   timeseriesResults?: Series[];
   timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+  timeseriesResultsUnits?: Record<string, DataUnit>;
   totalIssuesCount?: string;
 };
 


### PR DESCRIPTION
Adds a getter for deriving the intended units for the metrics widgets in the tracemetrics dataset config. Adds it to the widget viewer chart and dashboard widgets. The result is that we have visible units in the tooltip UI and the yAxis.

This involves setting the units object in the widget queries component which then passes it down and we pass it along to where it needs to be read. It seems like in other datasets we've used the aggregate name to derive this, but I'm doing it by series name because e.g. `avg(memory)` (probably bytes) is different from `avg(latency)` (probably ms) which is a possibility in the future.

Note: in doing this work, we discovered the widget viewer is still using the old visualization. We need to port it over, but until then, this displays differently when a new chart is opened in the viewer.