### PR TITLE
feat(preprod): Add size status check project config values to project endpoints

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1168,6 +1168,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:toolbar_allowed_origins": "\n".join(
                 self.get_value_with_default(attrs, "sentry:toolbar_allowed_origins") or []
             ),
+            "sentry:preprod_size_status_checks_enabled": options.get(
+                "sentry:preprod_size_status_checks_enabled", False
+            ),
+            "sentry:preprod_size_status_checks_rules": options.get(
+                "sentry:preprod_size_status_checks_rules"
+            ),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
         }
 

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -943,6 +943,16 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 project.update_option(
                     "sentry:uptime_autodetection", bool(options["sentry:uptime_autodetection"])
                 )
+            if "sentry:preprod_size_status_checks_enabled" in options:
+                project.update_option(
+                    "sentry:preprod_size_status_checks_enabled",
+                    bool(options["sentry:preprod_size_status_checks_enabled"]),
+                )
+            if "sentry:preprod_size_status_checks_rules" in options:
+                project.update_option(
+                    "sentry:preprod_size_status_checks_rules",
+                    options["sentry:preprod_size_status_checks_rules"],
+                )
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -68,6 +68,8 @@ OPTION_KEYS = frozenset(
         "sentry:autofix_automation_tuning",
         "sentry:seer_scanner_automation",
         "sentry:debug_files_role",
+        "sentry:preprod_size_status_checks_enabled",
+        "sentry:preprod_size_status_checks_rules",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",


### PR DESCRIPTION
So that we can set and read these values from the frontend settings page