### PR TITLE
feat(preprod): Remove reads from deprecated fields and use PreprodArtifactMobileAppInfo table

### DIFF
--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -53,7 +53,9 @@ class PreprodArtifactEndpoint(ProjectEndpoint):
             return args, kwargs
 
         try:
-            head_artifact = PreprodArtifact.objects.get(id=int(head_artifact_id))
+            head_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
+                id=int(head_artifact_id)
+            )
         except (PreprodArtifact.DoesNotExist, ValueError):
             raise HeadPreprodArtifactResourceDoesNotExist
         else:
@@ -67,7 +69,9 @@ class PreprodArtifactEndpoint(ProjectEndpoint):
             return args, kwargs
 
         try:
-            base_artifact = PreprodArtifact.objects.get(id=int(base_artifact_id))
+            base_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
+                id=int(base_artifact_id)
+            )
         except (PreprodArtifact.DoesNotExist, ValueError):
             raise BasePreprodArtifactResourceDoesNotExist
         else:

--- a/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
@@ -102,7 +102,7 @@ class OrganizationPreprodListBuildsEndpoint(OrganizationEndpoint):
             if parsed_version:
                 queryset = queryset.filter(
                     app_id__icontains=parsed_version.app_id,
-                    build_version__icontains=parsed_version.build_version,
+                    mobile_app_info__build_version__icontains=parsed_version.build_version,
                 )
                 release_version_parsed = True
 
@@ -113,16 +113,16 @@ class OrganizationPreprodListBuildsEndpoint(OrganizationEndpoint):
 
             build_version = params.get("build_version")
             if build_version:
-                queryset = queryset.filter(build_version__icontains=build_version)
+                queryset = queryset.filter(mobile_app_info__build_version__icontains=build_version)
 
         query = params.get("query")
         if query and query.strip():
             search_term = query.strip()
 
             search_query = (
-                Q(app_name__icontains=search_term)
+                Q(mobile_app_info__app_name__icontains=search_term)
                 | Q(app_id__icontains=search_term)
-                | Q(build_version__icontains=search_term)
+                | Q(mobile_app_info__build_version__icontains=search_term)
                 | Q(
                     commit_comparison__head_sha__icontains=search_term,
                     commit_comparison__organization_id=organization.id,

--- a/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
@@ -86,7 +86,7 @@ class OrganizationPreprodListBuildsEndpoint(OrganizationEndpoint):
 
         queryset = (
             PreprodArtifact.objects.select_related(
-                "project", "build_configuration", "commit_comparison"
+                "project", "build_configuration", "commit_comparison", "mobile_app_info"
             )
             .prefetch_related("preprodartifactsizemetrics_set")
             .filter(project_id__in=project_ids)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
@@ -84,6 +84,8 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
             InstallablePreprodArtifact.objects.filter(preprod_artifact_id=head_artifact_id_int)
         )
 
+        mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+
         artifact_info = {
             "id": preprod_artifact.id,
             "state": preprod_artifact.state,
@@ -107,21 +109,9 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
             # App information
             "app_info": {
                 "app_id": preprod_artifact.app_id,
-                "app_name": (
-                    preprod_artifact.mobile_app_info.app_name
-                    if hasattr(preprod_artifact, "mobile_app_info")
-                    else None
-                ),
-                "build_version": (
-                    preprod_artifact.mobile_app_info.build_version
-                    if hasattr(preprod_artifact, "mobile_app_info")
-                    else None
-                ),
-                "build_number": (
-                    preprod_artifact.mobile_app_info.build_number
-                    if hasattr(preprod_artifact, "mobile_app_info")
-                    else None
-                ),
+                "app_name": mobile_app_info.app_name if mobile_app_info else None,
+                "build_version": mobile_app_info.build_version if mobile_app_info else None,
+                "build_number": mobile_app_info.build_number if mobile_app_info else None,
                 "main_binary_identifier": preprod_artifact.main_binary_identifier,
             },
             # File information

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
@@ -60,6 +60,7 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
                 "project__organization",
                 "commit_comparison",
                 "build_configuration",
+                "mobile_app_info",
             ).get(id=head_artifact_id_int)
         except PreprodArtifact.DoesNotExist:
             return Response(
@@ -106,9 +107,21 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
             # App information
             "app_info": {
                 "app_id": preprod_artifact.app_id,
-                "app_name": preprod_artifact.app_name,
-                "build_version": preprod_artifact.build_version,
-                "build_number": preprod_artifact.build_number,
+                "app_name": (
+                    preprod_artifact.mobile_app_info.app_name
+                    if hasattr(preprod_artifact, "mobile_app_info")
+                    else None
+                ),
+                "build_version": (
+                    preprod_artifact.mobile_app_info.build_version
+                    if hasattr(preprod_artifact, "mobile_app_info")
+                    else None
+                ),
+                "build_number": (
+                    preprod_artifact.mobile_app_info.build_number
+                    if hasattr(preprod_artifact, "mobile_app_info")
+                    else None
+                ),
                 "main_binary_identifier": preprod_artifact.main_binary_identifier,
             },
             # File information

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -67,16 +67,10 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
 
         if format_type == "plist":
             app_id = preprod_artifact.app_id
-            build_version = (
-                preprod_artifact.mobile_app_info.build_version
-                if hasattr(preprod_artifact, "mobile_app_info")
-                else None
-            )
-            app_name = (
-                preprod_artifact.mobile_app_info.app_name
-                if hasattr(preprod_artifact, "mobile_app_info")
-                else None
-            )
+
+            mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+            build_version = mobile_app_info.build_version if mobile_app_info else None
+            app_name = mobile_app_info.app_name if mobile_app_info else None
             if not app_id or not build_version or not app_name:
                 return Response({"error": "App details not found"}, status=404)
 
@@ -143,18 +137,11 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
 
             fp = file_obj.getfile()
             filename = preprod_artifact.app_id or "app"
-            build_version = (
-                preprod_artifact.mobile_app_info.build_version
-                if hasattr(preprod_artifact, "mobile_app_info")
-                else None
-            )
+            mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+            build_version = mobile_app_info.build_version if mobile_app_info else None
             if build_version:
                 filename += f"@{build_version}"
-            build_number = (
-                preprod_artifact.mobile_app_info.build_number
-                if hasattr(preprod_artifact, "mobile_app_info")
-                else None
-            )
+            build_number = mobile_app_info.build_number if mobile_app_info else None
             if build_number:
                 filename += f"+{build_number}"
             ext = format_type if format_type else "bin"

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -40,6 +40,7 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
             installable = InstallablePreprodArtifact.objects.select_related(
                 "preprod_artifact",
                 "preprod_artifact__project",
+                "preprod_artifact__mobile_app_info",
             ).get(
                 url_path=url_path,
             )
@@ -66,8 +67,16 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
 
         if format_type == "plist":
             app_id = preprod_artifact.app_id
-            build_version = preprod_artifact.build_version
-            app_name = preprod_artifact.app_name
+            build_version = (
+                preprod_artifact.mobile_app_info.build_version
+                if hasattr(preprod_artifact, "mobile_app_info")
+                else None
+            )
+            app_name = (
+                preprod_artifact.mobile_app_info.app_name
+                if hasattr(preprod_artifact, "mobile_app_info")
+                else None
+            )
             if not app_id or not build_version or not app_name:
                 return Response({"error": "App details not found"}, status=404)
 
@@ -134,10 +143,20 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
 
             fp = file_obj.getfile()
             filename = preprod_artifact.app_id or "app"
-            if preprod_artifact.build_version:
-                filename += f"@{preprod_artifact.build_version}"
-            if preprod_artifact.build_number:
-                filename += f"+{preprod_artifact.build_number}"
+            build_version = (
+                preprod_artifact.mobile_app_info.build_version
+                if hasattr(preprod_artifact, "mobile_app_info")
+                else None
+            )
+            if build_version:
+                filename += f"@{build_version}"
+            build_number = (
+                preprod_artifact.mobile_app_info.build_number
+                if hasattr(preprod_artifact, "mobile_app_info")
+                else None
+            )
+            if build_number:
+                filename += f"+{build_number}"
             ext = format_type if format_type else "bin"
             filename += f".{ext}"
             response = FileResponse(

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -270,25 +270,9 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             head_artifact.state = PreprodArtifact.ArtifactState.FAILED
             updated_fields.append("state")
 
-        if "build_version" in data:
-            head_artifact.build_version = data["build_version"]
-            updated_fields.append("build_version")
-
-        if "build_number" in data:
-            head_artifact.build_number = data["build_number"]
-            updated_fields.append("build_number")
-
         if "app_id" in data:
             head_artifact.app_id = data["app_id"]
             updated_fields.append("app_id")
-
-        if "app_name" in data:
-            head_artifact.app_name = data["app_name"]
-            updated_fields.append("app_name")
-
-        if "app_icon_id" in data:
-            head_artifact.app_icon_id = data["app_icon_id"]
-            updated_fields.append("app_icon_id")
 
         mobile_app_info_updates = {}
         if "build_version" in data:
@@ -380,16 +364,26 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 }
             )
 
+        build_version = (
+            head_artifact.mobile_app_info.build_version
+            if hasattr(head_artifact, "mobile_app_info")
+            else None
+        )
+        build_number = (
+            head_artifact.mobile_app_info.build_number
+            if hasattr(head_artifact, "mobile_app_info")
+            else None
+        )
         if (
             head_artifact.app_id
-            and head_artifact.build_version
+            and build_version
             and head_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
         ):
             find_or_create_release(
                 project=project,
                 package=head_artifact.app_id,
-                version=head_artifact.build_version,
-                build_number=head_artifact.build_number,
+                version=build_version,
+                build_number=build_number,
             )
 
         return Response(

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -364,16 +364,9 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 }
             )
 
-        build_version = (
-            head_artifact.mobile_app_info.build_version
-            if hasattr(head_artifact, "mobile_app_info")
-            else None
-        )
-        build_number = (
-            head_artifact.mobile_app_info.build_number
-            if hasattr(head_artifact, "mobile_app_info")
-            else None
-        )
+        mobile_app_info = getattr(head_artifact, "mobile_app_info", None)
+        build_version = mobile_app_info.build_version if mobile_app_info else None
+        build_number = mobile_app_info.build_number if mobile_app_info else None
         if (
             head_artifact.app_id
             and build_version

--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -145,32 +145,19 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
                 "No artifact found for binary identifier with version %s", provided_build_version
             )
 
-        build_version = (
-            preprod_artifact.mobile_app_info.build_version
-            if preprod_artifact and hasattr(preprod_artifact, "mobile_app_info")
-            else None
-        )
-        build_number = (
-            preprod_artifact.mobile_app_info.build_number
-            if preprod_artifact and hasattr(preprod_artifact, "mobile_app_info")
-            else None
-        )
-        app_name = (
-            preprod_artifact.mobile_app_info.app_name
-            if preprod_artifact and hasattr(preprod_artifact, "mobile_app_info")
-            else None
-        )
-        if preprod_artifact and build_version and build_number:
+        mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+
+        if preprod_artifact and mobile_app_info:
             current = InstallableBuildDetails(
                 id=str(preprod_artifact.id),
-                build_version=build_version,
-                build_number=build_number,
+                build_version=mobile_app_info.build_version,
+                build_number=mobile_app_info.build_number,
                 release_notes=(
                     preprod_artifact.extras.get("release_notes")
                     if preprod_artifact.extras
                     else None
                 ),
-                app_name=app_name,
+                app_name=mobile_app_info.app_name,
                 download_url=get_download_url_for_artifact(preprod_artifact),
                 created_date=preprod_artifact.date_added.isoformat(),
             )
@@ -224,21 +211,10 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
                     ),
                 )
                 if not preprod_artifact or preprod_artifact.id != best_artifact.id:
