### PR TITLE
chore: Refactor InvoiceDetails view to not use deprecatedRouteProps

### DIFF
--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -28,6 +28,7 @@ type ParamKeys =
   | 'eventSlug'
   | 'fineTuneType'
   | 'groupId'
+  | 'invoiceGuid'
   | 'id'
   | 'installationId'
   | 'integrationId'

--- a/static/gsAdmin/views/invoiceDetails.tsx
+++ b/static/gsAdmin/views/invoiceDetails.tsx
@@ -28,7 +28,7 @@ import {InvoiceStatus} from 'getsentry/types';
 
 const ERR_MESSAGE = 'There was an internal error updating this invoice';
 
-function InvoiceDetails() {
+export default function InvoiceDetails() {
   const {invoiceId, orgId, region} = useParams<{
     invoiceId: string;
     orgId: string;
@@ -332,5 +332,3 @@ function InvoiceDetails() {
     />
   );
 }
-
-export default InvoiceDetails;

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -87,7 +87,6 @@ const settingsRoutes = (): SentryRouteObject => ({
             {
               index: true,
               component: make(() => import('../views/invoiceDetails')),
-              deprecatedRouteProps: true,
             },
           ],
         },

--- a/static/gsApp/views/invoiceDetails/index.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/index.spec.tsx
@@ -15,7 +15,7 @@ import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import InvoiceDetails from 'getsentry/views/invoiceDetails';
 
 describe('InvoiceDetails', () => {
-  const {organization, router, routerProps} = initializeOrg();
+  const {organization} = initializeOrg();
   const basicInvoice = InvoiceFixture(
     {
       dateCreated: '2021-09-20T22:33:38.042Z',
@@ -77,7 +77,14 @@ describe('InvoiceDetails', () => {
       method: 'GET',
       body: basicInvoice,
     });
-    render(<InvoiceDetails {...routerProps} params={params} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
     await waitFor(() => expect(mockapi).toHaveBeenCalled());
 
     expect(await screen.findByText('Sentry')).toBeInTheDocument();
@@ -109,7 +116,14 @@ describe('InvoiceDetails', () => {
       method: 'GET',
       body: annualInvoice,
     });
-    render(<InvoiceDetails {...routerProps} params={params} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
     await waitFor(() => expect(mockapi).toHaveBeenCalled());
 
     expect(
@@ -126,7 +140,14 @@ describe('InvoiceDetails', () => {
       body: creditInvoice,
     });
     const creditParams = {invoiceGuid: creditInvoice.id};
-    render(<InvoiceDetails {...routerProps} params={creditParams} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${creditParams.invoiceGuid}/`,
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
     await waitFor(() => expect(mockapi).toHaveBeenCalled());
 
     expect(await screen.findByText('Sentry')).toBeInTheDocument();
@@ -141,7 +162,14 @@ describe('InvoiceDetails', () => {
       statusCode: 404,
       body: {},
     });
-    render(<InvoiceDetails {...routerProps} params={params} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
     await waitFor(() => expect(mockapi).toHaveBeenCalled());
 
     expect(
@@ -150,11 +178,6 @@ describe('InvoiceDetails', () => {
   });
 
   it('renders without pay now for self serve partner', async () => {
-    router.location = {
-      ...router.location,
-      query: {referrer: 'billing-failure'},
-    };
-
     const pastDueInvoice = InvoiceFixture(
       {
         amount: 8900,
@@ -186,7 +209,15 @@ describe('InvoiceDetails', () => {
       body: pastDueInvoice,
     });
 
-    render(<InvoiceDetails {...routerProps} params={pastDueParams} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${pastDueParams.invoiceGuid}/`,
+          query: {referrer: 'billing-failure'},
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
 
     await waitFor(() => expect(mockapiInvoice).toHaveBeenCalled());
 
@@ -206,7 +237,14 @@ describe('InvoiceDetails', () => {
       url: `/customers/${organization.slug}/invoices/${basicInvoice.id}/`,
       method: 'POST',
     });
-    render(<InvoiceDetails {...routerProps} params={params} />);
+    render(<InvoiceDetails />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+        },
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
+      },
+    });
     await waitFor(() => expect(mockget).toHaveBeenCalled());
 
     const input = await screen.findByPlaceholderText('you@example.com');
@@ -258,13 +296,13 @@ describe('InvoiceDetails', () => {
     });
 
     renderGlobalModal();
-    render(<InvoiceDetails {...routerProps} params={pastDueParams} />, {
+    render(<InvoiceDetails />, {
       initialRouterConfig: {
         location: {
-          pathname: `/organizations/${organization.slug}/invoices/${pastDueInvoice.id}/`,
+          pathname: `/organizations/${organization.slug}/invoices/${pastDueParams.invoiceGuid}/`,
           query: {referrer: 'billing-failure'},
         },
-        route: `/organizations/${organization.slug}/invoices/:invoiceGuid/`,
+        route: '/organizations/:orgId/invoices/:invoiceGuid/',
       },
     });
 
@@ -301,7 +339,14 @@ describe('InvoiceDetails', () => {
         method: 'GET',
         body: basicInvoice,
       });
-      render(<InvoiceDetails {...routerProps} params={params} />);
+      render(<InvoiceDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+          },
+          route: '/organizations/:orgId/invoices/:invoiceGuid/',
+        },
+      });
 
       await waitFor(() => expect(mockInvoice).toHaveBeenCalled());
 
@@ -338,7 +383,14 @@ describe('InvoiceDetails', () => {
         method: 'GET',
         body: basicInvoiceWithSentryTaxIds,
       });
-      render(<InvoiceDetails {...routerProps} params={params} />);
+      render(<InvoiceDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+          },
+          route: '/organizations/:orgId/invoices/:invoiceGuid/',
+        },
+      });
 
       await waitFor(() => expect(mockInvoice).toHaveBeenCalled());
       expect(await screen.findByText('Country Id: 1234')).toBeInTheDocument();
@@ -359,7 +411,14 @@ describe('InvoiceDetails', () => {
         method: 'GET',
         body: basicInvoiceReverseCharge,
       });
-      render(<InvoiceDetails {...routerProps} params={params} />);
+      render(<InvoiceDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/invoices/${params.invoiceGuid}/`,
+          },
+          route: '/organizations/:orgId/invoices/:invoiceGuid/',
+        },
+      });
 
       await waitFor(() => expect(mockInvoice).toHaveBeenCalled());
       expect(await screen.findByText('VAT')).toBeInTheDocument();

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -10,9 +10,9 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import {InvoiceStatus} from 'getsentry/types';
@@ -23,9 +23,9 @@ import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/componen
 
 import InvoiceDetailsActions from './actions';
 
-interface Props extends RouteComponentProps<{invoiceGuid: string}, unknown> {}
+function InvoiceDetails() {
+  const {invoiceGuid} = useParams<{invoiceGuid: string}>();
 
-function InvoiceDetails({params}: Props) {
   const organization = useOrganization();
   const {
     data: billingDetails,
@@ -41,10 +41,9 @@ function InvoiceDetails({params}: Props) {
     isPending: isInvoiceLoading,
     isError: isInvoiceError,
     refetch: invoiceRefetch,
-  } = useApiQuery<Invoice>(
-    [`/customers/${organization.slug}/invoices/${params.invoiceGuid}/`],
-    {staleTime: Infinity}
-  );
+  } = useApiQuery<Invoice>([`/customers/${organization.slug}/invoices/${invoiceGuid}/`], {
+    staleTime: Infinity,
+  });
 
   if (isBillingDetailsError || isInvoiceError) {
     return (


### PR DESCRIPTION
There are actually two InvoiceDetails views, one for gsApp and one in gsAdmin.