### PR TITLE
feat(uptime): Add task-based retry for out-of-order backlog processing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -925,6 +925,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tempest.tasks",
     "sentry.uptime.autodetect.notifications",
     "sentry.uptime.autodetect.tasks",
+    "sentry.uptime.consumers.tasks",
     "sentry.uptime.rdap.tasks",
     "sentry.uptime.subscriptions.tasks",
     "sentry.workflow_engine.tasks.delayed_workflows",

--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.locks import locks
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import uptime_tasks
+from sentry.taskworker.retry import Retry
+from sentry.uptime.consumers.results_consumer import (
+    create_backfill_misses,
+    get_host_provider_if_valid,
+    process_result_internal,
+)
+from sentry.uptime.models import UptimeSubscription, get_detector
+from sentry.uptime.utils import build_backlog_key, build_last_update_key, get_cluster
+from sentry.utils import json, metrics
+from sentry.workflow_engine.models.detector import Detector
+
+logger = logging.getLogger(__name__)
+
+# 7 attempts over 180 seconds
+BACKOFF_SCHEDULE = [10, 20, 30, 30, 30, 30, 30]
+
+
+@instrumented_task(
+    name="sentry.uptime.consumers.tasks.process_uptime_backlog",
+    namespace=uptime_tasks,
+    retry=Retry(times=3, delay=1),
+)
+def process_uptime_backlog(subscription_id: str, attempt: int = 1):
+    """
+    Process buffered out-of-order results for a subscription.
+
+    Attempts to process results in scheduled_check_time order. If gaps remain, reschedules with backoff.
+    After max attempts, processes all results and allows normal backfill.
+    """
+    cluster = get_cluster()
+    backlog_key = build_backlog_key(subscription_id)
+    task_scheduled_key = f"uptime:backlog_task_scheduled:{subscription_id}"
+    schedule_lock_key = f"uptime:backlog_schedule_lock:{subscription_id}"
+
+    try:
+        subscription = UptimeSubscription.objects.get(id=subscription_id)
+        detector = get_detector(subscription, prefetch_workflow_data=True)
+    except (UptimeSubscription.DoesNotExist, Detector.DoesNotExist):
+        logger.warning(
+            "uptime.backlog.subscription_not_found",
+            extra={"subscription_id": subscription_id},
+        )
+        schedule_lock = locks.get(schedule_lock_key, duration=10, name="uptime.backlog.schedule")
+        with schedule_lock.acquire():
+            cluster.delete(backlog_key)
+            cluster.delete(task_scheduled_key)
+        return
+
+    last_update_key = build_last_update_key(detector)
+    last_update_ms = int(cluster.get(last_update_key) or 0)
+    subscription_interval_ms = subscription.interval_seconds * 1000
+    expected_next_ms = last_update_ms + subscription_interval_ms
+    processed_count = 0
+    queued_results_raw: list[tuple[bytes, float]] = cluster.zrange(
+        backlog_key, 0, -1, withscores=True
+    )
+    host_provider = get_host_provider_if_valid(subscription)
+
+    for result_json, scheduled_time_ms in queued_results_raw:
+        if int(scheduled_time_ms) != expected_next_ms:
+            logger.info(
+                "uptime.backlog.gap_detected",
+                extra={
+                    "subscription_id": subscription_id,
+                    "expected_ms": expected_next_ms,
+                    "found_ms": int(scheduled_time_ms),
+                },
+            )
+            break
+
+        result = json.loads(result_json)
+        metric_tags = {
+            "status": result["status"],
+            "uptime_region": result["region"],
+            "host_provider": host_provider,
+        }
+        process_result_internal(
+            detector,
+            subscription,
+            result,
+            {**metric_tags},
+            cluster,
+        )
+        cluster.zrem(backlog_key, result_json)
+        metrics.incr("uptime.backlog.removed", amount=1, sample_rate=1.0, tags=metric_tags)
+        expected_next_ms += subscription_interval_ms
+        processed_count += 1
+
+    # If we've hit max attempts process all remaining with backfill
+    if attempt >= len(BACKOFF_SCHEDULE):
+        logger.warning(
+            "uptime.backlog.timeout",
+            extra={
+                "subscription_id": subscription_id,
+                "attempt": attempt,
+                "total_wait_seconds": sum(BACKOFF_SCHEDULE[: attempt - 1]),
+            },
+        )
+        metrics.incr("uptime.backlog.timeout", amount=1, sample_rate=1.0)
+
+        for result_json, _ in cluster.zrange(backlog_key, 0, -1, withscores=True):
+            result = json.loads(result_json)
+            metric_tags = {
+                "status": result["status"],
+                "uptime_region": result["region"],
+                "host_provider": host_provider,
+            }
+            create_backfill_misses(
+                detector,
+                subscription,
+                result,
+                last_update_ms,
+                metric_tags,
+                cluster,
+            )
+            process_result_internal(
+                detector,
+                subscription,
+                result,
+                metric_tags,
+                cluster,
+            )
+            cluster.zrem(backlog_key, result_json)
+            metrics.incr("uptime.backlog.removed", amount=1, sample_rate=1.0, tags=metric_tags)
+            last_update_ms = result["scheduled_check_time_ms"]
+
+    schedule_lock = locks.get(schedule_lock_key, duration=10, name="uptime.backlog.schedule")
+    with schedule_lock.acquire():
+        remaining = cluster.zcard(backlog_key)
+
+        if remaining == 0:
+            # Queue cleared - clean up and exit
+            cluster.delete(task_scheduled_key)
+            logger.info(
+                "uptime.backlog.cleared",
+                extra={"subscription_id": subscription_id, "processed_count": processed_count},
+            )
+            return
+
+        if processed_count > 0:
+            next_attempt = 1
+            logger.info(
+                "uptime.backlog.progress_made",
+                extra={
+                    "subscription_id": subscription_id,
+                    "processed_count": processed_count,
+                    "remaining_items": remaining,
+                },
+            )
+        else:
+            # No progress - reschedule with backoff
+            next_attempt = attempt + 1
+            logger.info(
+                "uptime.backlog.rescheduling",
+                extra={
+                    "subscription_id": subscription_id,
+                    "attempt": attempt,
+                    "next_attempt": next_attempt,
+                    "remaining_items": remaining,
+                },
+            )
+
+        next_backoff = BACKOFF_SCHEDULE[next_attempt - 1]
+        remaining_time_seconds = sum(BACKOFF_SCHEDULE[next_attempt - 1 :]) + 60
+        cluster.expire(task_scheduled_key, remaining_time_seconds)
+        process_uptime_backlog.apply_async(
+            args=[subscription_id], countdown=next_backoff, kwargs={"attempt": next_attempt}
+        )

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -22,5 +22,15 @@ def build_fingerprint(detector: Detector) -> list[str]:
     return [build_detector_fingerprint_component(detector)]
 
 
