### PR TITLE
ref(searchQueryBuilder): Move GetTagValues to searchQueryBuilder

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -6,6 +6,7 @@ import {fetchTagValues, useFetchOrganizationTags} from 'sentry/actionCreators/ta
 import {EMAIL_REGEX} from 'sentry/components/events/contexts/knownContext/user';
 import type {SearchGroup} from 'sentry/components/searchBar/types';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import type {Tag, TagCollection} from 'sentry/types/group';
@@ -27,7 +28,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 const EXCLUDED_TAGS: string[] = [
   // These are found in issue platform and redundant (= __.name, ex os.name)

--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -8,6 +8,7 @@ import {
 } from 'sentry/components/events/searchBarFieldConstants';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -25,7 +26,6 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useTags from 'sentry/utils/useTags';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 interface TransactionSearchQueryBuilderProps {
   initialQuery: string;

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -11,7 +11,10 @@ import {
 import * as Sentry from '@sentry/react';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
-import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
+import type {
+  GetTagValues,
+  SearchQueryBuilderProps,
+} from 'sentry/components/searchQueryBuilder';
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {useHandleSearch} from 'sentry/components/searchQueryBuilder/hooks/useHandleSearch';
 import {
@@ -31,7 +34,6 @@ import {getFieldDefinition} from 'sentry/utils/fields';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 interface SearchQueryBuilderContextData {
   actionBarRef: React.RefObject<HTMLDivElement | null>;

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -25,11 +25,16 @@ import {queryIsValid} from 'sentry/components/searchQueryBuilder/utils';
 import type {SearchConfig} from 'sentry/components/searchSyntax/parser';
 import {IconCase, IconClose, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {SavedSearchType, TagCollection} from 'sentry/types/group';
+import type {SavedSearchType, Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import type {FieldKind} from 'sentry/utils/fields';
 import PanelProvider from 'sentry/utils/panelProvider';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
+
+export type GetTagValues = (
+  tag: Pick<Tag, 'key' | 'name'> & {kind: FieldKind | undefined},
+  searchQuery: string
+) => Promise<string[]>;
 
 export interface SearchQueryBuilderProps {
   /**

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -1,10 +1,11 @@
 import trimStart from 'lodash/trimStart';
 
 import type {Client, ResponseMeta} from 'sentry/api';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
@@ -13,7 +14,6 @@ import type {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {AggregationOutputType, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {isEquation} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
-import type {FieldKind} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import type {
@@ -53,11 +53,6 @@ export type SearchBarDataProviderProps = {
   pageFilters: PageFilters;
   widgetQuery?: WidgetQuery;
 };
-
-export type GetTagValues = (
-  tag: Pick<Tag, 'key' | 'name'> & {kind: FieldKind | undefined},
-  searchQuery: string
-) => Promise<string[]>;
 
 export interface SearchBarData {
   getFilterKeySections: () => FilterKeySection[];

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -2,6 +2,7 @@ import {useCallback} from 'react';
 
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
@@ -11,7 +12,6 @@ import {SavedSearchType} from 'sentry/types/group';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {
-  GetTagValues,
   SearchBarData,
   SearchBarDataProviderProps,
   WidgetBuilderSearchBarProps,

--- a/static/app/views/detectors/datasetConfig/components/releaseSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/releaseSearchBar.tsx
@@ -1,5 +1,6 @@
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
@@ -7,7 +8,6 @@ import type {TagCollection} from 'sentry/types/group';
 import {SavedSearchType} from 'sentry/types/group';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 import {
   SESSION_STATUSES,
   SESSIONS_FILTER_TAGS,

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import {FieldKind} from 'sentry/utils/fields';
@@ -8,7 +9,6 @@ import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 import type {
   TraceItemDataset,
   UseTraceItemAttributeBaseProps,

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -145,7 +145,7 @@ export function TransactionNameSearchBar(props: SearchBarProps) {
         );
 
         const parsedResults = results.reduce(
-          (searchGroup: SearchGroup, item) => {
+          (searchGroup: SearchGroup, item: string) => {
             searchGroup.children.push({
               value: item,
               title: item,

--- a/static/app/views/insights/sessions/components/releaseTableSearch.tsx
+++ b/static/app/views/insights/sessions/components/releaseTableSearch.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 import {FieldKey} from 'sentry/utils/fields';
@@ -11,7 +12,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 export default function ReleaseTableSearch() {
   const location = useLocation();

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -1,6 +1,6 @@
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {TagValue} from 'sentry/types/group';
 import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 /**
  * Returns a function that fetches tag values for a given tag key. Useful as

--- a/static/app/views/projectDetail/projectFilters.tsx
+++ b/static/app/views/projectDetail/projectFilters.tsx
@@ -5,10 +5,10 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 import type {TagValueLoader} from 'sentry/views/issueList/types';
 
 type Props = {

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -19,6 +19,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {ReleasesSortOption} from 'sentry/constants/releases';
@@ -38,7 +39,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 import ReleaseArchivedNotice from 'sentry/views/releases/detail/overview/releaseArchivedNotice';
 import MobileBuilds from 'sentry/views/releases/list/mobileBuilds';
 import ReleaseHealthCTA from 'sentry/views/releases/list/releaseHealthCTA';

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -4,6 +4,7 @@ import orderBy from 'lodash/orderBy';
 import {fetchTagValues, useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import {EMAIL_REGEX} from 'sentry/components/events/contexts/knownContext/user';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -24,7 +25,6 @@ import {
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import type {GetTagValues} from 'sentry/views/dashboards/datasetConfig/base';
 
 const getReplayFieldDefinition = (key: string) => getFieldDefinition(key, 'replay');
 


### PR DESCRIPTION
`GetTagValues` lived in `sentry/views/dashboards/datasetConfig/base` but was the official type of the
`getTagValues` prop of the `SearchQueryBuilder` from `static/app/components/searchQueryBuilder/*`.
This moves `GetTagValues` to `static/app/components/searchQueryBuilder` and updates all callers.