### PR TITLE
fix(billing): Handle undefined partner

### DIFF
--- a/static/gsApp/utils/partnerships.tsx
+++ b/static/gsApp/utils/partnerships.tsx
@@ -1,7 +1,7 @@
 import type {Subscription} from 'getsentry/types';
 
 export function isDisabledByPartner(subscription: Subscription): boolean {
-  if (subscription.partner === null) {
+  if (!subscription.partner) {
     return false;
   }
   return (


### PR DESCRIPTION
Fixes JAVASCRIPT-364G and JAVASCRIPT-363Z

`subscription.partner` is undefined when `subscription` is undefined, which occurs sometimes for newly created orgs where the subscription has not been instantiated yet.