+def build_backlog_key(subscription_id: str) -> str:
+    """Redis sorted set key for buffered out-of-order results."""
+    return f"uptime:backlog:{subscription_id}"
+
+
+def build_backlog_task_flag_key(subscription_id: str) -> str:
+    """Redis flag key tracking if retry task is scheduled."""
+    return f"uptime:backlog_task:{subscription_id}"
+
+
 def get_cluster() -> RedisCluster | StrictRedis:
     return redis.redis_clusters.get(settings.SENTRY_UPTIME_DETECTOR_CLUSTER)

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -27,9 +27,14 @@ def build_backlog_key(subscription_id: str) -> str:
     return f"uptime:backlog:{subscription_id}"
 
 
-def build_backlog_task_flag_key(subscription_id: str) -> str:
+def build_backlog_task_scheduled_key(subscription_id: str) -> str:
     """Redis flag key tracking if retry task is scheduled."""
-    return f"uptime:backlog_task:{subscription_id}"
+    return f"uptime:backlog_task_scheduled:{subscription_id}"
+
+
+def build_backlog_schedule_lock_key(subscription_id: str) -> str:
+    """Redis lock key for coordinating backlog task scheduling."""
+    return f"uptime:backlog_schedule_lock:{subscription_id}"
 
 
 def get_cluster() -> RedisCluster | StrictRedis:

