### PR TITLE
feat(preprod): Add new /builds/ endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -1,0 +1,149 @@
+from collections.abc import Sequence
+from typing import Any
+
+from django.db.models import Q
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
+from sentry.api.event_search import (
+    AggregateFilter,
+    ParenExpression,
+    QueryToken,
+    SearchConfig,
+    SearchFilter,
+    parse_search_query,
+)
+from sentry.api.paginator import OffsetPaginator
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models.organization import Organization
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
+from sentry.preprod.models import PreprodArtifact
+
+ERR_FEATURE_REQUIRED = "Feature {} is not enabled for the organization."
+
+search_config = SearchConfig.create_from(
+    SearchConfig(),
+    # Text keys we allow operators to be used on
+    # text_operator_keys={"app_id"},
+    # Keys that support numeric comparisons
+    # numeric_keys={"state", "pr_number"},
+    # Keys that support date filtering
+    # date_keys={"date_built", "date_added"},
+    # Key mappings for user-friendly names
+    key_mappings={
+        "app_id": ["app_id", "package_name", "bundle_id"],
+    },
+    # Allowed search keys
+    allowed_keys={
+        "app_id",
+        "package_name",
+        "bundle_id",
+    },
+    # Enable boolean operators
+    # allow_boolean=True,
+    # Enable wildcard free text search
+    # wildcard_free_text=True,
+    # Which key we should return any free text under
+    free_text_key="text",
+)
+
+
+def apply_filters(
+    queryset: BaseQuerySet[PreprodArtifact], filters: Sequence[QueryToken]
+) -> BaseQuerySet[PreprodArtifact]:
+    for token in filters:
+        # Skip operators and other non-filter types
+        if isinstance(token, str):  # Handles "AND", "OR" literals
+            raise InvalidSearchQuery(f"Boolean operators are not supported: {token}")
+        if isinstance(token, AggregateFilter):
+            raise InvalidSearchQuery("Aggregate filters are not supported")
+        if isinstance(token, ParenExpression):
+            raise InvalidSearchQuery("Parenthetical expressions are not supported")
+
+        # Now we know it's a SearchFilter
+        assert isinstance(token, SearchFilter)  # for mypy
+
+        name = token.key.name
+
+        # We don't currently support free text:
+        if name == "text":
+            continue
+
+        # We don't have to handle boolean operators or perens here
+        # since allow_boolean is not set in SearchConfig.
+        d = {}
+        if token.is_in_filter:
+            d[f"{token.key.name}__in"] = token.value.value
+        else:
+            d[token.key.name] = token.value.value
+
+        q = Q(**d)
+        if token.is_negation:
+            q = ~q
+        queryset = queryset.filter(q)
+    return queryset
+
+
+def on_results(artifacts: Sequence[PreprodArtifact]) -> list[dict[str, Any]]:
+    return [transform_preprod_artifact_to_build_details(artifact).dict() for artifact in artifacts]
+
+
+@region_silo_endpoint
+class BuildsEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:preprod-frontend-routes", organization, actor=request.user
+        ):
+            return Response(
+                {"detail": ERR_FEATURE_REQUIRED.format("organizations:preprod-frontend-routes")},
+                status=403,
+            )
+
+        paginate = lambda queryset: self.paginate(
+            order_by="-date_added",
+            request=request,
+            queryset=queryset,
+            on_results=on_results,
+            paginator_cls=OffsetPaginator,
+        )
+
+        try:
+            params = self.get_filter_params(request, organization, date_filter_optional=True)
+        except NoProjects:
+            return paginate(PreprodArtifact.objects.none())
+
+        start = params["start"]
+        end = params["end"]
+        # Builds don't have environments so we ignore environments from
+        # params on purpose.
+
+        queryset = PreprodArtifact.objects.filter(project_id__in=params["project_id"])
+
+        if start:
+            queryset = queryset.filter(date_added__gte=start)
+        if end:
+            queryset = queryset.filter(date_added__lte=end)
+
+        query = request.GET.get("query", "").strip()
+        try:
+            search_filters = parse_search_query(query, config=search_config)
+        except InvalidSearchQuery as e:
+            # CodeQL complains about str(e) below but ~all handlers
+            # of InvalidSearchQuery do the same as this.
+            return Response({"detail": str(e)}, status=400)
+        queryset = apply_filters(queryset, search_filters)
+
+        return paginate(queryset)

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.urls import re_path
 
