### PR TITLE
fix(aci): clip open period bubble overflow

### DIFF
--- a/static/app/views/detectors/hooks/useIncidentMarkers.tsx
+++ b/static/app/views/detectors/hooks/useIncidentMarkers.tsx
@@ -162,14 +162,25 @@ function IncidentMarkerSeries({
     const [incidentStartX, incidentStartY] = startCoord;
     const [incidentEndX] = endCoord;
 
-    // Width between two timestamps
-    const width = Math.max(incidentEndX - incidentStartX, 2);
+    // ECharts provides coordinate system boundaries via params.coordSys
+    // https://echarts.apache.org/en/option.html#series-custom.renderItem.arguments.params
+    const coordSys = params.coordSys as any;
+    const chartLeft = coordSys.x ?? 0;
+    const chartRight = (coordSys.x ?? 0) + (coordSys.width ?? 0);
+
+    // Clip bubble coordinates to stay within visible chart area
+    // This prevents overflow when incidents start before or extend past the visible time range
+    const clippedStartX = Math.max(incidentStartX, chartLeft);
+    const clippedEndX = Math.min(incidentEndX, chartRight);
+
+    // Width between two timestamps, adjusted for clipping
+    const width = Math.max(clippedEndX - clippedStartX, 2);
 
     const renderMarkerPadding = 2;
 
     const shape = {
-      // Position the rectangle in the space created by the grid/xAxis offset
-      x: incidentStartX,
+      // Position the rectangle using clipped coordinates to prevent overflow
+      x: clippedStartX,
       y: incidentStartY + renderMarkerPadding - 1,
       width,
       height: INCIDENT_MARKER_HEIGHT,


### PR DESCRIPTION
fixes open period bubble overflow on the left

before
<img width="1030" height="274" alt="Screenshot 2026-01-07 at 11 13 31 AM" src="https://github.com/user-attachments/assets/35ad00db-2792-4b33-ae35-a31f072a0ec8" />

after
<img width="983" height="299" alt="Screenshot 2026-01-07 at 11 13 46 AM" src="https://github.com/user-attachments/assets/6fc665ad-932d-4c8f-9614-9388e1bcfb2f" />

I believe the other differences in the 2 screenshots are because the zoom/scale in my 2 tabs is different, not sure how or why so pls disregard