-                    best_build_version = (
-                        best_artifact.mobile_app_info.build_version
-                        if hasattr(best_artifact, "mobile_app_info")
-                        else None
-                    )
-                    best_build_number = (
-                        best_artifact.mobile_app_info.build_number
-                        if hasattr(best_artifact, "mobile_app_info")
-                        else None
-                    )
-                    best_app_name = (
-                        best_artifact.mobile_app_info.app_name
-                        if hasattr(best_artifact, "mobile_app_info")
-                        else None
-                    )
+                    mobile_app_info = getattr(best_artifact, "mobile_app_info", None)
+                    best_build_version = mobile_app_info.build_version if mobile_app_info else None
+                    best_build_number = mobile_app_info.build_number if mobile_app_info else None
+                    best_app_name = mobile_app_info.app_name if mobile_app_info else None
                     if best_build_version and best_build_number:
                         update = InstallableBuildDetails(
                             id=str(best_artifact.id),

--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -206,7 +206,7 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
                 best_artifact = max(
                     installable_artifacts,
                     key=lambda a: (
-                        (a.mobile_app_info.build_number if hasattr(a, "mobile_app_info") else 0),
+                        (a.mobile_app_info.build_number if a.mobile_app_info.build_number else 0),
                         a.date_added,
                     ),
                 )

--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -147,7 +147,12 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
 
         mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
 
-        if preprod_artifact and mobile_app_info:
+        if (
+            preprod_artifact
+            and mobile_app_info
+            and mobile_app_info.build_version
+            and mobile_app_info.build_number
+        ):
             current = InstallableBuildDetails(
                 id=str(preprod_artifact.id),
                 build_version=mobile_app_info.build_version,

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -188,9 +188,13 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
 
     return BuildDetailsAppInfo(
         app_id=artifact.app_id,
-        name=artifact.app_name,
-        version=artifact.build_version,
-        build_number=artifact.build_number,
+        name=(artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None),
+        version=(
+            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
+        ),
+        build_number=(
+            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+        ),
         date_added=(artifact.date_added.isoformat() if artifact.date_added else None),
         date_built=(artifact.date_built.isoformat() if artifact.date_built else None),
         artifact_type=artifact.artifact_type,
@@ -198,7 +202,9 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
         build_configuration=(
             artifact.build_configuration.name if artifact.build_configuration else None
         ),
-        app_icon_id=artifact.app_icon_id,
+        app_icon_id=(
+            artifact.mobile_app_info.app_icon_id if hasattr(artifact, "mobile_app_info") else None
+        ),
         apple_app_info=apple_app_info,
         android_app_info=android_app_info,
     )

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -186,15 +186,13 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
             )
         )
 
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+
     return BuildDetailsAppInfo(
         app_id=artifact.app_id,
-        name=(artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None),
-        version=(
-            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
-        ),
-        build_number=(
-            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-        ),
+        name=mobile_app_info.app_name if mobile_app_info else None,
+        version=(mobile_app_info.build_version if mobile_app_info else None),
+        build_number=(mobile_app_info.build_number if mobile_app_info else None),
         date_added=(artifact.date_added.isoformat() if artifact.date_added else None),
         date_built=(artifact.date_built.isoformat() if artifact.date_built else None),
         artifact_type=artifact.artifact_type,
@@ -202,9 +200,7 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
         build_configuration=(
             artifact.build_configuration.name if artifact.build_configuration else None
         ),
-        app_icon_id=(
-            artifact.mobile_app_info.app_icon_id if hasattr(artifact, "mobile_app_info") else None
-        ),
+        app_icon_id=(mobile_app_info.app_icon_id if mobile_app_info else None),
         apple_app_info=apple_app_info,
         android_app_info=android_app_info,
     )

