### PR TITLE
chore(ask-seer): Clean up old explore traces flags

### DIFF
--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -92,8 +92,6 @@ class TraceExplorerAIQuery(OrganizationEndpoint):
             )
 
         if not features.has(
-            "organizations:gen-ai-explore-traces", organization=organization, actor=request.user
-        ) or not features.has(
             "organizations:gen-ai-features", organization=organization, actor=request.user
         ):
             return Response(

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -80,8 +80,6 @@ class TraceExplorerAISetup(OrganizationEndpoint):
             )
 
         if not features.has(
-            "organizations:gen-ai-explore-traces", organization=organization, actor=request.user
-        ) or not features.has(
             "organizations:gen-ai-features", organization=organization, actor=request.user
         ):
             return Response(


### PR DESCRIPTION
These have been fully rolled out, and will be removed from the FE as well once these are merged.