### PR TITLE
ref(preprod): Migrate preprod routes to /explore/build/ (EME-725)

### DIFF
--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -7,12 +7,14 @@ from sentry.preprod.models import PreprodArtifact
 def get_preprod_artifact_url(preprod_artifact: PreprodArtifact) -> str:
     """
     Build a region/customer-domain aware absolute URL for the preprod artifact UI.
+
+    New URL format: /organizations/{org}/explore/build/{artifact_id}/size/?project={project}
     """
     organization: Organization = Organization.objects.get_from_cache(
         id=preprod_artifact.project.organization_id
     )
 
-    path = f"/organizations/{organization.slug}/preprod/{preprod_artifact.project.slug}/{preprod_artifact.id}"
+    path = f"/organizations/{organization.slug}/explore/build/{preprod_artifact.id}/size/?project={preprod_artifact.project.slug}"
     return organization.absolute_url(path)
 
 
@@ -21,9 +23,11 @@ def get_preprod_artifact_comparison_url(
 ) -> str:
     """
     Build a region/customer-domain aware absolute URL for the preprod artifact comparison UI.
+
+    New URL format: /organizations/{org}/explore/build/compare/{head_id}/{base_id}/?project={project}
     """
     organization: Organization = Organization.objects.get_from_cache(
         id=preprod_artifact.project.organization_id
     )
