### PR TITLE
feat(uptime): Add consumer-side queueing for out-of-order results

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -522,6 +522,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable email notifications when auto-detected uptime monitors graduate from onboarding
     manager.add("organizations:uptime-auto-detected-monitor-emails", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable task-based retry for out-of-order uptime results
+    manager.add("organizations:uptime-backlog-retry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable endpoint and frontend for AI-powered UF summaries
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -14,6 +14,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
 
 from sentry import features
 from sentry.conf.types.kafka_definition import Topic
+from sentry.locks import locks
 from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
@@ -38,8 +39,16 @@ from sentry.uptime.subscriptions.tasks import (
     update_remote_uptime_subscription,
 )
 from sentry.uptime.types import UptimeMonitorMode
-from sentry.uptime.utils import build_last_seen_interval_key, build_last_update_key, get_cluster
-from sentry.utils import metrics
+from sentry.uptime.utils import (
+    build_backlog_key,
+    build_backlog_schedule_lock_key,
+    build_backlog_task_scheduled_key,
+    build_last_seen_interval_key,
+    build_last_update_key,
+    get_cluster,
+)
+from sentry.utils import json, metrics
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -194,7 +203,7 @@ def create_backfill_misses(
 
     # If the scheduled check is two or more intervals since the last seen check, we can declare the
     # intervening checks missed...
-    if last_update_ms > 0 and num_intervals > 1:
+    if num_intervals > 1:
         # ... but it might be the case that the user changed the frequency of the detector.  So, first
         # verify that the interval in postgres is the same as the last-seen interval (in redis).
         # We only store in redis when we encounter a difference like this, which means we won't be able
@@ -346,6 +355,69 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
     def get_subscription_id(self, result: CheckResult) -> str:
         return result["subscription_id"]
 
+    def queue_result_for_retry(
+        self,
+        subscription: UptimeSubscription,
+        result: CheckResult,
+        metric_tags: dict[str, str],
+        cluster,
+    ) -> None:
+        """
+        Queue an out-of-order result for retry processing. Adds result to Redis sorted set and schedules task if needed.
+        """
+        from sentry.uptime.consumers.tasks import process_uptime_backlog
+
+        subscription_id = str(subscription.id)
+        backlog_key = build_backlog_key(subscription_id)
+        task_scheduled_key = build_backlog_task_scheduled_key(subscription_id)
+        schedule_lock_key = build_backlog_schedule_lock_key(subscription_id)
+        schedule_lock = locks.get(schedule_lock_key, duration=10, name="uptime.backlog.schedule")
+        lock_acquired = False
+
+        try:
+            schedule_lock.blocking_acquire(0.1, 3).__enter__()
+            lock_acquired = True
+        except UnableToAcquireLock:
+            # The lock shouldn't fail, but if it does we'd prefer to try and put this in the queue
+            # regardless, so that we don't have to drop it
+            metrics.incr(
+                "uptime.backlog.lock_failed",
+                amount=1,
+                sample_rate=1.0,
+                tags=metric_tags,
+            )
+
+        try:
+            result_json = json.dumps(result)
+            pipeline = cluster.pipeline()
+            pipeline.zadd(backlog_key, {result_json: int(result["scheduled_check_time_ms"])})
+            pipeline.expire(backlog_key, 600)
+            pipeline.exists(task_scheduled_key)
+            task_scheduled = pipeline.execute()[2]
+            metrics.incr(
+                "uptime.backlog.added",
+                amount=1,
+                sample_rate=1.0,
+                tags=metric_tags,
+            )
+            if not task_scheduled:
+                cluster.set(task_scheduled_key, "1", ex=300)
+                process_uptime_backlog.apply_async(
+                    args=[subscription_id],
+                    countdown=10,
+                    kwargs={"attempt": 1},
+                )
+                logger.info(
+                    "uptime.backlog.task_scheduled",
+                    extra={
+                        "subscription_id": subscription_id,
+                        "buffer_size": cluster.zcard(backlog_key),
+                    },
+                )
+        finally:
+            if lock_acquired:
+                schedule_lock.release()
+
     def handle_result(self, subscription: UptimeSubscription | None, result: CheckResult):
         if random.random() < 0.01:
             logger.info("process_result", extra=result)
@@ -454,7 +526,20 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 )
             return
 
-        create_backfill_misses(detector, subscription, result, last_update_ms, metric_tags, cluster)
+        if last_update_ms > 0:
+            subscription_interval_ms = subscription.interval_seconds * 1000
+            expected_next_ms = last_update_ms + subscription_interval_ms
+            is_out_of_order = result["scheduled_check_time_ms"] != expected_next_ms
+
+            if is_out_of_order:
+                if features.has("organizations:uptime-backlog-retry", organization):
+                    self.queue_result_for_retry(subscription, result, metric_tags, cluster)
+                    return
+
+                create_backfill_misses(
+                    detector, subscription, result, last_update_ms, metric_tags, cluster
+                )
+
         process_result_internal(detector, subscription, result, metric_tags, cluster)
 
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -414,6 +414,12 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                         "buffer_size": cluster.zcard(backlog_key),
                     },
                 )
+                metrics.incr(
+                    "uptime.backlog.task_scheduled",
+                    amount=1,
+                    sample_rate=1.0,
+                    tags=metric_tags,
+                )
         finally:
             if lock_acquired:
                 schedule_lock.release()

--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -31,7 +31,7 @@ BACKOFF_SCHEDULE = [10, 20, 30, 30, 30, 30, 30]
 @instrumented_task(
     name="sentry.uptime.consumers.tasks.process_uptime_backlog",
     namespace=uptime_tasks,
-    retry=Retry(times=3, delay=1),
+    retry=Retry(times=3, delay=1, on=(Exception,)),
 )
 def process_uptime_backlog(subscription_id: str, attempt: int = 1):
     """

--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -150,6 +150,7 @@ def process_uptime_backlog(subscription_id: str, attempt: int = 1):
                 "uptime.backlog.cleared",
                 extra={"subscription_id": subscription_id, "processed_count": processed_count},
             )
+            metrics.incr("uptime.backlog.cleared", amount=1, sample_rate=1.0)
             return
 
         if processed_count > 0:
@@ -174,6 +175,7 @@ def process_uptime_backlog(subscription_id: str, attempt: int = 1):
                     "remaining_items": remaining,
                 },
             )
+            metrics.incr("uptime.backlog.rescheduling", amount=1, sample_rate=1.0)
 
         next_backoff = BACKOFF_SCHEDULE[next_attempt - 1]
         remaining_time_seconds = sum(BACKOFF_SCHEDULE[next_attempt - 1 :]) + 60


### PR DESCRIPTION
Add logic to detect and queue out-of-order uptime results for retry processing instead of immediately creating backfill misses.

We keep this functionality behind a feature flag so that we can try it out first.

<!-- Describe your PR here. -->