### PR TITLE
feat(explorer): add support for coding agent handoffs

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -21,8 +21,9 @@ from sentry.seer.autofix.prompts import (
     solution_prompt,
     triage_prompt,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.utils import AutofixStoppingPoint, get_project_seer_preferences
 from sentry.seer.explorer.client import SeerExplorerClient
+from sentry.seer.explorer.client_models import SeerRunState
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 
@@ -230,3 +231,110 @@ def get_autofix_explorer_state(organization: Organization, group_id: int):
 
     # Return the most recent run's state
     return client.get_run(runs[0].run_id)
+
+
+def generate_autofix_handoff_prompt(
+    state: SeerRunState,
+    instruction: str | None = None,
+) -> str:
+    """
+    Generate a prompt for coding agents from autofix run state.
+
+    Extracts root_cause and solution artifacts to create a comprehensive
+    prompt for the coding agent.
+    """
+    parts = ["Please fix the following issue. Ensure that your fix is fully working."]
+
+    if instruction and instruction.strip():
+        parts.append(instruction.strip())
+
+    artifacts = state.get_artifacts()
+
+    # Add root cause if present
+    root_cause = artifacts.get("root_cause")
+    if root_cause and root_cause.data:
+        parts.append("## Root Cause Analysis")
+        if "one_line_description" in root_cause.data:
+            parts.append(root_cause.data["one_line_description"])
+        if "five_whys" in root_cause.data:
+            for i, why in enumerate(root_cause.data["five_whys"], 1):
+                parts.append(f"{i}. {why}")
+        if "reproduction_steps" in root_cause.data:
+            for step in root_cause.data["reproduction_steps"]:
+                parts.append(f"- {step}")
+
+    # Add solution if present
+    solution = artifacts.get("solution")
+    if solution and solution.data:
+        parts.append("## Proposed Solution")
+        if "one_line_summary" in solution.data:
+            parts.append(solution.data["one_line_summary"])
+        if "steps" in solution.data:
+            for step in solution.data["steps"]:
+                if isinstance(step, dict):
+                    title = step.get("title", "")
+                    desc = step.get("description", "")
+                    parts.append(f"- **{title}**: {desc}")
+
+    return "\n\n".join(parts)
+
+
+def trigger_coding_agent_handoff(
+    group: Group,
+    run_id: int,
+    integration_id: int,
+) -> dict[str, list]:
+    """
+    Trigger a coding agent handoff for an existing Explorer-based autofix run.
+
+    This fetches the current run state, generates a prompt from artifacts
+    (root cause, solution, file patches), and launches coding agents.
+
+    Args:
+        group: The Sentry group (issue)
+        run_id: The existing Explorer run ID
+        integration_id: The coding agent integration ID (e.g., Cursor)
+
+    Returns:
+        Dictionary with 'successes' and 'failures' lists
+    """
+    client = SeerExplorerClient(
+        organization=group.organization,
+        user=None,
+        category_key="autofix",
+        category_value=str(group.id),
+    )
+    state = client.get_run(run_id)
+
+    repos = list(state.get_diffs_by_repo().keys())
+    repos.extend(r for r in state.repo_pr_states.keys() if r not in repos)
+    if not repos:
+        return {"successes": [], "failures": [{"error": "No repositories found in run state"}]}
+
+    prompt = generate_autofix_handoff_prompt(state)
+
+    # Fetch project preferences for auto_create_pr setting
+    auto_create_pr = False
+    try:
+        preference_response = get_project_seer_preferences(group.project_id)
+        if preference_response and preference_response.preference:
+            if preference_response.preference.automation_handoff:
+                auto_create_pr = preference_response.preference.automation_handoff.auto_create_pr
+    except Exception:
+        logger.exception(
+            "autofix.coding_agent_handoff.get_preferences_error",
+            extra={
+                "organization_id": group.organization.id,
+                "run_id": run_id,
+                "project_id": group.project_id,
+            },
+        )
+
+    return client.launch_coding_agents(
+        run_id=run_id,
+        integration_id=integration_id,
+        prompt=prompt,
+        repos=repos,
+        branch_name_base=group.title or "seer",
+        auto_create_pr=auto_create_pr,
+    )

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -5,11 +5,21 @@ from typing import TYPE_CHECKING
 
 from sentry.models.group import Group
 from sentry.models.organization import Organization
-from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_explorer
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.autofix_agent import (
+    AutofixStep,
+    trigger_autofix_explorer,
+    trigger_coding_agent_handoff,
+)
+from sentry.seer.autofix.utils import AutofixStoppingPoint, get_project_seer_preferences
 from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_utils import fetch_run_status
 from sentry.seer.explorer.on_completion_hook import ExplorerOnCompletionHook
+from sentry.seer.models import (
+    AutofixHandoffPoint,
+    SeerApiError,
+    SeerApiResponseValidationError,
+    SeerAutomationHandoffConfiguration,
+)
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 
@@ -217,6 +227,14 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
             # We've reached the stopping point
             return
 
+        # Check if we should trigger coding agent handoff instead of continuing
+        handoff_config = cls._get_handoff_config_if_applicable(
+            stopping_point, current_step, group_id
+        )
+        if handoff_config:
+            cls._trigger_coding_agent_handoff(organization, run_id, group_id, handoff_config)
+            return
+
         # Special case: if stopping_point is open_pr and we just finished code_changes, push changes
         if (
             stopping_point == AutofixStoppingPoint.OPEN_PR
@@ -286,4 +304,108 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
             logger.exception(
                 "autofix.on_completion_hook.push_changes_failed",
                 extra={"run_id": run_id, "organization_id": organization.id},
+            )
+
+    @classmethod
+    def _get_handoff_config_if_applicable(
+        cls,
+        stopping_point: AutofixStoppingPoint,
+        current_step: AutofixStep | None,
+        group_id: int,
+    ) -> SeerAutomationHandoffConfiguration | None:
+        """
+        Read project preferences and return handoff config if applicable.
+
+        Handoff is triggered when:
+        - current_step is ROOT_CAUSE
+        - stopping_point is SOLUTION, CODE_CHANGES, or OPEN_PR
+        - automation_handoff is configured with handoff_point = ROOT_CAUSE
+        """
+        # Only trigger handoff after root cause is completed
+        if current_step != AutofixStep.ROOT_CAUSE:
+            return None
+
+        # Only trigger handoff when continuing beyond root cause
+        if stopping_point not in [
+            AutofixStoppingPoint.SOLUTION,
+            AutofixStoppingPoint.CODE_CHANGES,
+            AutofixStoppingPoint.OPEN_PR,
+        ]:
+            return None
+
+        # Check project preferences
+        group = Group.objects.get(id=group_id)
+        try:
+            preference_response = get_project_seer_preferences(group.project_id)
+        except (SeerApiError, SeerApiResponseValidationError):
+            logger.exception(
+                "autofix.on_completion_hook.get_preferences_failed",
+                extra={"group_id": group_id, "project_id": group.project_id},
+            )
+            return None
+        if not preference_response.preference:
+            return None
+        handoff_config = preference_response.preference.automation_handoff
+        if not handoff_config:
+            return None
+
+        # Verify the handoff point matches
+        if handoff_config.handoff_point != AutofixHandoffPoint.ROOT_CAUSE:
+            return None
+
+        return handoff_config
+
+    @classmethod
+    def _trigger_coding_agent_handoff(
+        cls,
+        organization: Organization,
+        run_id: int,
+        group_id: int,
+        handoff_config: SeerAutomationHandoffConfiguration,
+    ) -> None:
+        """Trigger coding agent handoff using the configured integration."""
+        logger.info(
+            "autofix.on_completion_hook.triggering_coding_agent_handoff",
+            extra={
+                "run_id": run_id,
+                "organization_id": organization.id,
+                "group_id": group_id,
+                "integration_id": handoff_config.integration_id,
+                "target": handoff_config.target,
+            },
+        )
+
+        try:
+            group = Group.objects.get(id=group_id)
+            result = trigger_coding_agent_handoff(
+                group=group,
+                run_id=run_id,
+                integration_id=handoff_config.integration_id,
+            )
+            logger.info(
+                "autofix.on_completion_hook.coding_agent_handoff_completed",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "successes": len(result.get("successes", [])),
+                    "failures": len(result.get("failures", [])),
+                },
+            )
+        except Group.DoesNotExist:
+            logger.exception(
+                "autofix.on_completion_hook.coding_agent_handoff_group_not_found",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "group_id": group_id,
+                },
+            )
+        except Exception:
+            logger.exception(
+                "autofix.on_completion_hook.coding_agent_handoff_failed",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "integration_id": handoff_config.integration_id,
+                },
             )

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -115,6 +115,34 @@ class PendingUserInput(BaseModel):
         extra = "allow"
 
 
