### PR TITLE
feat(issues): Implement task for invalidating issue owners cache

### DIFF
--- a/src/sentry/tasks/codeowners/__init__.py
+++ b/src/sentry/tasks/codeowners/__init__.py
@@ -1,7 +1,9 @@
 __all__ = (
     "code_owners_auto_sync",
+    "invalidate_project_issue_owners_cache",
     "update_code_owners_schema",
 )
 
 from .code_owners_auto_sync import code_owners_auto_sync
+from .invalidate_project_issue_owners_cache import invalidate_project_issue_owners_cache
 from .update_code_owners_schema import update_code_owners_schema

--- a/src/sentry/tasks/codeowners/invalidate_project_issue_owners_cache.py
+++ b/src/sentry/tasks/codeowners/invalidate_project_issue_owners_cache.py
@@ -1,0 +1,21 @@
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import issues_tasks
+
+
+@instrumented_task(
+    name="sentry.tasks.invalidate_project_issue_owners_cache",
+    namespace=issues_tasks,
+    processing_deadline_duration=600,
+    silo_mode=SiloMode.REGION,
+)
+def invalidate_project_issue_owners_cache(project_id: int) -> None:
+    """
+    Invalidate the issue owners debounce cache for all groups in a project.
+
+    This is called asynchronously when CODEOWNERS or ownership rules change,
+    allowing groups to re-evaluate ownership on their next event.
+    """
+    from sentry.models.groupowner import GroupOwner
+
+    GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(project_id)


### PR DESCRIPTION
The `GroupOwner.invalidate_debounce_issue_owners_evaluation_cache` functionality can be expensive for larger projects, causing [timeouts](https://sentry.sentry.io/issues/6731345393/?project=1&referrer=Linear) in related tasks such as `code_owners_auto_sync`. This PR defines a new task to run this cache invalidation. Follow-up work will migrate the existing synchronous calls to run this cache invalidation to instead trigger this async task.

Precursor to https://github.com/getsentry/sentry/pull/105770.