--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 
 def is_installable_artifact(artifact: PreprodArtifact) -> bool:
     # TODO: Adjust this logic when we have a better way to determine if an artifact is installable
-    return artifact.installable_app_file_id is not None and artifact.build_number is not None
+    build_number = (
+        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+    )
+    return artifact.installable_app_file_id is not None and build_number is not None
 
 
 def get_download_count_for_artifact(artifact: PreprodArtifact) -> int:

--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -15,9 +15,8 @@ logger = logging.getLogger(__name__)
 
 def is_installable_artifact(artifact: PreprodArtifact) -> bool:
     # TODO: Adjust this logic when we have a better way to determine if an artifact is installable
-    build_number = (
-        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-    )
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    build_number = mobile_app_info.build_number if mobile_app_info else None
     return artifact.installable_app_file_id is not None and build_number is not None
 
 

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -78,9 +78,15 @@ def produce_preprod_size_metric_to_eap(
             "apple" if artifact.is_ios() else "android" if artifact.is_android() else None
         ),
         "app_id": artifact.app_id,
-        "app_name": artifact.app_name,
-        "build_version": artifact.build_version,
-        "build_number": artifact.build_number,
+        "app_name": (
+            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
+        ),
+        "build_version": (
+            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
+        ),
+        "build_number": (
+            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+        ),
         "main_binary_identifier": artifact.main_binary_identifier,
         "artifact_date_built": (
             int(artifact.date_built.timestamp()) if artifact.date_built else None
@@ -164,9 +170,15 @@ def produce_preprod_build_distribution_to_eap(
             "apple" if artifact.is_ios() else "android" if artifact.is_android() else None
         ),
         "app_id": artifact.app_id,
-        "app_name": artifact.app_name,
-        "build_version": artifact.build_version,
-        "build_number": artifact.build_number,
+        "app_name": (
+            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
+        ),
+        "build_version": (
+            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
+        ),
+        "build_number": (
+            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+        ),
         "main_binary_identifier": artifact.main_binary_identifier,
         "artifact_date_built": (
             int(artifact.date_built.timestamp()) if artifact.date_built else None

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -60,6 +60,7 @@ def produce_preprod_size_metric_to_eap(
     item_id_str = f"size_metric_{size_metric.id}"
     item_id = hex_to_item_id(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex)
 
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
     attributes: dict[str, Any] = {
         "preprod_artifact_id": size_metric.preprod_artifact_id,
         "size_metric_id": size_metric.id,
@@ -78,15 +79,9 @@ def produce_preprod_size_metric_to_eap(
             "apple" if artifact.is_ios() else "android" if artifact.is_android() else None
         ),
         "app_id": artifact.app_id,
-        "app_name": (
-            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
-        ),
-        "build_version": (
-            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
-        ),
-        "build_number": (
-            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-        ),
+        "app_name": mobile_app_info.app_name if mobile_app_info else None,
+        "build_version": mobile_app_info.build_version if mobile_app_info else None,
+        "build_number": mobile_app_info.build_number if mobile_app_info else None,
         "main_binary_identifier": artifact.main_binary_identifier,
         "artifact_date_built": (
             int(artifact.date_built.timestamp()) if artifact.date_built else None
@@ -161,6 +156,7 @@ def produce_preprod_build_distribution_to_eap(
     item_id_str = f"build_distribution_{artifact.id}"
     item_id = hex_to_item_id(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex)
 
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
     attributes: dict[str, Any] = {
         "preprod_artifact_id": artifact.id,
         "sub_item_type": "build_distribution",
@@ -170,15 +166,9 @@ def produce_preprod_build_distribution_to_eap(
             "apple" if artifact.is_ios() else "android" if artifact.is_android() else None
         ),
         "app_id": artifact.app_id,
-        "app_name": (
-            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
-        ),
-        "build_version": (
-            artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
-        ),
-        "build_number": (
-            artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-        ),
+        "app_name": mobile_app_info.app_name if mobile_app_info else None,
+        "build_version": mobile_app_info.build_version if mobile_app_info else None,
+        "build_number": mobile_app_info.build_number if mobile_app_info else None,
         "main_binary_identifier": artifact.main_binary_identifier,
         "artifact_date_built": (
             int(artifact.date_built.timestamp()) if artifact.date_built else None

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -64,9 +64,8 @@ def bulk_delete_artifacts(
             all_file_ids.append(artifact.file_id)
         if artifact.installable_app_file_id:
             all_file_ids.append(artifact.installable_app_file_id)
-        app_icon_id = (
-            artifact.mobile_app_info.app_icon_id if hasattr(artifact, "mobile_app_info") else None
-        )
+        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        app_icon_id = mobile_app_info.app_icon_id if mobile_app_info else None
         if app_icon_id:
             try:
                 all_file_ids.append(int(app_icon_id))

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -64,9 +64,12 @@ def bulk_delete_artifacts(
             all_file_ids.append(artifact.file_id)
         if artifact.installable_app_file_id:
             all_file_ids.append(artifact.installable_app_file_id)
-        if artifact.app_icon_id:
+        app_icon_id = (
+            artifact.mobile_app_info.app_icon_id if hasattr(artifact, "mobile_app_info") else None
+        )
+        if app_icon_id:
             try:
-                all_file_ids.append(int(artifact.app_icon_id))
+                all_file_ids.append(int(app_icon_id))
             except (ValueError, TypeError):
                 pass
 

--- a/src/sentry/preprod/size_analysis/issues.py
+++ b/src/sentry/preprod/size_analysis/issues.py
@@ -16,19 +16,15 @@ def artifact_to_tags(artifact: PreprodArtifact) -> dict[str, Any]:
 
     if artifact.app_id:
         tags["app_id"] = artifact.app_id
-    app_name = artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
-    if app_name:
-        tags["app_name"] = app_name
-    build_version = (
-        artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
-    )
-    if build_version:
-        tags["build_version"] = build_version
-    build_number = (
-        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-    )
-    if build_number:
-        tags["build_number"] = build_number
+
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    if mobile_app_info is not None:
+        if mobile_app_info.app_name:
+            tags["app_name"] = mobile_app_info.app_name
+        if mobile_app_info.build_version:
+            tags["build_version"] = mobile_app_info.build_version
+        if mobile_app_info.build_number:
+            tags["build_number"] = mobile_app_info.build_number
     if artifact.build_configuration:
         tags["build_configuration"] = artifact.build_configuration.name
     if artifact.artifact_type is not None:

--- a/src/sentry/preprod/size_analysis/issues.py
+++ b/src/sentry/preprod/size_analysis/issues.py
@@ -16,12 +16,19 @@ def artifact_to_tags(artifact: PreprodArtifact) -> dict[str, Any]:
 
     if artifact.app_id:
         tags["app_id"] = artifact.app_id
-    if artifact.app_name:
-        tags["app_name"] = artifact.app_name
-    if artifact.build_version:
-        tags["build_version"] = artifact.build_version
-    if artifact.build_number:
-        tags["build_number"] = artifact.build_number
+    app_name = artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
+    if app_name:
+        tags["app_name"] = app_name
+    build_version = (
+        artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
+    )
+    if build_version:
+        tags["build_version"] = build_version
+    build_number = (
+        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+    )
+    if build_number:
+        tags["build_number"] = build_number
     if artifact.build_configuration:
         tags["build_configuration"] = artifact.build_configuration.name
     if artifact.artifact_type is not None:

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -293,18 +293,26 @@ def manual_size_analysis_comparison(
         )
         return
 
-    head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-        preprod_artifact_id__in=[head_artifact.id],
-        preprod_artifact__project__organization_id=org_id,
-        preprod_artifact__project_id=project_id,
-    ).select_related("preprod_artifact")
+    head_size_metrics_qs = (
+        PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact_id__in=[head_artifact.id],
+            preprod_artifact__project__organization_id=org_id,
+            preprod_artifact__project_id=project_id,
+        )
+        .select_related("preprod_artifact")
+        .select_related("preprod_artifact__mobile_app_info")
+    )
     head_size_metrics = list(head_size_metrics_qs)
 
-    base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-        preprod_artifact_id__in=[base_artifact.id],
-        preprod_artifact__project__organization_id=org_id,
-        preprod_artifact__project_id=project_id,
-    ).select_related("preprod_artifact")
+    base_size_metrics_qs = (
+        PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact_id__in=[base_artifact.id],
+            preprod_artifact__project__organization_id=org_id,
+            preprod_artifact__project_id=project_id,
+        )
+        .select_related("preprod_artifact")
+        .select_related("preprod_artifact__mobile_app_info")
+    )
     base_size_metrics = list(base_size_metrics_qs)
 
     logger.info(

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -113,9 +113,8 @@ def _format_artifact_summary(
         if metric_type_display:
             qualifiers.append(metric_type_display)
 
-        artifact_app_name = (
-            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
-        )
+        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        artifact_app_name = mobile_app_info.app_name if mobile_app_info else None
         app_name = (
             f"{artifact_app_name or '--'}{' (' + ', '.join(qualifiers) + ')' if qualifiers else ''}"
         )
@@ -268,12 +267,9 @@ def _get_size_metric_display_data(
 def _format_version_string(artifact: PreprodArtifact, default: str = "-") -> str:
     """Format version string from build_version and build_number."""
     version_parts = []
-    build_version = (
-        artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
-    )
-    build_number = (
-        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
-    )
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    build_version = mobile_app_info.build_version if mobile_app_info else None
+    build_number = mobile_app_info.build_number if mobile_app_info else None
     if build_version:
         version_parts.append(build_version)
     if build_number:

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -113,8 +113,11 @@ def _format_artifact_summary(
         if metric_type_display:
             qualifiers.append(metric_type_display)
 
+        artifact_app_name = (
+            artifact.mobile_app_info.app_name if hasattr(artifact, "mobile_app_info") else None
+        )
         app_name = (
-            f"{artifact.app_name or '--'}{' (' + ', '.join(qualifiers) + ')' if qualifiers else ''}"
+            f"{artifact_app_name or '--'}{' (' + ', '.join(qualifiers) + ')' if qualifiers else ''}"
         )
 
         # App ID
@@ -265,10 +268,16 @@ def _get_size_metric_display_data(
 def _format_version_string(artifact: PreprodArtifact, default: str = "-") -> str:
     """Format version string from build_version and build_number."""
     version_parts = []
-    if artifact.build_version:
-        version_parts.append(artifact.build_version)
-    if artifact.build_number:
-        version_parts.append(f"({artifact.build_number})")
+    build_version = (
+        artifact.mobile_app_info.build_version if hasattr(artifact, "mobile_app_info") else None
+    )
+    build_number = (
+        artifact.mobile_app_info.build_number if hasattr(artifact, "mobile_app_info") else None
+    )
+    if build_version:
+        version_parts.append(build_version)
+    if build_number:
+        version_parts.append(f"({build_number})")
     return " ".join(version_parts) if version_parts else default
 
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2649,6 +2649,7 @@ class Factories:
         date_added: datetime | None = None,
         build_configuration: PreprodBuildConfiguration | None = None,
         extras: dict | None = None,
+        create_mobile_app_info: bool = True,
         **kwargs,
     ) -> PreprodArtifact:
         artifact = PreprodArtifact.objects.create(
@@ -2665,6 +2666,19 @@ class Factories:
         )
         if date_added is not None:
             artifact.update(date_added=date_added)
+
+        build_version = kwargs.get("build_version", None)
+        build_number = kwargs.get("build_number", None)
+        app_name = kwargs.get("app_name", None)
+        app_icon_id = kwargs.get("app_icon_id", None)
+        if create_mobile_app_info and (build_version or build_number or app_name or app_icon_id):
+            Factories.create_preprod_artifact_mobile_app_info(
+                artifact=artifact,
+                build_version=build_version,
+                build_number=build_number,
+                app_name=app_name,
+                app_icon_id=app_icon_id,
+            )
 
         return artifact
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2692,14 +2692,17 @@ class Factories:
         app_icon_id: str | None = None,
         **kwargs,
     ) -> PreprodArtifactMobileAppInfo:
-        return PreprodArtifactMobileAppInfo.objects.create(
+        obj, _ = PreprodArtifactMobileAppInfo.objects.update_or_create(
             preprod_artifact=preprod_artifact,
-            build_version=build_version,
-            build_number=build_number,
-            app_name=app_name,
-            app_icon_id=app_icon_id,
-            **kwargs,
+            defaults={
+                "build_version": build_version,
+                "build_number": build_number,
+                "app_name": app_name,
+                "app_icon_id": app_icon_id,
+                **kwargs,
+            },
         )
+        return obj
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2673,7 +2673,7 @@ class Factories:
         app_icon_id = kwargs.get("app_icon_id", None)
         if create_mobile_app_info and (build_version or build_number or app_name or app_icon_id):
             Factories.create_preprod_artifact_mobile_app_info(
-                artifact=artifact,
+                preprod_artifact=artifact,
                 build_version=build_version,
                 build_number=build_number,
                 app_name=app_name,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2643,9 +2643,6 @@ class Factories:
         state: int = PreprodArtifact.ArtifactState.PROCESSED,
         artifact_type: int | None = PreprodArtifact.ArtifactType.APK,
         app_id: str = "com.example.app",
-        app_name: str | None = None,
-        build_version: str | None = None,
-        build_number: int | None = None,
         commit_comparison: CommitComparison | None = None,
         file_id: int | None = None,
         installable_app_file_id: int | None = None,
@@ -2659,9 +2656,6 @@ class Factories:
             state=state,
             artifact_type=artifact_type,
             app_id=app_id,
-            app_name=app_name,
-            build_version=build_version,
-            build_number=build_number,
             commit_comparison=commit_comparison,
             file_id=file_id,
             installable_app_file_id=installable_app_file_id,
@@ -2672,21 +2666,26 @@ class Factories:
         if date_added is not None:
             artifact.update(date_added=date_added)
 
-        mobile_app_info_fields: dict[str, Any] = {}
-        if build_version is not None:
-            mobile_app_info_fields["build_version"] = build_version
-        if build_number is not None:
-            mobile_app_info_fields["build_number"] = build_number
-        if app_name is not None:
-            mobile_app_info_fields["app_name"] = app_name
-
-        if mobile_app_info_fields:
-            PreprodArtifactMobileAppInfo.objects.create(
-                preprod_artifact=artifact,
-                **mobile_app_info_fields,
-            )
-
         return artifact
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_preprod_artifact_mobile_app_info(
+        preprod_artifact: PreprodArtifact,
+        build_version: str | None = None,
+        build_number: int | None = None,
+        app_name: str | None = None,
+        app_icon_id: str | None = None,
+        **kwargs,
+    ) -> PreprodArtifactMobileAppInfo:
+        return PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=preprod_artifact,
+            build_version=build_version,
+            build_number=build_number,
+            app_name=app_name,
+            app_icon_id=app_icon_id,
+            **kwargs,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -43,6 +43,7 @@ from sentry.monitors.models import (
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.preprod.models import (
     PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
@@ -922,6 +923,13 @@ class Fixtures:
         if project is None:
             project = self.project
         return Factories.create_preprod_artifact(project=project, **kwargs)
+
+    def create_preprod_artifact_mobile_app_info(
+        self, preprod_artifact: PreprodArtifact, **kwargs
+    ) -> PreprodArtifactMobileAppInfo:
+        return Factories.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=preprod_artifact, **kwargs
+        )
 
     def create_preprod_artifact_size_metrics(
         self, preprod_artifact: PreprodArtifact, **kwargs

--- a/tests/sentry/deletions/test_preprod_artifact.py
+++ b/tests/sentry/deletions/test_preprod_artifact.py
@@ -62,7 +62,7 @@ class PreprodArtifactDeletionTaskTest(TestCase):
         assert not PreprodArtifact.objects.filter(id=artifact.id).exists()
         assert not File.objects.filter(id=main_file.id).exists()
         assert not File.objects.filter(id=installable_file.id).exists()
-        assert not File.objects.filter(id=mobile_app_info.app_icon_id).exists()
+        assert not File.objects.filter(id=str(mobile_app_info.app_icon_id)).exists()
         assert not File.objects.filter(id=analysis_file.id).exists()
         assert not PreprodArtifactSizeMetrics.objects.filter(id=size_metric.id).exists()
         assert not InstallablePreprodArtifact.objects.filter(id=installable.id).exists()

--- a/tests/sentry/deletions/test_preprod_artifact.py
+++ b/tests/sentry/deletions/test_preprod_artifact.py
@@ -34,11 +34,14 @@ class PreprodArtifactDeletionTaskTest(TestCase):
             project=self.project,
             file_id=main_file.id,
             installable_app_file_id=installable_file.id,
-            app_icon_id=str(app_icon_file.id),
-            app_name="test_app",
             app_id="com.test.app",
+        )
+        mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
+            app_name="test_app",
+            app_icon_id=str(app_icon_file.id),
         )
 
         analysis_file = self.create_file(name="analysis.json", type="application/json")
@@ -59,7 +62,7 @@ class PreprodArtifactDeletionTaskTest(TestCase):
         assert not PreprodArtifact.objects.filter(id=artifact.id).exists()
         assert not File.objects.filter(id=main_file.id).exists()
         assert not File.objects.filter(id=installable_file.id).exists()
-        assert not File.objects.filter(id=app_icon_file.id).exists()
+        assert not File.objects.filter(id=mobile_app_info.app_icon_id).exists()
         assert not File.objects.filter(id=analysis_file.id).exists()
         assert not PreprodArtifactSizeMetrics.objects.filter(id=size_metric.id).exists()
         assert not InstallablePreprodArtifact.objects.filter(id=installable.id).exists()

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -271,6 +271,10 @@ class BuildsEndpointTest(APITestCase):
         # Create an installable artifact (has both installable_app_file_id and build_number)
         artifact = self.create_preprod_artifact(
             installable_app_file_id=12345,
+        )
+        # build_number must be in mobile_app_info for is_installable check
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact,
             build_number=100,
         )
         # Create InstallablePreprodArtifact records with download counts
@@ -335,6 +339,10 @@ class BuildsEndpointTest(APITestCase):
         artifact1 = self.create_preprod_artifact(
             app_id="com.app.one",
             installable_app_file_id=11111,
+        )
+        # build_number must be in mobile_app_info for is_installable check
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact1,
             build_number=1,
         )
         self.create_installable_preprod_artifact(artifact1, download_count=100)
@@ -342,6 +350,10 @@ class BuildsEndpointTest(APITestCase):
         artifact2 = self.create_preprod_artifact(
             app_id="com.app.two",
             installable_app_file_id=22222,
+        )
+        # build_number must be in mobile_app_info for is_installable check
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact2,
             build_number=2,
         )
         self.create_installable_preprod_artifact(artifact2, download_count=50)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
@@ -43,12 +43,15 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.APK,
             app_id="com.example.app",
-            app_name="TestApp",
-            build_version="1.0.0",
-            build_number=42,
             build_configuration=None,
             installable_app_file_id=1234,
             commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info1 = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.artifact1,
+            build_version="1.0.0",
+            build_number=42,
+            app_name="TestApp",
         )
 
         self.artifact2 = self.create_preprod_artifact(
@@ -57,12 +60,15 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             app_id="com.example.app2",
-            app_name="TestApp2",
-            build_version="2.0.0",
-            build_number=43,
             build_configuration=None,
             installable_app_file_id=1235,
             commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info2 = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.artifact2,
+            build_version="2.0.0",
+            build_number=43,
+            app_name="TestApp2",
         )
 
         self.artifact3 = self.create_preprod_artifact(
@@ -71,12 +77,15 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
             state=PreprodArtifact.ArtifactState.UPLOADED,
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
             app_id="com.example.app3",
-            app_name="TestApp3",
-            build_version="3.0.0",
-            build_number=44,
             build_configuration=None,
             installable_app_file_id=1236,
             commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info3 = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.artifact3,
+            build_version="3.0.0",
+            build_number=44,
+            app_name="TestApp3",
         )
 
         self.artifact4 = self.create_preprod_artifact(
@@ -85,12 +94,15 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.APK,
             app_id="com.example.app4",
-            app_name="TestApp4",
-            build_version="4.0.0",
-            build_number=45,
             build_configuration=None,
             installable_app_file_id=1237,
             commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info4 = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.artifact4,
+            build_version="4.0.0",
+            build_number=45,
+            app_name="TestApp4",
         )
 
         self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})

--- a/tests/sentry/preprod/api/endpoints/test_project_installable_preprod_artifact_download.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_installable_preprod_artifact_download.py
@@ -21,8 +21,11 @@ class ProjectInstallablePreprodArtifactDownloadEndpointTest(TestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
             installable_app_file_id=self.file.id,
-            build_version="1.2.3",
             app_id="com.example.TestApp",
+        )
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version="1.2.3",
             app_name="TestApp",
         )
 

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -59,12 +59,8 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert self.preprod_artifact.date_built is not None
         assert self.preprod_artifact.date_built.isoformat() == "2024-01-01T00:00:00+00:00"
         assert self.preprod_artifact.artifact_type == 1
-
-        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
-            preprod_artifact=self.preprod_artifact
-        )
-        assert mobile_app_info.build_version == "1.2.3"
-        assert mobile_app_info.build_number == 123
+        assert self.preprod_artifact.mobile_app_info.build_version == "1.2.3"
+        assert self.preprod_artifact.mobile_app_info.build_number == 123
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_partial_update(self) -> None:
@@ -356,12 +352,12 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
 
         self.preprod_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
         self.preprod_artifact.app_id = "com.example.app"
-        self.preprod_artifact.save()
-        PreprodArtifactMobileAppInfo.objects.create(
+        self.create_preprod_artifact_mobile_app_info(
             preprod_artifact=self.preprod_artifact,
             build_version="1.0.0",
             build_number=123,
         )
+        self.preprod_artifact.save()
 
         response = self._make_request({})
         assert response.status_code == 200
@@ -472,19 +468,13 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert response.status_code == 200
         resp_data = response.json()
         assert resp_data["success"] is True
-        assert set(resp_data["updatedFields"]) == {"state"}
 
-        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
-            preprod_artifact=self.preprod_artifact
-        )
-        assert mobile_app_info.build_version == "1.2.3"
-        assert mobile_app_info.build_number == 456
-        assert mobile_app_info.app_name == "Test App"
-        assert mobile_app_info.app_icon_id == "icon-123"
+        assert self.preprod_artifact.mobile_app_info.build_version == "1.2.3"
+        assert self.preprod_artifact.mobile_app_info.build_number == 456
+        assert self.preprod_artifact.mobile_app_info.app_name == "Test App"
+        assert self.preprod_artifact.mobile_app_info.app_icon_id == "icon-123"
 
         self.preprod_artifact.refresh_from_db()
-        assert self.preprod_artifact.mobile_app_info.id == mobile_app_info.id
-        assert mobile_app_info.preprod_artifact.id == self.preprod_artifact.id
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_updates_existing_mobile_app_info(self) -> None:
@@ -496,14 +486,11 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         response1 = self._make_request(initial_data)
         assert response1.status_code == 200
 
-        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
-            preprod_artifact=self.preprod_artifact
-        )
-        assert mobile_app_info.build_version == "1.0.0"
-        assert mobile_app_info.build_number == 100
-        assert mobile_app_info.app_name == "Initial App"
-        assert mobile_app_info.app_icon_id is None
-        initial_mobile_app_info_id = mobile_app_info.id
+        assert self.preprod_artifact.mobile_app_info.build_version == "1.0.0"
+        assert self.preprod_artifact.mobile_app_info.build_number == 100
+        assert self.preprod_artifact.mobile_app_info.app_name == "Initial App"
+        assert self.preprod_artifact.mobile_app_info.app_icon_id is None
+        initial_mobile_app_info_id = self.preprod_artifact.mobile_app_info.id
 
         updated_data = {
             "build_version": "2.0.0",
@@ -513,19 +500,14 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         response2 = self._make_request(updated_data)
         assert response2.status_code == 200
 
-        mobile_app_info_after = PreprodArtifactMobileAppInfo.objects.get(
+        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
             preprod_artifact=self.preprod_artifact
         )
-        assert mobile_app_info_after.id == initial_mobile_app_info_id
-        assert mobile_app_info_after.build_version == "2.0.0"
-        assert mobile_app_info_after.build_number == 200
-        assert mobile_app_info_after.app_name == "Initial App"
-        assert mobile_app_info_after.app_icon_id == "new-icon-456"
-
-        count = PreprodArtifactMobileAppInfo.objects.filter(
-            preprod_artifact=self.preprod_artifact
-        ).count()
-        assert count == 1
+        assert mobile_app_info.build_version == "2.0.0"
+        assert mobile_app_info.build_number == 200
+        assert mobile_app_info.app_name == "Initial App"
+        assert mobile_app_info.app_icon_id == "new-icon-456"
+        assert mobile_app_info.id == initial_mobile_app_info_id
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_partial_mobile_app_info_update(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -34,12 +34,14 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
             file_id=self.file.id,
             artifact_type=PreprodArtifact.ArtifactType.APK,
             app_id="com.example.app",
-            app_name="TestApp",
-            build_version="1.0.0",
-            build_number=42,
             build_configuration=None,
             installable_app_file_id=1234,
             commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version="1.0.0",
+            build_number=42,
         )
 
         # Enable the feature flag for all tests by default
@@ -68,9 +70,9 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         resp_data = response.json()
         assert resp_data["state"] == self.preprod_artifact.state
         assert resp_data["app_info"]["app_id"] == self.preprod_artifact.app_id
-        assert resp_data["app_info"]["name"] == self.preprod_artifact.app_name
-        assert resp_data["app_info"]["version"] == self.preprod_artifact.build_version
-        assert resp_data["app_info"]["build_number"] == self.preprod_artifact.build_number
+        assert resp_data["app_info"]["name"] == self.mobile_app_info.app_name
+        assert resp_data["app_info"]["version"] == self.mobile_app_info.build_version
+        assert resp_data["app_info"]["build_number"] == self.mobile_app_info.build_number
         assert resp_data["app_info"]["artifact_type"] == self.preprod_artifact.artifact_type
 
     def test_get_build_details_distribution_info(self) -> None:
@@ -489,10 +491,13 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
             file_id=base_file.id,
             artifact_type=self.preprod_artifact.artifact_type,
             app_id=self.preprod_artifact.app_id,
+            commit_comparison=base_commit_comparison,
+        )
+        base_mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=base_artifact,
             app_name=self.preprod_artifact.app_name,
             build_version="0.9.0",
             build_number=41,
-            commit_comparison=base_commit_comparison,
         )
 
         url = self._get_url()
@@ -505,10 +510,10 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert resp_data["base_artifact_id"] == str(base_artifact.id)
         assert resp_data["base_build_info"] is not None
         # base_build_info now returns full BuildDetailsAppInfo
-        assert resp_data["base_build_info"]["version"] == "0.9.0"
-        assert resp_data["base_build_info"]["build_number"] == 41
+        assert resp_data["base_build_info"]["version"] == base_mobile_app_info.build_version
+        assert resp_data["base_build_info"]["build_number"] == base_mobile_app_info.build_number
         assert resp_data["base_build_info"]["app_id"] == base_artifact.app_id
-        assert resp_data["base_build_info"]["name"] == base_artifact.app_name
+        assert resp_data["base_build_info"]["name"] == base_mobile_app_info.app_name
         assert resp_data["base_build_info"]["artifact_type"] == base_artifact.artifact_type
         assert "date_added" in resp_data["base_build_info"]
         assert "date_built" in resp_data["base_build_info"]

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
@@ -59,7 +59,15 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
             "main_binary_identifier": "test-identifier-123",
         }
         defaults.update(kwargs)
