### PR TITLE
feat(dashboards): display http response codes as fraction in prebuilt dashboard

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/constants.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/constants.ts
@@ -1,0 +1,5 @@
+import {SpanFields} from 'sentry/views/insights/types';
+
+export const PERCENTAGE_3XX = `equation|count_if(${SpanFields.SPAN_STATUS_CODE},between,300,399) / count(${SpanFields.SPAN_DURATION})`;
+export const PERCENTAGE_4XX = `equation|count_if(${SpanFields.SPAN_STATUS_CODE},between,400,499) / count(${SpanFields.SPAN_DURATION})`;
+export const PERCENTAGE_5XX = `equation|count_if(${SpanFields.SPAN_STATUS_CODE},between,500,599) / count(${SpanFields.SPAN_DURATION})`;

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -4,6 +4,11 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
+  PERCENTAGE_3XX,
+  PERCENTAGE_4XX,
+  PERCENTAGE_5XX,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/constants';
+import {
   AVERAGE_DURATION_TEXT,
   BASE_FILTERS,
   DASHBOARD_TITLE,
@@ -94,7 +99,7 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       ],
     },
     {
-      id: '3xx-count-big-number',
+      id: '3xx-percentage-big-number',
       title: t('3XX'),
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.SPANS,
@@ -102,16 +107,16 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('3XX'),
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
-          fields: [`count(${SpanFields.SPAN_DURATION})`],
-          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          conditions: `${FILTER_STRING}`,
+          fields: [PERCENTAGE_3XX],
+          aggregates: [PERCENTAGE_3XX],
           columns: [],
-          orderby: `count(${SpanFields.SPAN_DURATION})`,
+          orderby: PERCENTAGE_3XX,
         },
       ],
     },
     {
-      id: '4xx-count-big-number',
+      id: '4xx-percentage-big-number',
       title: t('4XX'),
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.SPANS,
@@ -119,16 +124,16 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('4XX'),
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
-          fields: [`count(${SpanFields.SPAN_DURATION})`],
-          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          conditions: `${FILTER_STRING}`,
+          fields: [PERCENTAGE_4XX],
+          aggregates: [PERCENTAGE_4XX],
           columns: [],
-          orderby: `count(${SpanFields.SPAN_DURATION})`,
+          orderby: PERCENTAGE_4XX,
         },
       ],
     },
     {
-      id: '5xx-count-big-number',
+      id: '5xx-percentage-big-number',
       title: t('5XX'),
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.SPANS,
@@ -136,11 +141,11 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('5XX'),
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
-          fields: [`count(${SpanFields.SPAN_DURATION})`],
-          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          conditions: `${FILTER_STRING}`,
+          fields: [PERCENTAGE_5XX],
+          aggregates: [PERCENTAGE_5XX],
           columns: [],
-          orderby: `count(${SpanFields.SPAN_DURATION})`,
+          orderby: PERCENTAGE_5XX,
         },
       ],
     },
@@ -211,27 +216,27 @@ const CHART_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '3XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_3XX],
+          aggregates: [PERCENTAGE_3XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_3XX,
         },
         {
           name: '4XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_4XX],
+          aggregates: [PERCENTAGE_4XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_4XX,
         },
         {
           name: '5XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_5XX],
+          aggregates: [PERCENTAGE_5XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_5XX,
         },
       ],
     },
@@ -249,6 +254,9 @@ const TRANSACTIONS_TABLE: Widget = {
     {
       aggregates: [
         'epm()',
+        PERCENTAGE_3XX,
+        PERCENTAGE_4XX,
+        PERCENTAGE_5XX,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],
@@ -256,12 +264,18 @@ const TRANSACTIONS_TABLE: Widget = {
       fields: [
         SpanFields.TRANSACTION,
         'epm()',
+        PERCENTAGE_3XX,
+        PERCENTAGE_4XX,
+        PERCENTAGE_5XX,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],
       fieldAliases: [
         t('Found In'),
         THROUGHPUT_TEXT,
+        t('3XXs'),
+        t('4XXs'),
+        t('5XXs'),
         DataTitles.avg,
         DataTitles.timeSpent,
       ],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
@@ -5,6 +5,11 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
+  PERCENTAGE_3XX,
+  PERCENTAGE_4XX,
+  PERCENTAGE_5XX,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/constants';
+import {
   AVERAGE_DURATION_TEXT,
   BASE_FILTERS,
   DASHBOARD_TITLE,
@@ -62,27 +67,27 @@ const FIRST_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '3XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_3XX],
+          aggregates: [PERCENTAGE_3XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_3XX,
         },
         {
           name: '4XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_4XX],
+          aggregates: [PERCENTAGE_4XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_4XX,
         },
         {
           name: '5XX',
-          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
-          fields: ['count(span.duration)'],
-          aggregates: ['count(span.duration)'],
+          conditions: FILTER_STRING,
+          fields: [PERCENTAGE_5XX],
+          aggregates: [PERCENTAGE_5XX],
           columns: [],
-          orderby: 'count(span.duration)',
+          orderby: PERCENTAGE_5XX,
         },
       ],
     },
@@ -100,6 +105,9 @@ const DOMAIN_TABLE: Widget = {
     {
       aggregates: [
         'epm()',
+        PERCENTAGE_3XX,
+        PERCENTAGE_4XX,
+        PERCENTAGE_5XX,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],
@@ -108,6 +116,9 @@ const DOMAIN_TABLE: Widget = {
         SpanFields.SPAN_DOMAIN,
         SpanFields.PROJECT,
         'epm()',
+        PERCENTAGE_3XX,
+        PERCENTAGE_4XX,
+        PERCENTAGE_5XX,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],
@@ -115,6 +126,9 @@ const DOMAIN_TABLE: Widget = {
         t('Domain'),
         t('Project'),
         `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,
+        t('3XXs'),
+        t('4XXs'),
+        t('5XXs'),
         DataTitles.avg,
         DataTitles.timeSpent,
       ],


### PR DESCRIPTION
Updates the http prebuilt dashboard to use the new count_if `between` operator so we can display the response codes as a fraction of the total responses, rather then the raw count.

<img width="1290" height="603" alt="image" src="https://github.com/user-attachments/assets/8255e526-3366-49ef-b552-861da5ad2fc1" />

There is another PR that will ensure these fractions are formatted as a percentage