-    path = f"/organizations/{organization.slug}/preprod/{preprod_artifact.project.slug}/compare/{preprod_artifact.id}/{base_artifact.id}"
+    path = f"/organizations/{organization.slug}/explore/build/compare/{preprod_artifact.id}/{base_artifact.id}?project={preprod_artifact.project.slug}"
     return organization.absolute_url(path)

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -7,6 +7,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getBuildInstallUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 import {
   FullRowLink,
@@ -32,7 +33,12 @@ export function PreprodBuildsDistributionTable({
   showProjectColumn,
 }: PreprodBuildsDistributionTableProps) {
   const rows = builds.map(build => {
-    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`;
+    const linkUrl =
+      getBuildInstallUrl({
+        organizationSlug,
+        projectId: build.project_id,
+        baseArtifactId: build.id,
+      }) ?? '';
     const isInstallable = build.distribution_info?.is_installable ?? false;
     const isRowDisabled = !isInstallable;
     const downloadCount = build.distribution_info?.download_count ?? 0;

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -9,6 +9,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconQuestion} from 'sentry/icons';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getBuildSizeUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -41,7 +42,12 @@ export function PreprodBuildsSizeTable({
   showProjectColumn,
 }: PreprodBuildsSizeTableProps) {
   const rows = builds.map(build => {
-    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
+    const linkUrl =
+      getBuildSizeUrl({
+        organizationSlug,
+        projectId: build.project_id,
+        baseArtifactId: build.id,
+      }) ?? '';
     return (
       <SimpleTable.Row key={build.id}>
         <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2382,6 +2382,51 @@ function buildRoutes(): RouteObject[] {
     children: profilingChildren,
   };
 
+  const buildChildren: SentryRouteObject[] = [
+    {
+      index: true,
+      component: make(() => import('sentry/views/preprod/buildList/buildList')),
+    },
+    {
+      path: ':artifactId/',
+      children: [
+        {
+          index: true,
+          component: errorHandler(RouteNotFound),
+        },
+        {
+          path: 'size/',
+          component: make(() => import('sentry/views/preprod/buildDetails/buildDetails')),
+        },
+        {
+          path: 'install/',
+          component: make(() => import('sentry/views/preprod/install/installPage')),
+        },
+      ],
+    },
+    {
+      path: 'compare/',
+      children: [
+        {
+          index: true,
+          component: errorHandler(RouteNotFound),
+        },
+        {
+          path: ':headArtifactId/',
+          component: make(
+            () => import('sentry/views/preprod/buildComparison/buildComparison')
+          ),
+        },
+        {
+          path: ':headArtifactId/:baseArtifactId/',
+          component: make(
+            () => import('sentry/views/preprod/buildComparison/buildComparison')
+          ),
+        },
+      ],
+    },
+  ];
+
   const exploreChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2425,6 +2470,11 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
+    },
+    {
+      path: 'build/',
+      component: make(() => import('sentry/views/preprod/index')),
+      children: buildChildren,
     },
   ];
   const exploreRoutes: SentryRouteObject = {
@@ -2486,48 +2536,6 @@ function buildRoutes(): RouteObject[] {
     withOrgPath: true,
     component: make(() => import('sentry/views/prevent/index')),
     children: codecovChildren,
-  };
-
-  const preprodChildren: SentryRouteObject[] = [
-    {
-      index: true,
-      component: make(() => import('sentry/views/preprod/buildList/buildList')),
-    },
-    {
-      path: ':artifactId/',
-      component: make(() => import('sentry/views/preprod/buildDetails/buildDetails')),
-    },
-    {
-      path: ':artifactId/install/',
-      component: make(() => import('sentry/views/preprod/install/installPage')),
-    },
-    {
-      path: 'compare/',
-      children: [
-        {
-          index: true,
-          component: errorHandler(RouteNotFound),
-        },
-        {
-          path: ':headArtifactId/',
-          component: make(
-            () => import('sentry/views/preprod/buildComparison/buildComparison')
-          ),
-        },
-        {
-          path: ':headArtifactId/:baseArtifactId/',
-          component: make(
-            () => import('sentry/views/preprod/buildComparison/buildComparison')
-          ),
-        },
-      ],
-    },
-  ];
-  const preprodRoutes: SentryRouteObject = {
-    path: '/preprod/:projectId/',
-    component: make(() => import('sentry/views/preprod/index')),
-    withOrgPath: true,
-    children: preprodChildren,
   };
 
   const pullRequestChildren: SentryRouteObject[] = [
@@ -2904,7 +2912,6 @@ function buildRoutes(): RouteObject[] {
       alertRoutes,
       monitorRoutes,
       preventRoutes,
-      preprodRoutes,
       pullRequestRoutes,
       replayRoutes,
       releasesRoutes,

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -8,7 +8,9 @@ import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildCompareHeaderContent';
@@ -23,12 +25,12 @@ export default function BuildComparison() {
     headArtifactId: string;
     // eslint-disable-next-line typescript-sort-keys/interface
     baseArtifactId: string | undefined;
-    projectId: string;
   }>();
 
   const headArtifactId = params.headArtifactId;
   const baseArtifactId = params.baseArtifactId;
-  const projectId = params.projectId;
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
 
   const headBuildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
@@ -40,6 +42,16 @@ export default function BuildComparison() {
         enabled: !!projectId && !!headArtifactId,
       }
     );
+
+  if (!projectId) {
+    return (
+      <Layout.Page>
+        <Alert type="error" showIcon>
+          {t('Project parameter required')}
+        </Alert>
+      </Layout.Page>
+    );
+  }
 
   if (headBuildDetailsQuery.isLoading) {
     return (

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -10,9 +10,11 @@ import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getBuildSizeUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface BuildButtonProps {
   buildDetails: BuildDetailsApiResponse;
@@ -32,7 +34,8 @@ function BuildButton({
   projectType,
 }: BuildButtonProps) {
   const organization = useOrganization();
-  const {projectId} = useParams<{projectId: string}>();
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
   const sha = buildDetails.vcs_info?.head_sha?.substring(0, 7);
   const branchName = buildDetails.vcs_info?.head_ref;
   const buildId = buildDetails.id;
@@ -41,7 +44,11 @@ function BuildButton({
   const dateBuilt = buildDetails.app_info?.date_built;
   const dateAdded = buildDetails.app_info?.date_added;
 
-  const buildUrl = `/organizations/${organization.slug}/preprod/${projectId}/${buildId}/`;
+  const buildUrl = getBuildSizeUrl({
+    organizationSlug: organization.slug,
+    projectId,
+    baseArtifactId: buildId,
+  });
   const platform = buildDetails.app_info?.platform ?? null;
 
   const dateToShow = dateBuilt || dateAdded;
@@ -194,9 +201,10 @@ export function SizeCompareSelectedBuilds({
   onTriggerComparison,
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
-  const {projectId} = useParams<{projectId: string}>();
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
   const platform = headBuildDetails.app_info?.platform ?? null;
-  const project = ProjectsStore.getBySlug(projectId);
+  const project = projectId ? ProjectsStore.getBySlug(projectId) : null;
   const projectType = project?.platform ?? null;
 
   return (

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -2,6 +2,7 @@ import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
@@ -12,8 +13,10 @@ import {
   useMutation,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
@@ -29,9 +32,10 @@ import {BuildDetailsSidebarContent} from './sidebar/buildDetailsSidebarContent';
 
 export default function BuildDetails() {
   const organization = useOrganization();
-  const params = useParams<{artifactId: string; projectId: string}>();
+  const params = useParams<{artifactId: string}>();
   const artifactId = params.artifactId;
-  const projectId = params.projectId;
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
 
   const buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
@@ -92,6 +96,16 @@ export default function BuildDetails() {
       addErrorMessage(t('Error: %s', error.message));
     },
   });
+
+  if (!projectId) {
+    return (
+      <Layout.Page>
+        <Alert type="error" showIcon>
+          {t('Project parameter required')}
+        </Alert>
+      </Layout.Page>
+    );
+  }
 
   const buildDetails = buildDetailsQuery.data;
   const version = buildDetails?.app_info?.version;

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -33,6 +33,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 import {useBuildDetailsActions} from './useBuildDetailsActions';
@@ -165,7 +166,11 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             }}
           />
           <Link
-            to={`/organizations/${organization.slug}/preprod/${projectId}/compare/${buildDetailsData.id}/`}
+            to={getBuildCompareUrl({
+              organizationSlug: organization.slug,
+              projectId,
+              headArtifactId: buildDetailsData.id,
+            })}
             onClick={handleCompareClick}
           >
             <Button size="sm" priority="default" icon={<IconTelescope />}>

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getBuildListUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
@@ -49,7 +50,12 @@ export function useBuildDetailsActions({
     onSuccess: () => {
       addSuccessMessage(t('Build deleted successfully'));
       // TODO(preprod): navigate back to the release page once built?
-      navigate(`/organizations/${organization.slug}/preprod/${projectId}/`);
+      navigate(
+        getBuildListUrl({
+          organizationSlug: organization.slug,
+          projectId,
+        })
+      );
     },
     onError: () => {
       addErrorMessage(t('Failed to delete build'));

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -25,6 +25,7 @@ import type {
   BuildDetailsSizeInfoSizeMetric,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -115,7 +116,12 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   // Build comparison URL using route params
   const comparisonUrl =
     baseArtifactId && projectId && artifactId
-      ? `/organizations/${organization.slug}/preprod/${projectId}/compare/${artifactId}/${baseArtifactId}/`
+      ? getBuildCompareUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId: artifactId,
+          baseArtifactId,
+        })
       : undefined;
 
   const totalPotentialSavings = processedInsights.reduce(

--- a/static/app/views/preprod/buildList/buildList.tsx
+++ b/static/app/views/preprod/buildList/buildList.tsx
@@ -1,6 +1,7 @@
 import {Flex} from '@sentry/scraps/layout';
 
 import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -12,15 +13,15 @@ import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import {usePreprodBuildsAnalytics} from 'sentry/views/preprod/hooks/usePreprodBuildsAnalytics';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
 
 export default function BuildList() {
   const organization = useOrganization();
-  const params = useParams<{projectId: string}>();
-  const projectId = params.projectId;
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
 
   const {cursor} = useLocationQuery({
     fields: {
@@ -67,6 +68,16 @@ export default function BuildList() {
     pageSource: 'preprod_builds_list',
     projectCount: 1,
   });
+
+  if (!projectId) {
+    return (
+      <Layout.Page>
+        <Alert type="error" showIcon>
+          {t('Project parameter required')}
+        </Alert>
+      </Layout.Page>
+    );
+  }
 
   return (
     <SentryDocumentTitle title="Build list">

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -13,7 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   formatBuildName,
-  getBaseBuildUrl,
+  getBuildSizeUrl,
 } from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   getBranchUrl,
@@ -87,7 +87,7 @@ export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
                 );
                 const baseBuildUrl =
                   buildDetailsData.base_artifact_id && projectId
-                    ? getBaseBuildUrl({
+                    ? getBuildSizeUrl({
                         baseArtifactId: buildDetailsData.base_artifact_id,
                         organizationSlug: organization.slug,
                         projectId,

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -1,11 +1,14 @@
 import {Heading} from '@sentry/scraps/text';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Container, Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildVcsInfo} from 'sentry/views/preprod/components/buildVcsInfo';
@@ -14,9 +17,10 @@ import {BuildInstallHeader} from 'sentry/views/preprod/install/buildInstallHeade
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function InstallPage() {
-  const params = useParams<{artifactId: string; projectId: string}>();
+  const params = useParams<{artifactId: string}>();
   const artifactId = params.artifactId;
-  const projectId = params.projectId;
+  const location = useLocation();
+  const projectId = decodeScalar(location.query.project);
   const organization = useOrganization();
 
   const buildDetailsQuery = useApiQuery<BuildDetailsApiResponse>(
@@ -28,6 +32,17 @@ export default function InstallPage() {
       enabled: !!projectId && !!artifactId,
     }
   );
+
+  if (!projectId) {
+    return (
+      <Layout.Page>
+        <Alert type="error" showIcon>
+          {t('Project parameter required')}
+        </Alert>
+      </Layout.Page>
+    );
+  }
+
   return (
     <SentryDocumentTitle title="Install">
       <Layout.Page>

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -4,14 +4,49 @@ interface BuildLinkParams {
   projectId: string;
 }
 
-export function getBaseBuildUrl(params: BuildLinkParams): string | null {
+export function getBuildSizeUrl(params: BuildLinkParams): string | null {
   const {organizationSlug, projectId, baseArtifactId} = params;
 
   if (!baseArtifactId) {
     return null;
   }
 
-  return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/`;
+  return `/organizations/${organizationSlug}/explore/build/${baseArtifactId}/size/?project=${projectId}`;
+}
+
+export function getBuildInstallUrl(params: BuildLinkParams): string | null {
+  const {organizationSlug, projectId, baseArtifactId} = params;
+
+  if (!baseArtifactId) {
+    return null;
+  }
+
+  return `/organizations/${organizationSlug}/explore/build/${baseArtifactId}/install?project=${projectId}`;
+}
+
+export function getBuildCompareUrl(params: {
+  headArtifactId: string;
+  organizationSlug: string;
+  projectId: string;
+  baseArtifactId?: string;
+}): string {
+  const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
+
+  let path = `/organizations/${organizationSlug}/explore/build/compare/${headArtifactId}`;
+  if (baseArtifactId) {
+    path += `/${baseArtifactId}`;
+  }
+  path += `?project=${projectId}`;
+
+  return path;
+}
+
+export function getBuildListUrl(params: {
+  organizationSlug: string;
+  projectId: string;
+}): string {
+  const {organizationSlug, projectId} = params;
+  return `/organizations/${organizationSlug}/explore/build/?project=${projectId}`;
 }
 
 export function formatBuildName(


### PR DESCRIPTION
Migrates preprod URL routes from `/preprod/:projectId/` to `/explore/build/` structure with query parameters, as specified in EME-725.

## Changes

### Route Structure
- Moved routes from `/preprod/:projectId/` to `/explore/build/` under explore parent
- Changed project identification from path params to query params (`?project=:project`)
- Added `/size/` path for build details (size analysis page)
- Kept `/install/` path for distribution page

### URL Mappings
- **Build list**: `/explore/build/?project=:project`
- **Size analysis**: `/explore/build/:artifactId/size/?project=:project`
- **Install page**: `/explore/build/:artifactId/install?project=:project`
- **Compare**: `/explore/build/compare/:head/:base/?project=:project`

### Code Changes
- Updated all URL builder functions to generate new URL format
- Migrated all components to read `projectId` from `location.query` instead of `useParams`
- Updated backend URL builders for GitHub status checks
- Renamed `getBaseBuildUrl()` → `getBuildSizeUrl()`
- Added `getBuildListUrl()` for build list navigation

## Breaking Changes

Hard cutover with **no backwards compatibility** - old `/preprod/` URLs will return 404.

Fixes EME-725