### PR TITLE
fix(ui): selecting of arbitrary relative periods in auditLogList

### DIFF
--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -15,7 +15,10 @@ import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import type {ChangeData} from 'sentry/components/timeRangeSelector';
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
-import {getAbsoluteSummary} from 'sentry/components/timeRangeSelector/utils';
+import {
+  getAbsoluteSummary,
+  getArbitraryRelativePeriod,
+} from 'sentry/components/timeRangeSelector/utils';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DateString} from 'sentry/types/core';
@@ -297,6 +300,7 @@ function AuditLogList({
   const {displayStart, displayEnd} = getDisplayValues();
 
   const currentValue = statsPeriod || allTime;
+  const arbitraryRelativePeriods = getArbitraryRelativePeriod(currentValue);
   let displayLabel: React.ReactNode;
 
   if (displayStart && displayEnd) {
@@ -307,6 +311,8 @@ function AuditLogList({
     displayLabel = getAbsoluteSummary(start, end, utc);
   } else if (currentValue === allTime) {
     displayLabel = allTime;
+  } else {
+    displayLabel = arbitraryRelativePeriods[currentValue];
   }
 
   const headerActions = (
@@ -318,6 +324,7 @@ function AuditLogList({
         onChange={onDateSelect}
         relativeOptions={{
           allTime,
+          ...arbitraryRelativePeriods,
         }}
         utc={utc}
         maxPickableDays={getDaysSinceDate(organization.dateCreated)}

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -125,4 +125,23 @@ describe('OrganizationAuditLog', () => {
       screen.getByText('edited metric alert rule "Failure rate too high"')
     ).toBeInTheDocument();
   });
+
+  it('allows filtering for arbitrary custom time ranges', async () => {
+    const {router} = render(<OrganizationAuditLog />);
+
+    await userEvent.click(screen.getByTestId('page-filter-timerange-selector'));
+
+    const searchbox = screen.getByPlaceholderText(/custom range/i);
+    await userEvent.type(searchbox, '2w');
+    await userEvent.click(screen.getByText('Last 2 weeks'));
+
+    expect(router.location).toEqual(
+      expect.objectContaining({
+        query: {statsPeriod: '2w'},
+      })
+    );
+    expect(screen.getByTestId('page-filter-timerange-selector')).toHaveTextContent(
+      'Last 2 weeks'
+    );
+  });
 });


### PR DESCRIPTION
I noticed that selecting an arbitrary period in the auditLog list works, but displays `Invalid Period` after selection. The filtering itself always worked because `statsPeriod` is correctly written to the url in any case.

before:

https://github.com/user-attachments/assets/d4967fae-34ec-4f5e-bf7d-d40268351835

after:

https://github.com/user-attachments/assets/927f92c8-bf6b-4297-88df-2a7bec2784d3