-        return self.create_preprod_artifact(**defaults)
+        self.preprod_artifact = self.create_preprod_artifact(**defaults)
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version=defaults["build_version"],
+            build_number=defaults["build_number"],
+            app_name=defaults.get("app_name"),
+            app_icon_id=defaults.get("app_icon_id"),
+        )
+        return self.preprod_artifact
 
     def _create_ios_artifact(self, **kwargs):
         """Helper to create an iOS artifact with default values"""
@@ -77,7 +85,15 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
             "main_binary_identifier": "test-identifier-123",
         }
         defaults.update(kwargs)
-        return self.create_preprod_artifact(**defaults)
+        self.preprod_artifact = self.create_preprod_artifact(**defaults)
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version=defaults["build_version"],
+            build_number=defaults["build_number"],
+            app_name=defaults.get("app_name"),
+            app_icon_id=defaults.get("app_icon_id"),
+        )
+        return self.preprod_artifact
 
     def test_missing_required_parameters(self):
         """Test that missing required parameters return 400"""

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -43,13 +43,16 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
             app_id="com.example.app",
-            app_name="Example App",
-            build_version="1.2.3",
-            build_number=100,
             main_binary_identifier="com.example.MainBinary",
             commit_comparison=commit_comparison,
             build_configuration=build_config,
             date_built=datetime(2024, 1, 1, 10, 0, 0, tzinfo=dt_timezone.utc),
