### PR TITLE
fix(taskworker): prevent taskworker from blocking tasks on stale cach…

### DIFF
--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -213,18 +213,20 @@ class ScheduleRunner:
             return 60
 
         while True:
+            # Peek at the top, and if it is due, pop, spawn and update last run time
             _, entry = self._heap[0]
             if entry.is_due():
                 heapq.heappop(self._heap)
                 try:
                     self._try_spawn(entry)
                 except Exception as e:
+                    # Trap errors from spawning/update state so that the heap stays consistent.
                     capture_exception(e)
                 heapq.heappush(self._heap, (entry.remaining_seconds(), entry))
                 continue
             else:
+                # The top of the heap isn't ready, break for sleep
                 break
-
         return self._heap[0][0]
 
     def _try_spawn(self, entry: ScheduleEntry) -> None:

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -213,19 +213,16 @@ class ScheduleRunner:
             return 60
 
         while True:
-            # Peek at the top, and if it is due, pop, spawn and update last run time
             _, entry = self._heap[0]
             if entry.is_due():
                 heapq.heappop(self._heap)
                 try:
                     self._try_spawn(entry)
                 except Exception as e:
-                    # Trap errors from spawning/update state so that the heap stays consistent.
                     capture_exception(e)
                 heapq.heappush(self._heap, (entry.remaining_seconds(), entry))
                 continue
             else:
-                # The top of the heap isn't ready, break for sleep
                 break
 
         return self._heap[0][0]
@@ -247,9 +244,8 @@ class ScheduleRunner:
                 sample_rate=1.0,
             )
         else:
-            # We were not able to set a key, load last run from storage.
             run_state = self._run_storage.read(entry.fullname)
-            entry.set_last_run(run_state)
+            entry.set_last_run(now)
 
             logger.info(
                 "taskworker.scheduler.sync_with_storage",

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -246,8 +246,12 @@ class ScheduleRunner:
                 sample_rate=1.0,
             )
         else:
-            run_state = self._run_storage.read(entry.fullname)
+            # We were not able to set a key, this could be because
+            # we are racing another scheduler instance, or a schedule
+            # was made more frequent. Advance to the present, so that
+            # we can align with the new schedule once the key expires.
             entry.set_last_run(now)
+            run_state = self._run_storage.read(entry.fullname)
 
             logger.info(
                 "taskworker.scheduler.sync_with_storage",


### PR DESCRIPTION
This PR fixes a bug in taskworkers that causes a stale redis lock to prevent all tasks with the same cron schedule from running. 
- When a task's schedule is shortened but an old Redis lock with a long TTL still existed, the scheduler enters a tight loop trying to spawn the "overdue" task, blocking all other tasks with the same schedule. Previously, syncing with a stale value made the scheduler think the task was hours overdue, causing remaining_seconds() to return 0. The task was pushed back onto the heap with `remaining=0`, keeping it at the top of the heap. Since is_due() also returned True (it recalculates from last_run), the while loop never broke, and other tasks never got a chance to be processed - the scheduler was in an infinite loop until the cache entry expired, and prevent all other tasks with the same schedule from running.
- When we can't acquire the lock, set `last_run = now` instead of the stale Redis value. By setting `last_run = now`, the scheduler correctly calculates the next scheduled time from the current moment, pushes the task back with a delay of the cron schedule and breaks the loop to allow other tasks to run.

Closes TET-1692