### PR TITLE
chore: Create a SubscriptionContext specifically for routes/views

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -2,7 +2,7 @@ import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import type {SentryRouteObject} from 'sentry/router/types';
 import errorHandler from 'sentry/utils/errorHandler';
 
-import SubscriptionContext from 'getsentry/components/subscriptionContext';
+import SubscriptionContext from 'getsentry/views/subscriptionContext';
 
 const settingsRoutes = (): SentryRouteObject => ({
   children: [
@@ -30,7 +30,6 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'cancel/',
           name: 'Cancel',
           component: errorHandler(SubscriptionContext),
-          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -82,7 +81,6 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'receipts/:invoiceGuid/',
           name: 'Receipt Details',
           component: errorHandler(SubscriptionContext),
-          deprecatedRouteProps: true,
           children: [
             {
               index: true,

--- a/static/gsApp/views/subscriptionContext.tsx
+++ b/static/gsApp/views/subscriptionContext.tsx
@@ -1,17 +1,13 @@
-import {Fragment} from 'react';
+import {Outlet} from 'react-router-dom';
 
 import useOrganization from 'sentry/utils/useOrganization';
 
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 
-type Props = {
-  children: React.ReactNode;
-};
-
-export default function SubscriptionContext(props: Props) {
+export default function SubscriptionContext() {
   const organization = useOrganization();
   return organization.access.includes('org:billing') ? (
-    <Fragment>{props.children}</Fragment>
+    <Outlet />
   ) : (
     <ContactBillingMembers />
   );


### PR DESCRIPTION
There are two files called `subscriptionContext` now. One is inside `views/` and uses the `<Outlet />` for rendering. The other (existing before) is inside `components/` and renders `{props.children}` so we can directly guard individual components within a page.