### PR TITLE
test(discover): Migrate query list off deprecated route mocks

### DIFF
--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -2,7 +2,6 @@ import {DiscoverSavedQueryFixture} from 'sentry-fixture/discover';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   screen,
@@ -26,8 +25,6 @@ describe('Discover > QueryList', () => {
   let updateHomepageMock: jest.Mock;
   let eventsStatsMock: jest.Mock;
   const refetchSavedQueries = jest.fn();
-
-  const {router} = initializeOrg();
 
   beforeAll(async () => {
     await import('sentry/components/modals/widgetBuilder/addToDashboardModal');
@@ -111,10 +108,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     await waitFor(() => {
@@ -143,7 +137,7 @@ describe('Discover > QueryList', () => {
     organization = OrganizationFixture({
       features: ['discover-basic', 'discover-query', 'performance-view'],
     });
-    render(
+    const {router} = render(
       <QueryList
         savedQuerySearchQuery=""
         organization={organization}
@@ -152,11 +146,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     await waitFor(() => {
@@ -192,10 +182,12 @@ describe('Discover > QueryList', () => {
     );
 
     await userEvent.click(screen.getAllByTestId(/card-*/).at(0)!);
-    expect(router.push).toHaveBeenLastCalledWith({
-      pathname: '/organizations/org-slug/explore/discover/results/',
-      query: expect.objectContaining({queryDataset: 'error-events'}),
-    });
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/discover/results/'
+    );
+    expect(router.location.query).toEqual(
+      expect.objectContaining({queryDataset: 'error-events'})
+    );
   });
 
   it('passes dataset to the query if flag is enabled', async () => {
@@ -211,10 +203,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     await waitFor(() => {
@@ -240,7 +229,7 @@ describe('Discover > QueryList', () => {
   });
 
   it('can duplicate and trigger change callback', async () => {
-    render(
+    const {router} = render(
       <QueryList
         savedQuerySearchQuery=""
         organization={organization}
@@ -249,11 +238,7 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;
@@ -264,10 +249,12 @@ describe('Discover > QueryList', () => {
     await userEvent.click(withinCard.getByText('Duplicate Query'));
 
     await waitFor(() => {
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: location.pathname,
-        query: {},
-      });
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: location.pathname,
+          query: {},
+        })
+      );
     });
 
     expect(duplicateMock).toHaveBeenCalled();
@@ -283,10 +270,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const card = screen.getAllByTestId(/card-*/).at(1);
@@ -300,7 +284,7 @@ describe('Discover > QueryList', () => {
   });
 
   it('redirects to Discover on card click', async () => {
-    render(
+    const {router} = render(
       <QueryList
         savedQuerySearchQuery=""
         organization={organization}
@@ -309,22 +293,20 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     await userEvent.click(screen.getAllByTestId(/card-*/).at(0)!);
-    expect(router.push).toHaveBeenLastCalledWith({
-      pathname: '/organizations/org-slug/explore/discover/results/',
-      query: {id: '1', statsPeriod: '14d'},
-    });
+    expect(router.location).toEqual(
+      expect.objectContaining({
+        pathname: '/organizations/org-slug/explore/discover/results/',
+        query: {id: '1', statsPeriod: '14d'},
+      })
+    );
   });
 
   it('can redirect on last query deletion', async () => {
-    render(
+    const {router} = render(
       <QueryList
         savedQuerySearchQuery=""
         organization={organization}
@@ -333,11 +315,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;
@@ -349,11 +327,11 @@ describe('Discover > QueryList', () => {
     expect(deleteMock).toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: location.pathname,
-        query: {cursor: undefined, statsPeriod: '14d'},
-      });
+      expect(router.location.query).toEqual(
+        expect.objectContaining({statsPeriod: '14d'})
+      );
     });
+    expect(router.location.query.cursor).toBeUndefined();
   });
 
   it('renders Add to Dashboard in context menu', async () => {
@@ -370,10 +348,7 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;
@@ -403,10 +378,7 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;
@@ -445,10 +417,7 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const chart = await screen.findByTestId('area-chart');
@@ -473,10 +442,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     await userEvent.click(screen.getByTestId('menu-trigger'));
@@ -582,10 +548,7 @@ describe('Discover > QueryList', () => {
           pageLinks=""
           location={location}
           refetchSavedQueries={refetchSavedQueries}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       const contextMenu = await screen.findByTestId('menu-trigger');
@@ -649,10 +612,7 @@ describe('Discover > QueryList', () => {
           pageLinks=""
           location={location}
           refetchSavedQueries={refetchSavedQueries}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       const contextMenu = await screen.findByTestId('menu-trigger');
@@ -789,10 +749,7 @@ describe('Discover > QueryList', () => {
         pageLinks=""
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const contextMenu = await screen.findByTestId('menu-trigger');


### PR DESCRIPTION
Uses the in-memory test router instead of custom router mocks