+        )
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact,
+            build_version="1.2.3",
+            build_number=100,
+            app_name="Example App",
         )
 
         size_metric = PreprodArtifactSizeMetrics.objects.create(
@@ -182,9 +185,6 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
             state=PreprodArtifact.ArtifactState.PROCESSED,
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
             app_id="com.example.app",
-            app_name="Example App",
-            build_version="1.2.3",
-            build_number=100,
             main_binary_identifier="com.example.MainBinary",
             commit_comparison=commit_comparison,
             build_configuration=build_config,
@@ -200,6 +200,12 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
                 "has_missing_dsym_binaries": True,
                 "has_proguard_mapping": False,
             },
+        )
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact,
+            build_version="1.2.3",
+            build_number=100,
+            app_name="Example App",
         )
 
         # Create multiple installables to test summing

--- a/tests/sentry/preprod/size_analysis/test_issues.py
+++ b/tests/sentry/preprod/size_analysis/test_issues.py
@@ -53,6 +53,12 @@ class DiffToOccurrenceTest(TestCase):
         assert event["tags"]["regression_kind"] == "install"
         assert event["tags"]["head.app_id"] == "com.example.app"
         assert event["tags"]["base.app_id"] == "com.example.app"
+        assert "head.app_name" not in event["tags"]
+        assert "base.app_name" not in event["tags"]
+        assert "head.build_version" not in event["tags"]
+        assert "base.build_version" not in event["tags"]
+        assert "head.build_number" not in event["tags"]
+        assert "base.build_number" not in event["tags"]
         assert len(occurrence.evidence_display) == 0
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
         assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
