### PR TITLE
fix(tracemetrics): Properly apply legend alias

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -329,5 +329,290 @@ describe('TraceMetricsConfig', () => {
       expect(result[0]!.seriesName).toBe('(no value) : avg(…)');
       expect(result[1]!.seriesName).toBe('(no value) : p50(…)');
     });
+
+    it('prefixes series names with query name using : separator for single aggregate and no groupings', () => {
+      const data: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 100}],
+            groupBy: [],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery: WidgetQuery = {
+        name: 'My Query',
+        fields: [],
+        columns: [],
+        fieldAliases: [],
+        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        conditions: '',
+        orderby: '',
+      };
+
+      const result = TraceMetricsConfig.transformSeries!(data, widgetQuery, organization);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.seriesName).toBe('My Query : avg(test_metric)');
+    });
+
+    it('prefixes series names with query name using : separator for multiple aggregates and no groupings', () => {
+      const data: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 100}],
+            groupBy: [],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'p50(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 80}],
+            groupBy: [],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery: WidgetQuery = {
+        name: 'My Query',
+        fields: [],
+        columns: [],
+        fieldAliases: [],
+        aggregates: [
+          'avg(value,test_metric,millisecond,-)',
+          'p50(value,test_metric,millisecond,-)',
+        ],
+        conditions: '',
+        orderby: '',
+      };
+
+      const result = TraceMetricsConfig.transformSeries!(data, widgetQuery, organization);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]!.seriesName).toBe('My Query : avg(test_metric)');
+      expect(result[1]!.seriesName).toBe('My Query : p50(test_metric)');
+    });
+
+    it('prefixes series names with query name using : separator for single aggregate with groupings', () => {
+      const data: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 100}],
+            groupBy: [{key: 'project', value: 'frontend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 200}],
+            groupBy: [{key: 'project', value: 'backend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery: WidgetQuery = {
+        name: 'My Query',
+        fields: [],
+        columns: ['project'],
+        fieldAliases: [],
+        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        conditions: '',
+        orderby: '',
+      };
+
+      const result = TraceMetricsConfig.transformSeries!(data, widgetQuery, organization);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]!.seriesName).toBe('My Query : frontend');
+      expect(result[1]!.seriesName).toBe('My Query : backend');
+    });
+
+    it('prefixes series names with query name using > separator for multiple aggregates and groupings', () => {
+      const data: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 100}],
+            groupBy: [{key: 'project', value: 'frontend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'avg(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 200}],
+            groupBy: [{key: 'project', value: 'backend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'p50(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 80}],
+            groupBy: [{key: 'project', value: 'frontend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'p50(value,test_metric,millisecond,-)',
+            values: [{timestamp: 1, value: 160}],
+            groupBy: [{key: 'project', value: 'backend'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery: WidgetQuery = {
+        name: 'My Query',
+        fields: [],
+        columns: ['project'],
+        fieldAliases: [],
+        aggregates: [
+          'avg(value,test_metric,millisecond,-)',
+          'p50(value,test_metric,millisecond,-)',
+        ],
+        conditions: '',
+        orderby: '',
+      };
+
+      const result = TraceMetricsConfig.transformSeries!(data, widgetQuery, organization);
+
+      expect(result).toHaveLength(4);
+      // With query name, multiple aggregates AND groupings, use > separator
+      expect(result[0]!.seriesName).toBe('My Query > frontend : avg(…)');
+      expect(result[1]!.seriesName).toBe('My Query > backend : avg(…)');
+      expect(result[2]!.seriesName).toBe('My Query > frontend : p50(…)');
+      expect(result[3]!.seriesName).toBe('My Query > backend : p50(…)');
+    });
+
+    it('distinguishes series from different widget queries using their query names', () => {
+      // Simulate data from first query named "Database Metrics"
+      const data1: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,db_latency,millisecond,-)',
+            values: [{timestamp: 1, value: 150}],
+            groupBy: [{key: 'environment', value: 'prod'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'avg(value,db_latency,millisecond,-)',
+            values: [{timestamp: 1, value: 75}],
+            groupBy: [{key: 'environment', value: 'dev'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery1: WidgetQuery = {
+        name: 'Database Metrics',
+        fields: [],
+        columns: ['environment'],
+        fieldAliases: [],
+        aggregates: ['avg(value,db_latency,millisecond,-)'],
+        conditions: '',
+        orderby: '',
+      };
+
+      // Simulate data from second query named "Cache Metrics"
+      const data2: EventsTimeSeriesResponse = {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,cache_hits,counter,-)',
+            values: [{timestamp: 1, value: 980}],
+            groupBy: [{key: 'environment', value: 'prod'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+          {
+            yAxis: 'avg(value,cache_hits,counter,-)',
+            values: [{timestamp: 1, value: 920}],
+            groupBy: [{key: 'environment', value: 'dev'}],
+            meta: {
+              interval: 0,
+              valueType: 'number',
+              valueUnit: null,
+            },
+          },
+        ],
+      };
+
+      const widgetQuery2: WidgetQuery = {
+        name: 'Cache Metrics',
+        fields: [],
+        columns: ['environment'],
+        fieldAliases: [],
+        aggregates: ['avg(value,cache_hits,counter,-)'],
+        conditions: '',
+        orderby: '',
+      };
+
+      const result1 = TraceMetricsConfig.transformSeries!(
+        data1,
+        widgetQuery1,
+        organization
+      );
+      const result2 = TraceMetricsConfig.transformSeries!(
+        data2,
+        widgetQuery2,
+        organization
+      );
+
+      // Verify first query produces labels with "Database Metrics"
+      expect(result1).toHaveLength(2);
+      expect(result1[0]!.seriesName).toBe('Database Metrics : prod');
+      expect(result1[1]!.seriesName).toBe('Database Metrics : dev');
+
+      // Verify second query produces labels with "Cache Metrics"
+      expect(result2).toHaveLength(2);
+      expect(result2[0]!.seriesName).toBe('Cache Metrics : prod');
+      expect(result2[1]!.seriesName).toBe('Cache Metrics : dev');
+    });
   });
 });

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -257,8 +257,9 @@ export const TraceMetricsConfig: DatasetConfig<
       // The function should always be defined when dealing with a successful
       // time series response
       const func = parseFunction(timeSeries.yAxis);
+      let yAxis = timeSeries.yAxis;
       if (func) {
-        timeSeries.yAxis = `${func.name}(${func.arguments[1] ?? '…'})`;
+        yAxis = `${func.name}(${func.arguments[1] ?? '…'})`;
       }
       return {
         data: timeSeries.values.map(value => ({
@@ -269,7 +270,7 @@ export const TraceMetricsConfig: DatasetConfig<
         seriesName: formatMetricsTimeseriesLabel({
           widgetQuery,
           func,
-          timeSeries,
+          timeSeries: {...timeSeries, yAxis},
         }),
       };
     });
@@ -292,13 +293,14 @@ export const TraceMetricsConfig: DatasetConfig<
     return data.timeSeries.reduce(
       (acc, timeSeries) => {
         const func = parseFunction(timeSeries.yAxis);
+        let yAxis = timeSeries.yAxis;
         if (func) {
-          timeSeries.yAxis = `${func.name}(${func.arguments[0] ?? '…'})`;
+          yAxis = `${func.name}(${func.arguments[1] ?? '…'})`;
         }
         const label = formatMetricsTimeseriesLabel({
           widgetQuery,
           func,
-          timeSeries,
+          timeSeries: {...timeSeries, yAxis},
         });
         acc[label] = timeSeries.meta.valueType as AggregationOutputType;
         return acc;
@@ -310,13 +312,14 @@ export const TraceMetricsConfig: DatasetConfig<
     return data.timeSeries.reduce(
       (acc, timeSeries) => {
         const func = parseFunction(timeSeries.yAxis);
+        let yAxis = timeSeries.yAxis;
         if (func) {
-          timeSeries.yAxis = `${func.name}(${func.arguments[0] ?? '…'})`;
+          yAxis = `${func.name}(${func.arguments[1] ?? '…'})`;
         }
         const label = formatMetricsTimeseriesLabel({
           widgetQuery,
           func,
-          timeSeries,
+          timeSeries: {...timeSeries, yAxis},
         });
 
         if (label.includes('per_second(')) {


### PR DESCRIPTION
Applying a legend alias in the widget builder wasn't working for metrics widgets. There were two steps to making this work:

1. Stop overwriting `timeSeries.yAxis` because once it was overridden, it would alter the data for subsequent rendering when applying the alias
2. In the `transformSeries` function, update the label formatter to add the correct separators and alias prefix

The logic follows what's provided for other previous datasets e.g.
- If you have a single aggregate, no groupings -> the alias prefixes the aggregate
- Single aggregate, groupings -> the alias prefixes the group labels
- Multiple aggregates, no groupings -> alias prefixes all aggregates
- Multiple aggregates, multiple groupings -> alias prefixes all of the groups, which also has an aggregate suffix (e.g. `My Alias > iOS : avg(latency)`)

When you have multiple filters, that's when the alias prefixes can differ because each series in the filter results gets aliased