### PR TITLE
fix(aci): use singular preferred detector in workflow processing round 2

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -124,9 +124,9 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData, notification_uuid: str) -> None:
-        from sentry.workflow_engine.processors.detector import get_specific_detector
+        from sentry.workflow_engine.processors.detector import get_preferred_detector
 
-        detector = get_specific_detector(event_data)
+        detector = get_preferred_detector(event_data)
 
         with metrics.timer(
             "workflow_engine.action.trigger.execution_time",

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -124,9 +124,9 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData, notification_uuid: str) -> None:
-        from sentry.workflow_engine.processors.detector import get_detector_from_event_data
+        from sentry.workflow_engine.processors.detector import get_specific_detector
 
-        detector = get_detector_from_event_data(event_data)
+        detector = get_specific_detector(event_data)
 
         with metrics.timer(
             "workflow_engine.action.trigger.execution_time",

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -356,13 +356,16 @@ def _get_detector_for_group(group: Group) -> Detector:
         return Detector.objects.get(project_id=group.project_id, type=IssueStreamGroupType.slug)
 
 
-def get_specific_detector(event_data: WorkflowEventData) -> Detector:
+def get_preferred_detector(event_data: WorkflowEventData) -> Detector:
     """
     Attempts to fetch the specific detector based on the GroupEvent or Activity in event_data
     """
     try:
         if isinstance(event_data.event, GroupEvent):
-            return _get_detector_for_event(event_data.event)
+            event_detectors = get_detectors_for_event_data(event_data)
+            if event_detectors is None:
+                raise Detector.DoesNotExist("No detectors found for event")
+            return event_detectors.preferred_detector
         elif isinstance(event_data.event, Activity):
             return _get_detector_for_group(event_data.group)
         else:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -316,7 +316,6 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
     try:
         if issue_occurrence is None or evt.group.issue_type == ErrorGroupType:
-            # if there are no detector settings, default to the error detector
             detector = Detector.get_error_detector_for_project(evt.project_id)
         else:
             detector = Detector.objects.get(

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -308,12 +308,12 @@ def _get_detector_for_event(event: GroupEvent) -> Detector:
     issue_occurrence = event.occurrence
 
     try:
-        if issue_occurrence is None or event.group.issue_type == ErrorGroupType:
-            detector = Detector.get_error_detector_for_project(event.group.project_id)
-        else:
+        if issue_occurrence is not None:
             detector = Detector.objects.get(
                 id=issue_occurrence.evidence_data.get("detector_id", None)
             )
+        else:
+            detector = Detector.get_error_detector_for_project(event.group.project_id)
     except Detector.DoesNotExist:
         metrics.incr("workflow_engine.detectors.error")
         detector_id = (

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -313,11 +313,10 @@ def _get_detector_for_event(event: GroupEvent) -> Detector:
 
     try:
         if issue_occurrence is not None:
-            detector = Detector.objects.filter(
-                id=issue_occurrence.evidence_data.get("detector_id", None)
-            ).first()
-            if detector is None:
+            detector_id = issue_occurrence.evidence_data.get("detector_id")
+            if detector_id is None:
                 raise SpecificDetectorNotFound
+            detector = Detector.objects.get(id=detector_id)
         else:
             detector = Detector.get_error_detector_for_project(event.group.project_id)
     except Detector.DoesNotExist:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection, Sequence
+from collections.abc import Sequence
 from dataclasses import asdict, replace
 from datetime import datetime
 from enum import StrEnum
@@ -380,7 +380,7 @@ def get_environment_by_event(event_data: WorkflowEventData) -> Environment | Non
 
 @scopedstats.timer()
 def _get_associated_workflows(
-    detectors: Collection[Detector], environment: Environment | None, event_data: WorkflowEventData
+    detector: Detector, environment: Environment | None, event_data: WorkflowEventData
 ) -> set[Workflow]:
     """
     This is a wrapper method to get the workflows associated with a detector and environment.
@@ -394,7 +394,7 @@ def _get_associated_workflows(
     workflows = set(
         Workflow.objects.filter(
             environment_filter,
-            detectorworkflow__detector_id__in=[detector.id for detector in detectors],
+            detectorworkflow__detector_id=detector.id,
             enabled=True,
         )
         .select_related("environment")
@@ -421,7 +421,7 @@ def _get_associated_workflows(
                 "event_data": asdict(event_data),
                 "event_environment_id": environment.id if environment else None,
                 "workflows": [workflow.id for workflow in workflows],
-                "detector_types": [detector.type for detector in detectors],
+                "detector_type": detector.type,
             },
         )
 
@@ -500,7 +500,9 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    workflows = _get_associated_workflows(event_detectors.detectors, environment, event_data)
+    workflows = _get_associated_workflows(
+        event_detectors.preferred_detector, environment, event_data
+    )
     workflow_evaluation_data.workflows = workflows
 
     if not workflows:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -30,7 +30,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
     process_data_condition_group,
 )
-from sentry.workflow_engine.processors.detector import get_detectors_for_event
+from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
     WorkflowEvaluation,
@@ -454,7 +454,7 @@ def process_workflows(
     )
 
     try:
-        event_detectors = get_detectors_for_event(event_data, detector)
+        event_detectors = get_detectors_for_event_data(event_data, detector)
 
         if not event_detectors:
             raise Detector.DoesNotExist("No Detectors associated with the issue were found")

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -91,7 +91,7 @@ def trigger_action(
     import uuid
 
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import get_detector_from_event_data
+    from sentry.workflow_engine.processors.detector import get_specific_detector
 
     # Generate UUID if not provided (handles version skew at task boundary)
     if notification_uuid is None:
@@ -129,7 +129,7 @@ def trigger_action(
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
 
-    detector = get_detector_from_event_data(event_data)
+    detector = get_specific_detector(event_data)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -91,7 +91,7 @@ def trigger_action(
     import uuid
 
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import get_specific_detector
+    from sentry.workflow_engine.processors.detector import get_preferred_detector
 
     # Generate UUID if not provided (handles version skew at task boundary)
     if notification_uuid is None:
@@ -129,7 +129,7 @@ def trigger_action(
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
 
-    detector = get_specific_detector(event_data)
+    detector = get_preferred_detector(event_data)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -71,7 +71,7 @@ class TestAction(TestCase):
             # Verify the registry was queried with the correct action type
             mock_get.assert_called_once_with(Action.Type.SLACK)
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
+    @patch("sentry.workflow_engine.processors.detector.get_preferred_detector")
     def test_trigger_calls_handler_execute(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_detector = Mock(spec=Detector, type="error")
@@ -88,7 +88,7 @@ class TestAction(TestCase):
             assert invocation.action == self.action
             assert invocation.detector == mock_detector
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
+    @patch("sentry.workflow_engine.processors.detector.get_preferred_detector")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_handler.execute.side_effect = Exception("Handler failed")
@@ -99,7 +99,7 @@ class TestAction(TestCase):
                 self.action.trigger(self.mock_event, notification_uuid=str(uuid.uuid4()))
 
     @patch("sentry.utils.metrics.incr")
-    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
+    @patch("sentry.workflow_engine.processors.detector.get_preferred_detector")
     def test_trigger_metrics(self, mock_get_detector: MagicMock, mock_incr: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_get_detector.return_value = Mock(spec=Detector, type="error")

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -31,7 +31,7 @@ from sentry.workflow_engine.processors.detector import (
     associate_new_group_with_detector,
     ensure_association_with_detector,
     get_detectors_for_event_data,
-    get_specific_detector,
+    get_preferred_detector,
     process_detectors,
 )
 from sentry.workflow_engine.types import (
@@ -947,7 +947,7 @@ class TestGetDetectorsForEvent(TestCase):
             assert result_excluded.preferred_detector == self.error_detector
 
 
-class TestGetSpecificDetector(TestCase):
+class TestGetPreferredDetector(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.group = self.create_group(project=self.project, type=MetricIssue.type_id)
@@ -976,7 +976,7 @@ class TestGetSpecificDetector(TestCase):
 
         event_data = WorkflowEventData(event=group_event, group=self.group)
 
-        result = get_specific_detector(event_data)
+        result = get_preferred_detector(event_data)
 
         assert result == self.detector
 
@@ -987,7 +987,7 @@ class TestGetSpecificDetector(TestCase):
 
         event_data = WorkflowEventData(event=group_event, group=self.group)
 
-        result = get_specific_detector(event_data)
+        result = get_preferred_detector(event_data)
 
         assert result == self.error_detector
 
@@ -1002,7 +1002,7 @@ class TestGetSpecificDetector(TestCase):
 
         event_data = WorkflowEventData(event=activity, group=self.group)
 
-        result = get_specific_detector(event_data)
+        result = get_preferred_detector(event_data)
 
         assert result == self.detector
 
@@ -1029,7 +1029,7 @@ class TestGetSpecificDetector(TestCase):
         event_data = WorkflowEventData(event=group_event, group=self.group)
 
         with pytest.raises(Detector.DoesNotExist):
-            get_specific_detector(event_data)
+            get_preferred_detector(event_data)
 
     def test_errors_on_no_detector(self) -> None:
         occurrence = IssueOccurrence(
@@ -1055,7 +1055,7 @@ class TestGetSpecificDetector(TestCase):
         event_data = WorkflowEventData(event=group_event, group=self.group)
 
         with pytest.raises(Detector.DoesNotExist):
-            get_specific_detector(event_data)
+            get_preferred_detector(event_data)
 
 
 class TestAssociateNewGroupWithDetector(TestCase):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -341,11 +341,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         mock_incr.assert_called_with("workflow_engine.detectors.error")  # called twice
         mock_logger.exception.assert_called_with(
-            "Detector not found for event",
+            "Issue stream detector not found for event",
             extra={
-                "event_id": self.event.event_id,
+                "project_id": self.group.project_id,
                 "group_id": self.group_event.group_id,
-                "detector_id": None,
             },
         )  # exception is called twice for both missing detectors
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -464,8 +464,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert len(result.data.triggered_actions) == 0
 
     @override_options({"workflow_engine.exclude_issue_stream_detector": False})
-    def test_multiple_detectors(self) -> None:
-        issue_stream_workflow, issue_stream_detector, _, _ = self.create_detector_and_workflow(
+    def test_multiple_detectors__preferred(self) -> None:
+        _, issue_stream_detector, _, _ = self.create_detector_and_workflow(
             name_prefix="issue_stream",
             workflow_triggers=self.create_data_condition_group(),
             detector_type=IssueStreamGroupType.slug,
@@ -476,7 +476,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow, issue_stream_workflow}
+        assert result.data.triggered_workflows == {self.error_workflow}
         assert result.data.associated_detector == self.error_detector
 
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry.eventstream.base import GroupState
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
@@ -63,7 +64,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
             )
         )
 
-        self.group, self.event, self.group_event = self.create_group_event()
+        self.group, self.event, self.group_event = self.create_group_event(
+            group_type_id=MetricIssue.type_id
+        )
         self.event_data = WorkflowEventData(
             event=self.group_event,
             group=self.group,
@@ -304,6 +307,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_issue_occurrence_event(self) -> None:
         issue_occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         self.group_event.occurrence = issue_occurrence
+        self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.data.triggered_workflows == {self.workflow}
@@ -670,6 +674,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
     buffer_timestamp = (FROZEN_TIME + timedelta(seconds=1)).timestamp()
 
     def setUp(self) -> None:
+        self.project = self.create_project(create_default_detectors=True)
         (
             self.workflow,
             self.detector,
@@ -679,7 +684,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         self.group, self.event, self.group_event = self.create_group_event(
-            occurrence=occurrence,
+            occurrence=occurrence, group_type_id=MetricIssue.type_id
         )
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
         self.action_group, _ = self.create_workflow_action(self.workflow)
@@ -877,17 +882,23 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         ) = self.create_detector_and_workflow()
 
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+        self.issue_stream_detector = self.create_detector(
+            project=self.project,
+            type=IssueStreamGroupType.slug,
+        )
 
         self.group, self.event, self.group_event = self.create_group_event(
-            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
+            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id}),
+            group_type_id=MetricIssue.type_id,
         )
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
         self.batch_client = DelayedWorkflowClient()
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.tasks.utils.IssueOccurrence.fetch")
+    @patch("sentry.workflow_engine.processors.action.Action.trigger")
     def test_metrics_issue_dual_processing_metrics(
-        self, mock_fetch: MagicMock, mock_incr: MagicMock
+        self, mock_trigger: MagicMock, mock_fetch: MagicMock, mock_incr: MagicMock
     ) -> None:
         mock_fetch.return_value = self.group_event.occurrence
 
@@ -901,6 +912,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             },
             sample_rate=1.0,
         )
+        mock_trigger.assert_called_once()
 
     def test_basic__no_filter(self) -> None:
         triggered_action_filters, _ = evaluate_workflows_action_filters(

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -547,10 +547,9 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
 
 
-class TestWorkflowEngineIntegrationFromFeedbackPostProcess(BaseWorkflowIntegrationTest):
-    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [6001]})
-    @with_feature("organizations:workflow-engine-single-process-workflows")
-    def test_workflow_engine(self) -> None:
+class TestWorkflowEngineIntegrationPostProcessRollout(BaseWorkflowIntegrationTest):
+    def setUp(self) -> None:
+        self.project = self.create_project(create_default_detectors=True)
         occurrence_data = self.build_occurrence_data(
             type=FeedbackGroup.type_id,
             event_id=self.event.event_id,
@@ -567,11 +566,65 @@ class TestWorkflowEngineIntegrationFromFeedbackPostProcess(BaseWorkflowIntegrati
         self.occurrence, group_info = save_issue_occurrence(occurrence_data, self.event)
         assert group_info is not None
 
-        self.group = Group.objects.get(grouphash__hash=self.occurrence.fingerprint[0])
-        assert self.group.type == FeedbackGroup.type_id
+        self.feedback_group = Group.objects.get(id=group_info.group.id)
+        assert self.feedback_group.type == FeedbackGroup.type_id
 
+    @override_options(
+        {
+            "workflow_engine.issue_alert.group.type_id.ga": [1],
+            "workflow_engine.exclude_issue_stream_detector": True,
+        }
+    )
+    def test_errors_only_rollout(self) -> None:
         with mock.patch(
             "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
         ) as mock_process_workflow:
-            self.call_post_process_group(self.group.id)
-            mock_process_workflow.assert_called_once()
+            self.call_post_process_group(self.feedback_group.id)
+            assert not mock_process_workflow.called
+
+    @override_options(
+        {
+            "workflow_engine.issue_alert.group.type_id.ga": [1],
+            "workflow_engine.exclude_issue_stream_detector": False,
+        }
+    )
+    def test_issue_stream_errors_only(self) -> None:
+        with mock.patch(
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
+        ) as mock_process_workflow:
+            self.call_post_process_group(self.feedback_group.id)
+            assert not mock_process_workflow.called  # still not called because not in rollout FF
+
+    @override_options(
+        {
+            "workflow_engine.issue_alert.group.type_id.ga": [1],
+            "workflow_engine.exclude_issue_stream_detector": False,
+            "workflow_engine.issue_alert.group.type_id.rollout": [6001],
+        }
+    )
+    @with_feature(
+        {
+            "organizations:workflow-engine-single-process-workflows": True,
+            "organizations:workflow-engine-log-evaluations": True,
+        }
+    )
+    @patch("sentry.workflow_engine.tasks.workflows.logger")
+    def test_rollout_new_issue_type(self, mock_logger: MagicMock) -> None:
+        with self.tasks():
+            self.call_post_process_group(self.feedback_group.id)
+
+        # log and exit because no workflows, but we fetched issue stream detector successfully
+        mock_logger.info.assert_any_call(
+            "workflow_engine.process_workflows.evaluation.workflows.not_triggered",
+            extra={
+                "event_id": self.event.event_id,
+                "group_id": self.feedback_group.id,
+                "detection_type": "issue_stream",
+                "workflow_ids": None,
+                "triggered_workflow_ids": [],
+                "delayed_conditions": None,
+                "action_filter_group_ids": [],
+                "triggered_action_ids": [],
+                "debug_msg": "No workflows are associated with the detector in the event",
+            },
+        )


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/105674 round 2 and tests the behavior that broke

This is safe to merge now that we don't have any non error, non metric issues going through workflow engine + the issue stream detector is currently disabled.