### PR TITLE
ref(theme): remove hover

### DIFF
--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -87,7 +87,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
         padding: space(0.5),
         borderRadius: theme.radius.md,
         '&focused': {
-          backgroundColor: theme.hover,
+          backgroundColor: theme.tokens.background.transparent.neutral.muted,
         },
       },
     },

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -87,7 +87,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
         padding: space(0.5),
         borderRadius: theme.radius.md,
         '&focused': {
-          backgroundColor: theme.tokens.background.transparent.neutral.muted,
+          backgroundColor: theme.tokens.interactive.transparent.neutral.background.active,
         },
       },
     },

--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -78,7 +78,7 @@ const CalendarStylesWrapper = styled('div')`
   }
 
   .rdrDayInPreview {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
 
   .rdrMonth {

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -218,7 +218,7 @@ const getStylesConfig = ({
         : {
             '&:hover': {
               cursor: 'pointer',
-              background: theme.hover,
+              background: theme.tokens.background.transparent.neutral.muted,
             },
           }),
     }),

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -218,7 +218,7 @@ const getStylesConfig = ({
         : {
             '&:hover': {
               cursor: 'pointer',
-              background: theme.tokens.background.transparent.neutral.muted,
+              background: theme.tokens.interactive.transparent.neutral.background.hover,
             },
           }),
     }),

--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -791,7 +791,7 @@ const TreeRow = styled('div')<{$isClickable?: boolean}>`
     cursor: pointer;
 
     &:hover {
-      background-color: ${p.theme.hover};
+      background-color: ${p.theme.tokens.background.transparent.neutral.muted};
     }
   `}
 `;

--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -791,7 +791,7 @@ const TreeRow = styled('div')<{$isClickable?: boolean}>`
     cursor: pointer;
 
     &:hover {
-      background-color: ${p.theme.tokens.background.transparent.neutral.muted};
+      background-color: ${p.theme.tokens.interactive.transparent.neutral.background.hover};
     }
   `}
 `;

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -212,7 +212,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     ${common}
 
     &:hover {
-      background: ${props.theme.tokens.background.transparent.neutral.muted};
+      background: ${props.theme.tokens.interactive.transparent.neutral.background.hover};
     }
   `;
 }

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -212,7 +212,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     ${common}
 
     &:hover {
-      background: ${props.theme.hover};
+      background: ${props.theme.tokens.background.transparent.neutral.muted};
     }
   `;
 }

--- a/static/app/components/profiling/profilingContextMenu.tsx
+++ b/static/app/components/profiling/profilingContextMenu.tsx
@@ -36,11 +36,12 @@ const MenuContentContainer = styled('div')`
   padding: 0 ${space(1)};
   border-radius: ${p => p.theme.radius.md};
   box-sizing: border-box;
-  background: ${p => (p.tabIndex === 0 ? p.theme.hover : undefined)};
+  background: ${p =>
+    p.tabIndex === 0 ? p.theme.tokens.background.transparent.neutral.muted : undefined};
 
   &:focus {
     color: ${p => p.theme.tokens.content.primary};
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
     outline: none;
   }
 `;
@@ -115,13 +116,16 @@ const MenuButton = styled('button')`
   padding: ${space(0.5)} ${space(1)};
   border-radius: ${p => p.theme.radius.md};
   box-sizing: border-box;
-  background: ${p => (p.tabIndex === 0 ? p.theme.hover : 'transparent')} !important;
+  background: ${p =>
+    p.tabIndex === 0
+      ? p.theme.tokens.background.transparent.neutral.muted
+      : 'transparent'} !important;
   pointer-events: ${p => (p.disabled ? 'none' : undefined)};
   opacity: ${p => (p.disabled ? 0.7 : undefined)};
 
   &:focus {
     color: ${p => p.theme.tokens.content.primary};
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
     outline: none;
   }
 

--- a/static/app/components/profiling/profilingContextMenu.tsx
+++ b/static/app/components/profiling/profilingContextMenu.tsx
@@ -37,11 +37,13 @@ const MenuContentContainer = styled('div')`
   border-radius: ${p => p.theme.radius.md};
   box-sizing: border-box;
   background: ${p =>
-    p.tabIndex === 0 ? p.theme.tokens.background.transparent.neutral.muted : undefined};
+    p.tabIndex === 0
+      ? p.theme.tokens.interactive.transparent.neutral.background.active
+      : undefined};
 
   &:focus {
     color: ${p => p.theme.tokens.content.primary};
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
     outline: none;
   }
 `;
