### PR TITLE
chore(code-review): Add org based feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,6 +74,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-run-per-commit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabled for orgs that participated in the code review beta
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables using sentry to forward directly to seer (instead of overwatch)
+    manager.add("organizations:code-review-direct-to-seer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Prevent Test Analytics
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -9,7 +9,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import options
+from sentry import features, options
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
@@ -103,7 +103,9 @@ def handle_issue_comment_event(
     if not is_pr_review_command(comment_body or ""):
         return
 
-    if not options.get("github.webhook.issue-comment"):
+    if not options.get("github.webhook.issue-comment") and features.has(
+        "organizations:code-review-direct-to-seer", organization
+    ):
         if comment_id:
             _add_eyes_reaction_to_comment(integration, organization, repo, str(comment_id))
 

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -9,7 +9,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import features, options
+from sentry import features
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
@@ -103,9 +103,7 @@ def handle_issue_comment_event(
     if not is_pr_review_command(comment_body or ""):
         return
 
-    if not options.get("github.webhook.issue-comment") and features.has(
-        "organizations:code-review-direct-to-seer", organization
-    ):
+    if features.has("organizations:code-review-direct-to-seer", organization):
         if comment_id:
             _add_eyes_reaction_to_comment(integration, organization, repo, str(comment_id))
 

--- a/src/sentry/testutils/helpers/github.py
+++ b/src/sentry/testutils/helpers/github.py
@@ -137,7 +137,11 @@ class GitHubWebhookTestCase(APITestCase):
 
 
 class GitHubWebhookCodeReviewTestCase(GitHubWebhookTestCase):
-    CODE_REVIEW_FEATURES = {"organizations:gen-ai-features", "organizations:code-review-beta"}
+    CODE_REVIEW_FEATURES = {
+        "organizations:gen-ai-features",
+        "organizations:code-review-beta",
+        "organizations:code-review-direct-to-seer",
+    }
 
     @contextmanager
     def code_review_setup(

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -164,8 +164,16 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
 
     @patch("sentry.seer.code_review.webhooks.issue_comment._add_eyes_reaction_to_comment")
     def test_skips_processing_when_option_is_true(self, mock_reaction: MagicMock) -> None:
-        """Test that when github.webhook.issue-comment option is True (kill switch), no processing occurs."""
-        with self.code_review_setup(forward_to_overwatch=True), self.tasks():
+        """
+        Test that when github.webhook.issue-comment option is True (kill switch), no processing occurs
+        if the organization has direct-to-seer False.
+        """
+        with (
+            self.code_review_setup(
+                features={"organizations:gen-ai-features"}, forward_to_overwatch=True
+            ),
+            self.tasks(),
+        ):
             event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
             response = self._send_issue_comment_event(event)
             assert response.status_code == 204


### PR DESCRIPTION
Add another feature flag layer to enable issue_comment just for the whitelisted orgs. 
Note the other feature flags per region/per webhook are still there controlling when to send to overwatch or not. Unfortunately I can't change the logic there in overwatch webhook_forwarder to check the org feature flag because it would call a regional model within control which is not allowed. 
So for our testing we'll just need to have double reviews or add a flag in overwatch (not hard). I think we can just do it this way to unblock our spot testing and then we can discuss a longer term plan for rollout.

This is since we haven't been able to get s4s and s4s2 fully hooked up for our testing.

Closes [CW-260](https://linear.app/getsentry/issue/CW-260/enable-testing-of-issue-comment-changes-by-org)