### PR TITLE
fix(aci): Hide link to all issues when metric alert uses invalid syntax

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -6,6 +6,7 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection';
 
 describe('MetricDetectorTriggeredSection', () => {
@@ -175,5 +176,60 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(contributingIssuesMock).toHaveBeenCalled();
 
     await screen.findByRole('link', {name: 'RequestError'});
+  });
+
+  it('renders boolean logic error when query contains OR', async () => {
+    const dataSourceWithOr = SnubaQueryDataSourceFixture({
+      queryObj: {
+        id: '1',
+        status: 1,
+        subscription: '1',
+        snubaQuery: {
+          aggregate: 'count()',
+          dataset: Dataset.ERRORS,
+          id: '',
+          query: 'browser.name:Chrome OR browser.name:Firefox',
+          timeWindow: 60,
+          eventTypes: [EventTypes.ERROR],
+        },
+      },
+    });
+
+    const event = EventFixture({
+      dateCreated: '2024-01-01T00:00:00Z',
+      occurrence: {
+        id: '1',
+        eventId: 'event-1',
+        fingerprint: ['fingerprint'],
+        issueTitle: 'Test Issue',
+        subtitle: 'Subtitle',
+        resourceId: 'resource-1',
+        evidenceData: {
+          conditions: [condition],
+          dataSources: [dataSourceWithOr],
+          value: 150,
+        },
+        evidenceDisplay: [],
+        type: 8001,
+        detectionTime: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    render(<MetricDetectorTriggeredSection event={event} />);
+
+    // Check that the boolean logic error alert is shown
+    expect(
+      await screen.findByText('Contributing issues unavailable for this detector.')
+    ).toBeInTheDocument();
+
+    // The View All button should not be present when there's boolean logic
+    expect(screen.queryByRole('button', {name: 'View All'})).not.toBeInTheDocument();
+
+    // The Open in Discover button should be present
+    expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2017-10-17T02%3A41%3A20.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
+    );
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -14,6 +14,7 @@ import GroupList from 'sentry/components/issues/groupList';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
+import {treeResultLocator} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, EventOccurrence} from 'sentry/types/event';
@@ -144,8 +145,13 @@ function ContributingIssues({
 
   const queryContainsBooleanLogic = useMemo(() => {
     try {
-      const parsedQuery = parseSearch(query);
-      return parsedQuery?.some(token => token.type === Token.LOGIC_BOOLEAN);
+      return treeResultLocator<boolean>({
+        tree: parseSearch(query) ?? [],
+        noResultValue: false,
+        visitorTest: ({token, returnResult}) => {
+          return token.type === Token.LOGIC_BOOLEAN ? returnResult(true) : null;
+        },
+      });
     } catch {
       return false;
     }

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
+import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
 import {Text} from '@sentry/scraps/text';
@@ -33,6 +33,7 @@ import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/de
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
 interface MetricDetectorEvidenceData {
@@ -108,7 +109,7 @@ function calculateStartOfInterval({
 /**
  * Issues list does not support AND/OR in the query, but Discover does.
  */
-function BooleanLogicError({discoverUrl}: {discoverUrl: string}) {
+function BooleanLogicError({discoverUrl}: {discoverUrl: LocationDescriptor}) {
   return (
     <Alert.Container>
       <Alert
@@ -170,14 +171,18 @@ function ContributingIssues({
     sort: aggregate === 'count_unique(user)' ? 'user' : 'freq',
   };
 
-  const discoverUrl = `/organizations/${organization.slug}/discover/results/?${qs.stringify(
-    {
+  const discoverUrl: LocationDescriptor = {
+    pathname: makeDiscoverPathname({
+      organization,
+      path: '/results/',
+    }),
+    query: {
       query,
       dataset: SavedQueryDatasets.ERRORS,
       start,
       end,
-    }
-  )}`;
+    },
+  };
 
   return (
     <InterimSection


### PR DESCRIPTION
The "view all" link was not useful because it linked to a broken view due to the syntax. This removes that link and adds some explanatory text.

<img width="1638" height="314" alt="CleanShot 2026-01-07 at 11 33 15@2x" src="https://github.com/user-attachments/assets/95b9536b-b2a5-43a1-8aae-b7ced77916ff" />
