### PR TITLE
feat(aci): Add inline alert creation inside monitor form

### DIFF
--- a/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
@@ -15,6 +15,7 @@ type DetectorCreateAnalyticsEventPayload =
 export type MonitorsEventParameters = {
   'automation.created': AutomationAnalyticsEventPayload & {
     organization: Organization;
+    source: 'drawer' | 'full';
     success: boolean;
   };
   'automation.updated': AutomationAnalyticsEventPayload & {

--- a/static/app/views/automations/components/automationBuilderDrawerForm.spec.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.spec.tsx
@@ -119,7 +119,7 @@ describe('AutomationBuilderDrawerForm', () => {
       <AutomationBuilderDrawerForm
         closeDrawer={closeDrawer}
         onSuccess={onSuccess}
-        connectedDetectorIds={['123']}
+        initialData={{detectorIds: ['123']}}
       />,
       {organization}
     );

--- a/static/app/views/automations/components/automationBuilderDrawerForm.spec.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.spec.tsx
@@ -1,0 +1,156 @@
+import {AutomationFixture} from 'sentry-fixture/automations';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+import {
+  ActionHandlerFixture,
+  DataConditionHandlerFixture,
+} from 'sentry-fixture/workflowEngine';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
+import {
+  DataConditionHandlerGroupType,
+  DataConditionHandlerSubgroupType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
+import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
+
+describe('AutomationBuilderDrawerForm', () => {
+  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+  const mockMember = MemberFixture({
+    user: UserFixture({id: '1', name: 'Test User', email: 'test@sentry.io'}),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/available-actions/`,
+      method: 'GET',
+      body: [
+        ActionHandlerFixture({
+          type: ActionType.SLACK,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [{id: '1', name: 'My Slack Workspace'}],
+        }),
+        ActionHandlerFixture({
+          type: ActionType.EMAIL,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-conditions/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
+          handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+          type: DataConditionType.TAGGED_EVENT,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-conditions/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      method: 'GET',
+      body: [mockMember],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      method: 'GET',
+      body: [mockMember],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('creates automation successfully and calls onSuccess', async () => {
+    const closeDrawer = jest.fn();
+    const onSuccess = jest.fn();
+    const createdAutomation = AutomationFixture({id: '123', name: 'Test Alert'});
+
+    const postMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: createdAutomation,
+    });
+
+    render(
+      <AutomationBuilderDrawerForm
+        closeDrawer={closeDrawer}
+        onSuccess={onSuccess}
+        connectedDetectorIds={['123']}
+      />,
+      {organization}
+    );
+
+    // Add an action
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    // Fill in the automation name - clear first to override auto-generated name
+    const nameInput = screen.getByRole('textbox', {name: 'Alert Name'});
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'My Test Alert');
+
+    // Submit the form
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'POST',
+          data: expect.objectContaining({
+            name: 'My Test Alert',
+            detectorIds: ['123'],
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith('123');
+    });
+  });
+});

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -1,0 +1,202 @@
+import {useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
+import {Observer} from 'mobx-react-lite';
+
+import {Button} from 'sentry/components/core/button';
+import {Flex, Stack} from 'sentry/components/core/layout';
+import TextField from 'sentry/components/forms/fields/textField';
+import Form from 'sentry/components/forms/form';
+import FormModel from 'sentry/components/forms/model';
+import type {OnSubmitCallback} from 'sentry/components/forms/types';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import AutomationBuilder from 'sentry/views/automations/components/automationBuilder';
+import {
+  AutomationBuilderContext,
+  useAutomationBuilderReducer,
+} from 'sentry/views/automations/components/automationBuilderContext';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
+import {
+  getNewAutomationData,
+  validateAutomationBuilderState,
+} from 'sentry/views/automations/components/automationFormData';
+import {ActionIntervalSelectField} from 'sentry/views/automations/components/forms/actionIntervalSelectField';
+import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
+import {
+  AutomationFormProvider,
+  useAutomationFormContext,
+} from 'sentry/views/automations/components/forms/context';
+import {useSetAutomaticAutomationName} from 'sentry/views/automations/components/forms/useSetAutomaticAutomationName';
+import {useCreateAutomation} from 'sentry/views/automations/hooks';
+import {useAutomationBuilderErrors} from 'sentry/views/automations/hooks/useAutomationBuilderErrors';
+
+const initialData = {
+  name: '',
+  environment: null,
+  frequency: 1440,
+  enabled: true,
+  projectIds: [],
+  detectorIds: [],
+};
+
+interface AutomationBuilderDrawerProps {
+  closeDrawer: () => void;
+  /**
+   * Detector IDs to connect this automation to
+   */
+  connectedDetectorIds?: string[];
+  /**
+   * Callback when automation is successfully created
+   */
+  onSuccess?: (automationId: string) => void;
+}
+
+function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormModel}) {
+  useSetAutomaticAutomationName();
+  const {setHasSetAutomationName} = useAutomationFormContext();
+
+  return (
+    <DrawerBody>
+      <Stack direction="column" gap="xl">
+        <Flex direction="column" gap="lg">
+          <Section>
+            <AutomationBuilder />
+          </Section>
+          <Section>
+            <ActionIntervalSelectField
+              label={t('Action Interval')}
+              help={t('Perform the actions above this often for an issue.')}
+            />
+          </Section>
+        </Flex>
+        <Section>
+          <EmbeddedTextField
+            required
+            name="name"
+            label={t('Alert Name')}
+            placeholder={t('Notify via Email')}
+            onKeyDown={() => setHasSetAutomationName(true)}
+            inline={false}
+          />
+        </Section>
+        <Flex justify="end" gap="md">
+          <Button type="button" onClick={closeDrawer}>
+            {t('Cancel')}
+          </Button>
+          <Observer>
+            {() => (
+              <Button priority="primary" type="submit" disabled={model.isSaving}>
+                {t('Create Alert')}
+              </Button>
+            )}
+          </Observer>
+        </Flex>
+      </Stack>
+    </DrawerBody>
+  );
+}
+
+/**
+ * A miminal form for creating a new automation, meant to be rendered in a drawer.
+ */
+export function AutomationBuilderDrawerForm({
+  connectedDetectorIds = [],
+  onSuccess,
+  closeDrawer,
+}: AutomationBuilderDrawerProps) {
+  const organization = useOrganization();
+  const model = useMemo(() => new FormModel(), []);
+  const {state, actions} = useAutomationBuilderReducer();
+
+  const {
+    errors: automationBuilderErrors,
+    setErrors: setAutomationBuilderErrors,
+    removeError,
+  } = useAutomationBuilderErrors();
+
+  const {mutateAsync: createAutomation, error} = useCreateAutomation();
+
+  const handleSubmit = useCallback<OnSubmitCallback>(
+    async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
+      const errors = validateAutomationBuilderState(state);
+      setAutomationBuilderErrors(errors);
+      const newAutomationData = getNewAutomationData(data as AutomationFormData, state);
+
+      if (Object.keys(errors).length === 0) {
+        try {
+          formModel.setFormSaving();
+          const automation = await createAutomation(newAutomationData);
+          onSubmitSuccess(formModel.getData());
+          trackAnalytics('automation.created', {
+            organization,
+            ...getAutomationAnalyticsPayload(newAutomationData),
+            source: 'drawer',
+            success: true,
+          });
+          onSuccess?.(automation.id);
+        } catch (err) {
+          onSubmitError(err);
+          trackAnalytics('automation.created', {
+            organization,
+            ...getAutomationAnalyticsPayload(newAutomationData),
+            source: 'drawer',
+            success: false,
+          });
+        }
+      } else {
+        trackAnalytics('automation.created', {
+          organization,
+          ...getAutomationAnalyticsPayload(newAutomationData),
+          source: 'drawer',
+          success: false,
+        });
+      }
+    },
+    [createAutomation, state, organization, onSuccess, setAutomationBuilderErrors]
+  );
+
+  return (
+    <Form
+      hideFooter
+      initialData={{...initialData, detectorIds: connectedDetectorIds}}
+      onSubmit={handleSubmit}
+      model={model}
+    >
+      <AutomationFormProvider>
+        <DrawerHeader hideBar />
+        <AutomationBuilderErrorContext.Provider
+          value={{
+            errors: automationBuilderErrors,
+            setErrors: setAutomationBuilderErrors,
+            removeError,
+            mutationErrors: error?.responseJSON,
+          }}
+        >
+          <AutomationBuilderContext.Provider
+            value={{
+              state,
+              actions,
+              showTriggerLogicTypeSelector: false,
+            }}
+          >
+            <FormBody closeDrawer={closeDrawer} model={model} />
+          </AutomationBuilderContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationFormProvider>
+    </Form>
+  );
+}
+
+const Section = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const EmbeddedTextField = styled(TextField)`
+  padding: 0;
+`;

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -10,7 +10,6 @@ import FormModel from 'sentry/components/forms/model';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import AutomationBuilder from 'sentry/views/automations/components/automationBuilder';
@@ -63,26 +62,22 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
     <DrawerBody>
       <Stack direction="column" gap="xl">
         <Flex direction="column" gap="lg">
-          <Section>
+          <Stack gap="md">
             <AutomationBuilder />
-          </Section>
-          <Section>
-            <ActionIntervalSelectField
-              label={t('Action Interval')}
-              help={t('Perform the actions above this often for an issue.')}
-            />
-          </Section>
-        </Flex>
-        <Section>
-          <EmbeddedTextField
-            required
-            name="name"
-            label={t('Alert Name')}
-            placeholder={t('Notify via Email')}
-            onKeyDown={() => setHasSetAutomationName(true)}
-            inline={false}
+          </Stack>
+          <ActionIntervalSelectField
+            label={t('Action Interval')}
+            help={t('Perform the actions above this often for an issue.')}
           />
-        </Section>
+        </Flex>
+        <EmbeddedTextField
+          required
+          name="name"
+          label={t('Alert Name')}
+          placeholder={t('Notify via Email')}
+          onKeyDown={() => setHasSetAutomationName(true)}
+          inline={false}
+        />
         <Flex justify="end" gap="md">
           <Button type="button" onClick={closeDrawer}>
             {t('Cancel')}
@@ -190,12 +185,6 @@ export function AutomationBuilderDrawerForm({
     </Form>
   );
 }
-
-const Section = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-`;
 
 const EmbeddedTextField = styled(TextField)`
   padding: 0;

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -1,9 +1,7 @@
 import {useCallback, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
-import SelectField from 'sentry/components/forms/fields/selectField';
 import type FormModel from 'sentry/components/forms/model';
 import {EnvironmentSelector} from 'sentry/components/workflowEngine/form/environmentSelector';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
@@ -12,19 +10,8 @@ import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import AutomationBuilder from 'sentry/views/automations/components/automationBuilder';
 import EditConnectedMonitors from 'sentry/views/automations/components/editConnectedMonitors';
+import {ActionIntervalSelectField} from 'sentry/views/automations/components/forms/actionIntervalSelectField';
 import {useSetAutomaticAutomationName} from 'sentry/views/automations/components/forms/useSetAutomaticAutomationName';
-
-const FREQUENCY_OPTIONS = [
-  {value: 5, label: t('5 minutes')},
-  {value: 10, label: t('10 minutes')},
-  {value: 30, label: t('30 minutes')},
-  {value: 60, label: t('60 minutes')},
-  {value: 180, label: t('3 hours')},
-  {value: 720, label: t('12 hours')},
-  {value: 1440, label: t('24 hours')},
-  {value: 10080, label: t('1 week')},
-  {value: 43200, label: t('30 days')},
-];
 
 export default function AutomationForm({model}: {model: FormModel}) {
   const initialConnectedIds = useFormField<Automation['detectorIds']>('detectorIds');
@@ -77,20 +64,8 @@ export default function AutomationForm({model}: {model: FormModel}) {
             {t('Perform the actions above this often for an issue.')}
           </Text>
         </Flex>
-        <EmbeddedSelectField
-          required
-          name="frequency"
-          inline={false}
-          clearable={false}
-          options={FREQUENCY_OPTIONS}
-        />
+        <ActionIntervalSelectField />
       </Card>
     </Flex>
   );
 }
-
-const EmbeddedSelectField = styled(SelectField)`
-  padding: 0;
-  font-weight: ${p => p.theme.fontWeight.normal};
-  text-transform: none;
-`;

--- a/static/app/views/automations/components/forms/actionIntervalSelectField.tsx
+++ b/static/app/views/automations/components/forms/actionIntervalSelectField.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import SelectField, {
+  type SelectFieldProps,
+} from 'sentry/components/forms/fields/selectField';
+import {t} from 'sentry/locale';
+
+const FREQUENCY_OPTIONS = [
+  {value: 5, label: t('5 minutes')},
+  {value: 10, label: t('10 minutes')},
+  {value: 30, label: t('30 minutes')},
+  {value: 60, label: t('60 minutes')},
+  {value: 180, label: t('3 hours')},
+  {value: 720, label: t('12 hours')},
+  {value: 1440, label: t('24 hours')},
+  {value: 10080, label: t('1 week')},
+  {value: 43200, label: t('30 days')},
+];
+
+type ActionIntervalSelectFieldProps = Partial<
+  SelectFieldProps<{label: string; value: number}>
+>;
+
+export function ActionIntervalSelectField(props: ActionIntervalSelectFieldProps) {
+  return (
+    <EmbeddedSelectField
+      required
+      name="frequency"
+      inline={false}
+      clearable={false}
+      options={FREQUENCY_OPTIONS}
+      label={t('Action Interval')}
+      {...props}
+    />
+  );
+}
+
+const EmbeddedSelectField = styled(SelectField)`
+  padding: 0;
+  font-weight: ${p => p.theme.fontWeight.normal};
+  text-transform: none;
+`;

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -41,6 +41,7 @@ import {EditAutomationActions} from 'sentry/views/automations/components/editAut
 import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
 import {AutomationFormProvider} from 'sentry/views/automations/components/forms/context';
 import {useAutomationQuery, useUpdateAutomation} from 'sentry/views/automations/hooks';
+import {useAutomationBuilderErrors} from 'sentry/views/automations/hooks/useAutomationBuilderErrors';
 import {
   makeAutomationBasePathname,
   makeAutomationDetailsPathname,
@@ -125,18 +126,13 @@ function AutomationEditForm({automation}: {automation: Automation}) {
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer(initialState);
 
-  const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
-    Record<string, any>
-  >({});
+  const {
+    errors: automationBuilderErrors,
+    setErrors: setAutomationBuilderErrors,
+    removeError,
+  } = useAutomationBuilderErrors();
 
   const {mutateAsync: updateAutomation, error} = useUpdateAutomation();
-
-  const removeError = useCallback((errorId: string) => {
-    setAutomationBuilderErrors(prev => {
-      const {[errorId]: _removedError, ...remainingErrors} = prev;
-      return remainingErrors;
-    });
-  }, []);
 
   const handleFormSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
@@ -168,7 +164,14 @@ function AutomationEditForm({automation}: {automation: Automation}) {
         }
       }
     },
-    [automation.id, organization, navigate, updateAutomation, state]
+    [
+      state,
+      setAutomationBuilderErrors,
+      automation.id,
+      updateAutomation,
+      organization,
+      navigate,
+    ]
   );
 
   return (

--- a/static/app/views/automations/hooks/useAutomationBuilderErrors.tsx
+++ b/static/app/views/automations/hooks/useAutomationBuilderErrors.tsx
@@ -1,0 +1,18 @@
+import {useCallback, useState} from 'react';
+
+/**
+ * Hook to manage automation builder validation errors state.
+ * Returns the errors state, setter, and a helper to remove individual errors.
+ */
+export function useAutomationBuilderErrors() {
+  const [errors, setErrors] = useState<Record<string, any>>({});
+
+  const removeError = useCallback((errorId: string) => {
+    setErrors(prev => {
+      const {[errorId]: _removedError, ...remainingErrors} = prev;
+      return remainingErrors;
+    });
+  }, []);
+
+  return {errors, setErrors, removeError};
+}

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -223,6 +223,7 @@ describe('AutomationNewSettings', () => {
       trigger_conditions_count: expect.any(Number),
       success: true,
       actions_count: expect.any(Number),
+      source: 'full',
     });
   });
 });

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react-lite';
@@ -34,6 +34,7 @@ import {EditableAutomationName} from 'sentry/views/automations/components/editab
 import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
 import {AutomationFormProvider} from 'sentry/views/automations/components/forms/context';
 import {useCreateAutomation} from 'sentry/views/automations/hooks';
+import {useAutomationBuilderErrors} from 'sentry/views/automations/hooks/useAutomationBuilderErrors';
 import {
   makeAutomationBasePathname,
   makeAutomationDetailsPathname,
@@ -79,15 +80,11 @@ export default function AutomationNewSettings() {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.lg;
 
-  const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
-    Record<string, any>
-  >({});
-  const removeError = useCallback((errorId: string) => {
-    setAutomationBuilderErrors(prev => {
-      const {[errorId]: _removedError, ...remainingErrors} = prev;
-      return remainingErrors;
-    });
-  }, []);
+  const {
+    errors: automationBuilderErrors,
+    setErrors: setAutomationBuilderErrors,
+    removeError,
+  } = useAutomationBuilderErrors();
 
   const initialConnectedIds = useMemo(() => {
     const connectedIdsQuery = location.query.connectedIds as
@@ -119,6 +116,7 @@ export default function AutomationNewSettings() {
           trackAnalytics('automation.created', {
             organization,
             ...getAutomationAnalyticsPayload(newAutomationData),
+            source: 'full',
             success: true,
           });
           navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
@@ -127,6 +125,7 @@ export default function AutomationNewSettings() {
           trackAnalytics('automation.created', {
             organization,
             ...getAutomationAnalyticsPayload(newAutomationData),
+            source: 'full',
             success: false,
           });
         }
@@ -134,11 +133,12 @@ export default function AutomationNewSettings() {
         trackAnalytics('automation.created', {
           organization,
           ...getAutomationAnalyticsPayload(newAutomationData),
+          source: 'full',
           success: false,
         });
       }
     },
-    [createAutomation, state, navigate, organization]
+    [createAutomation, state, navigate, organization, setAutomationBuilderErrors]
   );
 
   return (

--- a/static/app/views/detectors/components/forms/automateSection.spec.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.spec.tsx
@@ -1,4 +1,11 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
+import {MemberFixture} from 'sentry-fixture/member';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
+import {
+  ActionHandlerFixture,
+  DataConditionHandlerFixture,
+} from 'sentry-fixture/workflowEngine';
 
 import {
   render,
@@ -7,13 +14,25 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
 
 import Form from 'sentry/components/forms/form';
+import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
+import {
+  DataConditionHandlerGroupType,
+  DataConditionHandlerSubgroupType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
+import {DetectorFormProvider} from 'sentry/views/detectors/components/forms/context';
 
 import {AutomateSection} from './automateSection';
 
 describe('AutomateSection', () => {
   const automation1 = AutomationFixture();
+  const project = ProjectFixture({id: '1', slug: 'test-project'});
+  const mockMember = MemberFixture({
+    user: UserFixture({id: '1', name: 'Test User', email: 'test@sentry.io'}),
+  });
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -31,18 +50,96 @@ describe('AutomateSection', () => {
       method: 'GET',
       body: [automation1],
     });
+
+    // Mocks for AutomationBuilderDrawerForm
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/available-actions/',
+      method: 'GET',
+      body: [
+        ActionHandlerFixture({
+          type: ActionType.SLACK,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [{id: '1', name: 'My Slack Workspace'}],
+        }),
+        ActionHandlerFixture({
+          type: ActionType.EMAIL,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/data-conditions/',
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
+          handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+          type: DataConditionType.TAGGED_EVENT,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/data-conditions/',
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      method: 'GET',
+      body: [mockMember],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      method: 'GET',
+      body: [mockMember],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      method: 'GET',
+      body: [project],
+    });
   });
 
   it('can connect an existing automation', async () => {
     render(
-      <Form>
-        <AutomateSection />
-      </Form>
+      <DetectorFormProvider detectorType="metric_issue" project={project}>
+        <Form>
+          <AutomateSection />
+        </Form>
+      </DetectorFormProvider>
     );
 
     expect(screen.getByText('Alert')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Connect an Alert'));
+    await userEvent.click(screen.getByText('Connect Existing Alerts'));
 
     const drawer = await screen.findByRole('complementary', {
       name: 'Connect Alerts',
@@ -68,9 +165,11 @@ describe('AutomateSection', () => {
 
   it('can disconnect an existing automation', async () => {
     render(
-      <Form initialData={{workflowIds: [automation1.id]}}>
-        <AutomateSection />
-      </Form>
+      <DetectorFormProvider detectorType="metric_issue" project={project}>
+        <Form initialData={{workflowIds: [automation1.id]}}>
+          <AutomateSection />
+        </Form>
+      </DetectorFormProvider>
     );
 
     // Should display automation as connected
@@ -98,5 +197,68 @@ describe('AutomateSection', () => {
         within(connectedAutomationsList).queryByText(automation1.name)
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('can create a new alert and add it to connected alerts', async () => {
+    const newAutomation = AutomationFixture({id: '999', name: 'My New Alert'});
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      method: 'POST',
+      body: newAutomation,
+    });
+
+    // Mock for fetching the newly created automation
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      method: 'GET',
+      match: [MockApiClient.matchQuery({id: [newAutomation.id]})],
+      body: [newAutomation],
+    });
+
+    render(
+      <DetectorFormProvider detectorType="metric_issue" project={project}>
+        <Form>
+          <AutomateSection />
+        </Form>
+      </DetectorFormProvider>
+    );
+
+    // Click "Create New Alert" button
+    await userEvent.click(screen.getByRole('button', {name: 'Create New Alert'}));
+
+    // Wait for the drawer to open
+    const drawer = await screen.findByRole('complementary', {
+      name: 'Create New Alert',
+    });
+
+    // Add an action to make the form valid
+    await selectEvent.select(
+      within(drawer).getByRole('textbox', {name: 'Add action'}),
+      'Slack'
+    );
+    await userEvent.type(
+      within(drawer).getByRole('textbox', {name: 'Target'}),
+      '#alerts'
+    );
+
+    // Fill in the automation name
+    const nameInput = within(drawer).getByRole('textbox', {name: 'Alert Name'});
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'My New Alert');
+
+    // Submit the form
+    await userEvent.click(within(drawer).getByRole('button', {name: 'Create Alert'}));
+
+    // Wait for the drawer to close and the new automation to appear in the connected list
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('complementary', {name: 'Create New Alert'})
+      ).not.toBeInTheDocument();
+    });
+
+    // The new automation should appear in the connected alerts section
+    expect(await screen.findByText('Connected Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('My New Alert')).toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -2,23 +2,26 @@ import {useCallback, useContext, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import {Flex} from 'sentry/components/core/layout';
+import {Flex, Stack} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import FormContext from 'sentry/components/forms/formContext';
 import useDrawer from 'sentry/components/globalDrawer';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {IconAdd, IconEdit} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
+import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
 
 export function AutomateSection() {
   const ref = useRef<HTMLButtonElement>(null);
   const formContext = useContext(FormContext);
   const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
 
+  const {project} = useDetectorFormContext();
   const workflowIds = useFormField('workflowIds') as string[];
   const setWorkflowIds = useCallback(
     (newWorkflowIds: string[]) =>
@@ -80,18 +83,36 @@ export function AutomateSection() {
     <Container>
       <Section
         title={t('Alert')}
-        description={t('Set up alerts to get notified on issues.')}
+        description={t('Confirgure alerting on this Monitor to get notified on issues.')}
       >
-        <Button
-          ref={ref}
-          size="sm"
-          style={{width: 'min-content'}}
-          priority="primary"
-          icon={<IconAdd />}
-          onClick={toggleDrawer}
-        >
-          {t('Connect an Alert')}
-        </Button>
+        <ConnectedAutomationsList
+          automationIds={[]}
+          cursor={undefined}
+          onCursor={() => {}}
+          emptyMessage={
+            <Stack gap="md" align="center" maxWidth="300px">
+              <Button
+                ref={ref}
+                size="sm"
+                style={{width: 'min-content'}}
+                onClick={toggleDrawer}
+              >
+                {t('Connect Existing Alerts')}
+              </Button>
+              <Button size="sm" icon={<IconAdd />} onClick={toggleDrawer}>
+                {t('Create New Alert')}
+              </Button>
+              <Text variant="muted" align="center">
+                {tct(
+                  'Alerts configured for all Issues in [projectName] will also apply to this Monitor.',
+                  {
+                    projectName: <strong>{project.slug}</strong>,
+                  }
+                )}
+              </Text>
+            </Stack>
+          }
+        />
       </Section>
     </Container>
   );

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -12,6 +12,7 @@ import Section from 'sentry/components/workflowEngine/ui/section';
 import {IconAdd, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
@@ -54,6 +55,25 @@ export function AutomateSection() {
     );
   };
 
+  const openCreateDrawer = () => {
+    if (isDrawerOpen) {
+      closeDrawer();
+    }
+
+    openDrawer(
+      () => (
+        <AutomationBuilderDrawerForm
+          closeDrawer={closeDrawer}
+          onSuccess={automationId => {
+            setWorkflowIds([...workflowIds, automationId]);
+            closeDrawer();
+          }}
+        />
+      ),
+      {ariaLabel: t('Create New Alert')}
+    );
+  };
+
   if (workflowIds.length > 0) {
     return (
       <Container>
@@ -67,8 +87,7 @@ export function AutomateSection() {
           />
         </Section>
         <ButtonWrapper justify="between">
-          {/* TODO: Implement create automation flow */}
-          <Button size="sm" icon={<IconAdd />} disabled>
+          <Button size="sm" icon={<IconAdd />} onClick={openCreateDrawer}>
             {t('Create New Alert')}
           </Button>
           <Button size="sm" icon={<IconEdit />} onClick={toggleDrawer}>
@@ -99,7 +118,7 @@ export function AutomateSection() {
               >
                 {t('Connect Existing Alerts')}
               </Button>
-              <Button size="sm" icon={<IconAdd />} onClick={toggleDrawer}>
+              <Button size="sm" icon={<IconAdd />} onClick={openCreateDrawer}>
                 {t('Create New Alert')}
               </Button>
               <Text variant="muted" align="center">

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -223,7 +223,9 @@ describe('DetectorEdit', () => {
       expect(screen.queryByRole('button', {name: 'Delete'})).not.toBeInTheDocument();
 
       // Can add an automation and save
-      await userEvent.click(screen.getByRole('button', {name: 'Connect an Alert'}));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Connect Existing Alerts'})
+      );
       const drawer = await screen.findByRole('complementary', {
         name: 'Connect Alerts',
       });


### PR DESCRIPTION
This adds a new "Create Alert" drawer with a similar, slightly stripped down alert creation form. This allows users to quickly create a new alert for their monitor without being taken out of the experience.

Summary of changes:

- Extracting out common form elements so they can be used in both form components
- Adds the new AutomationBuilderDrawerForm component
- Updates the "Alert" section of the monitor form to use the new design and the "create alert" flow

https://github.com/user-attachments/assets/286cbdd6-f8cf-4949-9202-ab0fb25de188

