### PR TITLE
fix(seer setting): Grey out Auto Open PRs when auto trigger is Off

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/projectDetailsForm.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/projectDetailsForm.spec.tsx
@@ -1,0 +1,44 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import ProjectDetailsForm from './projectDetailsForm';
+
+describe('ProjectDetailsForm', () => {
+  const organization = OrganizationFixture();
+  const defaultPreference = {
+    repositories: [],
+    automated_run_stopping_point: 'code_changes' as const,
+    automation_handoff: undefined,
+  };
+
+  it('disables PR Auto Creation toggle when Auto-Triggered Fixes is off', async () => {
+    const project = ProjectFixture({autofixAutomationTuning: 'off'});
+
+    render(
+      <ProjectDetailsForm canWrite project={project} preference={defaultPreference} />,
+      {organization}
+    );
+
+    const toggle = screen.getByRole('checkbox', {name: /Allow PR Auto Creation/i});
+    expect(toggle).toBeDisabled();
+
+    await userEvent.hover(toggle);
+    expect(
+      await screen.findByText('Turn on Auto-Triggered Fixes to use this feature.')
+    ).toBeInTheDocument();
+  });
+
+  it('enables PR Auto Creation toggle when Auto-Triggered Fixes is on', () => {
+    const project = ProjectFixture({autofixAutomationTuning: 'medium'});
+
+    render(
+      <ProjectDetailsForm canWrite project={project} preference={defaultPreference} />,
+      {organization}
+    );
+
+    const toggle = screen.getByRole('checkbox', {name: /Allow PR Auto Creation/i});
+    expect(toggle).toBeEnabled();
+  });
+});

--- a/static/gsApp/views/seerAutomation/components/projectDetails/projectDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/projectDetailsForm.tsx
@@ -60,9 +60,9 @@ export default function ProjectDetailsForm({canWrite, project, preference}: Prop
               },
               {
                 name: 'automated_run_stopping_point',
-                label: t('Allow PR Creation'),
+                label: t('Allow PR Auto Creation'),
                 help: t(
-                  'Seer will be able to make a pull requests for highly actionable issues.'
+                  'Seer will be able to automatically make a pull requests for highly actionable issues.'
                 ),
                 type: 'boolean',
                 setValue: (
@@ -72,8 +72,17 @@ export default function ProjectDetailsForm({canWrite, project, preference}: Prop
                   value: boolean
                 ): ProjectSeerPreferences['automated_run_stopping_point'] =>
                   value ? 'open_pr' : 'code_changes',
-                disabled: () => Boolean(preference?.automation_handoff),
-                disabledReason: () => {
+                disabled: ({model}) => {
+                  const autofixTuning = model?.getValue('autofixAutomationTuning');
+                  const isAutofixOff = !autofixTuning || autofixTuning === 'off';
+                  return isAutofixOff || Boolean(preference?.automation_handoff);
+                },
+                disabledReason: ({model}) => {
+                  const autofixTuning = model?.getValue('autofixAutomationTuning');
+                  const isAutofixOff = !autofixTuning || autofixTuning === 'off';
+                  if (isAutofixOff) {
+                    return t('Turn on Auto-Triggered Fixes to use this feature.');
+                  }
                   if (preference?.automation_handoff) {
                     return t(
                       'This setting is not available when using background agents.'


### PR DESCRIPTION
## PR Details
+ Auto Open PRs will now be greyed out if Auto Trigger fixes is Off.
+ Made small changes to the name and description text too. 

Fixes ENG-6241
