### PR TITLE
feat(digests): Add Redis Cluster compatible backend

### DIFF
--- a/src/sentry/digests/backends/__init__.py
+++ b/src/sentry/digests/backends/__init__.py
@@ -1,0 +1,3 @@
+from sentry.digests.backends.redis import RedisBackend, RedisClusterBackend
+
+__all__ = ["RedisBackend", "RedisClusterBackend"]

--- a/src/sentry/scripts/digests/digests_cluster.lua
+++ b/src/sentry/scripts/digests/digests_cluster.lua
@@ -1,0 +1,459 @@
+-- Utilities
+
+local noop = function ()
+    return
+end
+
+local function identity(...)
+    return ...
+end
+
+local function table_extend(t, items, length)
+    -- The table length can be provided if you know the length of the table
+    -- beforehand to avoid a potentially expensive length operator call.
+    if length == nil then
+        length = #t
+    end
+    for i, item in ipairs(items) do
+        t[length + i] = item
+    end
+end
+
+local function chunked(size, iterator, state, ...)
+    local next = {iterator(state, ...)}
+    local chunk_count = 1
+
+    return function ()
+        local item_count = 0
+        if #next == 0 then
+            return nil
+        end
+
+        return chunk_count, function ()
+            if item_count == size or #next == 0 then
+                chunk_count = chunk_count + 1
+                return nil
+            end
+
+            local result = next
+            next = {iterator(state, result[1])}
+
+            item_count = item_count + 1
+            return item_count, unpack(result)
+        end
+    end
+end
+
+
+-- Argument Parsing
+
+local function argument_parser(callback)
+    if callback == nil then
+        callback = identity
+    end
+
+    return function (cursor, arguments)
+        return cursor + 1, callback(arguments[cursor])
+    end
+end
+
+local function object_argument_parser(schema, callback)
+    if callback == nil then
+        callback = identity
+    end
+
+    return function (cursor, arguments)
+        local result = {}
+        for i, specification in ipairs(schema) do
+            local key, parser = unpack(specification)
+            cursor, result[key] = parser(cursor, arguments)
+        end
+        return cursor, callback(result)
+    end
+end
+
+local function variadic_argument_parser(argument_parser)
+    return function (cursor, arguments)
+        local results = {}
+        local i = 1
+        while arguments[cursor] ~= nil do
+            cursor, results[i] = argument_parser(cursor, arguments)
+            i = i + 1
+        end
+        return cursor, results
+    end
+end
+
+local function multiple_argument_parser(...)
+    local parsers = {...}
+    return function (cursor, arguments)
+        local results = {}
+        for i, parser in ipairs(parsers) do
+            cursor, results[i] = parser(cursor, arguments)
+        end
+        return cursor, unpack(results)
+    end
+end
+
+
+-- Redis Helpers
+
+local function zrange_scored_iterator(result)
+    local i = -1
+    return function ()
+        i = i + 2
+        return result[i], result[i+1]
+    end
+end
+
+local function zrange_move_slice(source, destination, threshold, callback)
+    local callback = callback
+    if callback == nil then
+        callback = noop
+    end
+
+    local keys = redis.call('ZRANGEBYSCORE', source, 0, threshold, 'WITHSCORES')
+    if #keys == 0 then
+        return
+    end
+
+    -- NOTE: The actual number of arguments is the chunk size * 2, since the
+    -- ZADD command takes two arguments per item.
+    for _, chunk_iterator in chunked(500, zrange_scored_iterator(keys)) do
+        local zadd_args = {}
+        local zrem_args = {}
+        for i, key, score in chunk_iterator do
+            table_extend(zadd_args, {score, key}, (i - 1) * 2)
+            zrem_args[i] = key
+            callback(key, score)
+        end
+
+        -- TODO: This should support modifiers, and maintenance ZADD should
+        -- include the "NX" modifier to avoid resetting schedules during a race
+        -- conditions between a digest task and the maintenance task.
+        redis.call('ZADD', destination, unpack(zadd_args))
+        redis.call('ZREM', source, unpack(zrem_args))
+    end
+end
+
+local function zset_trim(key, capacity, callback)
+    local callback = callback
+    if callback == nil then
+        callback = noop
+    end
+
+    local n = 0
+
+    -- ZCARD is O(1) while ZREVRANGE is O(log(N)+M) so as long as the set is
+    -- generally smaller than the limit (which seems like a safe assumption)
+    -- then its cheaper just to check here and exit if there's nothing to do.
+    if redis.call('ZCARD', key) <= capacity then
+        return n
+    end
+
+    local items = redis.call('ZREVRANGE', key, capacity, -1)
+    for _, item in ipairs(items) do
+        redis.call('ZREM', key, item)
+        callback(item)
+        n = n + 1
+    end
+
+    return n
+end
+
+
+-- Timeline and Schedule Operations
+
+local function schedule(configuration, deadline)
+    local response = {}
+    local i = 0
+    zrange_move_slice(
+        configuration:get_schedule_waiting_key(),
+        configuration:get_schedule_ready_key(),
+        deadline,
+        function (timeline_id, timestamp)
+            i = i + 1
+            response[i] = {timeline_id, timestamp}
+        end
+    )
+    return response
+end
+
+local function maintenance(configuration, deadline)
+    zrange_move_slice(
+        configuration:get_schedule_ready_key(),
+        configuration:get_schedule_waiting_key(),
+        deadline
+    )
+end
+
+local function add_timeline_to_schedule(configuration, timeline_id, timestamp, increment, maximum)
+    -- If the timeline is already in the "ready" set, this is a noop.
+    if redis.call('ZSCORE', configuration:get_schedule_ready_key(), timeline_id) ~= false then
+        return false
+    end
+
+    local score = redis.call('ZSCORE', configuration:get_schedule_waiting_key(), timeline_id)
+    if score == false then
+        -- If the timeline isn't already in either set, add it to the "ready" set with
+        -- the provided timestamp. This allows for immediate scheduling, bypassing the
+        -- imposed delay of the "waiting" state. (This should also be ZADD NX, but
+        -- like above, this allows us to still work with older Redis.)
+        redis.call('ZADD', configuration:get_schedule_ready_key(), timestamp, timeline_id)
+        return true
+    end
+
+    -- If the timeline is already in the "waiting" set, increase the delay by
+    -- min(current schedule + increment value, maximum delay after last
+    -- processing time).
+    local last_processed = tonumber(redis.call('GET', configuration:get_timeline_last_processed_timestamp_key(timeline_id)))
+    local update = nil
+    if last_processed == nil then
+        -- If the last processed timestamp is missing for some reason (possibly
+        -- evicted), be conservative and allow the timeline to be scheduled
+        -- with either the current schedule time or provided timestamp,
+        -- whichever is smaller.
+        update = math.min(score, timestamp)
+    else
+        update = math.min(
+            score + increment,
+            last_processed + maximum
+        )
+    end
+
+    if update ~= score then
+        -- This should technically be ZADD XX for correctness (this item
+        -- should always exist, and we established that above) but not
+        -- using that here doesn't break anything and allows use to use
+        -- older Redis versions.
+        redis.call('ZADD', configuration:get_schedule_waiting_key(), update, timeline_id)
+    end
+
+    return false
+end
+
+local function truncate_timeline(configuration, timeline_id, capacity)
+    return zset_trim(
+        configuration:get_timeline_key(timeline_id),
+        capacity,
+        function (record_id)
+            redis.call('DEL', configuration:get_timeline_record_key(timeline_id, record_id))
+        end
+    )
+end
+
+local function truncate_digest(configuration, timeline_id, capacity)
+    return zset_trim(
+        configuration:get_timeline_digest_key(timeline_id),
+        capacity,
+        function (record_id)
+            redis.call('DEL', configuration:get_timeline_record_key(timeline_id, record_id))
+        end
+    )
+end
+
+local function add_record_to_timeline(configuration, timeline_id, record_id, value, timestamp, delay_increment, delay_maximum, timeline_capacity, truncation_chance)
+    redis.call('SETEX', configuration:get_timeline_record_key(timeline_id, record_id), configuration.ttl, value)
+    redis.call('ZADD', configuration:get_timeline_key(timeline_id), timestamp, record_id)
+    redis.call('EXPIRE', configuration:get_timeline_key(timeline_id), configuration.ttl)
+
+    local ready = add_timeline_to_schedule(configuration, timeline_id, timestamp, delay_increment, delay_maximum)
+
+    if timeline_capacity > 0 and math.random() < truncation_chance then
+        truncate_timeline(configuration, timeline_id, timeline_capacity)
+    end
+
+    return ready
+end
+
+local function digest_timeline(configuration, timeline_id, timeline_capacity)
+    -- Check to ensure that the timeline is in the correct state.
+    if redis.call('ZSCORE', configuration:get_schedule_ready_key(), timeline_id) == false then
+        error('err(invalid_state): timeline is not in the ready state, cannot be digested')
+    end
+
+    local digest_key = configuration:get_timeline_digest_key(timeline_id)
+    local timeline_key = configuration:get_timeline_key(timeline_id)
+    if redis.call('EXISTS', timeline_key) == 1 then
+        if redis.call('EXISTS', digest_key) == 1 then
+            -- If the digest set already exists (possibly because we already tried
+            -- to send it and failed for some reason), merge any new data into it.
+            redis.call('ZUNIONSTORE', digest_key, 2, timeline_key, digest_key, 'AGGREGATE', 'MAX')
+            redis.call('DEL', timeline_key)
+
+            -- After merging, we have to do a capacity check (if we didn't,
+            -- it's possible that this digest could grow to an unbounded size
+            -- if it is never actually closed.)
+            if timeline_capacity > 0 then
+                truncate_digest(configuration, timeline_id, timeline_capacity)
+            end
+        else
+            -- Otherwise, we can just move the timeline contents to the digest key.
+            redis.call('RENAME', timeline_key, digest_key)
+        end
+        redis.call('EXPIRE', digest_key, configuration.ttl)
+    end
+
+    local results = {}
+    local records = redis.call('ZREVRANGE', digest_key, 0, -1, 'WITHSCORES')
+    local i = 0
+    for key, score in zrange_scored_iterator(records) do
+        i = i + 1
+        results[i] = {
+            key,
+            redis.call('GET', configuration:get_timeline_record_key(timeline_id, key)),
+            score
+        }
+    end
+
+    return results
+end
+
+local function close_digest(configuration, timeline_id, delay_minimum, record_ids)
+    local timeline_key = configuration:get_timeline_key(timeline_id)
+    local digest_key = configuration:get_timeline_digest_key(timeline_id)
+
+    for _, chunk_iterator in chunked(1000, ipairs(record_ids)) do
+        local record_id_chunk = {}
+        local record_key_chunk = {}
+        for i, _, record_id in chunk_iterator do
+            record_id_chunk[i] = record_id
+            record_key_chunk[i] = configuration:get_timeline_record_key(timeline_id, record_id)
+        end
+        redis.call('ZREM', digest_key, unpack(record_id_chunk))
+        redis.call('DEL', unpack(record_key_chunk))
+    end
+
+    -- If this digest didn't contain any data (no record IDs) and there isn't
+    -- any data left in the timeline or digest sets, we can safely remove this
+    -- timeline reference from all schedule sets.
+    if #record_ids > 0 or redis.call('ZCARD', timeline_key) > 0 or redis.call('ZCARD', digest_key) > 0 then
+        redis.call('SETEX', configuration:get_timeline_last_processed_timestamp_key(timeline_id), configuration.ttl, configuration.timestamp)
+        redis.call('ZREM', configuration:get_schedule_ready_key(), timeline_id)
+        redis.call('ZADD', configuration:get_schedule_waiting_key(), configuration.timestamp + delay_minimum, timeline_id)
+    else
+        redis.call('DEL', configuration:get_timeline_last_processed_timestamp_key(timeline_id))
+        redis.call('ZREM', configuration:get_schedule_ready_key(), timeline_id)
+        redis.call('ZREM', configuration:get_schedule_waiting_key(), timeline_id)
+    end
+end
+
+local function delete_timeline(configuration, timeline_id)
+    truncate_timeline(configuration, timeline_id, 0)
+    truncate_digest(configuration, timeline_id, 0)
+    redis.call('DEL', configuration:get_timeline_last_processed_timestamp_key(timeline_id))
+    redis.call('ZREM', configuration:get_schedule_ready_key(), timeline_id)
+    redis.call('ZREM', configuration:get_schedule_waiting_key(), timeline_id)
+end
+
+
+-- Command Execution
+
+local configuration_argument_parser = object_argument_parser({
+    {"namespace", argument_parser()},
+    {"ttl", argument_parser(tonumber)},
+    {"timestamp", argument_parser(tonumber)},
+}, function (configuration)
+    math.randomseed(math.floor(configuration.timestamp))
+
+    function configuration:get_schedule_waiting_key()
+        return string.format('%s:s:w', self.namespace)
+    end
+
+    function configuration:get_schedule_ready_key()
+        return string.format('%s:s:r', self.namespace)
+    end
+
+    function configuration:get_timeline_key(timeline_id)
+        return string.format('%s:t:{%s}', self.namespace, timeline_id)
+    end
+
+    function configuration:get_timeline_digest_key(timeline_id)
+        return string.format('%s:t:{%s}:d', self.namespace, timeline_id)
+    end
+
+    function configuration:get_timeline_last_processed_timestamp_key(timeline_id)
+        return string.format('%s:t:{%s}:l', self.namespace, timeline_id)
+    end
+
+    function configuration:get_timeline_record_key(timeline_id, record_id)
+        return string.format('%s:t:{%s}:r:%s', self.namespace, timeline_id, record_id)
+    end
+
+    return configuration
+end)
+
+local commands = {
+    SCHEDULE = function (cursor, arguments)
+        local cursor, configuration, deadline = multiple_argument_parser(
+            configuration_argument_parser,
+            argument_parser(tonumber)
+        )(cursor, arguments)
+        return schedule(configuration, deadline)
+    end,
+    MAINTENANCE = function (cursor, arguments)
+        local cursor, configuration, deadline = multiple_argument_parser(
+            configuration_argument_parser,
+            argument_parser(tonumber)
+        )(cursor, arguments)
+        return maintenance(configuration, deadline)
+    end,
+    ADD = function (cursor, arguments)
+        local cursor, configuration, arguments = multiple_argument_parser(
+            configuration_argument_parser,
+            object_argument_parser({
+                {"timeline_id", argument_parser()},
+                {"record_id", argument_parser()},
+                {"value", argument_parser()},
+                {"timestamp", argument_parser(tonumber)},
+                {"delay_increment", argument_parser(tonumber)},
+                {"delay_maximum", argument_parser(tonumber)},
+                {"timeline_capacity", argument_parser(tonumber)},
+                {"truncation_chance", argument_parser(tonumber)},
+            })
+        )(cursor, arguments)
+        return add_record_to_timeline(
+            configuration,
+            arguments.timeline_id,
+            arguments.record_id,
+            arguments.value,
+            arguments.timestamp,
+            arguments.delay_increment,
+            arguments.delay_maximum,
+            arguments.timeline_capacity,
+            arguments.truncation_chance
+        )
+    end,
+    DELETE = function (cursor, arguments)
+        local cursor, configuration, timeline_id = multiple_argument_parser(
+            configuration_argument_parser,
+            argument_parser()
+        )(cursor, arguments)
+        return delete_timeline(configuration, timeline_id)
+    end,
+    DIGEST_OPEN = function (cursor, arguments)
+        local cursor, configuration, timeline_id, timeline_capacity = multiple_argument_parser(
+            configuration_argument_parser,
+            argument_parser(),
+            argument_parser(tonumber)
+        )(cursor, arguments)
+        return digest_timeline(configuration, timeline_id, timeline_capacity)
+    end,
+    DIGEST_CLOSE = function (cursor, arguments)
+        local cursor, configuration, timeline_id, delay_minimum, record_ids = multiple_argument_parser(
+            configuration_argument_parser,
+            argument_parser(),
+            argument_parser(tonumber),
+            variadic_argument_parser(argument_parser())
+        )(cursor, arguments)
+        return close_digest(configuration, timeline_id, delay_minimum, record_ids)
+    end,
+}
+
+local cursor, command = argument_parser(
+    function (argument)
+        return commands[argument]
+    end
+)(1, ARGV)
+
+return command(cursor, ARGV)