--- a/tests/sentry/uptime/consumers/test_tasks.py
+++ b/tests/sentry/uptime/consumers/test_tasks.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import cast
+from unittest import mock
+from uuid import uuid4
+
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
+    CHECKSTATUS_SUCCESS,
+    CHECKSTATUSREASONTYPE_TIMEOUT,
+)
+
+from sentry.testutils.cases import UptimeTestCase
+from sentry.uptime.consumers.tasks import process_uptime_backlog
+from sentry.uptime.utils import build_backlog_key, build_last_update_key, get_cluster
+from sentry.utils import json
+
+
+class TestProcessUptimeBacklog(UptimeTestCase):
+    def setUp(self):
+        super().setUp()
+        self.subscription = self.create_uptime_subscription(
+            subscription_id=uuid4().hex, interval_seconds=300
+        )
+        self.detector = self.create_uptime_detector(uptime_subscription=self.subscription)
+
+    def test_empty_queue(self):
+        """Task should exit gracefully when queue is empty."""
+        cluster = get_cluster()
+        task_scheduled_key = f"uptime:backlog_task_scheduled:{self.subscription.id}"
+
+        with mock.patch("sentry.uptime.consumers.tasks.logger") as logger:
+            process_uptime_backlog(str(self.subscription.id))
+            # Empty queue falls through to "cleared" with processed_count=0
+            logger.info.assert_called_with(
+                "uptime.backlog.cleared",
+                extra={"subscription_id": str(self.subscription.id), "processed_count": 0},
+            )
+
+        assert cluster.exists(task_scheduled_key) == 0
+
+    def test_subscription_not_found(self):
+        """Task should handle missing subscription gracefully."""
+        fake_id = "999999"
+        cluster = get_cluster()
+
+        backlog_key = build_backlog_key(fake_id)
+        task_scheduled_key = f"uptime:backlog_task_scheduled:{fake_id}"
+        result = {
+            "guid": uuid4().hex,
+            "subscription_id": fake_id,
+            "status": CHECKSTATUS_SUCCESS,
+            "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "timeout"},
+            "trace_id": uuid4().hex,
+            "span_id": uuid4().hex,
+            "region": "us-west",
+            "scheduled_check_time_ms": 1000000000000,
+            "actual_check_time_ms": 1000000000000,
+            "duration_ms": 100,
+            "request_info": None,
+        }
+        cluster.zadd(
+            backlog_key, {json.dumps(result): cast(int, result["scheduled_check_time_ms"])}
+        )
+
+        with mock.patch("sentry.uptime.consumers.tasks.logger") as logger:
+            process_uptime_backlog(fake_id)
+            logger.warning.assert_called_with(
+                "uptime.backlog.subscription_not_found", extra={"subscription_id": fake_id}
+            )
+
+        assert cluster.exists(backlog_key) == 0
+        assert cluster.exists(task_scheduled_key) == 0
+
+    def test_processes_consecutive_results(self):
+        """Task should process consecutive results from queue."""
+        cluster = get_cluster()
+        base_time = 1000000000000
+        last_update_key = build_last_update_key(self.detector)
+        cluster.set(last_update_key, base_time)
+        backlog_key = build_backlog_key(str(self.subscription.id))
+        task_scheduled_key = f"uptime:backlog_task_scheduled:{self.subscription.id}"
+        result1 = {
+            "guid": uuid4().hex,
+            "subscription_id": str(self.subscription.id),
+            "status": CHECKSTATUS_SUCCESS,
+            "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "timeout"},
+            "trace_id": uuid4().hex,
+            "span_id": uuid4().hex,
+            "region": "us-west",
+            "scheduled_check_time_ms": base_time + 300000,
+            "actual_check_time_ms": base_time + 300000,
+            "duration_ms": 100,
+            "request_info": None,
+        }
+        result2 = {
+            "guid": uuid4().hex,
+            "subscription_id": str(self.subscription.id),
+            "status": CHECKSTATUS_SUCCESS,
+            "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "timeout"},
+            "trace_id": uuid4().hex,
+            "span_id": uuid4().hex,
+            "region": "us-west",
+            "scheduled_check_time_ms": base_time + 600000,
+            "actual_check_time_ms": base_time + 600000,
+            "duration_ms": 100,
+            "request_info": None,
+        }
+        cluster.zadd(
+            backlog_key, {json.dumps(result1): cast(int, result1["scheduled_check_time_ms"])}
+        )
+        cluster.zadd(
+            backlog_key, {json.dumps(result2): cast(int, result2["scheduled_check_time_ms"])}
+        )
+        with mock.patch("sentry.uptime.consumers.tasks.logger") as logger:
+            process_uptime_backlog(str(self.subscription.id))
+            logger.info.assert_called_with(
+                "uptime.backlog.cleared",
+                extra={"subscription_id": str(self.subscription.id), "processed_count": 2},
+            )
+
+        assert cluster.zcard(backlog_key) == 0
+        assert int(cluster.get(last_update_key) or 0) == base_time + 600000
+        assert cluster.exists(task_scheduled_key) == 0
+
+    def test_stops_at_gap(self):
+        """Task should stop at gaps and reschedule."""
+        cluster = get_cluster()
+        base_time = 1000000000000
+        last_update_key = build_last_update_key(self.detector)
+        cluster.set(last_update_key, base_time)
+
+        backlog_key = build_backlog_key(str(self.subscription.id))
+        result1 = {
+            "guid": uuid4().hex,
+            "subscription_id": str(self.subscription.id),
+            "status": CHECKSTATUS_SUCCESS,
+            "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "timeout"},
+            "trace_id": uuid4().hex,
+            "span_id": uuid4().hex,
+            "region": "us-west",
+            "scheduled_check_time_ms": base_time + 600000,  # +10 minutes (gap!)
+            "actual_check_time_ms": base_time + 600000,
+            "duration_ms": 100,
+            "request_info": None,
+        }
+
+        cluster.zadd(
+            backlog_key, {json.dumps(result1): cast(int, result1["scheduled_check_time_ms"])}
+        )
+
+        # Run task with mocked apply_async to prevent actual rescheduling (lock is managed internally)
+        with (
+            mock.patch("sentry.uptime.consumers.tasks.logger") as logger,
+            mock.patch(
+                "sentry.uptime.consumers.tasks.process_uptime_backlog.apply_async"
+            ) as mock_apply_async,
+        ):
+            process_uptime_backlog(str(self.subscription.id), attempt=1)
+            logger.info.assert_any_call(
+                "uptime.backlog.gap_detected",
+                extra={
+                    "subscription_id": str(self.subscription.id),
+                    "expected_ms": base_time + 300000,
+                    "found_ms": base_time + 600000,
+                },
+            )
+            logger.info.assert_any_call(
+                "uptime.backlog.rescheduling",
+                extra={
+                    "subscription_id": str(self.subscription.id),
+                    "remaining_items": 1,
+                    "attempt": 1,
+                    "next_attempt": 2,
+                },
+            )
+            mock_apply_async.assert_called_once()
+            call_args, call_kwargs = mock_apply_async.call_args
+            assert call_kwargs["args"] == [str(self.subscription.id)]
+            assert call_kwargs["countdown"] == 20
+            assert call_kwargs["kwargs"]["attempt"] == 2
+
+        assert cluster.zcard(backlog_key) == 1

