### PR TITLE
feat(code_review): Use GitHub org names whitelisting for testing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -690,7 +690,7 @@ register("overwatch.enabled-regions", default=[], flags=FLAG_AUTOMATOR_MODIFIABL
 # enable verbose debug logging for overwatch webhook forwarding
 register("overwatch.forward-webhooks.verbose", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Control forwarding of specific GitHub webhook types to overwatch (True) or seer (False)
+# Control forwarding of GitHub webhook events to Overwatch
 register("github.webhook.issue-comment", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -146,7 +146,11 @@ class OverwatchGithubWebhookForwarder:
                 # feature isn't enabled, no work to do
                 return
 
-            github_org = event.get("repository", {}).get("owner", {}).get("login")
+            repository = event.get("repository", {})
+            github_org = None
+            if isinstance(repository, dict):
+                github_org = repository.get("owner", {}).get("login")
+
             if github_org and github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
                 verbose_log(
                     "overwatch.debug.github_org_not_whitelisted",

--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -17,6 +17,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.overwatch_webhooks.types import OrganizationSummary, WebhookDetails
 from sentry.overwatch_webhooks.webhook_publisher import OverwatchWebhookPublisher
 from sentry.seer.code_review.utils import get_webhook_option_key
+from sentry.seer.code_review.webhooks.config import GH_ORGS_TO_ONLY_SEND_TO_SEER
 from sentry.types.region import get_region_by_name
 from sentry.utils import metrics
 
@@ -143,6 +144,17 @@ class OverwatchGithubWebhookForwarder:
             enabled_regions = options.get("overwatch.enabled-regions")
             if not enabled_regions:
                 # feature isn't enabled, no work to do
+                return
+
+            github_org = event.get("repository", {}).get("owner", {}).get("login")
+            if github_org and github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
+                verbose_log(
+                    "overwatch.debug.github_org_not_whitelisted",
+                    extra={
+                        "github_org": github_org,
+                        "whitelisted_orgs": list(GH_ORGS_TO_ONLY_SEND_TO_SEER),
+                    },
+                )
                 return
 
             orgs_by_region = self._get_org_summaries_by_region_for_integration(

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -1,6 +1,6 @@
 from sentry.integrations.github.webhook_types import GithubWebhookType
 
-WHITELISTED_GITHUB_ORGS = {
+GH_ORGS_TO_ONLY_SEND_TO_SEER = {
     "sentry-ecosystem",  # on s4s2 & us
     "coding-workflows-s4s",  # on us
     "sentry-coding-workflows",  # on us

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -1,5 +1,11 @@
 from sentry.integrations.github.webhook_types import GithubWebhookType
 
+WHITELISTED_GITHUB_ORGS = {
+    "sentry-ecosystem",  # on s4s2 & us
+    "coding-workflows-s4s",  # on us
+    "sentry-coding-workflows",  # on us
+}
+
 # Mapping of webhook types to their corresponding option keys
 WEBHOOK_TYPE_TO_OPTION_KEY = {
     GithubWebhookType.ISSUE_COMMENT: "github.webhook.issue-comment",

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -9,7 +9,6 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import options
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
@@ -19,6 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
+from .config import WHITELISTED_GITHUB_ORGS
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,8 @@ def handle_issue_comment_event(
     if not is_pr_review_command(comment_body or ""):
         return
 
-    if not options.get("github.webhook.issue-comment"):
+    github_org = event.get("repository", {}).get("owner", {}).get("login")
+    if github_org in WHITELISTED_GITHUB_ORGS:
         if comment_id:
             _add_eyes_reaction_to_comment(integration, organization, repo, str(comment_id))
 

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -18,7 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
-from .config import WHITELISTED_GITHUB_ORGS
+from .config import GH_ORGS_TO_ONLY_SEND_TO_SEER
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def handle_issue_comment_event(
         return
 
     github_org = event.get("repository", {}).get("owner", {}).get("login")
-    if github_org in WHITELISTED_GITHUB_ORGS:
+    if github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
         if comment_id:
             _add_eyes_reaction_to_comment(integration, organization, repo, str(comment_id))
 

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -18,7 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
-from .config import WHITELISTED_GITHUB_ORGS
+from .config import GH_ORGS_TO_ONLY_SEND_TO_SEER
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ def handle_pull_request_event(
         return
 
     github_org = event.get("repository", {}).get("owner", {}).get("login")
-    if github_org in WHITELISTED_GITHUB_ORGS:
+    if github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
         from .task import schedule_task
 
         schedule_task(

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -10,7 +10,6 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import options
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.models.organization import Organization
@@ -19,6 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
+from .config import WHITELISTED_GITHUB_ORGS
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,8 @@ def handle_pull_request_event(
         _warn_and_increment_metric(ErrorStatus.DRAFT_PR, action=action_value, extra=extra)
         return
 
-    if not options.get("github.webhook.pr"):
+    github_org = event.get("repository", {}).get("owner", {}).get("login")
+    if github_org in WHITELISTED_GITHUB_ORGS:
         from .task import schedule_task
 
         schedule_task(

--- a/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
+++ b/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
@@ -155,6 +155,30 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
             mock_enqueue.assert_not_called()
 
     @override_options({"overwatch.enabled-regions": ["us"]})
+    def test_forward_if_applicable_skips_seer_only_orgs(self):
+        organization = self.create_organization(name="Test Org", slug="test-org", region="us")
+        self.create_organization_integration(
+            integration=self.integration,
+            organization_id=organization.id,
+        )
+
+        event = {
+            "action": "pull_request",
+            "repository": {"owner": {"login": "sentry-ecosystem"}},
+            "commits": [],
+        }
+
+        with patch.object(OverwatchWebhookPublisher, "enqueue_webhook") as mock_enqueue:
+            self.forwarder.forward_if_applicable(
+                event,
+                headers={
+                    GITHUB_WEBHOOK_TYPE_HEADER_KEY: "pull_request",
+                    GITHUB_INSTALLATION_TARGET_ID_HEADER: "987654",
+                },
+            )
+            mock_enqueue.assert_not_called()
+
+    @override_options({"overwatch.enabled-regions": ["us"]})
     def test_forward_if_applicable_successful_forwarding(self):
         organization = self.create_organization(name="Test Org", slug="test-org", region="us")
         self.create_organization_integration(

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -51,7 +51,10 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
         return self._send_webhook_event(GithubWebhookType.ISSUE_COMMENT, event_data)
 
     def _build_issue_comment_event(
-        self, comment_body: str, comment_id: int | None = 123456789
+        self,
+        comment_body: str,
+        comment_id: int | None = 123456789,
+        github_org: str = "sentry-ecosystem",
     ) -> bytes:
         event = {
             "action": "created",
@@ -61,7 +64,7 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             },
             "issue": {
                 "number": 42,
-                "pull_request": {"url": "https://api.github.com/repos/owner/repo/pulls/42"},
+                "pull_request": {"url": f"https://api.github.com/repos/{github_org}/repo/pulls/42"},
                 "user": {
                     "id": 12345678,
                     "login": "pr-author",
@@ -69,8 +72,12 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             },
             "repository": {
                 "id": 12345,
-                "full_name": "owner/repo",
-                "html_url": "https://github.com/owner/repo",
+                "full_name": f"{github_org}/repo",
+                "html_url": f"https://github.com/{github_org}/repo",
+                "owner": {
+                    "login": github_org,
+                    "id": 12345,
+                },
             },
             "sender": {
                 "id": 87654321,
@@ -120,7 +127,7 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert response.status_code == 204
 
             self.mock_reaction.assert_called_once_with(
-                "owner/repo", "123456789", GitHubReaction.EYES
+                "sentry-ecosystem/repo", "123456789", GitHubReaction.EYES
             )
             self.mock_seer.assert_called_once()
 
@@ -142,17 +149,6 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             mock_reaction.assert_not_called()
             self.mock_seer.assert_called_once()
 
-    @patch("sentry.seer.code_review.webhooks.issue_comment._add_eyes_reaction_to_comment")
-    def test_skips_processing_when_option_is_true(self, mock_reaction: MagicMock) -> None:
-        """Test that when github.webhook.issue-comment option is True (kill switch), no processing occurs."""
-        with self.code_review_setup(options={"github.webhook.issue-comment": True}), self.tasks():
-            event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-            response = self._send_issue_comment_event(event)
-            assert response.status_code == 204
-
-            mock_reaction.assert_not_called()
-            self.mock_seer.assert_not_called()
-
     def test_validates_seer_request_contains_trigger_metadata(self) -> None:
         """Test that Seer request includes trigger metadata from the comment."""
         with self.code_review_setup(), self.tasks():
@@ -170,3 +166,27 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "test-user"
             assert payload["data"]["config"]["trigger_comment_id"] == 123456789
             assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
+
+    def test_processes_whitelisted_github_org(self) -> None:
+        """Test that whitelisted GitHub organizations are processed."""
+        with self.code_review_setup(), self.tasks():
+            event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
+
+            response = self._send_issue_comment_event(event)
+            assert response.status_code == 204
+
+            self.mock_reaction.assert_called_once()
+            self.mock_seer.assert_called_once()
+
+    def test_skips_non_whitelisted_github_org(self) -> None:
+        """Test that non-whitelisted GitHub organizations are skipped."""
+        with self.code_review_setup(), self.tasks():
+            event = self._build_issue_comment_event(
+                f"Please {SENTRY_REVIEW_COMMAND} this PR", github_org="random-org"
+            )
+
+            response = self._send_issue_comment_event(event)
+            assert response.status_code == 204
+
+            self.mock_reaction.assert_not_called()
+            self.mock_seer.assert_not_called()


### PR DESCRIPTION
We have tried using `s4s` and `s4s2` for testing but there are all sorts of problems.

We will be using the GitHub org to determine if to send to Seer.