### PR TITLE
feat(grouping): Add clearer component ignoring test inputs

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/javascript-single-non-url-frame.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-single-non-url-frame.json
@@ -1,0 +1,11 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "abs_path": "/Users/Maisey/dogs/are/great.js",
+        "filename": "great.js"
+      }
+    ]
+  },
+  "platform": "javascript"
+}

--- a/tests/sentry/grouping/grouping_inputs/javascript-single-url-frame.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-single-url-frame.json
@@ -1,0 +1,11 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "abs_path": "https://sentry.io/dogs/are/great.js",
+        "filename": "great.js"
+      }
+    ]
+  },
+  "platform": "javascript"
+}

--- a/tests/sentry/grouping/grouping_inputs/javascript-url-path-as-module.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-url-path-as-module.json
@@ -1,0 +1,15 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "abs_path": "https://sentry.io/dogs/are/great.js",
+        "module": "dogs.are.great"
+      },
+      {
+        "abs_path": "https://sentry.io/adopt/dont/shop.js",
+        "module": "adopt/dont/shop.js"
+      }
+    ]
+  },
+  "platform": "javascript"
+}

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,33 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "top-level",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "top-level",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "d2ab6870c762b8a67d831c2a608bbfb4"
+    contributing component: stacktrace
+    hint: None
+    root_component:
+      system*
+        stacktrace*
+          frame*
+            filename*
+              "great.js"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_single_url_frame.pysnap
@@ -1,0 +1,21 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: fallback
+hashing_metadata: {
+  "fallback_reason": "no_contributing_frames"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "fallback",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.fallback": {
+    "fallback_reason": "no_contributing_frames"
+  }
+}
+---
+contributing variants:
+  fallback*
+    hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
@@ -1,0 +1,33 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "top-level",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "top-level",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "1001e7b7dd0155a6d4021cd6d6b9f50d"
+    contributing component: stacktrace
+    hint: None
+    root_component:
+      system*
+        stacktrace*
+          frame*
+            module*
+              "dogs.are.great"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,33 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "top-level",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "top-level",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "d2ab6870c762b8a67d831c2a608bbfb4"
+    contributing component: stacktrace
+    hint: None
+    root_component:
+      system*
+        stacktrace*
+          frame*
+            filename*
+              "great.js"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
@@ -1,0 +1,21 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: fallback
+hashing_metadata: {
+  "fallback_reason": "no_contributing_frames"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "fallback",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.fallback": {
+    "fallback_reason": "no_contributing_frames"
+  }
+}
+---
+contributing variants:
+  fallback*
+    hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
@@ -1,0 +1,33 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "top-level",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "top-level",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "1001e7b7dd0155a6d4021cd6d6b9f50d"
+    contributing component: stacktrace
+    hint: None
+    root_component:
+      system*
+        stacktrace*
+          frame*
+            module*
+              "dogs.are.great"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,118 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system stacktrace takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system stacktrace takes precedence",
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "event-level stacktrace — all frames",
+      "hash": "d2ab6870c762b8a67d831c2a608bbfb4",
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_single_url_frame.pysnap
@@ -1,0 +1,126 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": null,
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": null,
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "fallback": {
+      "contributes": true,
+      "description": "fallback grouping",
+      "hash": "d41d8cd98f00b204e9800998ecf8427e",
+      "hint": null,
+      "key": "fallback",
+      "type": "fallback"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no contributing frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "ignored single non-URL JavaScript frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — all frames",
+      "hash": null,
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
@@ -1,0 +1,188 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system stacktrace takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "dogs.are.great"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "ignored bad javascript module",
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "adopt/dont/shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system stacktrace takes precedence",
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "dogs.are.great"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "ignored bad javascript module",
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "adopt/dont/shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "event-level stacktrace — all frames",
+      "hash": "1001e7b7dd0155a6d4021cd6d6b9f50d",
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,118 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2025-11-21",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system stacktrace takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system stacktrace takes precedence",
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "event-level stacktrace — all frames",
+      "hash": "d2ab6870c762b8a67d831c2a608bbfb4",
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_url_frame.pysnap
@@ -1,0 +1,126 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2025-11-21",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": null,
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": null,
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "fallback": {
+      "contributes": true,
+      "description": "fallback grouping",
+      "hash": "d41d8cd98f00b204e9800998ecf8427e",
+      "hint": null,
+      "key": "fallback",
+      "type": "fallback"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no contributing frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "ignored single non-URL JavaScript frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": []
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — all frames",
+      "hash": null,
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
@@ -1,0 +1,188 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2025-11-21",
+  "variants": {
+    "app_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system stacktrace takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because it contains no in-app frames",
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "dogs.are.great"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "non app frame",
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "ignored bad javascript module",
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "adopt/dont/shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "event-level stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system stacktrace takes precedence",
+      "key": "app_stacktrace",
+      "type": "component"
+    },
+    "system_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "stacktrace",
+            "name": "stacktrace",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "dogs.are.great"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "great.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "frame",
+                "name": null,
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "ignored bad javascript module",
+                    "id": "module",
+                    "name": null,
+                    "values": [
+                      "adopt/dont/shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored because frame points to a URL",
+                    "id": "filename",
+                    "name": null,
+                    "values": [
+                      "shop.js"
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": null,
+                    "id": "function",
+                    "name": null,
+                    "values": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "event-level stacktrace — all frames",
+      "hash": "1001e7b7dd0155a6d4021cd6d6b9f50d",
+      "hint": null,
+      "key": "system_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,24 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system stacktrace takes precedence
+  root_component:
+    app (ignored because system stacktrace takes precedence)
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          filename*
+            "great.js"
+--------------------------------------------------------------------------
+system:
+  hash: "d2ab6870c762b8a67d831c2a608bbfb4"
+  contributing component: stacktrace
+  hint: None
+  root_component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "great.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_single_url_frame.pysnap
@@ -1,0 +1,27 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: None
+  root_component:
+    app
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          filename (ignored because frame points to a URL)
+            "great.js"
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  hint: None
+  root_component:
+    system
+      stacktrace (ignored because it contains no contributing frames)
+        frame (ignored single non-URL JavaScript frame)
+          filename (ignored because frame points to a URL)
+            "great.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_url_path_as_module.pysnap
@@ -1,0 +1,38 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system stacktrace takes precedence
+  root_component:
+    app (ignored because system stacktrace takes precedence)
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          module*
+            "dogs.are.great"
+          filename (ignored because frame points to a URL)
+            "great.js"
+        frame (non app frame)
+          module (ignored bad javascript module)
+            "adopt/dont/shop.js"
+          filename (ignored because frame points to a URL)
+            "shop.js"
+--------------------------------------------------------------------------
+system:
+  hash: "1001e7b7dd0155a6d4021cd6d6b9f50d"
+  contributing component: stacktrace
+  hint: None
+  root_component:
+    system*
+      stacktrace*
+        frame*
+          module*
+            "dogs.are.great"
+          filename (ignored because frame points to a URL)
+            "great.js"
+        frame
+          module (ignored bad javascript module)
+            "adopt/dont/shop.js"
+          filename (ignored because frame points to a URL)
+            "shop.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -1,0 +1,24 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system stacktrace takes precedence
+  root_component:
+    app (ignored because system stacktrace takes precedence)
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          filename*
+            "great.js"
+--------------------------------------------------------------------------
+system:
+  hash: "d2ab6870c762b8a67d831c2a608bbfb4"
+  contributing component: stacktrace
+  hint: None
+  root_component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "great.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
@@ -1,0 +1,27 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: None
+  root_component:
+    app
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          filename (ignored because frame points to a URL)
+            "great.js"
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  hint: None
+  root_component:
+    system
+      stacktrace (ignored because it contains no contributing frames)
+        frame (ignored single non-URL JavaScript frame)
+          filename (ignored because frame points to a URL)
+            "great.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_url_path_as_module.pysnap
@@ -1,0 +1,38 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system stacktrace takes precedence
+  root_component:
+    app (ignored because system stacktrace takes precedence)
+      stacktrace (ignored because it contains no in-app frames)
+        frame (non app frame)
+          module*
+            "dogs.are.great"
+          filename (ignored because frame points to a URL)
+            "great.js"
+        frame (non app frame)
+          module (ignored bad javascript module)
+            "adopt/dont/shop.js"
+          filename (ignored because frame points to a URL)
+            "shop.js"
+--------------------------------------------------------------------------
+system:
+  hash: "1001e7b7dd0155a6d4021cd6d6b9f50d"
+  contributing component: stacktrace
+  hint: None
+  root_component:
+    system*
+      stacktrace*
+        frame*
+          module*
+            "dogs.are.great"
+          filename (ignored because frame points to a URL)
+            "great.js"
+        frame
+          module (ignored bad javascript module)
+            "adopt/dont/shop.js"
+          filename (ignored because frame points to a URL)
+            "shop.js"


### PR DESCRIPTION
In our grouping algorithm, one of our checks for whether or not to use a given stacktrace is implemented backwards: We claim to ignore a frame if its `abs_path` isn't a URL, but then only actually do that if its `abs_path` is in fact a URL. 

This will be fixed in the upcoming new grouping config, but in the process of making that change, it became clear that some of our relevant tests are quite hard to reason about. Specifically, we have two grouping snapshot inputs called `frame_ignores_module_if_page_url` and `frame_ignores_module_if_page_url-2`, which have a few problems:

- `frame_ignores_module_if_page_url` doesn't illustrate what it says it does at all, in that the module isn't in fact ignored. What it does turn out to illustrate is the URL/non-URL frame ignoring bug discussed above.

- `frame_ignores_module_if_page_url-2` does illustrate the module ignoring, but a) its title isn't as clear as it might be, b) it includes a function component, which muddies the waters in terms of what's ignored or not, and c) though it doesn't currently illustrate the URL/non-URL frame ignoring behavior which was previously discussed, once the bug is fixed it will, which will be another thing adding mud to the aforementioned proverbial water.

To fix these problems, this PR adds three new inputs: one to illustrate the module ignoring (and only the module ignoring), and one each to illustrate the URL and non-URL frame ignoring cases, respectively. This should make it easier to see the effects of the bug fix, as only the latter two inputs should be affected. 

(A follow-up PR will remove the bad inputs. Doing both in a single PR was confusing GitHub, making it think that things had been renamed and slightly modified rather than replaced.)