--- a/tests/sentry/uptime/test_utils.py
+++ b/tests/sentry/uptime/test_utils.py
@@ -1,4 +1,4 @@
-from sentry.uptime.utils import build_backlog_key, build_backlog_task_flag_key
+from sentry.uptime.utils import build_backlog_key, build_backlog_task_scheduled_key
 
 
 class TestBuildBacklogKey:
@@ -9,5 +9,7 @@ class TestBuildBacklogKey:
 
 class TestBuildBacklogTaskFlagKey:
     def test_formats_correctly(self):
-        assert build_backlog_task_flag_key("123") == "uptime:backlog_task:123"
-        assert build_backlog_task_flag_key("abc-def") == "uptime:backlog_task:abc-def"
+        assert build_backlog_task_scheduled_key("123") == "uptime:backlog_task_scheduled:123"
+        assert (
+            build_backlog_task_scheduled_key("abc-def") == "uptime:backlog_task_scheduled:abc-def"
+        )

--- a/tests/sentry/uptime/test_utils.py
+++ b/tests/sentry/uptime/test_utils.py
@@ -1,0 +1,13 @@
+from sentry.uptime.utils import build_backlog_key, build_backlog_task_flag_key
+
+
+class TestBuildBacklogKey:
+    def test_formats_correctly(self):
+        assert build_backlog_key("123") == "uptime:backlog:123"
+        assert build_backlog_key("abc-def") == "uptime:backlog:abc-def"
+
+
+class TestBuildBacklogTaskFlagKey:
+    def test_formats_correctly(self):
+        assert build_backlog_task_flag_key("123") == "uptime:backlog_task:123"
+        assert build_backlog_task_flag_key("abc-def") == "uptime:backlog_task:abc-def"


### PR DESCRIPTION
Implement task to process buffered out-of-order uptime results with backoff. This is part of solving false missed check detections caused by Arroyo's multiprocessing mode processing results out of order.