+from sentry.preprod.api.endpoints.builds import BuildsEndpoint
 from sentry.preprod.api.endpoints.project_preprod_artifact_image import (
     ProjectPreprodArtifactImageEndpoint,
 )
@@ -141,6 +142,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/pr-comments/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
         OrganizationPrCommentsEndpoint.as_view(),
         name="sentry-api-0-organization-pr-comments",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/builds/$",
+        BuildsEndpoint.as_view(),
+        name="sentry-api-0-organization-builds",
     ),
 ]
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2577,11 +2577,12 @@ class Factories:
         commit_comparison: CommitComparison | None = None,
         file_id: int | None = None,
         installable_app_file_id: int | None = None,
+        date_added: datetime | None = None,
         build_configuration: PreprodBuildConfiguration | None = None,
         extras: dict | None = None,
         **kwargs,
     ) -> PreprodArtifact:
-        return PreprodArtifact.objects.create(
+        artifact = PreprodArtifact.objects.create(
             project=project,
             state=state,
             artifact_type=artifact_type,
@@ -2596,6 +2597,9 @@ class Factories:
             extras=extras,
             **kwargs,
         )
+        if date_added is not None:
+            artifact.update(date_added=date_added)
+        return artifact
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -205,6 +205,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/available-actions/'
   | '/organizations/$organizationIdOrSlug/avatar/'
   | '/organizations/$organizationIdOrSlug/broadcasts/'
+  | '/organizations/$organizationIdOrSlug/builds/'
   | '/organizations/$organizationIdOrSlug/builtin-symbol-sources/'
   | '/organizations/$organizationIdOrSlug/chunk-upload/'
   | '/organizations/$organizationIdOrSlug/code-mappings/'

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -1,0 +1,255 @@
+from unittest.mock import ANY
+
+from django.urls import reverse
+from django.utils.functional import cached_property
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
+
+
+class BuildsEndpointTest(APITestCase):
+
+    @cached_property
+    def user_auth_token(self):
+        auth_token = self.create_user_auth_token(
+            self.user, scope_list=["org:admin", "project:admin"]
+        )
+        return auth_token.token
+
+    def _request(self, query, token=None):
+        token = self.user_auth_token if token is None else token
+        url = reverse(
+            "sentry-api-0-organization-builds",
+            args=[self.organization.slug],
+            query=query,
+        )
+        return self.client.get(url, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    def test_needs_feature(self) -> None:
+        response = self._request({})
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": "Feature organizations:preprod-frontend-routes is not enabled for the organization."
+        }
+
+    def test_invalid_token(self) -> None:
+        response = self._request({}, token="Invalid")
+        assert response.status_code == 401
+        assert response.json() == {"detail": "Invalid token"}
+
+    def test_wrong_user(self) -> None:
+        random_user = self.create_user("foo@localhost")
+        auth_token = self.create_user_auth_token(
+            random_user, scope_list=["org:admin", "project:admin"]
+        )
+
+        response = self._request({}, token=auth_token.token)
+        assert response.status_code == 403
+        assert response.json() == {"detail": "You do not have permission to perform this action."}
+
+    def test_missing_scopes(self) -> None:
+        auth_token = self.create_user_auth_token(self.user, scope_list=[])
+
+        response = self._request({}, token=auth_token.token)
+        assert response.status_code == 403
+        assert response.json() == {"detail": "You do not have permission to perform this action."}
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_no_builds(self) -> None:
+        response = self._request({})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_one_build(self) -> None:
+        self.create_preprod_artifact()
+        response = self._request({})
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "id": ANY,
+                "state": 3,
+                "app_info": {
+                    "app_id": "com.example.app",
+                    "name": None,
+                    "version": None,
+                    "build_number": None,
+                    "date_added": ANY,
+                    "date_built": None,
+                    "artifact_type": 2,
+                    "platform": "android",
+                    "is_installable": False,
+                    "build_configuration": None,
+                    "app_icon_id": None,
+                    "apple_app_info": None,
+                    "android_app_info": {
+                        "has_proguard_mapping": True,
+                    },
+                },
+                "base_artifact_id": None,
+                "base_build_info": None,
+                "distribution_info": {
+                    "download_count": 0,
+                    "is_installable": False,
+                    "release_notes": None,
+                },
+                "vcs_info": {
+                    "head_sha": None,
+                    "base_sha": None,
+                    "provider": None,
+                    "head_repo_name": None,
+                    "base_repo_name": None,
+                    "head_ref": None,
+                    "base_ref": None,
+                    "pr_number": None,
+                },
+                "project_id": ANY,
+                "posted_status_checks": None,
+                "project_slug": "bar",
+                "size_info": None,
+            }
+        ]
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_bad_project(self) -> None:
+        self.create_preprod_artifact()
+        response = self._request({"project": [1]})
+        assert response.status_code == 403
+        assert response.json() == {"detail": "You do not have permission to perform this action."}
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_bad_project_slug(self) -> None:
+        self.create_preprod_artifact()
+        response = self._request({"projectSlug": ["invalid"]})
+        assert response.status_code == 403
+        assert response.json() == {"detail": "You do not have permission to perform this action."}
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_build_in_another_project(self) -> None:
+        another_project = self.create_project(name="Baz", slug="baz")
+        self.create_preprod_artifact(project=another_project)
+        response = self._request({"project": [self.project.id]})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_build_in_another_project_slug(self) -> None:
+        another_project = self.create_project(name="Baz", slug="baz")
+        self.create_preprod_artifact(project=another_project)
+        response = self._request({"projectSlug": [self.project.slug]})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_build_in_this_project(self) -> None:
+        self.create_preprod_artifact()
+        response = self._request({"project": [self.project.id]})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_build_in_this_project_slug(self) -> None:
+        self.create_preprod_artifact()
+        response = self._request({"projectSlug": [self.project.slug]})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_multiple_projects(self) -> None:
+        project_a = self.create_project(name="AAA", slug="aaa")
+        self.create_preprod_artifact(project=project_a)
+        project_b = self.create_project(name="BBB", slug="bbb")
+        self.create_preprod_artifact(project=project_b)
+        response = self._request({"project": [project_a.id, project_b.id]})
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_multiple_project_slugs(self) -> None:
+        project_a = self.create_project(name="AAA", slug="aaa")
+        self.create_preprod_artifact(project=project_a)
+        project_b = self.create_project(name="BBB", slug="bbb")
+        self.create_preprod_artifact(project=project_b)
+        response = self._request({"projectSlug": [project_a.slug, project_b.slug]})
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_per_page_respected(self) -> None:
+        self.create_preprod_artifact()
+        self.create_preprod_artifact()
+        response = self._request({"per_page": 1})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_start_end_respected(self) -> None:
+        self.create_preprod_artifact(date_added=before_now(days=5))
+        middle = self.create_preprod_artifact(date_added=before_now(days=3))
+        self.create_preprod_artifact(date_added=before_now(days=1))
+
+        response = self._request({"start": before_now(days=4), "end": before_now(days=2)})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["id"] == str(middle.id)
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_invalid(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        response = self._request({"query": "no_such_key:foo"})
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid key for this search: no_such_key"}
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_app_id_equals(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "app_id:foo"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["app_info"]["app_id"] == "foo"
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_app_id_not_equals(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "!app_id:foo"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["app_info"]["app_id"] == "bar"
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_app_id_in(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "app_id:[baz,foo]"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["app_info"]["app_id"] == "foo"
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_app_id_in_is_list(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "app_id:[aaafooaaa]"})
+        assert response.status_code == 200
+        assert len(response.json()) == 0
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_package_name_is_app_id_alias(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "package_name:foo"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["app_info"]["app_id"] == "foo"
+
+    @with_feature("organizations:preprod-frontend-routes")
+    def test_query_bundle_id_is_app_id_alias(self) -> None:
+        self.create_preprod_artifact(app_id="foo")
+        self.create_preprod_artifact(app_id="bar")
+        response = self._request({"query": "bundle_id:foo"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["app_info"]["app_id"] == "foo"


### PR DESCRIPTION
This allows structured search over 'builds' (PreprodArtifacts). Start with
handling only `app_id` (and two aliases `package_name` for Android and `bundle_id` for iOS).
We can add more fields in follow ups. Long term hopefully this can replace both of the other
'list-build' endpoints however I don't want to break them while this is under construction.
