### PR TITLE
ref(preprod): Centralize URL building in helper functions

### DIFF
--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -7,6 +7,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getInstallBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 import {
   FullRowLink,
@@ -32,7 +33,12 @@ export function PreprodBuildsDistributionTable({
   showProjectColumn,
 }: PreprodBuildsDistributionTableProps) {
   const rows = builds.map(build => {
-    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}/install/`;
+    const linkUrl =
+      getInstallBuildUrl({
+        organizationSlug,
+        projectId: build.project_id.toString(),
+        baseArtifactId: build.id,
+      }) ?? '';
     const isInstallable = build.distribution_info?.is_installable ?? false;
     const isRowDisabled = !isInstallable;
     const downloadCount = build.distribution_info?.download_count ?? 0;

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -7,7 +7,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getInstallBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getInstallBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 import {
   FullRowLink,
@@ -34,7 +34,7 @@ export function PreprodBuildsDistributionTable({
 }: PreprodBuildsDistributionTableProps) {
   const rows = builds.map(build => {
     const linkUrl =
-      getInstallBuildUrl({
+      getInstallBuildPath({
         organizationSlug,
         projectId: build.project_id.toString(),
         baseArtifactId: build.id,

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -9,6 +9,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconQuestion} from 'sentry/icons';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getSizeBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -41,7 +42,12 @@ export function PreprodBuildsSizeTable({
   showProjectColumn,
 }: PreprodBuildsSizeTableProps) {
   const rows = builds.map(build => {
-    const linkUrl = `/organizations/${organizationSlug}/preprod/${build.project_id}/${build.id}`;
+    const linkUrl =
+      getSizeBuildUrl({
+        organizationSlug,
+        projectId: build.project_id.toString(),
+        baseArtifactId: build.id,
+      }) ?? '';
     return (
       <SimpleTable.Row key={build.id}>
         <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -9,7 +9,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconQuestion} from 'sentry/icons';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getSizeBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -43,7 +43,7 @@ export function PreprodBuildsSizeTable({
 }: PreprodBuildsSizeTableProps) {
   const rows = builds.map(build => {
     const linkUrl =
-      getSizeBuildUrl({
+      getSizeBuildPath({
         organizationSlug,
         projectId: build.project_id.toString(),
         baseArtifactId: build.id,

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -6,6 +6,7 @@ import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDispl
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+import {getInstallBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 const organization = OrganizationFixture({
   features: ['preprod-build-distribution'],
@@ -83,7 +84,11 @@ describe('PreprodBuildsTable', () => {
     const rowLink = screen.getByRole('link', {name: /Example App/});
     expect(rowLink).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/preprod/1/build-1/install/`
+      getInstallBuildUrl({
+        organizationSlug: organization.slug,
+        projectId: '1',
+        baseArtifactId: 'build-1',
+      })
     );
     expect(
       screen.queryByRole('link', {name: /Non Installable App/})

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -6,7 +6,7 @@ import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDispl
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
-import {getInstallBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getInstallBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 const organization = OrganizationFixture({
   features: ['preprod-build-distribution'],
@@ -84,7 +84,7 @@ describe('PreprodBuildsTable', () => {
     const rowLink = screen.getByRole('link', {name: /Example App/});
     expect(rowLink).toHaveAttribute(
       'href',
-      getInstallBuildUrl({
+      getInstallBuildPath({
         organizationSlug: organization.slug,
         projectId: '1',
         baseArtifactId: 'build-1',

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -36,6 +36,7 @@ import type {
   SizeAnalysisComparisonResults,
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 function getMainComparison(
   response: SizeComparisonApiResponse | undefined
@@ -106,7 +107,12 @@ export function SizeCompareMainContent() {
     },
     onSuccess: () => {
       navigate(
-        `/organizations/${organization.slug}/preprod/${projectId}/compare/${headArtifactId}/${baseArtifactId}/`
+        getBuildCompareUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId,
+          baseArtifactId,
+        })
       );
     },
     onError: error => {
@@ -258,7 +264,11 @@ export function SizeCompareMainContent() {
         isComparing={false}
         onClearBaseBuild={() => {
           navigate(
-            `/organizations/${organization.slug}/preprod/${projectId}/compare/${headArtifactId}/`
+            getBuildCompareUrl({
+              organizationSlug: organization.slug,
+              projectId,
+              headArtifactId,
+            })
           );
         }}
       />

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -36,7 +36,7 @@ import type {
   SizeAnalysisComparisonResults,
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
-import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 function getMainComparison(
   response: SizeComparisonApiResponse | undefined
@@ -107,7 +107,7 @@ export function SizeCompareMainContent() {
     },
     onSuccess: () => {
       navigate(
-        getBuildCompareUrl({
+        getCompareBuildUrl({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId,
@@ -264,7 +264,7 @@ export function SizeCompareMainContent() {
         isComparing={false}
         onClearBaseBuild={() => {
           navigate(
-            getBuildCompareUrl({
+            getCompareBuildUrl({
               organizationSlug: organization.slug,
               projectId,
               headArtifactId,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -36,7 +36,7 @@ import type {
   SizeAnalysisComparisonResults,
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
-import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 function getMainComparison(
   response: SizeComparisonApiResponse | undefined
@@ -107,7 +107,7 @@ export function SizeCompareMainContent() {
     },
     onSuccess: () => {
       navigate(
-        getCompareBuildUrl({
+        getCompareBuildPath({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId,
@@ -264,7 +264,7 @@ export function SizeCompareMainContent() {
         isComparing={false}
         onClearBaseBuild={() => {
           navigate(
-            getCompareBuildUrl({
+            getCompareBuildPath({
               organizationSlug: organization.slug,
               projectId,
               headArtifactId,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -13,7 +13,7 @@ import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getSizeBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface BuildButtonProps {
   buildDetails: BuildDetailsApiResponse;
@@ -43,7 +43,7 @@ function BuildButton({
   const dateAdded = buildDetails.app_info?.date_added;
 
   const buildUrl =
-    getSizeBuildUrl({
+    getSizeBuildPath({
       organizationSlug: organization.slug,
       projectId,
       baseArtifactId: buildId,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -13,6 +13,7 @@ import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getSizeBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface BuildButtonProps {
   buildDetails: BuildDetailsApiResponse;
@@ -41,7 +42,12 @@ function BuildButton({
   const dateBuilt = buildDetails.app_info?.date_built;
   const dateAdded = buildDetails.app_info?.date_added;
 
-  const buildUrl = `/organizations/${organization.slug}/preprod/${projectId}/${buildId}/`;
+  const buildUrl =
+    getSizeBuildUrl({
+      organizationSlug: organization.slug,
+      projectId,
+      baseArtifactId: buildId,
+    }) ?? '';
   const platform = buildDetails.app_info?.platform ?? null;
 
   const dateToShow = dateBuilt || dateAdded;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -42,7 +42,7 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
-import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -123,7 +123,7 @@ export function SizeCompareSelectionContent({
     },
     onSuccess: () => {
       navigate(
-        getBuildCompareUrl({
+        getCompareBuildUrl({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId: headBuildDetails.id,
@@ -173,7 +173,7 @@ export function SizeCompareSelectionContent({
             // Clear cursor when search query changes to avoid pagination issues
             if (cursor) {
               navigate(
-                getBuildCompareUrl({
+                getCompareBuildUrl({
                   organizationSlug: organization.slug,
                   projectId,
                   headArtifactId: headBuildDetails.id,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -42,7 +42,7 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
-import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -123,7 +123,7 @@ export function SizeCompareSelectionContent({
     },
     onSuccess: () => {
       navigate(
-        getCompareBuildUrl({
+        getCompareBuildPath({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId: headBuildDetails.id,
@@ -173,7 +173,7 @@ export function SizeCompareSelectionContent({
             // Clear cursor when search query changes to avoid pagination issues
             if (cursor) {
               navigate(
-                getCompareBuildUrl({
+                getCompareBuildPath({
                   organizationSlug: organization.slug,
                   projectId,
                   headArtifactId: headBuildDetails.id,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -42,6 +42,7 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -122,7 +123,12 @@ export function SizeCompareSelectionContent({
     },
     onSuccess: () => {
       navigate(
-        `/organizations/${organization.slug}/preprod/${projectId}/compare/${headBuildDetails.id}/${selectedBaseBuild?.id}/`
+        getBuildCompareUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId: headBuildDetails.id,
+          baseArtifactId: selectedBaseBuild?.id,
+        })
       );
     },
     onError: error => {
@@ -167,7 +173,11 @@ export function SizeCompareSelectionContent({
             // Clear cursor when search query changes to avoid pagination issues
             if (cursor) {
               navigate(
-                `/organizations/${organization.slug}/preprod/${projectId}/compare/${headBuildDetails.id}/`,
+                getBuildCompareUrl({
+                  organizationSlug: organization.slug,
+                  projectId,
+                  headArtifactId: headBuildDetails.id,
+                }),
                 {replace: true}
               );
             }

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -33,7 +33,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 import {useBuildDetailsActions} from './useBuildDetailsActions';
@@ -166,7 +166,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             }}
           />
           <Link
-            to={getBuildCompareUrl({
+            to={getCompareBuildUrl({
               organizationSlug: organization.slug,
               projectId,
               headArtifactId: buildDetailsData.id,

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -33,7 +33,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 import {useBuildDetailsActions} from './useBuildDetailsActions';
@@ -166,7 +166,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             }}
           />
           <Link
-            to={getCompareBuildUrl({
+            to={getCompareBuildPath({
               organizationSlug: organization.slug,
               projectId,
               headArtifactId: buildDetailsData.id,

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -33,6 +33,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 import {useBuildDetailsActions} from './useBuildDetailsActions';
@@ -165,7 +166,11 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             }}
           />
           <Link
-            to={`/organizations/${organization.slug}/preprod/${projectId}/compare/${buildDetailsData.id}/`}
+            to={getBuildCompareUrl({
+              organizationSlug: organization.slug,
+              projectId,
+              headArtifactId: buildDetailsData.id,
+            })}
             onClick={handleCompareClick}
           >
             <Button size="sm" priority="default" icon={<IconTelescope />}>

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getBuildListUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getListBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
@@ -51,7 +51,7 @@ export function useBuildDetailsActions({
       addSuccessMessage(t('Build deleted successfully'));
       // TODO(preprod): navigate back to the release page once built?
       navigate(
-        getBuildListUrl({
+        getListBuildUrl({
           organizationSlug: organization.slug,
           projectId,
         })

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getListBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getListBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
@@ -51,7 +51,7 @@ export function useBuildDetailsActions({
       addSuccessMessage(t('Build deleted successfully'));
       // TODO(preprod): navigate back to the release page once built?
       navigate(
-        getListBuildUrl({
+        getListBuildPath({
           organizationSlug: organization.slug,
           projectId,
         })

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getBuildListUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
@@ -49,7 +50,12 @@ export function useBuildDetailsActions({
     onSuccess: () => {
       addSuccessMessage(t('Build deleted successfully'));
       // TODO(preprod): navigate back to the release page once built?
-      navigate(`/organizations/${organization.slug}/preprod/${projectId}/`);
+      navigate(
+        getBuildListUrl({
+          organizationSlug: organization.slug,
+          projectId,
+        })
+      );
     },
     onError: () => {
       addErrorMessage(t('Failed to delete build'));

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -25,7 +25,7 @@ import type {
   BuildDetailsSizeInfoSizeMetric,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
-import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -116,7 +116,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   // Build comparison URL using route params
   const comparisonUrl =
     baseArtifactId && projectId && artifactId
-      ? getCompareBuildUrl({
+      ? getCompareBuildPath({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId: artifactId,

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -25,7 +25,7 @@ import type {
   BuildDetailsSizeInfoSizeMetric,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
-import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -116,7 +116,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   // Build comparison URL using route params
   const comparisonUrl =
     baseArtifactId && projectId && artifactId
-      ? getBuildCompareUrl({
+      ? getCompareBuildUrl({
           organizationSlug: organization.slug,
           projectId,
           headArtifactId: artifactId,

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -25,6 +25,7 @@ import type {
   BuildDetailsSizeInfoSizeMetric,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+import {getBuildCompareUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -115,7 +116,12 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   // Build comparison URL using route params
   const comparisonUrl =
     baseArtifactId && projectId && artifactId
-      ? `/organizations/${organization.slug}/preprod/${projectId}/compare/${artifactId}/${baseArtifactId}/`
+      ? getBuildCompareUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId: artifactId,
+          baseArtifactId,
+        })
       : undefined;
 
   const totalPotentialSavings = processedInsights.reduce(

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -13,7 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   formatBuildName,
-  getBaseBuildUrl,
+  getBaseBuildPath,
 } from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   getBranchUrl,
@@ -87,7 +87,7 @@ export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
                 );
                 const baseBuildUrl =
                   buildDetailsData.base_artifact_id && projectId
-                    ? getBaseBuildUrl({
+                    ? getBaseBuildPath({
                         baseArtifactId: buildDetailsData.base_artifact_id,
                         organizationSlug: organization.slug,
                         projectId,

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -14,6 +14,45 @@ export function getBaseBuildUrl(params: BuildLinkParams): string | null {
   return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/`;
 }
 
+export function getSizeBuildUrl(params: BuildLinkParams): string | null {
+  return getBaseBuildUrl(params);
+}
+
+export function getInstallBuildUrl(params: BuildLinkParams): string | null {
+  const {organizationSlug, projectId, baseArtifactId} = params;
+
+  if (!baseArtifactId) {
+    return null;
+  }
+
+  return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/install/`;
+}
+
+export function getBuildCompareUrl(params: {
+  headArtifactId: string;
+  organizationSlug: string;
+  projectId: string;
+  baseArtifactId?: string;
+}): string {
+  const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
+
+  let path = `/organizations/${organizationSlug}/preprod/${projectId}/compare/${headArtifactId}`;
+  if (baseArtifactId) {
+    path += `/${baseArtifactId}`;
+  }
+  path += '/';
+
+  return path;
+}
+
+export function getBuildListUrl(params: {
+  organizationSlug: string;
+  projectId: string;
+}): string {
+  const {organizationSlug, projectId} = params;
+  return `/organizations/${organizationSlug}/preprod/${projectId}/`;
+}
+
 export function formatBuildName(
   version: string | number | null | undefined,
   buildNumber: string | number | null | undefined

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -1,34 +1,34 @@
 interface BuildLinkParams {
-  baseArtifactId: string | null | undefined;
   organizationSlug: string;
   projectId: string;
+  baseArtifactId?: string;
 }
 
-export function getBaseBuildUrl(params: BuildLinkParams): string | null {
+export function getBaseBuildPath(params: BuildLinkParams): string | undefined {
   const {organizationSlug, projectId, baseArtifactId} = params;
 
   if (!baseArtifactId) {
-    return null;
+    return undefined;
   }
 
   return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/`;
 }
 
-export function getSizeBuildUrl(params: BuildLinkParams): string | null {
-  return getBaseBuildUrl(params);
+export function getSizeBuildPath(params: BuildLinkParams): string | undefined {
+  return getBaseBuildPath(params);
 }
 
-export function getInstallBuildUrl(params: BuildLinkParams): string | null {
-  const baseUrl = getBaseBuildUrl(params);
+export function getInstallBuildPath(params: BuildLinkParams): string | undefined {
+  const basePath = getBaseBuildPath(params);
 
-  if (!baseUrl) {
-    return null;
+  if (!basePath) {
+    return undefined;
   }
 
-  return `${baseUrl}install/`;
+  return `${basePath}install/`;
 }
 
-export function getCompareBuildUrl(params: {
+export function getCompareBuildPath(params: {
   headArtifactId: string;
   organizationSlug: string;
   projectId: string;
@@ -36,16 +36,15 @@ export function getCompareBuildUrl(params: {
 }): string {
   const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
 
-  let path = `/organizations/${organizationSlug}/preprod/${projectId}/compare/${headArtifactId}`;
+  let path = `/organizations/${organizationSlug}/preprod/${projectId}/compare/${headArtifactId}/`;
   if (baseArtifactId) {
-    path += `/${baseArtifactId}`;
+    path += `${baseArtifactId}/`;
   }
-  path += '/';
 
   return path;
 }
 
-export function getListBuildUrl(params: {
+export function getListBuildPath(params: {
   organizationSlug: string;
   projectId: string;
 }): string {

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -19,13 +19,13 @@ export function getSizeBuildUrl(params: BuildLinkParams): string | null {
 }
 
 export function getInstallBuildUrl(params: BuildLinkParams): string | null {
-  const {organizationSlug, projectId, baseArtifactId} = params;
+  const baseUrl = getBaseBuildUrl(params);
 
-  if (!baseArtifactId) {
+  if (!baseUrl) {
     return null;
   }
 
-  return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/install/`;
+  return `${baseUrl}install/`;
 }
 
 export function getCompareBuildUrl(params: {

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -28,7 +28,7 @@ export function getInstallBuildUrl(params: BuildLinkParams): string | null {
   return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/install/`;
 }
 
-export function getBuildCompareUrl(params: {
+export function getCompareBuildUrl(params: {
   headArtifactId: string;
   organizationSlug: string;
   projectId: string;
@@ -45,7 +45,7 @@ export function getBuildCompareUrl(params: {
   return path;
 }
 
-export function getBuildListUrl(params: {
+export function getListBuildUrl(params: {
   organizationSlug: string;
   projectId: string;
 }): string {


### PR DESCRIPTION
Refactors hardcoded preprod URL strings to use centralized helper functions, establishing a single source of truth for URL patterns to make it easier to change these in the future.
This doesn't change any behavior, just migrates to using functions instead of hard-coded urls.

Related to EME-725