### PR TITLE
fix(billing): Set max image width in CTA

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -61,7 +61,9 @@ function Cta({
         {icon && <Flex align="center">{icon}</Flex>}
         {image && (
           <Flex align="center">
-            <Image src={image} alt={imageAlt} />
+            <Container maxWidth="200px">
+              <Image src={image} alt={imageAlt} />
+            </Container>
           </Flex>
         )}
         <Text bold align={isBanner ? 'left' : 'center'} size="lg" textWrap="balance">


### PR DESCRIPTION
closes https://www.notion.so/sentry/UI-subscription-page-nits-2cc8b10e4b5d80658675c8b1975701f4?source=copy_link

<img width="402" height="390" alt="Screenshot 2026-01-07 at 1 47 50 PM" src="https://github.com/user-attachments/assets/2fa645a4-aa0a-4b63-bb84-5f1d4243454e" />
