### PR TITLE
fix(seer): Retry transient HTTP errors in get_anomaly_data Seer calls

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -55,7 +55,12 @@ SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
     timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
 )
 
-SEER_RETRIES = Retry(total=2, backoff_factor=0.5)
+SEER_RETRIES = Retry(
+    total=2,
+    backoff_factor=0.5,
+    status_forcelist=[408, 429, 502, 503, 504],
+    allowed_methods=["GET", "POST"],
+)
 
 
 def get_anomaly_data_from_seer(

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -209,6 +209,7 @@ def get_anomaly_threshold_data_from_seer(
             connection_pool=SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             path=SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
             body=json.dumps(payload).encode("utf-8"),
+            retries=SEER_RETRIES,
         )
     except (TimeoutError, MaxRetryError):
         logger.warning("anomaly_threshold.timeout_error_hitting_seer_endpoint")


### PR DESCRIPTION
Currently we retry network issues, but not explicit transient HTTP errors.

Should mitigate SENTRY-3EXM.