+class CodingAgentResult(BaseModel):
+    """Result from a coding agent."""
+
+    description: str
+    repo_provider: str
+    repo_full_name: str
+    branch_name: str | None = None
+    pr_url: str | None = None
+
+    class Config:
+        extra = "allow"
+
+
+class ExplorerCodingAgentState(BaseModel):
+    """State of a coding agent launched from an Explorer run."""
+
+    id: str
+    status: Literal["pending", "running", "completed", "failed"]
+    agent_url: str | None = None
+    provider: str  # e.g., "cursor_background_agent"
+    name: str
+    started_at: datetime
+    results: list[CodingAgentResult] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+
 class SeerRunState(BaseModel):
     """State of a Seer Explorer session."""
 
@@ -123,8 +151,9 @@ class SeerRunState(BaseModel):
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
     pending_user_input: PendingUserInput | None = None
-    repo_pr_states: dict[str, RepoPRState] = {}
+    repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)
     metadata: dict[str, Any] | None = None
+    coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict)
 
     class Config:
         extra = "allow"

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -1,0 +1,149 @@
+"""
+Coding agent handoff support for Explorer runs.
+
+This module provides functions to launch coding agents (like Cursor) from Explorer runs.
+It reuses the core coding agent infrastructure from sentry.seer.autofix.coding_agent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from requests import HTTPError
+from rest_framework.exceptions import PermissionDenied
+
+from sentry import features
+from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
+from sentry.models.organization import Organization
+from sentry.seer.autofix.coding_agent import (
+    _validate_and_get_integration,
+    sanitize_branch_name,
+    store_coding_agent_states_to_seer,
+)
+from sentry.seer.autofix.utils import CodingAgentState
+from sentry.seer.models import SeerApiError, SeerRepoDefinition
+from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger(__name__)
+
+
+def launch_coding_agents(
+    organization: Organization,
+    integration_id: int,
+    run_id: int,
+    prompt: str,
+    repos: list[str],
+    branch_name_base: str = "explorer-fix",
+    auto_create_pr: bool = False,
+) -> dict[str, list]:
+    """
+    Launch third-party coding agents for an Explorer run.
+
+    Args:
+        organization: The organization
+        integration_id: The coding agent integration ID
+        run_id: The Explorer run ID (used to store coding agent state)
+        prompt: The instruction/prompt for the coding agent
+        repos: List of repo names to target (format: "owner/name")
+        branch_name_base: Base name for the branch (random suffix will be added)
+        auto_create_pr: Whether to automatically create a PR when agent finishes
+
+    Returns:
+        Dictionary with 'successes' and 'failures' lists
+
+    Raises:
+        NotFound: If integration not found
+        PermissionDenied: If feature not enabled for the organization
+        ValidationError: If integration is invalid
+    """
+    if not features.has("organizations:seer-coding-agent-integrations", organization):
+        raise PermissionDenied("Feature not available")
+
+    integration, installation = _validate_and_get_integration(organization, integration_id)
+
+    successes = []
+    failures = []
+    states_to_store: list[CodingAgentState] = []
+
+    for repo_name in repos:
+        # Parse repo_name into owner/name
+        parts = repo_name.split("/")
+        if len(parts) != 2:
+            failures.append(
+                {
+                    "repo_name": repo_name,
+                    "error_message": f"Invalid repository name format: {repo_name}",
+                }
+            )
+            continue
+
+        owner, name = parts
+
+        # Create a SeerRepoDefinition for the launch request
+        repo = SeerRepoDefinition(
+            provider="github",  # TODO: Support other providers
+            owner=owner,
+            name=name,
+            external_id=repo_name,  # Using full name as external_id for now
+        )
+
+        launch_request = CodingAgentLaunchRequest(
+            prompt=prompt,
+            repository=repo,
+            branch_name=sanitize_branch_name(branch_name_base),
+            auto_create_pr=auto_create_pr,
+        )
+
+        try:
+            coding_agent_state = installation.launch(launch_request)
+        except (HTTPError, ApiError) as e:
+            logger.exception(
+                "explorer.coding_agent.launch_error",
+                extra={
+                    "organization_id": organization.id,
+                    "run_id": run_id,
+                    "repo_name": repo_name,
+                },
+            )
+            failures.append(
+                {
+                    "repo_name": repo_name,
+                    "error_message": str(e),
+                }
+            )
+            continue
+
+        states_to_store.append(coding_agent_state)
+        successes.append(
+            {
+                "repo_name": repo_name,
+                "coding_agent_state": coding_agent_state.dict(),
+            }
+        )
+
+    # Store the coding agent states to Seer
+    try:
+        store_coding_agent_states_to_seer(run_id=run_id, coding_agent_states=states_to_store)
+    except SeerApiError:
+        logger.exception(
+            "explorer.coding_agent.seer_storage_error",
+            extra={
+                "organization_id": organization.id,
+                "run_id": run_id,
+                "repos": repos,
+            },
+        )
+
+    logger.info(
+        "explorer.coding_agent.launch_result",
+        extra={
+            "organization_id": organization.id,
+            "integration_id": integration_id,
+            "provider": integration.provider,
+            "run_id": run_id,
+            "repos_succeeded": len(successes),
+            "repos_failed": len(failures),
+        },
+    )
+
+    return {"successes": successes, "failures": failures}

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -3,10 +3,135 @@ from unittest.mock import MagicMock, patch
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     build_step_prompt,
+    generate_autofix_handoff_prompt,
     trigger_autofix_explorer,
+    trigger_coding_agent_handoff,
 )
+from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, SeerRunState
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
+
+
+class TestGenerateAutofixHandoffPrompt(TestCase):
+    """Tests for generate_autofix_handoff_prompt function."""
+
+    def _make_state_with_artifacts(self, artifacts: list[Artifact]) -> SeerRunState:
+        """Helper to create a SeerRunState with given artifacts."""
+        return SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Analysis"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    artifacts=artifacts,
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+    def test_basic_prompt_without_artifacts(self):
+        """Test prompt generation with no artifacts."""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        prompt = generate_autofix_handoff_prompt(state)
+
+        assert "Please fix the following issue" in prompt
+        assert "Root Cause" not in prompt
+        assert "Solution" not in prompt
+
+    def test_prompt_with_instruction(self):
+        """Test that custom instruction is included in prompt."""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        prompt = generate_autofix_handoff_prompt(state, instruction="Focus on the database layer")
+
+        assert "Focus on the database layer" in prompt
+
+    def test_prompt_with_root_cause_artifact(self):
+        """Test prompt includes root cause details."""
+        state = self._make_state_with_artifacts(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={
+                        "one_line_description": "Memory leak in cache handler",
+                        "five_whys": ["Cache not cleared", "No TTL set"],
+                        "reproduction_steps": ["Step 1", "Step 2"],
+                    },
+                    reason="Analysis complete",
+                )
+            ]
+        )
+
+        prompt = generate_autofix_handoff_prompt(state)
+
+        assert "## Root Cause Analysis" in prompt
+        assert "Memory leak in cache handler" in prompt
+        assert "1. Cache not cleared" in prompt
+        assert "2. No TTL set" in prompt
+        assert "- Step 1" in prompt
+        assert "- Step 2" in prompt
+
+    def test_prompt_with_solution_artifact(self):
+        """Test prompt includes solution details."""
+        state = self._make_state_with_artifacts(
+            [
+                Artifact(
+                    key="solution",
+                    data={
+                        "one_line_summary": "Add TTL to cache entries",
+                        "steps": [
+                            {"title": "Step 1", "description": "Add TTL parameter"},
+                            {"title": "Step 2", "description": "Update cache config"},
+                        ],
+                    },
+                    reason="Solution generated",
+                )
+            ]
+        )
+
+        prompt = generate_autofix_handoff_prompt(state)
+
+        assert "## Proposed Solution" in prompt
+        assert "Add TTL to cache entries" in prompt
+        assert "**Step 1**: Add TTL parameter" in prompt
+        assert "**Step 2**: Update cache config" in prompt
+
+    def test_prompt_with_both_artifacts(self):
+        """Test prompt includes both root cause and solution."""
+        state = self._make_state_with_artifacts(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={"one_line_description": "Bug in handler"},
+                    reason="Found",
+                ),
+                Artifact(
+                    key="solution",
+                    data={"one_line_summary": "Fix the handler"},
+                    reason="Proposed",
+                ),
+            ]
+        )
+
+        prompt = generate_autofix_handoff_prompt(state)
+
+        assert "## Root Cause Analysis" in prompt
+        assert "Bug in handler" in prompt
+        assert "## Proposed Solution" in prompt
+        assert "Fix the handler" in prompt
 
 
 class TestBuildStepPrompt(TestCase):
@@ -136,3 +261,212 @@ class TestTriggerAutofixExplorer(TestCase):
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.SOLUTION_STARTED.value
         assert call_kwargs["payload"]["run_id"] == 67890
+
+
+class TestTriggerCodingAgentHandoff(TestCase):
+    """Tests for trigger_coding_agent_handoff function."""
+
+    def setUp(self):
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+
+    def _make_run_state(self, artifacts: list[Artifact] | None = None) -> SeerRunState:
+        """Helper to create a SeerRunState with given artifacts."""
+        return SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Analysis"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    artifacts=artifacts or [],
+                    merged_file_patches=[],
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": MagicMock(repo_name="owner/repo")},
+        )
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_success(self, mock_client_class, mock_get_prefs):
+        """Test successful coding agent handoff."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={"one_line_description": "Bug found"},
+                    reason="test",
+                )
+            ]
+        )
+        mock_client.launch_coding_agents.return_value = {
+            "successes": [{"repo_name": "owner/repo"}],
+            "failures": [],
+        }
+        mock_get_prefs.return_value = None
+
+        result = trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        assert len(result["successes"]) == 1
+        mock_client.get_run.assert_called_once_with(123)
+        mock_client.launch_coding_agents.assert_called_once()
+
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_no_repos(self, mock_client_class):
+        """Test handoff with no repositories returns failure."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        # State with no repos in diffs or pr_states
+        state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={},
+        )
+        mock_client.get_run.return_value = state
+
+        result = trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        assert len(result["failures"]) == 1
+        assert "No repositories found" in result["failures"][0]["error"]
+        mock_client.launch_coding_agents.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_generates_prompt_from_artifacts(
+        self, mock_client_class, mock_get_prefs
+    ):
+        """Test that prompt is generated from run state artifacts."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={"one_line_description": "Memory leak in cache"},
+                    reason="test",
+                ),
+                Artifact(
+                    key="solution",
+                    data={"one_line_summary": "Add TTL to cache"},
+                    reason="test",
+                ),
+            ]
+        )
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = None
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        # Verify prompt was generated and passed to launch_coding_agents
+        call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
+        prompt = call_kwargs["prompt"]
+        assert "Memory leak in cache" in prompt
+        assert "Add TTL to cache" in prompt
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_uses_group_title_for_branch(
+        self, mock_client_class, mock_get_prefs
+    ):
+        """Test that branch_name_base is set to the group title."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = None
+
+        # Set a specific title on the group
+        self.group.message = "NullPointerException in UserService"
+        self.group.save()
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
+        assert call_kwargs["branch_name_base"] == self.group.title
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_fetches_auto_create_pr_from_preferences(
+        self, mock_client_class, mock_get_prefs
+    ):
+        """Test that auto_create_pr is fetched from project preferences."""
+        from sentry.seer.models import (
+            AutofixHandoffPoint,
+            PreferenceResponse,
+            SeerAutomationHandoffConfiguration,
+            SeerProjectPreference,
+        )
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+
+        # Set up preferences with auto_create_pr=True
+        handoff_config = SeerAutomationHandoffConfiguration(
+            handoff_point=AutofixHandoffPoint.ROOT_CAUSE,
+            target="cursor_background_agent",
+            integration_id=456,
+            auto_create_pr=True,
+        )
+        preference = SeerProjectPreference(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            repositories=[],
+            automation_handoff=handoff_config,
+        )
+        mock_get_prefs.return_value = PreferenceResponse(
+            preference=preference, code_mapping_repos=[]
+        )
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
+        assert call_kwargs["auto_create_pr"] is True
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_defaults_auto_create_pr_false(
+        self, mock_client_class, mock_get_prefs
+    ):
+        """Test that auto_create_pr defaults to False when not configured."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = None
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            integration_id=456,
+        )
+
+        call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
+        assert call_kwargs["auto_create_pr"] is False

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -15,6 +15,13 @@ from sentry.seer.explorer.client_models import (
     MemoryBlock,
     Message,
 )
