### PR TITLE
ref(preprod): Use Response instead of JsonResponse in artifact image endpoint

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -318,15 +318,14 @@ def send_email(user_id: int, subject: str, body: str) -> None:
 Following Django REST Framework standards, all error responses must use `"detail"` as the key for error messages.
 
 ```python
-from django.http import JsonResponse
 from rest_framework.response import Response
 
 # ✅ CORRECT: Use "detail" for error messages
-return JsonResponse({"detail": "Internal server error"}, status=500)
+return Response({"detail": "Internal server error"}, status=500)
 return Response({"detail": "Invalid input"}, status=400)
 
 # ❌ WRONG: Don't use "error" or other keys
-return JsonResponse({"error": "Internal server error"}, status=500)
+return Response({"error": "Internal server error"}, status=500)
 return Response({"message": "Invalid input"}, status=400)
 ```
 

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -52,4 +53,4 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
                     "image_id": image_id,
                 },
             )
-            return JsonResponse({"detail": "Internal server error"}, status=500)
+            return Response({"detail": "Internal server error"}, status=500)


### PR DESCRIPTION
## Summary

Standardize error response handling in the artifact image endpoint to use Django REST Framework's `Response` class instead of Django's `JsonResponse`.