### PR TITLE
feat(explorer-autofix): add UI for coding handoff in autofix

### DIFF
--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -41,6 +41,7 @@ import {
   IconFix,
   IconFocus,
   IconGroup,
+  IconOpen,
   IconUser,
   IconWarning,
 } from 'sentry/icons';
@@ -51,7 +52,11 @@ import type {Member, Organization} from 'sentry/types/organization';
 import type {AvatarUser} from 'sentry/types/user';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
-import type {ExplorerFilePatch, RepoPRState} from 'sentry/views/seerExplorer/types';
+import type {
+  ExplorerCodingAgentState,
+  ExplorerFilePatch,
+  RepoPRState,
+} from 'sentry/views/seerExplorer/types';
 
 export type ArtifactData = Record<string, unknown>;
 
@@ -763,6 +768,156 @@ export function CodeChangesCard({patches, prStates, onCreatePR}: CodeChangesCard
     </ArtifactCard>
   );
 }
+
+interface CodingAgentHandoffCardProps {
+  codingAgents: Record<string, ExplorerCodingAgentState>;
+}
+
+/**
+ * Card showing the status of coding agents launched from an Explorer run.
+ */
+export function CodingAgentHandoffCard({codingAgents}: CodingAgentHandoffCardProps) {
+  const agents = Object.values(codingAgents);
+
+  if (agents.length === 0) {
+    return null;
+  }
+
+  const getStatusText = (status: ExplorerCodingAgentState['status']) => {
+    switch (status) {
+      case 'pending':
+        return t('Pending...');
+      case 'running':
+        return t('Running...');
+      case 'completed':
+        return t('Completed');
+      case 'failed':
+        return t('Failed');
+      default:
+        return status;
+    }
+  };
+
+  const getProviderDisplayName = (provider: string) => {
+    if (provider === 'cursor_background_agent') {
+      return t('Cursor Cloud Agent');
+    }
+    return t('Coding Agent');
+  };
+
+  return (
+    <ArtifactCard
+      title={t('Coding Agent')}
+      icon={<IconCode size="md" variant="accent" />}
+    >
+      <Flex direction="column" gap="xl">
+        {agents.map(agent => (
+          <CodingAgentSection key={agent.id}>
+            <Flex justify="between" align="center">
+              <Flex direction="column" gap="xs">
+                <Text size="lg" bold>
+                  {agent.name}
+                </Text>
+                <Text variant="muted" size="sm">
+                  {getProviderDisplayName(agent.provider)}
+                </Text>
+              </Flex>
+              <CodingAgentStatusTag $status={agent.status}>
+                {getStatusText(agent.status)}
+              </CodingAgentStatusTag>
+            </Flex>
+
+            {agent.results && agent.results.length > 0 && (
+              <Flex direction="column" gap="md">
+                {agent.results.map((result, index) => (
+                  <CodingAgentResultItem key={index}>
+                    <Text size="sm" as="div">
+                      <StyledMarkedText text={result.description} inline as="span" />
+                    </Text>
+                    {result.branch_name && (
+                      <Text variant="muted" size="sm">
+                        {t('Branch')}: {result.branch_name}
+                      </Text>
+                    )}
+                  </CodingAgentResultItem>
+                ))}
+              </Flex>
+            )}
+
+            <Flex gap="md" justify="end">
+              {agent.agent_url && (
+                <a href={agent.agent_url} target="_blank" rel="noopener noreferrer">
+                  <Button size="sm" icon={<IconOpen />}>
+                    {t('Open in Cursor')}
+                  </Button>
+                </a>
+              )}
+              {agent.results
+                ?.filter(result => result.pr_url)
+                .map(result => (
+                  <a
+                    key={result.pr_url}
+                    href={result.pr_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button size="sm" icon={<IconOpen />} priority="primary">
+                      {t('View Pull Request')}
+                    </Button>
+                  </a>
+                ))}
+            </Flex>
+          </CodingAgentSection>
+        ))}
+      </Flex>
+    </ArtifactCard>
+  );
+}
+
+const CodingAgentSection = styled('div')`
+  &:not(:last-child) {
+    margin-bottom: ${p => p.theme.space.xl};
+    padding-bottom: ${p => p.theme.space.xl};
+    border-bottom: 1px solid ${p => p.theme.border};
+  }
+`;
+
+const CodingAgentStatusTag = styled('span')<{
+  $status: ExplorerCodingAgentState['status'];
+}>`
+  display: inline-flex;
+  align-items: center;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  border-radius: ${p => p.theme.radius.sm};
+  font-size: ${p => p.theme.fontSize.sm};
+  font-weight: ${p => p.theme.fontWeight.normal};
+  background-color: ${p => {
+    switch (p.$status) {
+      case 'completed':
+        return p.theme.alert.success.backgroundLight;
+      case 'failed':
+        return p.theme.alert.danger.backgroundLight;
+      default:
+        return p.theme.blue100;
+    }
+  }};
+  color: ${p => {
+    switch (p.$status) {
+      case 'completed':
+        return p.theme.successText;
+      case 'failed':
+        return p.theme.errorText;
+      default:
+        return p.theme.blue400;
+    }
+  }};
+`;
+
+const CodingAgentResultItem = styled('div')`
+  padding: ${p => p.theme.space.md};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.radius.sm};
+`;
 
 const TreeContainer = styled('div')<{columnCount: number}>`
   display: grid;

--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -143,9 +143,15 @@ export function ExplorerSeerDrawer({
   aiConfig,
 }: ExplorerSeerDrawerProps) {
   const organization = useOrganization();
-  const {runState, isLoading, isPolling, startStep, createPR, reset} = useExplorerAutofix(
-    group.id
-  );
+  const {
+    runState,
+    isLoading,
+    isPolling,
+    startStep,
+    createPR,
+    reset,
+    triggerCodingAgentHandoff,
+  } = useExplorerAutofix(group.id);
 
   // Extract data from run state
   const blocks = useMemo(() => runState?.blocks ?? [], [runState?.blocks]);
@@ -188,6 +194,15 @@ export function ExplorerSeerDrawer({
       openSeerExplorer({startNewRun: true});
     }
   }, [runState?.run_id]);
+
+  const handleCodingAgentHandoff = useCallback(
+    async (integrationId: number) => {
+      if (runState?.run_id) {
+        await triggerCodingAgentHandoff(runState.run_id, integrationId);
+      }
+    },
+    [triggerCodingAgentHandoff, runState?.run_id]
+  );
 
   const {copy} = useCopyToClipboard();
   const handleCopyMarkdown = useCallback(() => {
@@ -382,6 +397,7 @@ export function ExplorerSeerDrawer({
               artifacts={artifacts}
               hasCodeChanges={hasChanges}
               onStartStep={handleStartStep}
+              onCodingAgentHandoff={handleCodingAgentHandoff}
               onOpenChat={handleOpenChat}
               isLoading={isPolling}
             />

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -74,3 +74,27 @@ export interface ExplorerSession {
   run_id: number;
   title: string; // ISO date string
 }
+
+/**
+ * Result from a coding agent (e.g., Cursor).
+ */
+export interface CodingAgentResult {
+  description: string;
+  repo_full_name: string;
+  repo_provider: string;
+  branch_name?: string;
+  pr_url?: string;
+}
+
+/**
+ * State of a coding agent launched from an Explorer run.
+ */
+export interface ExplorerCodingAgentState {
+  id: string;
+  name: string;
+  provider: string;
+  started_at: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  agent_url?: string;
+  results?: CodingAgentResult[];
+}


### PR DESCRIPTION
Adds UI for triggering cursor handoff in new autofix. Copies same button style as old UI

<img width="735" height="374" alt="Screenshot 2026-01-07 at 12 14 50 PM" src="https://github.com/user-attachments/assets/3dd1e5af-84b2-455e-b88f-b4cefa258669" />