@@ -118,14 +120,14 @@ const MenuButton = styled('button')`
   box-sizing: border-box;
   background: ${p =>
     p.tabIndex === 0
-      ? p.theme.tokens.background.transparent.neutral.muted
+      ? p.theme.tokens.interactive.transparent.neutral.background.active
       : 'transparent'} !important;
   pointer-events: ${p => (p.disabled ? 'none' : undefined)};
   opacity: ${p => (p.disabled ? 0.7 : undefined)};
 
   &:focus {
     color: ${p => p.theme.tokens.content.primary};
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
     outline: none;
   }
 

--- a/static/app/components/searchBar/searchDropdown.tsx
+++ b/static/app/components/searchBar/searchDropdown.tsx
@@ -561,9 +561,11 @@ const SearchListItem = styled('li')<{isChild?: boolean; isDisabled?: boolean}>`
       return css`
         cursor: pointer;
 
-        &:hover,
+        &:hover {
+          background: ${p.theme.tokens.interactive.transparent.neutral.background.hover};
+        }
         &.active {
-          background: ${p.theme.tokens.background.transparent.neutral.muted};
+          background: ${p.theme.tokens.interactive.transparent.neutral.background.active};
         }
       `;
     }

--- a/static/app/components/searchBar/searchDropdown.tsx
+++ b/static/app/components/searchBar/searchDropdown.tsx
@@ -563,7 +563,7 @@ const SearchListItem = styled('li')<{isChild?: boolean; isDisabled?: boolean}>`
 
         &:hover,
         &.active {
-          background: ${p.theme.hover};
+          background: ${p.theme.tokens.background.transparent.neutral.muted};
         }
       `;
     }

