### PR TITLE
fix(escalating-forecast): bump down step size for generating forecasts

### DIFF
--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -24,7 +24,7 @@ ParsedGroupsCount = dict[int, GroupCount]
 
 logger = logging.getLogger(__name__)
 
-ITERATOR_CHUNK = 5_000
+ITERATOR_CHUNK = 1_000
 
 
 @instrumented_task(


### PR DESCRIPTION
Refs SENTRY-4A8H

We're seeing timeouts when generating escalating forecasts on the postgres query. We previously decreased the iterator size from 10k to 5k in https://github.com/getsentry/sentry/pull/104662, but this didn't improve error rates. I believe this is since the queries seem to start timing out in the ~thousands of groups queried, so stepping through by 5k didn't affect the timeouts at all. This decreases the iterator step size to 1k, which should result in smaller queries.