### PR TITLE
ref(billing): Remove usage of `deprecatedRouteProps` for `UsageLog` component

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -70,13 +70,11 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'usage-log/',
           name: 'Usage Log',
           component: make(() => import('../views/subscriptionPage/usageLog')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'activity-logs/',
           name: 'Activity Logs',
           component: make(() => import('../views/subscriptionPage/usageLog')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'receipts/:invoiceGuid/',

--- a/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
@@ -1,4 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
@@ -14,7 +13,6 @@ describe('Subscription Usage Log', () => {
     access: ['org:billing'],
   });
   const sub = SubscriptionFixture({organization});
-  const mockLocation = LocationFixture();
 
   beforeEach(() => {
     organization.features = [];
@@ -78,7 +76,7 @@ describe('Subscription Usage Log', () => {
       body: {rows: [UsageLogFixture()], eventNames},
     });
 
-    render(<UsageLog location={mockLocation} />, {organization});
+    render(<UsageLog />, {organization});
 
     await screen.findByText(/Select Action/i);
     expect(screen.getByRole('heading', {name: /Activity Logs/i})).toBeInTheDocument();
@@ -96,7 +94,7 @@ describe('Subscription Usage Log', () => {
       body: {rows: [], eventNames},
     });
 
-    render(<UsageLog location={mockLocation} />, {organization});
+    render(<UsageLog />, {organization});
 
     await screen.findByText(/Select Action/i);
     expect(screen.getByText(/No entries available/i)).toBeInTheDocument();
@@ -115,7 +113,7 @@ describe('Subscription Usage Log', () => {
       },
     });
 
-    render(<UsageLog location={mockLocation} />, {organization});
+    render(<UsageLog />, {organization});
 
     await screen.findByText(/Select Action/i);
     expect(screen.getByText('On-demand Edit')).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageLog.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
-import type {Location} from 'history';
 import upperFirst from 'lodash/upperFirst';
 
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
@@ -22,6 +21,7 @@ import type {User} from 'sentry/types/user';
 import {getTimeFormat} from 'sentry/utils/dates';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -73,10 +73,6 @@ interface UsageLogs {
   rows: AuditLog[];
 }
 
-type Props = {
-  location: Location;
-};
-
 function SkeletonEntry() {
   return (
     <Timeline.Item
@@ -88,8 +84,9 @@ function SkeletonEntry() {
   );
 }
 
-function UsageLog({location}: Props) {
+export default function UsageLog() {
   const organization = useOrganization();
+  const location = useLocation();
   const navigate = useNavigate();
   const theme = useTheme();
   const {
@@ -230,5 +227,3 @@ function UsageLog({location}: Props) {
     </SubscriptionPageContainer>
   );
 }
-
-export default UsageLog;


### PR DESCRIPTION
Migrates the `UsageLog` route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7