### PR TITLE
fix(search-bar): Use search context parseQuery function

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -142,15 +142,6 @@ export function SearchQueryBuilderProvider({
   const [displayAskSeerState, setDisplayAskSeerState] = useState(false);
   const displayAskSeer = enableAISearch ? displayAskSeerState : false;
 
-  const {state, dispatch} = useQueryBuilderState({
-    initialQuery,
-    getFieldDefinition: fieldDefinitionGetter,
-    disabled,
-    displayAskSeerFeedback,
-    setDisplayAskSeerFeedback,
-    replaceRawSearchKeys,
-  });
-
   const stableFieldDefinitionGetter = useMemo(
     () => fieldDefinitionGetter,
     [fieldDefinitionGetter]
@@ -189,6 +180,17 @@ export function SearchQueryBuilderProvider({
       filterKeyAliases,
     ]
   );
+
+  const {state, dispatch} = useQueryBuilderState({
+    initialQuery,
+    getFieldDefinition: fieldDefinitionGetter,
+    disabled,
+    displayAskSeerFeedback,
+    setDisplayAskSeerFeedback,
+    replaceRawSearchKeys,
+    parseQuery,
+  });
+
   const parsedQuery = useMemo(() => parseQuery(state.query), [parseQuery, state.query]);
 
   const previousQuery = usePrevious(state.query);

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,5 +1,7 @@
 import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
+import {FieldKind, type FieldDefinition} from 'sentry/utils/fields';
 
 import {replaceFreeTextTokens} from './useQueryBuilderState';
 
@@ -13,7 +15,6 @@ describe('replaceFreeTextTokens', () => {
       };
       input: {
         currentQuery: string;
-        getFieldDefinition: () => null;
         rawSearchReplacement: string[];
       };
     };
@@ -22,7 +23,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there are no tokens',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: '',
         },
@@ -34,7 +34,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the replace raw search keys is empty',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: [],
           currentQuery: '',
         },
@@ -46,7 +45,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the replace raw search keys is an empty string',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: [''],
           currentQuery: '',
         },
@@ -58,7 +56,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is no raw search replacement',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: [],
           currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
         },
@@ -70,7 +67,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there are no free text tokens',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
         },
@@ -82,7 +78,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there only valid action tokens',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: 'span.op:eq',
         },
@@ -94,7 +89,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there only space free text tokens in the action',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: 'span.op:eq    ',
         },
@@ -106,7 +100,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is one free text token',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: 'test',
         },
@@ -118,7 +111,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is one free text token that has a space',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: 'test test',
         },
@@ -130,7 +122,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a token present',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: 'span.op:eq test',
         },
@@ -142,7 +133,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a replace token present',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test test2`,
         },
@@ -154,7 +144,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a replace token present with a space',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test other value`,
         },
@@ -167,7 +156,6 @@ describe('replaceFreeTextTokens', () => {
         description:
           'when there is already a replace token present with a different operator',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `span.description:test other value`,
         },
@@ -179,7 +167,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the value contains an asterisks, it sets to is',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `span.description:test te*st`,
         },
@@ -191,7 +178,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the value contains a space and asterisks, it sets to is',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `te*st test`,
         },
@@ -204,7 +190,6 @@ describe('replaceFreeTextTokens', () => {
         description:
           'when the value contains multiple spaces, it removes them and will replace them with a single space, and apply fuzzy matching',
         input: {
-          getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `test  test`,
         },
@@ -213,12 +198,46 @@ describe('replaceFreeTextTokens', () => {
           focusOverride: {itemKey: 'freeText:1'},
         },
       },
+      {
+        description: 'when the value is an aggregate filter token, it ignores it',
+        input: {
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `p75(span.duration):>300ms test`,
+        },
+        expected: {
+          query: `p75(span.duration):>300ms span.description:${WildcardOperators.CONTAINS}test`,
+          focusOverride: {itemKey: 'freeText:2'},
+        },
+      },
     ];
 
     it.each(testCases)('$description', ({input, expected}) => {
       const result = replaceFreeTextTokens(
         input.currentQuery,
-        input.getFieldDefinition,
+        (query: string) =>
+          parseQueryBuilderValue(
+            query,
+            (key: string) => {
+              if (key === 'span.duration') {
+                return {
+                  desc: 'The total time taken by the span',
+                  kind: 'metric',
+                  valueType: 'duration',
+                } as FieldDefinition;
+              }
+              return null;
+            },
+            {
+              disallowUnsupportedFilters: true,
+              filterKeys: {
+                'span.duration': {
+                  key: 'span.duration',
+                  name: 'span.duration',
+                  kind: FieldKind.MEASUREMENT,
+                },
+              },
+            }
+          ),
         input.rawSearchReplacement
       );
 


### PR DESCRIPTION
Found an issue with the auto-replace search key functionality of the search query builder with aggregate functions. I made the move to utilize the `parseQuery` function that is setup in the query builder context. This also means that whenever we parse queries in the query builder state it will use that configured parser with all of the options passed through.

Ticket: EXP-649

Before:


https://github.com/user-attachments/assets/acfba46a-4678-4194-8492-ee6567e27a2e


After:

https://github.com/user-attachments/assets/751b4928-a78f-4876-868c-107a117a0431