### PR TITLE
feat(explorer): add coding agent handoff UI for explorer autofix

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -14,6 +14,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {
   Artifact,
   Block,
+  ExplorerCodingAgentState,
   ExplorerFilePatch,
   RepoPRState,
 } from 'sentry/views/seerExplorer/types';
@@ -89,6 +90,7 @@ interface ExplorerAutofixState {
   run_id: number;
   status: 'processing' | 'completed' | 'error' | 'awaiting_user_input';
   updated_at: string;
+  coding_agents?: Record<string, ExplorerCodingAgentState>;
   pending_user_input?: {
     data: Record<string, unknown>;
     id: string;
@@ -399,6 +401,36 @@ export function useExplorerAutofix(
     );
   }, [queryClient, orgSlug, groupId]);
 
+  /**
+   * Trigger coding agent handoff for an existing run.
+   */
+  const triggerCodingAgentHandoff = useCallback(
+    async (runId: number, integrationId: number) => {
+      setWaitingForResponse(true);
+
+      try {
+        await api.requestPromise(`/organizations/${orgSlug}/issues/${groupId}/autofix/`, {
+          method: 'POST',
+          data: {
+            step: 'coding_agent_handoff',
+            run_id: runId,
+            integration_id: integrationId,
+          },
+        });
+
+        // Invalidate to fetch fresh data
+        queryClient.invalidateQueries({
+          queryKey: makeExplorerAutofixQueryKey(orgSlug, groupId),
+        });
+      } catch (e: any) {
+        setWaitingForResponse(false);
+        addErrorMessage(e?.responseJSON?.detail ?? 'Failed to launch coding agent');
+        throw e;
+      }
+    },
+    [api, orgSlug, groupId, queryClient]
+  );
+
   // Clear waiting state when we get a response
   if (waitingForResponse && runState) {
     const hasLoadingBlock = runState.blocks.some(block => block.loading);
@@ -432,5 +464,9 @@ export function useExplorerAutofix(
      * Reset the autofix state.
      */
     reset,
+    /**
+     * Trigger coding agent handoff for an existing run.
+     */
+    triggerCodingAgentHandoff,
   };
 }

--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -41,6 +41,7 @@ import {
   IconFix,
   IconFocus,
   IconGroup,
+  IconOpen,
   IconUser,
   IconWarning,
 } from 'sentry/icons';
@@ -51,7 +52,11 @@ import type {Member, Organization} from 'sentry/types/organization';
 import type {AvatarUser} from 'sentry/types/user';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
-import type {ExplorerFilePatch, RepoPRState} from 'sentry/views/seerExplorer/types';
+import type {
+  ExplorerCodingAgentState,
+  ExplorerFilePatch,
+  RepoPRState,
+} from 'sentry/views/seerExplorer/types';
 
 export type ArtifactData = Record<string, unknown>;
 
@@ -763,6 +768,156 @@ export function CodeChangesCard({patches, prStates, onCreatePR}: CodeChangesCard
     </ArtifactCard>
   );
 }
