### PR TITLE
chore: Refactor LegalAndCompliance view to not use deprecatedRouteProps

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -113,7 +113,6 @@ const settingsRoutes = (): SentryRouteObject => ({
       path: 'legal/',
       name: 'Legal & Compliance',
       component: make(() => import('../views/legalAndCompliance/legalAndCompliance')),
-      deprecatedRouteProps: true,
     },
     {
       name: 'Support',

--- a/static/gsApp/views/legalAndCompliance/legalAndCompliance.tsx
+++ b/static/gsApp/views/legalAndCompliance/legalAndCompliance.tsx
@@ -1,34 +1,32 @@
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationRegionAction} from 'sentry/views/settings/organizationGeneralSettings/organizationRegionAction';
 
-import withSubscription from 'getsentry/components/withSubscription';
-import type {Subscription} from 'getsentry/types';
+import useSubscription from 'getsentry/hooks/useSubscription';
 import {GDPRPanel} from 'getsentry/views/legalAndCompliance/gdprPanel';
 import {TermsAndConditions} from 'getsentry/views/legalAndCompliance/termsAndConditions';
 import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
-type Props = RouteComponentProps<unknown, unknown> & {
-  organization: Organization;
-  subscription: Subscription;
-};
+export default function LegalAndCompliance() {
+  const organization = useOrganization();
+  const subscription = useSubscription();
 
-function LegalAndCompliance(props: Props) {
+  if (!subscription) {
+    return <LoadingIndicator />;
+  }
+
   return (
     <SubscriptionPageContainer background="secondary">
       <SentryDocumentTitle title={t('Legal & Compliance')} />
       <SettingsPageHeader
         title="Legal & Compliance"
-        action={OrganizationRegionAction({organization: props.organization})}
+        action={OrganizationRegionAction({organization})}
       />
-      <TermsAndConditions {...props} />
-      <GDPRPanel subscription={props.subscription} />
+      <TermsAndConditions subscription={subscription} />
+      <GDPRPanel subscription={subscription} />
     </SubscriptionPageContainer>
   );
 }
-
-export default withOrganization(withSubscription(LegalAndCompliance));


### PR DESCRIPTION
This is the page available at `/settings/legal/`