### PR TITLE
fix(insights): create alert button broken insights/explore

### DIFF
--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -301,7 +301,7 @@ describe('CreateAlertFromViewButton', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
     expect(router.location.pathname).toBe(
-      '/organizations/org-slug/monitors/new/settings/'
+      '/organizations/org-slug/monitors/new/settings'
     );
     expect(router.location.query).toEqual(
       expect.objectContaining({

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -169,10 +169,14 @@ export function BaseChartActionDropdown({
     menuOptions.push(menuOption);
   }
 
+  const newAlertLabel = organization.features.includes('workflow-engine-ui')
+    ? t('Create a Monitor for')
+    : t('Create an Alert for');
+
   if (alertMenuOptions.length > 0) {
     menuOptions.push({
       key: 'create-alert',
-      label: t('Create Alert for'),
+      label: newAlertLabel,
       isSubmenu: true,
       children: alertMenuOptions.map(option => ({
         ...option,

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
@@ -48,7 +48,7 @@ export function getMetricMonitorUrl({
   } as const;
 
   return {
-    pathname: makeMonitorCreatePathname(organization.slug),
+    pathname: `${makeMonitorCreatePathname(organization.slug)}settings`,
     query: queryParams,
   };
 }

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
@@ -3,7 +3,7 @@ import type {Project} from 'sentry/types/project';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {parseEventTypesFromQuery} from 'sentry/views/detectors/datasetConfig/eventTypes';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
-import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
+import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
 
 type Params = {
   aggregate: string;
@@ -48,7 +48,7 @@ export function getMetricMonitorUrl({
   } as const;
 
   return {
-    pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
+    pathname: makeMonitorCreatePathname(organization.slug),
     query: queryParams,
   };
 }


### PR DESCRIPTION
Quick fix for broken link when trying to create an alert from an insights chart or from explore.

If we add a trailing slash to`${makeMonitorCreatePathname(organization.slug)}settings` results in the final url being `monitors/new/settings/organization/` instead of `monitors/new/settings/`

This seems to be do to a regex in `normalizeUrl` which replaces `/settings/` with `/settings/organization` https://github.com/getsentry/sentry/blob/309a2c69be51ba9359d15526d905ff3107235d22/static/app/utils/url/normalizeUrl.tsx#L10-L13

This is just a quick fix to put up before we figure out if it's safe to modify the regex