### PR TITLE
ref(features): Remove unused profiling feature flag

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -81,7 +81,6 @@ UNUSED_ON_FRONTEND_FEATURES: Final = "unusedFeatures"
 # and add a lot of latency ~100-300ms per flag for large organizations
 # so we exclude them from the response if the unusedFeatures collapse parameter is set
 PROJECT_FEATURES_NOT_USED_ON_FRONTEND = {
-    "profiling-ingest-unsampled-profiles",
     "discard-transaction",
     "first-event-severity-calculation",
     "alert-filters",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -695,8 +695,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable Triage signals V0 for AI powered issue classification in sentry
     manager.add("projects:triage-signals-v0", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
-    manager.add("projects:profiling-ingest-unsampled-profiles", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-
     manager.add("projects:project-detail-apple-app-hang-rate", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # fmt: on
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -67,7 +67,6 @@ EXPOSABLE_FEATURES = [
     "organizations:session-replay",
     "organizations:standalone-span-ingestion",
     "projects:discard-transaction",
-    "projects:profiling-ingest-unsampled-profiles",
     "projects:span-metrics-extraction",
     "projects:span-metrics-extraction-addons",
     "organizations:indexed-spans-extraction",


### PR DESCRIPTION
Removed in options automator: https://github.com/getsentry/sentry-options-automator/pull/6063