@@ -64,7 +70,19 @@ class DiffToOccurrenceTest(TestCase):
         project = self.create_project()
 
         head_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=head_artifact,
+            build_version="1.2.3",
+            build_number=100,
+            app_name="Example App",
+        )
         base_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=base_artifact,
+            build_version="1.2.2",
+            build_number=99,
+            app_name="Example App",
+        )
 
         head_metric = self.create_preprod_artifact_size_metrics(
             head_artifact,
@@ -106,6 +124,12 @@ class DiffToOccurrenceTest(TestCase):
         assert event["tags"]["regression_kind"] == "download"
         assert event["tags"]["head.app_id"] == "com.example.app"
         assert event["tags"]["base.app_id"] == "com.example.app"
+        assert event["tags"]["head.app_name"] == "Example App"
+        assert event["tags"]["base.app_name"] == "Example App"
+        assert event["tags"]["head.build_version"] == "1.2.3"
+        assert event["tags"]["base.build_version"] == "1.2.2"
+        assert event["tags"]["head.build_number"] == "100"
+        assert event["tags"]["base.build_number"] == "99"
         assert len(occurrence.evidence_display) == 0
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
         assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
@@ -120,9 +144,12 @@ class ArtifactToTagsTest(TestCase):
         artifact = self.create_preprod_artifact(
             project=project,
             app_id="com.example.app",
-            app_name="Example App",
+        )
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=artifact,
             build_version="1.2.3",
             build_number=456,
+            app_name="Example App",
         )
 
         tags = artifact_to_tags(artifact)

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -6,6 +6,7 @@ from sentry.integrations.source_code_management.status_check import StatusCheckS
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.models import (
     PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
 )