+
+interface CodingAgentHandoffCardProps {
+  codingAgents: Record<string, ExplorerCodingAgentState>;
+}
+
+/**
+ * Card showing the status of coding agents launched from an Explorer run.
+ */
+export function CodingAgentHandoffCard({codingAgents}: CodingAgentHandoffCardProps) {
+  const agents = Object.values(codingAgents);
+
+  if (agents.length === 0) {
+    return null;
+  }
+
+  const getStatusText = (status: ExplorerCodingAgentState['status']) => {
+    switch (status) {
+      case 'pending':
+        return t('Pending...');
+      case 'running':
+        return t('Running...');
+      case 'completed':
+        return t('Completed');
+      case 'failed':
+        return t('Failed');
+      default:
+        return status;
+    }
+  };
+
+  const getProviderDisplayName = (provider: string) => {
+    if (provider === 'cursor_background_agent') {
+      return t('Cursor Cloud Agent');
+    }
+    return t('Coding Agent');
+  };
+
+  return (
+    <ArtifactCard
+      title={t('Coding Agent')}
+      icon={<IconCode size="md" variant="accent" />}
+    >
+      <Flex direction="column" gap="xl">
+        {agents.map(agent => (
+          <CodingAgentSection key={agent.id}>
+            <Flex justify="between" align="center">
+              <Flex direction="column" gap="xs">
+                <Text size="lg" bold>
+                  {agent.name}
+                </Text>
+                <Text variant="muted" size="sm">
+                  {getProviderDisplayName(agent.provider)}
+                </Text>
+              </Flex>
+              <CodingAgentStatusTag $status={agent.status}>
+                {getStatusText(agent.status)}
+              </CodingAgentStatusTag>
+            </Flex>
+
+            {agent.results && agent.results.length > 0 && (
+              <Flex direction="column" gap="md">
+                {agent.results.map((result, index) => (
+                  <CodingAgentResultItem key={index}>
+                    <Text size="sm" as="div">
+                      <StyledMarkedText text={result.description} inline as="span" />
+                    </Text>
+                    {result.branch_name && (
+                      <Text variant="muted" size="sm">
+                        {t('Branch')}: {result.branch_name}
+                      </Text>
+                    )}
+                  </CodingAgentResultItem>
+                ))}
+              </Flex>
+            )}
+
+            <Flex gap="md" justify="end">
+              {agent.agent_url && (
+                <a href={agent.agent_url} target="_blank" rel="noopener noreferrer">
+                  <Button size="sm" icon={<IconOpen />}>
+                    {t('Open in Cursor')}
+                  </Button>
+                </a>
+              )}
+              {agent.results
+                ?.filter(result => result.pr_url)
+                .map(result => (
+                  <a
+                    key={result.pr_url}
+                    href={result.pr_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button size="sm" icon={<IconOpen />} priority="primary">
+                      {t('View Pull Request')}
+                    </Button>
+                  </a>
+                ))}
+            </Flex>
+          </CodingAgentSection>
+        ))}
+      </Flex>
+    </ArtifactCard>
+  );
+}
+
+const CodingAgentSection = styled('div')`
+  &:not(:last-child) {
+    margin-bottom: ${p => p.theme.space.xl};
+    padding-bottom: ${p => p.theme.space.xl};
+    border-bottom: 1px solid ${p => p.theme.border};
+  }
+`;
+
+const CodingAgentStatusTag = styled('span')<{
+  $status: ExplorerCodingAgentState['status'];
+}>`
+  display: inline-flex;
+  align-items: center;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  border-radius: ${p => p.theme.radius.sm};
+  font-size: ${p => p.theme.fontSize.sm};
+  font-weight: ${p => p.theme.fontWeight.normal};
+  background-color: ${p => {
+    switch (p.$status) {
+      case 'completed':
+        return p.theme.alert.success.backgroundLight;
+      case 'failed':
+        return p.theme.alert.danger.backgroundLight;
+      default:
+        return p.theme.blue100;
+    }
+  }};
+  color: ${p => {
+    switch (p.$status) {
+      case 'completed':
+        return p.theme.successText;
+      case 'failed':
+        return p.theme.errorText;
+      default:
+        return p.theme.blue400;
+    }
+  }};
+`;
+
+const CodingAgentResultItem = styled('div')`
+  padding: ${p => p.theme.space.md};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.radius.sm};
+`;
 
 const TreeContainer = styled('div')<{columnCount: number}>`
   display: grid;

--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -20,6 +20,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesCard,
+  CodingAgentHandoffCard,
   ImpactCard,
   RootCauseCard,
   SolutionCard,
@@ -143,9 +144,15 @@ export function ExplorerSeerDrawer({
   aiConfig,
 }: ExplorerSeerDrawerProps) {
   const organization = useOrganization();
-  const {runState, isLoading, isPolling, startStep, createPR, reset} = useExplorerAutofix(
-    group.id
-  );
+  const {
+    runState,
+    isLoading,
+    isPolling,
+    startStep,
+    createPR,
+    reset,
+    triggerCodingAgentHandoff,
+  } = useExplorerAutofix(group.id);
 
   // Extract data from run state
   const blocks = useMemo(() => runState?.blocks ?? [], [runState?.blocks]);
@@ -154,6 +161,7 @@ export function ExplorerSeerDrawer({
   const loadingBlock = useMemo(() => blocks.find(block => block.loading), [blocks]);
   const hasChanges = checkHasCodeChanges(blocks);
   const prStates = runState?.repo_pr_states;
+  const codingAgents = runState?.coding_agents;
 
   const orderedArtifactKeys = useMemo(
     () => getOrderedArtifactKeys(blocks, artifacts),
@@ -188,6 +196,15 @@ export function ExplorerSeerDrawer({
       openSeerExplorer({startNewRun: true});
     }
   }, [runState?.run_id]);
+
+  const handleCodingAgentHandoff = useCallback(
+    async (integrationId: number) => {
+      if (runState?.run_id) {
+        await triggerCodingAgentHandoff(runState.run_id, integrationId);
+      }
+    },
+    [triggerCodingAgentHandoff, runState?.run_id]
+  );
 
   const {copy} = useCopyToClipboard();
   const handleCopyMarkdown = useCallback(() => {
@@ -361,6 +378,10 @@ export function ExplorerSeerDrawer({
                 onCreatePR={handleCreatePR}
               />
             )}
+            {/* Coding agent handoff status */}
+            {codingAgents && Object.keys(codingAgents).length > 0 && (
+              <CodingAgentHandoffCard codingAgents={codingAgents} />
+            )}
           </AnimatePresence>
 
           {/* Status card when processing */}
@@ -381,7 +402,11 @@ export function ExplorerSeerDrawer({
             <ExplorerNextSteps
               artifacts={artifacts}
               hasCodeChanges={hasChanges}
+              hasCodingAgents={
+                codingAgents !== undefined && Object.keys(codingAgents).length > 0
+              }
               onStartStep={handleStartStep}
+              onCodingAgentHandoff={handleCodingAgentHandoff}
               onOpenChat={handleOpenChat}
               isLoading={isPolling}
             />

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -74,3 +74,27 @@ export interface ExplorerSession {
   run_id: number;
   title: string; // ISO date string
 }
+
+/**
+ * Result from a coding agent (e.g., Cursor).
+ */
+interface CodingAgentResult {
+  description: string;
+  repo_full_name: string;
+  repo_provider: string;
+  branch_name?: string;
+  pr_url?: string;
+}
+
+/**
+ * State of a coding agent launched from an Explorer run.
+ */
+export interface ExplorerCodingAgentState {
+  id: string;
+  name: string;
+  provider: string;
+  started_at: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  agent_url?: string;
+  results?: CodingAgentResult[];
+}


### PR DESCRIPTION
Add frontend support for coding agent handoff in explorer-based autofix. Uses split-button dropdown pattern matching legacy autofix UI.
