### PR TITLE
chore(llm-detector): Remove retries for LLM Detector

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 from django.conf import settings
 from pydantic import BaseModel, ValidationError
-from urllib3 import Retry
 
 from sentry import features, options
 from sentry.constants import VALID_PLATFORMS
@@ -29,7 +28,6 @@ logger = logging.getLogger("sentry.tasks.llm_issue_detection")
 
 SEER_ANALYZE_ISSUE_ENDPOINT_PATH = "/v1/automation/issue-detection/analyze"
 SEER_TIMEOUT_S = 180
-SEER_RETRIES = Retry(total=1, backoff_factor=2, status_forcelist=[408, 429, 502, 503, 504])
 START_TIME_DELTA_MINUTES = 30
 TRANSACTION_BATCH_SIZE = 100
 NUM_TRANSACTIONS_TO_PROCESS = 20
@@ -38,7 +36,6 @@ NUM_TRANSACTIONS_TO_PROCESS = 20
 seer_issue_detection_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=SEER_TIMEOUT_S,
-    retries=SEER_RETRIES,
     maxsize=10,
 )
 

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -36,6 +36,7 @@ NUM_TRANSACTIONS_TO_PROCESS = 20
 seer_issue_detection_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=SEER_TIMEOUT_S,
+    retries=0,
     maxsize=10,
 )
 


### PR DESCRIPTION
we were seeing some unexpected behavior with the same request being processed multiple times. removing the retries to see if it has an impact (can add back one once we have a better understanding on why it's happening) 