--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -26,7 +26,7 @@ const BaseSplitDivider = styled(({icon, ...props}: DividerProps) => (
 
   &:hover,
   &[data-is-held='true'] {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
   &[data-is-held='true'] {
     user-select: none;

--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -24,12 +24,12 @@ const BaseSplitDivider = styled(({icon, ...props}: DividerProps) => (
   user-select: inherit;
   background: inherit;
 
-  &:hover,
-  &[data-is-held='true'] {
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
   &[data-is-held='true'] {
     user-select: none;
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 
   &[data-slide-direction='leftright'] {

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -265,7 +265,7 @@ const StyledLink = styled(Link)`
   color: ${p => p.theme.colors.gray500};
   &:hover {
     color: ${p => p.theme.colors.gray500};
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 `;
 

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -265,7 +265,7 @@ const StyledLink = styled(Link)`
   color: ${p => p.theme.colors.gray500};
   &:hover {
     color: ${p => p.theme.colors.gray500};
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
 `;
 

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -233,7 +233,7 @@ const generateButtonTheme = (
     color: tokens.content.primary,
     colorActive: tokens.content.primary,
     background: alias.background,
-    backgroundActive: alias.hover,
+    backgroundActive: tokens.background.transparent.neutral.muted,
     border: alias.border,
     borderActive: alias.border,
     borderTranslucent: alias.translucentBorder,
@@ -1226,13 +1226,6 @@ const generateAliases = (tokens: Tokens, colors: typeof lightColors) => ({
    */
   disabled: colors.gray400,
   disabledBorder: colors.gray400,
-
-  /**
-   * Indicates a "hover" state. Deprecated – use `InteractionStateLayer` instead for
-   * interaction (hover/press) states.
-   * @deprecated
-   */
-  hover: colors.gray100,
 
   /**
    * Indicates that something is "active" or "selected"

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -455,9 +455,11 @@ const DropdownListItem = styled(ListItem)`
   padding: ${space(1)} ${space(2)};
   cursor: pointer;
 
-  &:hover,
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
   &.active {
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;
 

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -457,7 +457,7 @@ const DropdownListItem = styled(ListItem)`
 
   &:hover,
   &.active {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
 `;
 

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -187,7 +187,7 @@ const ResizeHandle = styled(Flex)`
 
   &:hover,
   &[data-is-held='true'] {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
 
   &[data-is-held='true'] {

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -185,12 +185,11 @@ const ResizeHandle = styled(Flex)`
   cursor: ew-resize;
   background: transparent;
 
-  &:hover,
-  &[data-is-held='true'] {
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
-
   &[data-is-held='true'] {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
     user-select: none;
   }
 

--- a/static/app/views/replays/detail/layout/splitDivider.tsx
+++ b/static/app/views/replays/detail/layout/splitDivider.tsx
@@ -24,11 +24,11 @@ const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>) => (
   user-select: inherit;
   background: inherit;
 
-  &:hover,
-  &[data-is-held='true'] {
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
   &[data-is-held='true'] {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
     user-select: none;
   }
 

--- a/static/app/views/replays/detail/layout/splitDivider.tsx
+++ b/static/app/views/replays/detail/layout/splitDivider.tsx
@@ -26,7 +26,7 @@ const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>) => (
 
   &:hover,
   &[data-is-held='true'] {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
   &[data-is-held='true'] {
     user-select: none;

--- a/static/app/views/seerExplorer/askUserQuestionBlock.tsx
+++ b/static/app/views/seerExplorer/askUserQuestionBlock.tsx
@@ -148,7 +148,9 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   flex-shrink: 0;
   cursor: pointer;
   background: ${p =>
-    p.isFocused ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
+    p.isFocused
+      ? p.theme.tokens.interactive.transparent.neutral.background.active
+      : 'transparent'};
 `;
 
 const BlockContentWrapper = styled('div')`

--- a/static/app/views/seerExplorer/askUserQuestionBlock.tsx
+++ b/static/app/views/seerExplorer/askUserQuestionBlock.tsx
@@ -147,7 +147,8 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   position: relative;
   flex-shrink: 0;
   cursor: pointer;
-  background: ${p => (p.isFocused ? p.theme.hover : 'transparent')};
+  background: ${p =>
+    p.isFocused ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
 `;
 
 const BlockContentWrapper = styled('div')`

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -465,7 +465,9 @@ const MenuItem = styled('div')<{isSelected: boolean}>`
   padding: ${p => p.theme.space.md};
   cursor: pointer;
   background: ${p =>
-    p.isSelected ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
+    p.isSelected
+      ? p.theme.tokens.interactive.transparent.neutral.background.active
+      : 'transparent'};
   border-bottom: 1px solid ${p => p.theme.border};
 
   &:last-child {
@@ -473,7 +475,7 @@ const MenuItem = styled('div')<{isSelected: boolean}>`
   }
 
   &:hover {
-    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 `;
 

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -464,7 +464,8 @@ const MenuPanel = styled('div')<{
 const MenuItem = styled('div')<{isSelected: boolean}>`
   padding: ${p => p.theme.space.md};
   cursor: pointer;
-  background: ${p => (p.isSelected ? p.theme.hover : 'transparent')};
+  background: ${p =>
+    p.isSelected ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
   border-bottom: 1px solid ${p => p.theme.border};
 
   &:last-child {
@@ -472,7 +473,7 @@ const MenuItem = styled('div')<{isSelected: boolean}>`
   }
 
   &:hover {
-    background: ${p => p.theme.hover};
+    background: ${p => p.theme.tokens.background.transparent.neutral.muted};
   }
 `;
 

--- a/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
+++ b/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
@@ -99,7 +99,8 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   position: relative;
   flex-shrink: 0;
   cursor: pointer;
-  background: ${p => (p.isFocused ? p.theme.hover : 'transparent')};
+  background: ${p =>
+    p.isFocused ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
 `;
 
 const BlockContentWrapper = styled('div')`

--- a/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
+++ b/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
@@ -100,7 +100,9 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   flex-shrink: 0;
   cursor: pointer;
   background: ${p =>
-    p.isFocused ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
+    p.isFocused
+      ? p.theme.tokens.interactive.transparent.neutral.background.active
+      : 'transparent'};
 `;
 
 const BlockContentWrapper = styled('div')`

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -193,6 +193,8 @@ const CenterSection = styled(motion.div)`
 const SessionHistoryButtonWrapper = styled('div')<{isSelected: boolean}>`
   button {
     background-color: ${p =>
-      p.isSelected ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
+      p.isSelected
+        ? p.theme.tokens.interactive.transparent.neutral.background.active
+        : 'transparent'};
   }
 `;

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -192,6 +192,7 @@ const CenterSection = styled(motion.div)`
 
 const SessionHistoryButtonWrapper = styled('div')<{isSelected: boolean}>`
   button {
-    background-color: ${p => (p.isSelected ? p.theme.hover : 'transparent')};
+    background-color: ${p =>
+      p.isSelected ? p.theme.tokens.background.transparent.neutral.muted : 'transparent'};
   }
 `;


### PR DESCRIPTION
Remove `theme.hover` from theme.
Some usage has been replaced with `theme.tokens.background.transparent.neutral.muted`, `:hover` states with `theme.tokens.interactive.transparent.neutral.background.hover`, and `:active`/`:focus` states with `theme.tokens.interactive.transparent.neutral.background.active`