### PR TITLE
feat(ci): setup-sentry skip-devservices mode

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Mode to bring up by new devservices'
     required: false
     default: 'default'
+  skip-devservices:
+    description: 'Skip bringing up devservices'
+    required: false
+    default: 'false'
 
 outputs:
   matrix-instance-number:
@@ -38,7 +42,7 @@ runs:
         # isn't right because job-total will be 3x larger and you'd never run 2/3 of the tests.
         # MATRIX_INSTANCE_TOTAL: ${{ strategy.job-total }}
       run: |
-        echo "SENTRY_SKIP_BACKEND_VALIDATION=1" >> $GITHUB_ENV
+        echo "SENTRY_SKIP_SERVICE_VALIDATION=1" >> $GITHUB_ENV
 
         # for actions/setup-python which always runs pip install
         echo "PIP_DISABLE_PIP_VERSION_CHECK=on" >> $GITHUB_ENV
@@ -122,6 +126,7 @@ runs:
         python3 -m tools.fast_editable --path .
 
     - name: Start new devservices
+      if: ${{ inputs.skip-devservices != 'true' }}
       shell: bash --noprofile --norc -eo pipefail -ux {0}
       env:
         WORKDIR: ${{ inputs.workdir }}

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -363,7 +363,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     configure_sdk()
 
-    setup_services(validate=not skip_service_validation)
+    setup_services(validate=False)
 
     import_grouptype()
 

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -363,7 +363,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     configure_sdk()
 
-    setup_services(validate=False)
+    setup_services(validate=not skip_service_validation)
 
     import_grouptype()
 

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -287,10 +287,10 @@ def pytest_configure(config: pytest.Config) -> None:
     sentry_sdk.get_global_scope().set_client(None)
     register_extensions()
 
-    from sentry.utils.redis import clusters
+    #from sentry.utils.redis import clusters
 
-    with clusters.get("default").all() as client:
-        client.flushdb()
+    #with clusters.get("default").all() as client:
+    #    client.flushdb()
 
 
 def register_extensions() -> None:

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -283,14 +283,20 @@ def pytest_configure(config: pytest.Config) -> None:
     asset_version_patcher.start()
     from sentry.runner.initializer import initialize_app
 
-    initialize_app({"settings": settings, "options": None})
+    SENTRY_SKIP_SERVICE_VALIDATION = "SENTRY_SKIP_SERVICE_VALIDATION" in os.environ
+
+    initialize_app(
+        {"settings": settings, "options": None},
+        skip_service_validation=SENTRY_SKIP_SERVICE_VALIDATION,
+    )
     sentry_sdk.get_global_scope().set_client(None)
     register_extensions()
 
-    #from sentry.utils.redis import clusters
+    if not SENTRY_SKIP_SERVICE_VALIDATION:
+        from sentry.utils.redis import clusters
 
-    #with clusters.get("default").all() as client:
-    #    client.flushdb()
+        with clusters.get("default").all() as client:
+            client.flushdb()
 
 
 def register_extensions() -> None:


### PR DESCRIPTION
This introduces the ability to skip devservices during setup-sentry which will be very useful for reducing overhead for pytest test collection for selective testing dynamic sharding.

Observing ~2m -> 15s setup-sentry in https://github.com/getsentry/sentry/pull/105706.

Also, `SENTRY_SKIP_SERVICE_VALIDATION=1 pytest --collect-only` now works _without any devservices running_. This wasn't the case before but it should be. 