### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for admin `BeaconDetails` route

### DIFF
--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -18,6 +18,7 @@ type ParamKeys =
   | 'appSlug'
   | 'authId'
   | 'automationId'
+  | 'beaconId'
   | 'codeId'
   | 'dashboardId'
   | 'dataForwarderId'

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -61,7 +61,6 @@ function buildRoutes() {
           {
             path: ':beaconId/',
             component: BeaconDetails,
-            deprecatedRouteProps: true,
           },
         ],
       },

--- a/static/gsAdmin/views/beaconDetails.tsx
+++ b/static/gsAdmin/views/beaconDetails.tsx
@@ -1,7 +1,7 @@
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useParams} from 'sentry/utils/useParams';
 
 import BeaconCheckins from 'admin/components/beacons/beaconCheckins';
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
@@ -9,9 +9,8 @@ import BeaconOverview from 'admin/components/beacons/beaconOverview';
 import RelatedBeacons from 'admin/components/beacons/relatedBeacons';
 import DetailsPage from 'admin/components/detailsPage';
 
-type Props = RouteComponentProps<{beaconId: string}, unknown>;
-
-function BeaconDetails({params}: Props) {
+export default function BeaconDetails() {
+  const params = useParams<{beaconId: string}>();
   const {data, isPending, isError} = useApiQuery<BeaconData>(
     [`/beacons/${params.beaconId}/`],
     {
@@ -54,5 +53,3 @@ function BeaconDetails({params}: Props) {
     />
   );
 }
-
-export default BeaconDetails;


### PR DESCRIPTION
Migrates the `BeaconDetails` admin route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7