### PR TITLE
test(dashboards): Switch orgDashboards off deprecatedRouterMocks

### DIFF
--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -9,9 +9,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import DashboardDetail from 'sentry/views/dashboards/detail';
 import OrgDashboards from 'sentry/views/dashboards/orgDashboards';
-import {DashboardState} from 'sentry/views/dashboards/types';
 
 describe('OrgDashboards', () => {
   const organization = OrganizationFixture({
@@ -26,6 +24,10 @@ describe('OrgDashboards', () => {
       query: {},
     },
     route: '/organizations/:orgId/dashboard/:dashboardId/',
+  };
+
+  const renderChildFn = () => {
+    return <div>Test</div>;
   };
 
   beforeEach(() => {
@@ -74,22 +76,10 @@ describe('OrgDashboards', () => {
       url: '/organizations/org-slug/dashboards/',
       body: [mockDashboardWithFilters],
     });
-    const {router} = render(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>,
-      {initialRouterConfig, organization}
-    );
+    const {router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig,
+      organization,
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -131,22 +121,10 @@ describe('OrgDashboards', () => {
         },
       },
     };
-    const {router} = render(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>,
-      {initialRouterConfig: routerConfigWithSort, organization}
-    );
+    const {router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig: routerConfigWithSort,
+      organization,
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -190,45 +168,23 @@ describe('OrgDashboards', () => {
       },
     };
 
-    const {router} = render(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>,
-      {initialRouterConfig: routerConfigWithProject, organization}
-    );
+    const {router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig: routerConfigWithProject,
+      organization,
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    expect(router.location.query).toEqual({});
+    expect(router.location.query).toEqual({
+      project: '1',
+    });
   });
 
   it('does not add query params for page filters if none are saved', async () => {
-    const {router} = render(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>,
-      {initialRouterConfig, organization}
-    );
+    const {router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig,
+      organization,
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -254,22 +210,10 @@ describe('OrgDashboards', () => {
       body: [mockDashboardWithFilters],
     });
 
-    const {rerender, router} = render(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>,
-      {initialRouterConfig, organization}
-    );
+    const {rerender, router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig,
+      organization,
+    });
 
     await waitFor(() => expect(router.location.query.project).toBe('1'));
 
@@ -277,21 +221,7 @@ describe('OrgDashboards', () => {
 
     await waitFor(() => expect(router.location.query).toEqual({}));
 
-    rerender(
-      <OrgDashboards>
-        {({dashboard, dashboards}) => {
-          return dashboard ? (
-            <DashboardDetail
-              initialState={DashboardState.VIEW}
-              dashboard={dashboard}
-              dashboards={dashboards}
-            />
-          ) : (
-            <div>loading</div>
-          );
-        }}
-      </OrgDashboards>
-    );
+    rerender(<OrgDashboards>{renderChildFn}</OrgDashboards>);
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -91,12 +91,12 @@ describe('OrgDashboards', () => {
       {initialRouterConfig, organization}
     );
 
-    await waitFor(() => {
-      expect(router.location.query).toEqual({
-        project: ['1', '2'],
-        environment: 'alpha',
-        statsPeriod: '7d',
-      });
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(router.location.query).toEqual({
+      project: ['1', '2'],
+      environment: 'alpha',
+      statsPeriod: '7d',
     });
   });
 
@@ -148,17 +148,17 @@ describe('OrgDashboards', () => {
       {initialRouterConfig: routerConfigWithSort, organization}
     );
 
-    await waitFor(() => {
-      expect(router.location.query).toEqual({
-        project: ['1', '2'],
-        environment: 'alpha',
-        statsPeriod: '7d',
-        sort: 'recentlyViewed',
-      });
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(router.location.query).toEqual({
+      project: ['1', '2'],
+      environment: 'alpha',
+      statsPeriod: '7d',
+      sort: 'recentlyViewed',
     });
   });
 
-  it('does not add query params for page filters if one of the filters is defined', () => {
+  it('does not add query params for page filters if one of the filters is defined', async () => {
     const mockDashboardWithFilters = {
       dateCreated: '2021-08-10T21:20:46.798237Z',
       id: '1',
@@ -207,10 +207,12 @@ describe('OrgDashboards', () => {
       {initialRouterConfig: routerConfigWithProject, organization}
     );
 
-    expect(router.location.query.project).toBe('1');
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(router.location.query).toEqual({});
   });
 
-  it('does not add query params for page filters if none are saved', () => {
+  it('does not add query params for page filters if none are saved', async () => {
     const {router} = render(
       <OrgDashboards>
         {({dashboard, dashboards}) => {
@@ -227,6 +229,8 @@ describe('OrgDashboards', () => {
       </OrgDashboards>,
       {initialRouterConfig, organization}
     );
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(router.location.query).toEqual({});
   });
@@ -290,6 +294,7 @@ describe('OrgDashboards', () => {
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    await waitFor(() => expect(router.location.query).toEqual({}));
+
+    expect(router.location.query).toEqual({});
   });
 });


### PR DESCRIPTION
uses the in-memory test router instead of our custom mocks