--- a/tests/sentry/digests/backends/test_redis_cluster.py
+++ b/tests/sentry/digests/backends/test_redis_cluster.py
@@ -1,0 +1,269 @@
+import time
+import uuid
+from functools import cached_property
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sentry.digests.backends.base import InvalidState
+from sentry.digests.backends.redis import RedisClusterBackend
+from sentry.digests.types import Notification, Record
+from sentry.models.project import Project
+from sentry.testutils.cases import TestCase
+
+
+class RedisClusterBackendTestCase(TestCase):
+    @cached_property
+    def project(self) -> Project:
+        return self.create_project(fire_project_created=True)
+
+    @cached_property
+    def notification(self) -> Notification:
+        rule = self.event.project.rule_set.all()[0]
+        return Notification(self.event, (rule.id,), str(uuid.uuid4()))
+
+    def test_basic(self) -> None:
+        backend = RedisClusterBackend()
+
+        # The first item should return "true", indicating that this timeline
+        # can be immediately dispatched to be digested.
+        record_1 = Record("record:1", self.notification, time.time())
+        assert backend.add("timeline", record_1) is True
+
+        # The second item should return "false", since it's ready to be
+        # digested but dispatching again would cause it to be sent twice.
+        record_2 = Record("record:2", self.notification, time.time())
+        assert backend.add("timeline", record_2) is False
+
+        # There's nothing to move between sets, so scheduling should return nothing.
+        assert set(backend.schedule(time.time())) == set()
+
+        with backend.digest("timeline", 0) as records:
+            assert {record.key for record in records} == {record_1.key, record_2.key}
+
+        # The schedule should now contain the timeline.
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
+
+        # We didn't add any new records so there's nothing to do here.
+        with backend.digest("timeline", 0) as records:
+            assert not records
+
+        # There's nothing to move between sets since the timeline contents no
+        # longer exist at this point.
+        assert set(backend.schedule(time.time())) == set()
+
+    def test_truncation(self) -> None:
+        backend = RedisClusterBackend(capacity=2, truncation_chance=1.0)
+
+        records = [Record(f"record:{i}", self.notification, time.time()) for i in range(4)]
+        for record in records:
+            backend.add("timeline", record)
+
+        with backend.digest("timeline", 0) as records:
+            assert {record.key for record in records} == {"record:2", "record:3"}
+
+    def test_maintenance_failure_recovery(self) -> None:
+        backend = RedisClusterBackend()
+
+        record_1 = Record("record:1", self.notification, time.time())
+        backend.add("timeline", record_1)
+
+        try:
+            with backend.digest("timeline", 0) as records:
+                raise Exception("This causes the digest to not be closed.")
+        except Exception:
+            pass
+
+        # Maintenance should move the timeline back to the waiting state, ...
+        backend.maintenance(time.time())
+
+        # ...and you can't send a digest in the waiting state.
+        with pytest.raises(InvalidState):
+            with backend.digest("timeline", 0):
+                raise AssertionError("unreachable")
+
+        record_2 = Record("record:2", self.notification, time.time())
+        backend.add("timeline", record_2)
+
+        # The schedule should now contain the timeline.
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
+
+        # The existing and new record should be there because the timeline
+        # contents were merged back into the digest.
+        with backend.digest("timeline", 0) as records:
+            assert {record.key for record in records} == {"record:1", "record:2"}
+
+    def test_maintenance_failure_recovery_with_capacity(self) -> None:
+        backend = RedisClusterBackend(capacity=10, truncation_chance=0.0)
+
+        t = time.time()
+
+        # Add 10 items to the timeline.
+        for i in range(10):
+            backend.add("timeline", Record(f"record:{i}", self.notification, t + i))
+
+        try:
+            with backend.digest("timeline", 0) as records:
+                raise Exception("This causes the digest to not be closed.")
+        except Exception:
+            pass
+
+        # The 10 existing items should now be in the digest set (the exception
+        # prevented the close operation from occurring, so they were never
+        # deleted from Redis or removed from the digest set.) If we add 10 more
+        # items, they should be added to the timeline set (not the digest set.)
+        for i in range(10, 20):
+            backend.add("timeline", Record(f"record:{i}", self.notification, t + i))
+
+        # Maintenance should move the timeline back to the waiting state, ...
+        backend.maintenance(time.time())
+
+        # The schedule should now contain the timeline.
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
+
+        # Only the new records should exist -- the older one should have been
+        # trimmed to avoid the digest growing beyond the timeline capacity.
+        with backend.digest("timeline", 0) as records:
+            expected_keys = {f"record:{i}" for i in range(10, 20)}
+            assert {record.key for record in records} == expected_keys
+
+    def test_delete(self) -> None:
+        backend = RedisClusterBackend()
+        backend.add("timeline", Record("record:1", self.notification, time.time()))
+        backend.delete("timeline")
+
+        with pytest.raises(InvalidState):
+            with backend.digest("timeline", 0):
+                raise AssertionError("unreachable")
+
+        assert set(backend.schedule(time.time())) == set()
+
+        # Verify keys are deleted (using hash tag format)
+        # Note: Keys should be cleaned up by the delete operation
+        keys = backend.cluster.keys("d:t:{timeline}*")
+        assert len(keys) == 0
+
+    def test_missing_record_contents(self) -> None:
+        backend = RedisClusterBackend()
+
+        record_1 = Record("record:1", self.notification, time.time())
+        backend.add("timeline", record_1)
+
+        # Delete the record data directly (simulating eviction)
+        # Note: Using hash tag format for Redis Cluster
+        backend.cluster.delete("d:t:{timeline}:r:record:1")
+
+        record_2 = Record("record:2", self.notification, time.time())
+        backend.add("timeline", record_2)
+
+        # Only the record that still has data should be returned
+        with backend.digest("timeline", 0) as records:
+            assert {record.key for record in records} == {"record:2"}
+
+    def test_large_digest(self) -> None:
+        backend = RedisClusterBackend()
+
+        n = 8192
+        t = time.time()
+        for i in range(n):
+            backend.add("timeline", Record(f"record:{i}", self.notification, t))
+
+        with backend.digest("timeline", 0) as records:
+            assert len(records) == n
+
+    def test_hash_tag_key_routing(self) -> None:
+        timeline_id = "test-timeline"
+
+        timeline_key = f"d:t:{{{timeline_id}}}"
+        digest_key = f"d:t:{{{timeline_id}}}:d"
+        record_key = f"d:t:{{{timeline_id}}}:r:record1"
+        last_processed_key = f"d:t:{{{timeline_id}}}:l"
+
+        assert "{test-timeline}" in timeline_key
+        assert "{test-timeline}" in digest_key
+        assert "{test-timeline}" in record_key
+        assert "{test-timeline}" in last_processed_key
+
+    def test_schedule_single_operation(self) -> None:
+        backend = RedisClusterBackend()
+
+        record = Record("record:1", self.notification, time.time())
+        backend.add("timeline", record)
+
+        with backend.digest("timeline", 0):
+            pass
+
+        entries = list(backend.schedule(time.time()))
+        assert len(entries) == 1
+        assert entries[0].key == "timeline"
+
+    def test_cluster_lock_routing(self) -> None:
+        backend = RedisClusterBackend()
+
+        timeline_key = "test-timeline"
+        lock = backend._get_timeline_lock(timeline_key, duration=30)
+
+        expected_lock_key = f"d:t:{{{timeline_key}}}"
+        assert expected_lock_key in str(lock)
+
+    def test_multiple_timelines(self) -> None:
+        backend = RedisClusterBackend()
+
+        record_1a = Record("record:1a", self.notification, time.time())
+        backend.add("timeline1", record_1a)
+
+        record_2a = Record("record:2a", self.notification, time.time())
+        backend.add("timeline2", record_2a)
+
+        assert set(backend.schedule(time.time())) == set()
+
+        with backend.digest("timeline1", 0) as records:
+            assert {record.key for record in records} == {"record:1a"}
+
+        with backend.digest("timeline2", 0) as records:
+            assert {record.key for record in records} == {"record:2a"}
+
+    def test_concurrent_add_operations(self) -> None:
+        backend = RedisClusterBackend()
+
+        t = time.time()
+
+        record_1 = Record("record:1", self.notification, t)
+        assert backend.add("timeline", record_1) is True
+
+        for i in range(2, 10):
+            record = Record(f"record:{i}", self.notification, t + i)
+            assert backend.add("timeline", record) is False
+
+        with backend.digest("timeline", 0) as records:
+            assert len(records) == 9
+
+    def test_validate_cluster_connectivity(self) -> None:
+        backend = RedisClusterBackend()
+        backend.validate()
+
+    def test_validate_cluster_failure(self) -> None:
+        with patch("sentry.utils.redis.redis_clusters.get_binary") as mock_get_cluster:
+            mock_cluster = Mock()
+            mock_cluster.ping.side_effect = Exception("Connection failed")
+            mock_get_cluster.return_value = mock_cluster
+
+            backend = RedisClusterBackend()
+
+            with pytest.raises(Exception):
+                backend.validate()
+
+    def test_digest_invalid_state(self) -> None:
+        backend = RedisClusterBackend()
+
+        record = Record("record:1", self.notification, time.time())
+        backend.add("timeline", record)
+
+        # First digest should work
+        with backend.digest("timeline", 0):
+            pass
+
+        # Timeline is now in waiting state, should raise InvalidState
+        with pytest.raises(InvalidState):
+            with backend.digest("timeline", 0):
+                raise AssertionError("unreachable")


### PR DESCRIPTION
Add RedisClusterBackend to support Redis Cluster deployments alongside the existing RedisBackend.

The current RedisBackend uses rb.Cluster with consistent hashing, which works well for single-node or master-replica Redis setups but is incompatible with Redis Cluster's slot-based sharding. Redis Cluster requires multi-key operations (like ZUNIONSTORE and RENAME) to operate on keys in the same hash slot, which the current implementation cannot guarantee.

This PR introduces RedisClusterBackend that uses hash tags `{timeline_id}` in key formats (e.g., `d:t:{timeline_id}` instead of `d:t:timeline_id`) to ensure all timeline-related keys route to the same slot. This enables atomic multi-key operations while maintaining the same digest functionality.

Key changes:
- New RedisClusterBackend class using redis_clusters client
- Cluster-compatible Lua script (digests_cluster.lua) with hash-tagged keys
- Simplified schedule/maintenance operations (single global operation vs. per-host iteration)
- Comprehensive test suite with 15 tests covering all operations

The new backend is designed to be used via configuration without requiring code changes to existing digest consumers.