@@ -41,6 +42,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                     project=self.project,
                     state=state,
                     app_id="com.example.app",
+                )
+                PreprodArtifactMobileAppInfo.objects.create(
+                    preprod_artifact=artifact,
                     build_version="1.0.0",
                     build_number=1,
                 )
@@ -61,6 +65,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.app",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -74,6 +81,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.app",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -116,9 +126,13 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                     project=self.project,
                     state=PreprodArtifact.ArtifactState.UPLOADING,
                     app_id="com.example.app",
-                    build_version=version,
-                    build_number=build_number,
                 )
+                if version is not None or build_number is not None:
+                    PreprodArtifactMobileAppInfo.objects.create(
+                        preprod_artifact=artifact,
+                        build_version=version,
+                        build_number=build_number,
+                    )
 
                 title, subtitle, summary = format_status_check_messages(
                     [artifact], {}, StatusCheckStatus.IN_PROGRESS
@@ -135,15 +149,17 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 PreprodArtifact.ArtifactState.UPLOADED,
             ]
         ):
-            artifacts.append(
-                PreprodArtifact.objects.create(
-                    project=self.project,
-                    state=state,
-                    app_id=f"com.example.app{i}",
-                    build_version="1.0.0",
-                    build_number=i + 1,
-                )
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=state,
+                app_id=f"com.example.app{i}",
             )
