### PR TITLE
ref(billing): Remove usage of `deprecatedRouteProps` for `BillingInformation` component

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -63,7 +63,6 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'details/',
           name: 'Billing Information',
           component: make(() => import('../views/subscriptionPage/billingInformation')),
-          deprecatedRouteProps: true,
         },
         // TODO(sub-v3): We're keeping both routes for now, but we should remove the usage-log route once we're confident in keeping the new name
         {

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -1,13 +1,12 @@
 import {useTheme} from '@emotion/react';
-import type {Location} from 'history';
 
 import {Flex} from 'sentry/components/core/layout';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import withOrganization from 'sentry/utils/withOrganization';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
@@ -18,15 +17,15 @@ import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
 type Props = {
-  location: Location;
-  organization: Organization;
   subscription: Subscription;
 };
 
 /**
  * Update Billing Information view.
  */
-function BillingInformation({organization, subscription, location}: Props) {
+function BillingInformation({subscription}: Props) {
+  const organization = useOrganization();
+  const location = useLocation();
   const hasBillingPerms = organization.access?.includes('org:billing');
   const theme = useTheme();
   const maxPanelWidth = theme.breakpoints.lg;
@@ -68,7 +67,7 @@ function BillingInformation({organization, subscription, location}: Props) {
   );
 }
 
-export default withSubscription(withOrganization(BillingInformation));
+export default withSubscription(BillingInformation);
 
 /** @internal exported for tests only */
 export {BillingInformation};


### PR DESCRIPTION
Migrates the `BillingInformation` route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7