### PR TITLE
fix(codeowners): preview file button slightly cut off

### DIFF
--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -343,7 +343,7 @@ const NoSourceFileBody = styled(PanelBody)`
 const SourceFileBody = styled(PanelBody)`
   display: grid;
   padding: 12px;
-  grid-template-columns: 30px 1fr 100px;
+  grid-template-columns: 30px 1fr auto;
   align-items: center;
 `;
 


### PR DESCRIPTION
The 'Preview File' button in "Import CODEOWNERS" is slightly cut off:
<img width="573" height="77" alt="Screenshot 2026-01-06 at 2 53 23 PM" src="https://github.com/user-attachments/assets/ec527056-9926-4f82-8971-c4ba5373916f" />

New:
<img width="561" height="75" alt="Screenshot 2026-01-06 at 2 53 52 PM" src="https://github.com/user-attachments/assets/67688898-10fd-4a08-879f-082d015717bc" />
