### PR TITLE
fix(aci): Don't process deleted workflows in process_delayed_workflows

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -228,6 +228,20 @@ class EventRedisData:
                     result[dcg_id] = timestamp
         return result
 
+    def filter_by_workflow_ids(self, valid_workflow_ids: set[WorkflowId]) -> EventRedisData:
+        """
+        Return a new EventRedisData containing only events for the given workflow IDs.
+        """
+        if not valid_workflow_ids:
+            return EventRedisData(events={})
+
+        filtered_events = {
+            key: instance
+            for key, instance in self.events.items()
+            if key.workflow_id in valid_workflow_ids
+        }
+        return EventRedisData(events=filtered_events)
+
 
 @dataclass
 class GroupQueryParams:
@@ -824,12 +838,33 @@ def process_delayed_workflows(
         redis_data = batch_client.for_project(project_id).get_hash_data(batch_key)
         event_data = EventRedisData.from_redis_data(redis_data, continue_on_error=True)
 
+        # Store original keys for cleanup - must clean all regardless of deletion status
+        original_event_keys = set(event_data.events.keys())
+        original_count = len(event_data.events)
+
         metrics.incr(
             "workflow_engine.delayed_workflow",
-            amount=len(event_data.events),
+            amount=original_count,
         )
 
         workflows_to_envs = fetch_workflows_envs(list(event_data.workflow_ids))
+
+        event_data = event_data.filter_by_workflow_ids(set(workflows_to_envs.keys()))
+
+        filtered_count = original_count - len(event_data.events)
+        if filtered_count > 0:
+            metrics.incr(
+                "workflow_engine.delayed_workflow.filtered_deleted_workflows",
+                amount=filtered_count,
+            )
+
+        # Early exit if all workflows deleted - still clean up Redis
+        if not event_data.events:
+            cleanup_redis_buffer(
+                batch_client.for_project(project_id), original_event_keys, batch_key
+            )
+            return
+
         data_condition_groups = fetch_data_condition_groups(list(event_data.dcg_ids))
         dcg_to_slow_conditions = get_slow_conditions_for_groups(list(event_data.dcg_ids))
 
@@ -858,6 +893,7 @@ def process_delayed_workflows(
         data_condition_groups, event_data, workflows_to_envs, dcg_to_slow_conditions
     )
     if not condition_groups:
+        cleanup_redis_buffer(batch_client.for_project(project_id), original_event_keys, batch_key)
         return
     logger.debug(
         "delayed_workflow.condition_query_groups",
@@ -918,4 +954,4 @@ def process_delayed_workflows(
     )
 
     fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
-    cleanup_redis_buffer(batch_client.for_project(project_id), event_data.events.keys(), batch_key)
+    cleanup_redis_buffer(batch_client.for_project(project_id), original_event_keys, batch_key)


### PR DESCRIPTION
If a workflow is being deleted, we should disregard any scheduled attempts to evaluate it.
It's still possible for it to be deleted while we're processing since we don't entirely do an up-front fetch, but this ensures a subsequent retry will not have the same issue.

Addresses ISWF-819.