+            PreprodArtifactMobileAppInfo.objects.create(
+                preprod_artifact=artifact,
+                build_version="1.0.0",
+                build_number=i + 1,
+            )
+            artifacts.append(artifact)
 
         title, subtitle, summary = format_status_check_messages(
             artifacts, {}, StatusCheckStatus.IN_PROGRESS
@@ -161,6 +177,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.app",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -207,6 +226,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.processing",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="2.1.0",
             build_number=15,
         )
@@ -252,9 +274,12 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.FAILED,
             app_id="com.example.app",
+            error_message="Build timeout",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
-            error_message="Build timeout",
         )
 
         title, subtitle, summary = format_status_check_messages(
@@ -300,6 +325,9 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.processed",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=processed_artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -320,6 +348,9 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.UPLOADING,
             app_id="com.example.uploading",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=uploading_artifact,
             build_version="1.0.0",
             build_number=2,
         )
@@ -329,9 +360,12 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.FAILED,
             app_id="com.example.failed",
+            error_message="Upload timeout",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=failed_artifact,
             build_version="1.0.0",
             build_number=3,
-            error_message="Upload timeout",
         )
         artifacts.append(failed_artifact)
 
@@ -362,6 +396,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
                 project=self.project,
                 state=PreprodArtifact.ArtifactState.PROCESSED,
                 app_id=f"com.example.app{i}",
+            )
+            PreprodArtifactMobileAppInfo.objects.create(
+                preprod_artifact=artifact,
                 build_version="1.0.0",
                 build_number=i + 1,
             )
@@ -395,6 +432,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.app",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -452,6 +492,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.android",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -514,6 +557,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.android",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_artifact,
             build_version="1.0.2",
             build_number=41,
         )
@@ -533,6 +579,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             commit_comparison=head_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.android",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=head_artifact,
             build_version="1.0.3",
             build_number=42,
         )
@@ -570,6 +619,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.app",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
             build_version="1.0.0",
             build_number=1,
         )
@@ -623,6 +675,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.ios",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_artifact,
             build_version="1.0.1",
             build_number=10,
         )
@@ -643,6 +698,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             commit_comparison=head_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.ios",
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=head_artifact,
             build_version="1.0.2",
             build_number=11,
         )
@@ -691,9 +749,12 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.android",
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=android_artifact,
             build_version="1.0.0",
             build_number=1,
-            artifact_type=PreprodArtifact.ArtifactType.AAB,
         )
 
         android_size_metrics = PreprodArtifactSizeMetrics.objects.create(
@@ -721,9 +782,12 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.ios",
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=ios_artifact,
             build_version="1.0.0",
             build_number=1,
-            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
         )
 
         ios_size_metrics = PreprodArtifactSizeMetrics.objects.create(
@@ -752,17 +816,23 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.android",
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=android_artifact,
             build_version="1.0.0",
             build_number=1,
-            artifact_type=PreprodArtifact.ArtifactType.AAB,
         )
         ios_artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.ios",
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=ios_artifact,
             build_version="2.0.0",
             build_number=2,
-            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
         )
 
         android_metrics = PreprodArtifactSizeMetrics.objects.create(
@@ -844,9 +914,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.mixed",
+            build_configuration=release_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_release_artifact,
             build_version="1.0.0",
             build_number=100,
-            build_configuration=release_config,
         )
 
         PreprodArtifactSizeMetrics.objects.create(
@@ -864,9 +937,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.mixed",
+            build_configuration=debug_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_debug_artifact,
             build_version="1.0.0",
             build_number=100,
-            build_configuration=debug_config,
         )
 
         PreprodArtifactSizeMetrics.objects.create(
@@ -884,9 +960,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=head_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.mixed",
+            build_configuration=debug_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=head_debug_artifact,
             build_version="1.0.1",
             build_number=101,
-            build_configuration=debug_config,
         )
 
         head_debug_metrics = PreprodArtifactSizeMetrics.objects.create(
@@ -945,9 +1024,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.release",
+            build_configuration=release_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_artifact,
             build_version="1.0.0",
             build_number=50,
-            build_configuration=release_config,
         )
 
         PreprodArtifactSizeMetrics.objects.create(
@@ -965,9 +1047,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=head_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.release",
+            build_configuration=release_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=head_artifact,
             build_version="1.0.1",
             build_number=51,
-            build_configuration=release_config,
         )
 
         head_metrics = PreprodArtifactSizeMetrics.objects.create(
@@ -1018,9 +1103,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.nomatch",
+            build_configuration=release_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=base_artifact,
             build_version="1.0.0",
             build_number=25,
-            build_configuration=release_config,
         )
 
         PreprodArtifactSizeMetrics.objects.create(
@@ -1038,9 +1126,12 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
             commit_comparison=head_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.example.nomatch",
+            build_configuration=debug_config,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=head_artifact,
             build_version="1.0.1",
             build_number=26,
-            build_configuration=debug_config,
         )
 
         head_metrics = PreprodArtifactSizeMetrics.objects.create(


### PR DESCRIPTION
Updates all reads from now-deprecated `PreprodArtifact` fields (`build_number`, `build_version` , `app_icon_id` and `app_name`) to use `PreprodArtifactMobileAppInfo` fields