### PR TITLE
fix(aci): "View monitor details" button should not replace url

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -102,8 +102,6 @@ export function DetectorSection({group, project}: {group: Group; project: Projec
         to={detectorPath}
         style={{width: '100%'}}
         size="sm"
-        replace
-        preventScrollReset
       >
         {issueConfig.detector.ctaText ?? t('View detector details')}
       </LinkButton>


### PR DESCRIPTION
Fixes back navigation when a user is viewing a metric issue, clicks to view monitor details, and wants to return to the metric issue. Cursor actually caught this [here](https://github.com/getsentry/sentry/pull/100577/files#r2389538614)