+from sentry.seer.models import (
+    AutofixHandoffPoint,
+    PreferenceResponse,
+    SeerAutomationHandoffConfiguration,
+    SeerProjectPreference,
+    SeerRepoDefinition,
+)
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 
@@ -315,3 +322,152 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         AutofixOnCompletionHook._send_step_webhook(self.organization, 123, {}, state)
 
         mock_broadcast.assert_not_called()
+
+
+class TestAutofixOnCompletionHookHandoff(TestCase):
+    """Tests for coding agent handoff logic in AutofixOnCompletionHook."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.group = self.create_group(project=self.project)
+
+    def _make_handoff_config(
+        self, handoff_point: AutofixHandoffPoint = AutofixHandoffPoint.ROOT_CAUSE
+    ) -> SeerAutomationHandoffConfiguration:
+        """Helper to create a handoff configuration."""
+        return SeerAutomationHandoffConfiguration(
+            handoff_point=handoff_point,
+            target="cursor_background_agent",
+            integration_id=123,
+            auto_create_pr=False,
+        )
+
+    def _make_preference_response(
+        self, handoff_config: SeerAutomationHandoffConfiguration | None = None
+    ) -> PreferenceResponse:
+        """Helper to create a preference response."""
+        preference = SeerProjectPreference(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            repositories=[
+                SeerRepoDefinition(
+                    provider="github",
+                    owner="owner",
+                    name="repo",
+                    external_id="123",
+                )
+            ],
+            automation_handoff=handoff_config,
+        )
+        return PreferenceResponse(preference=preference, code_mapping_repos=[])
+
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_get_handoff_config_returns_none_when_not_root_cause_step(self, mock_get_prefs):
+        """Returns None when current step is not ROOT_CAUSE."""
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            current_step=AutofixStep.SOLUTION,  # Not ROOT_CAUSE
+            group_id=self.group.id,
+        )
+
+        assert result is None
+        mock_get_prefs.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_get_handoff_config_returns_none_when_stopping_at_root_cause(self, mock_get_prefs):
+        """Returns None when stopping point is ROOT_CAUSE (no handoff needed)."""
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
+            current_step=AutofixStep.ROOT_CAUSE,
+            group_id=self.group.id,
+        )
+
+        assert result is None
+        mock_get_prefs.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_get_handoff_config_returns_none_when_no_handoff_configured(self, mock_get_prefs):
+        """Returns None when project has no automation_handoff configured."""
+        mock_get_prefs.return_value = self._make_preference_response(handoff_config=None)
+
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            current_step=AutofixStep.ROOT_CAUSE,
+            group_id=self.group.id,
+        )
+
+        assert result is None
+
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_get_handoff_config_returns_config_when_applicable(self, mock_get_prefs):
+        """Returns handoff config when all conditions are met."""
+        handoff_config = self._make_handoff_config()
+        mock_get_prefs.return_value = self._make_preference_response(handoff_config=handoff_config)
+
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            current_step=AutofixStep.ROOT_CAUSE,
+            group_id=self.group.id,
+        )
+
+        assert result == handoff_config
+
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_get_handoff_config_returns_none_when_handoff_point_mismatch(self, mock_get_prefs):
+        """Returns None when handoff_point is not ROOT_CAUSE."""
+        handoff_config = self._make_handoff_config(
+            handoff_point=AutofixHandoffPoint.SOLUTION  # Not ROOT_CAUSE
+        )
+        mock_get_prefs.return_value = self._make_preference_response(handoff_config=handoff_config)
+
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            current_step=AutofixStep.ROOT_CAUSE,
+            group_id=self.group.id,
+        )
+
+        assert result is None
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    @patch("sentry.seer.autofix.on_completion_hook.get_project_seer_preferences")
+    def test_maybe_continue_pipeline_triggers_handoff_when_configured(
+        self, mock_get_prefs, mock_trigger_handoff
+    ):
+        """Triggers handoff instead of continuing pipeline when handoff is configured."""
+        handoff_config = self._make_handoff_config()
+        mock_get_prefs.return_value = self._make_preference_response(handoff_config=handoff_config)
+        mock_trigger_handoff.return_value = {"successes": [], "failures": []}
+
+        state = MagicMock()
+        state.metadata = {
+            "stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
+            "group_id": self.group.id,
+        }
+        state.has_code_changes.return_value = (False, True)
+        artifacts = {
+            "root_cause": Artifact(key="root_cause", data={"cause": "test"}, reason="test")
+        }
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, artifacts)
+
+        mock_trigger_handoff.assert_called_once()
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    def test_trigger_coding_agent_handoff_calls_function(self, mock_trigger):
+        """Test _trigger_coding_agent_handoff calls the trigger function correctly."""
+        mock_trigger.return_value = {"successes": [{"repo": "owner/repo"}], "failures": []}
+        handoff_config = self._make_handoff_config()
+
+        AutofixOnCompletionHook._trigger_coding_agent_handoff(
+            organization=self.organization,
+            run_id=123,
+            group_id=self.group.id,
+            handoff_config=handoff_config,
+        )
+
+        mock_trigger.assert_called_once()
+        call_kwargs = mock_trigger.call_args.kwargs
+        assert call_kwargs["run_id"] == 123
+        assert call_kwargs["integration_id"] == 123

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -1,0 +1,137 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework.exceptions import PermissionDenied
+
+from sentry.seer.explorer.coding_agent_handoff import launch_coding_agents
+from sentry.testutils.cases import TestCase
+
+
+class TestLaunchCodingAgents(TestCase):
+    """Tests for launch_coding_agents function."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.run_id = 12345
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_raises_permission_denied_without_feature(self, mock_features):
+        """Test that PermissionDenied is raised when feature flag is disabled."""
+        mock_features.return_value = False
+
+        with pytest.raises(PermissionDenied, match="Feature not available"):
+            launch_coding_agents(
+                organization=self.organization,
+                integration_id=1,
+                run_id=self.run_id,
+                prompt="Fix the bug",
+                repos=["owner/repo"],
+            )
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_successful_launch(self, mock_features, mock_validate, mock_store):
+        """Test successful coding agent launch."""
+        mock_features.return_value = True
+
+        mock_integration = MagicMock()
+        mock_integration.provider = "cursor"
+        mock_installation = MagicMock()
+        mock_installation.launch.return_value = MagicMock(
+            dict=lambda: {"id": "agent-123", "url": "https://cursor.sh/agent"}
+        )
+        mock_validate.return_value = (mock_integration, mock_installation)
+
+        result = launch_coding_agents(
+            organization=self.organization,
+            integration_id=1,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=["owner/repo"],
+        )
+
+        assert len(result["successes"]) == 1
+        assert len(result["failures"]) == 0
+        assert result["successes"][0]["repo_name"] == "owner/repo"
+        mock_installation.launch.assert_called_once()
+        mock_store.assert_called_once()
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_invalid_repo_format(self, mock_features, mock_validate, mock_store):
+        """Test that invalid repo format is handled as failure."""
+        mock_features.return_value = True
+        mock_integration = MagicMock()
+        mock_installation = MagicMock()
+        mock_validate.return_value = (mock_integration, mock_installation)
+
+        result = launch_coding_agents(
+            organization=self.organization,
+            integration_id=1,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=["invalid-repo-no-slash"],
+        )
+
+        assert len(result["successes"]) == 0
+        assert len(result["failures"]) == 1
+        assert "Invalid repository name format" in result["failures"][0]["error_message"]
+        mock_installation.launch.assert_not_called()
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_multiple_repos_partial_failure(self, mock_features, mock_validate, mock_store):
+        """Test handling of partial failures across multiple repos."""
+        from requests import HTTPError
+
+        mock_features.return_value = True
+        mock_integration = MagicMock()
+        mock_integration.provider = "cursor"
+        mock_installation = MagicMock()
+        # First call succeeds, second fails
+        mock_installation.launch.side_effect = [
+            MagicMock(dict=lambda: {"id": "agent-1"}),
+            HTTPError("API Error"),
+        ]
+        mock_validate.return_value = (mock_integration, mock_installation)
+
+        result = launch_coding_agents(
+            organization=self.organization,
+            integration_id=1,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=["owner/repo1", "owner/repo2"],
+        )
+
+        assert len(result["successes"]) == 1
+        assert len(result["failures"]) == 1
+        assert result["successes"][0]["repo_name"] == "owner/repo1"
+        assert result["failures"][0]["repo_name"] == "owner/repo2"
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_branch_name_is_sanitized(self, mock_features, mock_validate, mock_store):
+        """Test that branch name is sanitized before launch."""
+        mock_features.return_value = True
+        mock_integration = MagicMock()
+        mock_installation = MagicMock()
+        mock_installation.launch.return_value = MagicMock(dict=lambda: {"id": "agent-1"})
+        mock_validate.return_value = (mock_integration, mock_installation)
+
+        launch_coding_agents(
+            organization=self.organization,
+            integration_id=1,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=["owner/repo"],
+            branch_name_base="my-fix",
+        )
+
+        # Verify launch was called with a sanitized branch name
+        launch_request = mock_installation.launch.call_args[0][0]
+        assert launch_request.branch_name.startswith("my-fix-")


### PR DESCRIPTION
- adds support in the Explorer Client for triggering a third party coding agent with a prompt and integration id provided
- updates Autofix-on-Explorer to allow triggering handoffs via API endpoint and via automation in on_completion_hook