### PR TITLE
ref(grouping): Remove `contributes` check for single JS frame ignoring

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -507,7 +507,6 @@ def _single_stacktrace_variant(
     # for grouping.
     if (
         len(frames) == 1
-        and frame_components[0].contributes
         and get_behavior_family_for_platform(frames[0].platform or event.platform) == "javascript"
         and not frames[0].function
     ):

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -82,7 +82,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": null,
+                "hint": "ignored single non-URL JavaScript frame",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
@@ -82,7 +82,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": null,
+                "hint": "ignored single non-URL JavaScript frame",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -22,6 +22,6 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame
+        frame (ignored single non-URL JavaScript frame)
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
@@ -22,6 +22,6 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame
+        frame (ignored single non-URL JavaScript frame)
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"


### PR DESCRIPTION
In our grouping algorithm, certain stacktraces are considered too low quality to use, among them certain* single-frame JavaScript stacks which contain code from unnamed functions. When we find such a stack, we set the frame component to be non-contributing, with a hint explaining why. However, this step is skipped if the frame is already marked as `contributes: False`.

On the one hand, this makes sense: Why bother to mark a frame as ignored if it's already being ignored? On the other hand, skipping this step means we also skip adding the hint. This PR therefore removes the `contributes` check in the relevant `if` statement, so that we're not only ignoring the frame, we're ignoring the frame and also explaining why.

_\* Specifically, we ignore such stacks if their single frame comes from a file whose `abs_path` is something other than a URL. Or at least, that's what we intend to do. In practice, this check is implemented backwards, something which will be fixed in the upcoming new grouping config. But the fact that it's currently backwards explains how one of the snapshots affected by this change can contain a frame component which says it's for a non-URL frame even though its child filename component says it does in fact come from a URL. This has been wrong for a long time, it's just much more obvious now that this PR includes the hint in the grouping info._