### PR TITLE
feat(preprod): Integrating status check settings into task logic

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -36,7 +36,7 @@ BUILD_1 = {
     "build_version": "1.0.3",
     "build_number": 42,
     "build_configuration": "Debug",  # Head build configuration
-    "base_build_configuration": "Release",  # Base build configuration (test different configs!)
+    "base_build_configuration": "Debug",  # Base build configuration (test different configs!)
     "state": "processed_with_metrics",  # uploading, uploaded, failed, processed_no_metrics, processed_with_metrics, metrics_pending
     "create_base_artifacts": True,  # Create base artifacts for size comparison
     "create_multiple_metrics": False,  # Create watch/dynamic feature metrics in addition to main
@@ -259,6 +259,7 @@ def create_base_artifacts_for_comparison(
             project=project,
             app_id=build_config["app_id"],
             app_name=build_config["app_name"],
+            artifact_type=build_config["artifact_type"],
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             build_version=build_config["build_version"],
@@ -387,6 +388,36 @@ def show_rule_evaluation(artifact_id: int) -> None:
         context = _get_artifact_filter_context(art)
 
         logger.info("\n  📱 %s (%s):", art.app_id, context.get("build.platform", "unknown"))
+
+        if size_metrics:
+            head_install = size_metrics.max_install_size
+            head_download = size_metrics.max_download_size
+            logger.info(
+                "     Current: install=%s MB, download=%s MB",
+                round(head_install / 1024 / 1024, 2) if head_install else None,
+                round(head_download / 1024 / 1024, 2) if head_download else None,
+            )
+
+        if base_metric:
+            base_install = base_metric.max_install_size
+            base_download = base_metric.max_download_size
+            logger.info(
+                "     Base: install=%s MB, download=%s MB",
+                round(base_install / 1024 / 1024, 2) if base_install else None,
+                round(base_download / 1024 / 1024, 2) if base_download else None,
+            )
+            if size_metrics and base_install and head_install:
+                diff_mb = (head_install - base_install) / 1024 / 1024
+                diff_pct = ((head_install - base_install) / base_install) * 100
+                logger.info(
+                    "     Diff: %s%s MB (%s%s%%)",
+                    "+" if diff_mb > 0 else "",
+                    round(diff_mb, 2),
+                    "+" if diff_pct > 0 else "",
+                    round(diff_pct, 1),
+                )
+        else:
+            logger.info("     Base: No base metrics found (diff rules won't trigger)")
 
         for rule in rules:
             matches = _rule_matches_artifact(rule, context)

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -349,6 +349,76 @@ def get_artifact_state_from_config(state_str: str) -> tuple:
     return state_map.get(state_str, (PreprodArtifact.ArtifactState.PROCESSED, False, None))
 
 
+def show_rule_evaluation(artifact_id: int) -> None:
+    """Show which rules matched and which triggered for all artifacts in the commit."""
+    from sentry.preprod.vcs.status_checks.size.tasks import (
+        _evaluate_rule_threshold,
+        _fetch_base_size_metrics,
+        _get_artifact_filter_context,
+        _get_status_check_rules,
+        _rule_matches_artifact,
+    )
+
+    artifact = PreprodArtifact.objects.get(id=artifact_id)
+
+    all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
+
+    rules = _get_status_check_rules(artifact.project)
+
+    if not rules:
+        logger.info("\n📋 No rules configured")
+        return
+
+    logger.info("\n📋 Rule Evaluation Results:")
+
+    base_metrics_map = _fetch_base_size_metrics(all_artifacts, artifact.project)
+
+    overall_triggered = False
+
+    for art in all_artifacts:
+        size_metrics = art.preprodartifactsizemetrics_set.filter(
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        ).first()
+
+        if not size_metrics:
+            continue
+
+        base_metric = base_metrics_map.get(art.id)
+        context = _get_artifact_filter_context(art)
+
+        logger.info("\n  📱 %s (%s):", art.app_id, context.get("build.platform", "unknown"))
+
+        for rule in rules:
+            matches = _rule_matches_artifact(rule, context)
+            triggered = (
+                _evaluate_rule_threshold(rule, size_metrics, base_metric) if matches else False
+            )
+
+            if triggered:
+                status = "🔴 TRIGGERED"
+                overall_triggered = True
+            elif matches:
+                status = "✓ Matches"
+            else:
+                status = "⊘ Filtered out"
+
+            logger.info(
+                "     %s | %s %s (threshold: %s%s)",
+                status,
+                rule.metric,
+                rule.measurement,
+                rule.value,
+                rule.unit,
+            )
+            if rule.filter_query:
+                logger.info("        Filter: %s", rule.filter_query)
+
+    if not overall_triggered:
+        logger.info("\n✅ All rules passed for all artifacts!")
+    else:
+        logger.info("\n❌ One or more rules triggered - check will fail")
+
+
 def main() -> None:
     """Main function to test size analysis status checks."""
     try:
@@ -522,7 +592,8 @@ def main() -> None:
         logger.info("Task result: %s", result)
         logger.info("✅ Status check function called successfully!")
 
-        # Show GitHub link
+        show_rule_evaluation(created_artifacts[0].id)
+
         logger.info("\n🔍 Check your GitHub status check at:")
         logger.info("   https://github.com/%s/commit/%s", REPO_NAME, COMMIT_SHA)
 

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -43,7 +43,7 @@ BUILD_1 = {
     "build_version": "1.0.3",
     "build_number": 42,
     "build_configuration": "Debug",  # Head build configuration
-    "base_build_configuration": "Debug",  # Base build configuration (test different configs!)
+    "base_build_configuration": "Release",  # Base build configuration (test different configs!)
     "state": "processed_with_metrics",  # uploading, uploaded, failed, processed_no_metrics, processed_with_metrics, metrics_pending
     "create_base_artifacts": True,  # Create base artifacts for size comparison
     "create_multiple_metrics": False,  # Create watch/dynamic feature metrics in addition to main

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -17,7 +17,14 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
 )
-from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    _evaluate_rule_threshold,
+    _fetch_base_size_metrics,
+    _get_artifact_filter_context,
+    _get_status_check_rules,
+    _rule_matches_artifact,
+    create_preprod_status_check_task,
+)
 
 #################
 # Configuration #
@@ -352,14 +359,6 @@ def get_artifact_state_from_config(state_str: str) -> tuple:
 
 def show_rule_evaluation(artifact_id: int) -> None:
     """Show which rules matched and which triggered for all artifacts in the commit."""
-    from sentry.preprod.vcs.status_checks.size.tasks import (
-        _evaluate_rule_threshold,
-        _fetch_base_size_metrics,
-        _get_artifact_filter_context,
-        _get_status_check_rules,
-        _rule_matches_artifact,
-    )
-
     artifact = PreprodArtifact.objects.get(id=artifact_id)
 
     all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
@@ -453,11 +452,19 @@ def show_rule_evaluation(artifact_id: int) -> None:
 def main() -> None:
     """Main function to test size analysis status checks."""
     try:
-        # Get project
         project = Project.objects.get(slug=PROJECT_SLUG, organization__slug=ORG_SLUG)
         logger.info("Found project: %s (ID: %s)", project.name, project.id)
 
-        # Get or create commit comparison
+        status_checks_enabled = project.get_option(
+            "sentry:preprod_size_status_checks_enabled", default=False
+        )
+
+        if not status_checks_enabled:
+            logger.info("⚠️  Status checks: DISABLED (no checks will be posted)")
+            sys.exit(0)
+
+        logger.info("✅ Status checks: ENABLED")
+
         commit_comparison, created = CommitComparison.objects.get_or_create(
             head_repo_name=REPO_NAME,
             head_sha=COMMIT_SHA,

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -433,12 +433,11 @@ def show_rule_evaluation(artifact_id: int) -> None:
                 status = "⊘ Filtered out"
 
             logger.info(
-                "     %s | %s %s (threshold: %s%s)",
+                "     %s | %s %s (threshold: %s)",
                 status,
                 rule.metric,
                 rule.measurement,
                 rule.value,
-                rule.unit,
             )
             if rule.filter_query:
                 logger.info("        Filter: %s", rule.filter_query)

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -455,7 +455,7 @@ def main() -> None:
         logger.info("Found project: %s (ID: %s)", project.name, project.id)
 
         status_checks_enabled = project.get_option(
-            "sentry:preprod_size_status_checks_enabled", default=False
+            "sentry:preprod_size_status_checks_enabled", default=True
         )
 
         if not status_checks_enabled:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1169,7 +1169,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 self.get_value_with_default(attrs, "sentry:toolbar_allowed_origins") or []
             ),
             "sentry:preprod_size_status_checks_enabled": options.get(
-                "sentry:preprod_size_status_checks_enabled", False
+                "sentry:preprod_size_status_checks_enabled", True
             ),
             "sentry:preprod_size_status_checks_rules": options.get(
                 "sentry:preprod_size_status_checks_rules"

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -409,7 +409,7 @@ def _fetch_base_size_metrics(
     return result
 
 
-def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | None]:
+def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str]:
     """
     Extract build metadata from an artifact for filter matching.
 
@@ -419,7 +419,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | N
     - app_id: The app ID (e.g., "com.example.app")
     - build_configuration: The build configuration name
     """
-    context: dict[str, str | None] = {}
+    context: dict[str, str] = {}
 
     if artifact.commit_comparison and artifact.commit_comparison.head_ref:
         context["git_head_ref"] = artifact.commit_comparison.head_ref
@@ -445,7 +445,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | N
     return context
 
 
-def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str | None]) -> bool:
+def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str]) -> bool:
     """
     Check if a rule's filters match the artifact's context.
 

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -365,7 +365,7 @@ def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
                 )
             )
         return rules
-    except (json.JSONDecodeError, TypeError, ValueError) as e:
+    except (json.JSONDecodeError, TypeError, ValueError, AttributeError) as e:
         logger.warning(
             "preprod.status_checks.rules.parse_error",
             extra={"project_id": project.id, "error": str(e)},

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -482,6 +482,9 @@ def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str | None]
     for group_key, group_filters in filters_by_group.items():
         artifact_value = context.get(group_filters[0].key.name)
 
+        if artifact_value is None:
+            return False
+
         group_matches = False
         for f in group_filters:
             if f.is_in_filter:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -434,7 +434,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | N
     if artifact.app_id:
         context["build.package_name"] = artifact.app_id
 
-    if artifact.build_configuration_id:
+    if artifact.build_configuration:
         try:
             context["build.build_configuration"] = artifact.build_configuration.name
         except Exception:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -47,13 +47,13 @@ preprod_artifact_search_config = SearchConfig.create_from(
     SearchConfig[Literal[True]](),
     key_mappings={
         "platform": ["platform"],
-        "branch": ["branch"],
+        "git_head_ref": ["git_head_ref"],
         "app_id": ["app_id"],
         "build_configuration": ["build_configuration"],
     },
     allowed_keys={
         "platform",
-        "branch",
+        "git_head_ref",
         "app_id",
         "build_configuration",
     },
@@ -414,7 +414,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | N
     Extract build metadata from an artifact for filter matching.
 
     Returns a dict with keys matching the filter key format:
-    - branch: The branch name (from commit_comparison.head_ref)
+    - git_head_ref: The git_head_ref name (from commit_comparison.head_ref)
     - platform: "ios" or "android" (derived from artifact_type)
     - app_id: The app ID (e.g., "com.example.app")
     - build_configuration: The build configuration name
@@ -422,7 +422,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | N
     context: dict[str, str | None] = {}
 
     if artifact.commit_comparison and artifact.commit_comparison.head_ref:
-        context["branch"] = artifact.commit_comparison.head_ref
+        context["git_head_ref"] = artifact.commit_comparison.head_ref
 
     if artifact.artifact_type is not None:
         if artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -338,18 +338,13 @@ def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
             )
             return []
 
-        required_fields = [
-            ("id", str),
-            ("metric", str),
-            ("measurement", str),
-            ("value", (int, float)),
-        ]
-
         rules: list[StatusCheckRule] = []
         for rule_dict in rules_data:
-            if not all(
-                isinstance(rule_dict.get(field), expected_type)
-                for field, expected_type in required_fields
+            if (
+                not isinstance(rule_dict.get("id"), str)
+                or not isinstance(rule_dict.get("metric"), str)
+                or not isinstance(rule_dict.get("measurement"), str)
+                or not isinstance(rule_dict.get("value"), (int, float))
             ):
                 logger.warning(
                     "preprod.status_checks.rules.invalid_rule",

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from django.db import router, transaction
 
+from sentry.api.event_search import SearchConfig, SearchFilter, parse_search_query
 from sentry.constants import ObjectStatus
+from sentry.exceptions import InvalidSearchQuery
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.github.status_check import GitHubCheckConclusion, GitHubCheckStatus
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -33,8 +36,77 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
+
+ENABLED_OPTION_KEY = "sentry:preprod_size_status_checks_enabled"
+RULES_OPTION_KEY = "sentry:preprod_size_status_checks_rules"
+
+preprod_artifact_search_config = SearchConfig.create_from(
+    SearchConfig[Literal[True]](),
+    key_mappings={
+        "build.platform": ["build.platform"],
+        "build.branch": ["build.branch"],
+        "build.package_name": ["build.package_name"],
+        "build.build_configuration": ["build.build_configuration"],
+    },
+    allowed_keys={
+        "build.platform",
+        "build.branch",
+        "build.package_name",
+        "build.build_configuration",
+    },
+)
+
+
+@dataclass
+class StatusCheckRule:
+    """A rule that defines when a status check should fail.
+
+    Measurement types:
+    - absolute: Fail if size exceeds threshold (e.g., "fail if > 50MB")
+    - absolute_diff: Fail if size increases by more than threshold (e.g., "fail if +5MB")
+    - relative_diff: Fail if size increases by more than percentage (e.g., "fail if +10%")
+
+    Examples:
+        StatusCheckRule(
+            id="rule-1",
+            metric="install_size",
+            measurement="absolute",
+            value=50.0,
+            unit="MB",
+            filter_query="platform:iOS"
+        )
+        Triggers failure if any iOS build exceeds 50MB.
+
+        StatusCheckRule(
+            id="rule-2",
+            metric="install_size",
+            measurement="absolute_diff",
+            value=5.0,
+            unit="MB",
+            filter_query="platform:iOS"
+        )
+        Triggers failure if any iOS build increases by more than 5MB.
+
+        StatusCheckRule(
+            id="rule-3",
+            metric="download_size",
+            measurement="relative_diff",
+            value=10.0,
+            unit="%",
+            filter_query=""
+        )
+        Triggers failure if any build's download size increases by more than 10%.
+    """
+
+    id: str
+    metric: str
+    measurement: str
+    value: float
+    unit: str
+    filter_query: str = ""
 
 
 @instrumented_task(
@@ -87,6 +159,17 @@ def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) ->
         )
         return
 
+    status_checks_enabled = preprod_artifact.project.get_option(ENABLED_OPTION_KEY, default=False)
+    if not status_checks_enabled:
+        logger.info(
+            "preprod.status_checks.create.disabled",
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "project_id": preprod_artifact.project.id,
+            },
+        )
+        return
+
     # Get all artifacts for this commit across all projects in the organization
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -122,7 +205,12 @@ def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) ->
                 size_metrics_map[metrics.preprod_artifact_id] = []
             size_metrics_map[metrics.preprod_artifact_id].append(metrics)
 
-    status = _compute_overall_status(all_artifacts, size_metrics_map)
+    rules = _get_status_check_rules(preprod_artifact.project)
+    base_size_metrics_map = _fetch_base_size_metrics(all_artifacts, preprod_artifact.project)
+
+    status = _compute_overall_status(
+        all_artifacts, size_metrics_map, rules=rules, base_size_metrics_map=base_size_metrics_map
+    )
 
     title, subtitle, summary = format_status_check_messages(all_artifacts, size_metrics_map, status)
 
@@ -234,8 +322,272 @@ class StatusCheckErrorType(StrEnum):
     """An integration configuration error (permissions, invalid request, etc.)."""
 
 
+def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
+    """
+    Fetch and parse status check rules from project options.
+
+    Returns an empty list if feature is disabled or no rules configured.
+    """
+
+    rules_json = project.get_option(RULES_OPTION_KEY, default=None)
+    if not rules_json:
+        return []
+
+    try:
+        rules_data = json.loads(rules_json)
+        if not isinstance(rules_data, list):
+            logger.warning(
+                "preprod.status_checks.rules.invalid_format",
+                extra={"project_id": project.id, "rules_type": type(rules_data).__name__},
+            )
+            return []
+
+        rules: list[StatusCheckRule] = []
+        for rule_dict in rules_data:
+            filter_query = rule_dict.get("filterQuery", "")
+            if not filter_query and "filters" in rule_dict:
+                logger.info(
+                    "preprod.status_checks.rules.legacy_format",
+                    extra={"project_id": project.id, "rule_id": rule_dict.get("id")},
+                )
+                continue
+
+            rules.append(
+                StatusCheckRule(
+                    id=rule_dict.get("id", ""),
+                    metric=rule_dict.get("metric", ""),
+                    measurement=rule_dict.get("measurement", ""),
+                    value=float(rule_dict.get("value", 0)),
+                    unit=rule_dict.get("unit", "MB"),
+                    filter_query=filter_query,
+                )
+            )
+        return rules
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        logger.warning(
+            "preprod.status_checks.rules.parse_error",
+            extra={"project_id": project.id, "error": str(e)},
+        )
+        return []
+
+
+def _fetch_base_size_metrics(
+    artifacts: list[PreprodArtifact], project: Project
+) -> dict[int, PreprodArtifactSizeMetrics]:
+    """
+    Fetch base artifact main size metrics for size comparison in absolute_diff rules.
+
+    Returns a map of {head_artifact_id: base_main_size_metrics} for artifacts that have
+    base artifacts with matching build configurations. Only returns the main artifact metrics.
+    """
+    base_artifact_map: dict[int, PreprodArtifact] = {}
+
+    for artifact in artifacts:
+        base_artifact = artifact.get_base_artifact_for_commit().first()
+        if base_artifact and base_artifact.build_configuration == artifact.build_configuration:
+            base_artifact_map[artifact.id] = base_artifact
+
+    if not base_artifact_map:
+        return {}
+
+    base_artifact_ids = list(base_artifact_map.values())
+    base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+        preprod_artifact_id__in=[ba.id for ba in base_artifact_ids],
+        preprod_artifact__project__organization_id=project.organization_id,
+        metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+    ).select_related("preprod_artifact")
+
+    result: dict[int, PreprodArtifactSizeMetrics] = {}
+    for head_artifact_id, base_artifact in base_artifact_map.items():
+        for metrics in base_size_metrics_qs:
+            if metrics.preprod_artifact_id == base_artifact.id:
+                result[head_artifact_id] = metrics
+                break
+
+    return result
+
+
+def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str | None]:
+    """
+    Extract build metadata from an artifact for filter matching.
+
+    Returns a dict with keys matching the filter key format:
+    - build.branch: The branch name (from commit_comparison.head_ref)
+    - build.platform: "ios" or "android" (derived from artifact_type)
+    - build.package_name: The app ID (e.g., "com.example.app")
+    - build.build_configuration: The build configuration name
+    """
+    context: dict[str, str | None] = {}
+
+    if artifact.commit_comparison and artifact.commit_comparison.head_ref:
+        context["build.branch"] = artifact.commit_comparison.head_ref
+
+    if artifact.artifact_type is not None:
+        if artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
+            context["build.platform"] = "ios"
+        elif artifact.artifact_type in (
+            PreprodArtifact.ArtifactType.AAB,
+            PreprodArtifact.ArtifactType.APK,
+        ):
+            context["build.platform"] = "android"
+
+    if artifact.app_id:
+        context["build.package_name"] = artifact.app_id
+
+    if artifact.build_configuration_id:
+        try:
+            context["build.build_configuration"] = artifact.build_configuration.name
+        except Exception:
+            pass
+
+    return context
+
+
+def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str | None]) -> bool:
+    """
+    Check if a rule's filters match the artifact's context.
+
+    Filter logic:
+    - Filters with the same key AND negation status are OR'd together
+    - Different groups (different key or negation) are AND'd together
+    - negated=True means the value should NOT match
+
+    If a rule has no filters, it matches all artifacts.
+    """
+    if not rule.filter_query.strip():
+        return True
+
+    try:
+        search_filters = parse_search_query(
+            rule.filter_query, config=preprod_artifact_search_config
+        )
+    except InvalidSearchQuery:
+        logger.warning(
+            "preprod.status_checks.invalid_filter_query",
+            extra={"rule_id": rule.id, "filter_query": rule.filter_query},
+        )
+        return False
+
+    filters_by_group: dict[str, list[SearchFilter]] = {}
+    for f in search_filters:
+        if not isinstance(f, SearchFilter):
+            continue
+        group_key = f"{f.key.name}:{'negated' if f.is_negation else 'normal'}"
+        if group_key not in filters_by_group:
+            filters_by_group[group_key] = []
+        filters_by_group[group_key].append(f)
+
+    for group_key, group_filters in filters_by_group.items():
+        artifact_value = context.get(group_filters[0].key.name)
+
+        group_matches = False
+        for f in group_filters:
+            if f.is_in_filter:
+                matches = artifact_value in f.value.value
+            else:
+                matches = artifact_value == f.value.value
+
+            if f.is_negation:
+                matches = not matches
+
+            if matches:
+                group_matches = True
+                break
+
+        if not group_matches:
+            return False
+
+    return True
+
+
+def _convert_to_bytes(value: float, unit: str) -> float:
+    """Convert a value from the given unit to bytes."""
+    if unit == "MB":
+        return value * 1024 * 1024
+    elif unit == "%":
+        # Percentage is handled separately in threshold evaluation
+        return value
+    else:
+        # Assume bytes if unknown
+        return value
+
+
+def _get_metric_value(size_metrics: PreprodArtifactSizeMetrics, metric: str) -> int | None:
+    """Get the relevant size value from metrics based on the metric type."""
+    if metric == "install_size":
+        return size_metrics.max_install_size
+    elif metric == "download_size":
+        return size_metrics.max_download_size
+    return None
+
+
+def _evaluate_rule_threshold(
+    rule: StatusCheckRule,
+    size_metrics: PreprodArtifactSizeMetrics | None,
+    base_size_metrics: PreprodArtifactSizeMetrics | None = None,
+) -> bool:
+    """
+    Check if the size metric exceeds the rule's threshold.
+
+    Returns True if the threshold is exceeded (rule triggers failure).
+
+    Measurement types:
+    - absolute: Compare the absolute size against the threshold
+    - absolute_diff: Compare the absolute size difference (in MB) from baseline
+    - relative_diff: Compare the relative size difference (in %) from baseline
+    """
+    if not size_metrics:
+        return False
+
+    if size_metrics.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED:
+        return False
+
+    current_value = _get_metric_value(size_metrics, rule.metric)
+    if current_value is None:
+        return False
+
+    threshold_bytes = _convert_to_bytes(rule.value, rule.unit)
+
+    if rule.measurement == "absolute":
+        return current_value > threshold_bytes
+
+    elif rule.measurement == "absolute_diff":
+        if not base_size_metrics:
+            return False
+
+        if base_size_metrics.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED:
+            return False
+
+        base_value = _get_metric_value(base_size_metrics, rule.metric)
+        if base_value is None:
+            return False
+
+        diff = current_value - base_value
+        return diff > threshold_bytes
+
+    elif rule.measurement == "relative_diff":
+        if not base_size_metrics:
+            return False
+
+        if base_size_metrics.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED:
+            return False
+
+        base_value = _get_metric_value(base_size_metrics, rule.metric)
+        if base_value is None or base_value == 0:
+            return False
+
+        diff = current_value - base_value
+        percent_diff = (diff / base_value) * 100
+        return percent_diff > rule.value
+
+    return False
+
+
 def _compute_overall_status(
-    artifacts: list[PreprodArtifact], size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]]
+    artifacts: list[PreprodArtifact],
+    size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]],
+    rules: list[StatusCheckRule] | None = None,
+    base_size_metrics_map: dict[int, PreprodArtifactSizeMetrics] | None = None,
 ) -> StatusCheckStatus:
     if not artifacts:
         raise ValueError("Cannot compute status for empty artifact list")
@@ -261,6 +613,40 @@ def _compute_overall_status(
                         size_metrics.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
                     ):
                         return StatusCheckStatus.IN_PROGRESS
+
+        if rules:
+            for artifact in artifacts:
+                context = _get_artifact_filter_context(artifact)
+                size_metrics_list = size_metrics_map.get(artifact.id, [])
+
+                main_metrics_list = [
+                    m
+                    for m in size_metrics_list
+                    if m.metrics_artifact_type
+                    == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+                ]
+                main_metric = main_metrics_list[0] if main_metrics_list else None
+
+                base_main_metric = (
+                    base_size_metrics_map.get(artifact.id) if base_size_metrics_map else None
+                )
+
+                for rule in rules:
+                    if _rule_matches_artifact(rule, context):
+                        if _evaluate_rule_threshold(rule, main_metric, base_main_metric):
+                            logger.info(
+                                "preprod.status_checks.rule_triggered",
+                                extra={
+                                    "artifact_id": artifact.id,
+                                    "rule_id": rule.id,
+                                    "metric": rule.metric,
+                                    "measurement": rule.measurement,
+                                    "threshold": rule.value,
+                                    "unit": rule.unit,
+                                },
+                            )
+                            return StatusCheckStatus.FAILURE
+
         return StatusCheckStatus.SUCCESS
     else:
         return StatusCheckStatus.IN_PROGRESS

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -344,7 +344,9 @@ def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
 
         rules: list[StatusCheckRule] = []
         for rule_dict in rules_data:
-            filter_query = rule_dict.get("filterQuery", "")
+            filter_query_raw = rule_dict.get("filterQuery", "")
+            filter_query = str(filter_query_raw) if filter_query_raw is not None else ""
+
             if not filter_query and "filters" in rule_dict:
                 logger.info(
                     "preprod.status_checks.rules.legacy_format",
@@ -454,7 +456,7 @@ def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str | None]
 
     If a rule has no filters, it matches all artifacts.
     """
-    if not rule.filter_query.strip():
+    if not rule.filter_query or not str(rule.filter_query).strip():
         return True
 
     try:

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -14,9 +14,11 @@ import type {TagCollection} from 'sentry/types/group';
 import {SectionLabel} from './statusCheckSharedComponents';
 import type {StatusCheckRule} from './types';
 import {
+  bytesToMB,
+  getDisplayUnit,
   getMeasurementLabel,
   getMetricLabel,
-  getUnitForMeasurement,
+  mbToBytes,
   MEASUREMENT_OPTIONS,
   METRIC_OPTIONS,
 } from './types';
@@ -28,20 +30,20 @@ interface Props {
 }
 
 const FILTER_KEYS: TagCollection = {
-  'build.platform': {key: 'build.platform', name: 'Platform'},
-  'build.package_name': {key: 'build.package_name', name: 'Package Name'},
-  'build.build_configuration': {
-    key: 'build.build_configuration',
+  platform: {key: 'platform', name: 'Platform'},
+  app_id: {key: 'app_id', name: 'App ID'},
+  build_configuration: {
+    key: 'build_configuration',
     name: 'Build Configuration',
   },
-  'build.branch': {key: 'build.branch', name: 'Branch'},
+  branch: {key: 'branch', name: 'Branch'},
 };
 
 const getTagValues = (
   tag: {key: string; name: string},
   _searchQuery: string
 ): Promise<string[]> => {
-  if (tag.key === 'build.platform') {
+  if (tag.key === 'platform') {
     return Promise.resolve(['android', 'ios']);
   }
   return Promise.resolve([]);
@@ -50,19 +52,19 @@ const getTagValues = (
 export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
   const [metric, setMetric] = useState(rule.metric);
   const [measurement, setMeasurement] = useState(rule.measurement);
-  const [value, setValue] = useState(rule.value);
+  const displayUnit = getDisplayUnit(measurement);
+  const initialDisplayValue = displayUnit === '%' ? rule.value : bytesToMB(rule.value);
+  const [displayValue, setDisplayValue] = useState(initialDisplayValue);
   const [filterQuery, setFilterQuery] = useState(rule.filterQuery ?? '');
 
-  const unit = getUnitForMeasurement(measurement);
-
   const handleSave = () => {
+    const valueInBytes = displayUnit === '%' ? displayValue : mbToBytes(displayValue);
     onSave({
       ...rule,
       filterQuery,
       measurement,
       metric,
-      unit,
-      value,
+      value: valueInBytes,
     });
   };
 
@@ -71,8 +73,9 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
   }, []);
 
   const handleDelete = () => {
-    const valueWithUnit =
-      rule.unit === '%' ? `${rule.value}%` : `${rule.value} ${rule.unit}`;
+    const ruleDisplayValue =
+      getDisplayUnit(rule.measurement) === '%' ? rule.value : bytesToMB(rule.value);
+    const valueWithUnit = `${ruleDisplayValue} ${getDisplayUnit(rule.measurement)}`;
     const ruleDescription = `${getMetricLabel(rule.metric)} - ${getMeasurementLabel(rule.measurement)}`;
 
     openConfirmModal({
@@ -111,8 +114,12 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
         />
         <Text variant="muted">{t('is greater than')}</Text>
         <Flex align="center" gap="xs">
-          <StyledNumberInput value={value} onChange={v => setValue(v ?? 0)} min={0} />
-          <Text variant="muted">{unit}</Text>
+          <StyledNumberInput
+            value={displayValue}
+            onChange={v => setDisplayValue(v ?? 0)}
+            min={0}
+          />
+          <Text variant="muted">{displayUnit}</Text>
         </Flex>
       </Flex>
 

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -36,7 +36,7 @@ const FILTER_KEYS: TagCollection = {
     key: 'build_configuration',
     name: 'Build Configuration',
   },
-  branch: {key: 'branch', name: 'Branch'},
+  git_head_ref: {key: 'git_head_ref', name: 'Branch'},
 };
 
 const getTagValues = (

--- a/static/app/views/settings/project/preprod/statusCheckRuleItem.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleItem.tsx
@@ -13,7 +13,7 @@ import {space} from 'sentry/styles/space';
 
 import {StatusCheckRuleForm} from './statusCheckRuleForm';
 import type {StatusCheckFilter, StatusCheckRule} from './types';
-import {getMeasurementLabel, getMetricLabel} from './types';
+import {bytesToMB, getDisplayUnit, getMeasurementLabel, getMetricLabel} from './types';
 
 interface Props {
   onDelete: () => void;
@@ -29,7 +29,7 @@ function FilterSummary({filters}: {filters: StatusCheckFilter[]}) {
     <Text size="sm" variant="muted" as="div">
       {Object.entries(grouped).map(([groupKey, groupFilters], groupIdx) => {
         const {key, negated} = groupFilters[0]!;
-        const keyLabel = key.replace('build.', '');
+        const keyLabel = key;
         return (
           <Fragment key={groupKey}>
             {groupIdx > 0 && ' • '}
@@ -57,8 +57,9 @@ export function StatusCheckRuleItem({
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const filters = parseFiltersForDisplay(rule.filterQuery);
 
-  const valueWithUnit =
-    rule.unit === '%' ? `${rule.value}%` : `${rule.value} ${rule.unit}`;
+  const displayUnit = getDisplayUnit(rule.measurement);
+  const displayValue = displayUnit === '%' ? rule.value : bytesToMB(rule.value);
+  const valueWithUnit = `${displayValue} ${displayUnit}`;
   const title = `${getMetricLabel(rule.metric)} • ${getMeasurementLabel(rule.measurement)} • ${valueWithUnit}`;
 
   return (

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -2,8 +2,6 @@ type MetricType = 'install_size' | 'download_size';
 
 type MeasurementType = 'absolute' | 'absolute_diff' | 'relative_diff';
 
-type UnitType = 'MB' | '%';
-
 export interface StatusCheckFilter {
   key: string;
   value: string;
@@ -14,7 +12,6 @@ export interface StatusCheckRule {
   id: string;
   measurement: MeasurementType;
   metric: MetricType;
-  unit: UnitType;
   value: number;
   filterQuery?: string;
 }
@@ -38,6 +35,14 @@ export function getMeasurementLabel(measurement: MeasurementType): string {
   return MEASUREMENT_OPTIONS.find(o => o.value === measurement)?.label ?? measurement;
 }
 
-export function getUnitForMeasurement(measurement: MeasurementType): UnitType {
+export function getDisplayUnit(measurement: MeasurementType): string {
   return measurement === 'relative_diff' ? '%' : 'MB';
+}
+
+export function bytesToMB(bytes: number): number {
+  return bytes / (1024 * 1024);
+}
+
+export function mbToBytes(mb: number): number {
+  return mb * 1024 * 1024;
 }

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -40,9 +40,9 @@ export function getDisplayUnit(measurement: MeasurementType): string {
 }
 
 export function bytesToMB(bytes: number): number {
-  return bytes / (1024 * 1024);
+  return bytes / (1000 * 1000);
 }
 
 export function mbToBytes(mb: number): number {
-  return mb * 1024 * 1024;
+  return mb * 1000 * 1000;
 }

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -9,12 +9,7 @@ import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
-import {
-  getUnitForMeasurement,
-  MEASUREMENT_OPTIONS,
-  METRIC_OPTIONS,
-  type StatusCheckRule,
-} from './types';
+import {MEASUREMENT_OPTIONS, METRIC_OPTIONS, type StatusCheckRule} from './types';
 
 const ENABLED_KEY = 'sentry:preprod_size_status_checks_enabled';
 const RULES_KEY = 'sentry:preprod_size_status_checks_rules';
@@ -43,7 +38,6 @@ function parseRules(raw: unknown): StatusCheckRule[] {
         metric,
         measurement,
         value: typeof r.value === 'number' ? r.value : 0,
-        unit: getUnitForMeasurement(measurement),
         filterQuery: typeof r.filterQuery === 'string' ? r.filterQuery : '',
       };
     });
@@ -52,7 +46,7 @@ function parseRules(raw: unknown): StatusCheckRule[] {
 export function useStatusCheckRules(project: Project) {
   const updateProject = useUpdateProject(project);
 
-  const enabled = project.options?.[ENABLED_KEY] === true;
+  const enabled = project.options?.[ENABLED_KEY] !== false;
   const rulesJson = project.options?.[RULES_KEY];
   const rules: StatusCheckRule[] = useMemo(() => {
     if (typeof rulesJson !== 'string') {
@@ -135,7 +129,6 @@ export function useStatusCheckRules(project: Project) {
       metric: DEFAULT_METRIC,
       measurement: DEFAULT_MEASUREMENT,
       value: 0,
-      unit: getUnitForMeasurement(DEFAULT_MEASUREMENT),
       filterQuery: '',
     };
   }, []);

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -1,0 +1,790 @@
+from __future__ import annotations
+
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodBuildConfiguration,
+)
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    StatusCheckRule,
+    _compute_overall_status,
+    _evaluate_rule_threshold,
+    _fetch_base_size_metrics,
+    _get_artifact_filter_context,
+    _get_status_check_rules,
+    _rule_matches_artifact,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class StatusCheckFiltersTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+
+        self.commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        self.build_config_debug = PreprodBuildConfiguration.objects.create(
+            project=self.project,
+            name="Debug",
+        )
+
+        self.build_config_release = PreprodBuildConfiguration.objects.create(
+            project=self.project,
+            name="Release",
+        )
+
+    def test_filter_context_includes_build_configuration(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_debug.id,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        assert context["build.platform"] == "ios"
+        assert context["build.branch"] == "feature/test"
+        assert context["build.package_name"] == "com.example.app"
+        assert context["build.build_configuration"] == "Debug"
+
+    def test_filter_context_without_build_configuration(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+            app_id="com.example.android",
+            commit_comparison=self.commit_comparison,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        assert context["build.platform"] == "android"
+        assert context["build.branch"] == "feature/test"
+        assert context["build.package_name"] == "com.example.android"
+        assert "build.build_configuration" not in context
+
+    def test_rule_matches_build_configuration_single_value(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_debug.id,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        rule_debug = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:Debug",
+        )
+
+        rule_release = StatusCheckRule(
+            id="rule2",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:Release",
+        )
+
+        assert _rule_matches_artifact(rule_debug, context) is True
+        assert _rule_matches_artifact(rule_release, context) is False
+
+    def test_rule_matches_build_configuration_multiple_values(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_release.id,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:[Debug,Release]",
+        )
+
+        assert _rule_matches_artifact(rule, context) is True
+
+    def test_rule_matches_build_configuration_negated(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_debug.id,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        rule_not_release = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="!build.build_configuration:Release",
+        )
+
+        rule_not_debug = StatusCheckRule(
+            id="rule2",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="!build.build_configuration:Debug",
+        )
+
+        assert _rule_matches_artifact(rule_not_release, context) is True
+        assert _rule_matches_artifact(rule_not_debug, context) is False
+
+    def test_rule_matches_combined_filters(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_release.id,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        rule_ios_release = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.platform:ios build.build_configuration:Release",
+        )
+
+        rule_android_release = StatusCheckRule(
+            id="rule2",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.platform:android build.build_configuration:Release",
+        )
+
+        rule_ios_debug = StatusCheckRule(
+            id="rule3",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.platform:ios build.build_configuration:Debug",
+        )
+
+        assert _rule_matches_artifact(rule_ios_release, context) is True
+        assert _rule_matches_artifact(rule_android_release, context) is False
+        assert _rule_matches_artifact(rule_ios_debug, context) is False
+
+    def test_status_check_fails_when_rule_matches_and_exceeds_threshold(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_debug.id,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=150 * 1024 * 1024,
+            max_install_size=150 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:Debug",
+        )
+
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
+        assert status == StatusCheckStatus.FAILURE
+
+    def test_status_check_succeeds_when_rule_matches_but_under_threshold(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_debug.id,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=50 * 1024 * 1024,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:Debug",
+        )
+
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
+        assert status == StatusCheckStatus.SUCCESS
+
+    def test_status_check_succeeds_when_rule_does_not_match(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+            build_configuration_id=self.build_config_release.id,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=150 * 1024 * 1024,
+            max_install_size=150 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="build.build_configuration:Debug",
+        )
+
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
+        assert status == StatusCheckStatus.SUCCESS
+
+    def test_parse_rules_from_project_options(self):
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_enabled",
+            True,
+        )
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_rules",
+            '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", '
+            '"value": 100, "unit": "MB", "filterQuery": "build.build_configuration:Debug"}]',
+        )
+
+        rules = _get_status_check_rules(self.project)
+
+        assert len(rules) == 1
+        assert rules[0].id == "rule1"
+        assert rules[0].metric == "install_size"
+        assert rules[0].measurement == "absolute"
+        assert rules[0].value == 100
+        assert rules[0].unit == "MB"
+        assert rules[0].filter_query == "build.build_configuration:Debug"
+
+    def test_evaluate_absolute_diff_threshold_exceeds(self):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        head_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=60 * 1024 * 1024,
+        )
+
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+        )
+
+        base_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute_diff",
+            value=5,
+            unit="MB",
+            filter_query="",
+        )
+
+        assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is True
+
+    def test_evaluate_absolute_diff_threshold_under(self):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        head_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=53 * 1024 * 1024,
+        )
+
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+        )
+
+        base_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute_diff",
+            value=5,
+            unit="MB",
+            filter_query="",
+        )
+
+        assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is False
+
+    def test_evaluate_relative_diff_threshold_exceeds(self):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        head_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=60 * 1024 * 1024,
+        )
+
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+        )
+
+        base_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="relative_diff",
+            value=10,
+            unit="%",
+            filter_query="",
+        )
+
+        assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is True
+
+    def test_evaluate_relative_diff_threshold_under(self):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        head_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=54 * 1024 * 1024,
+        )
+
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+        )
+
+        base_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="relative_diff",
+            value=10,
+            unit="%",
+            filter_query="",
+        )
+
+        assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is False
+
+    def test_evaluate_rule_with_no_base_metrics_returns_false(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=60 * 1024 * 1024,
+        )
+
+        rule_absolute_diff = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute_diff",
+            value=5,
+            unit="MB",
+            filter_query="",
+        )
+
+        rule_relative_diff = StatusCheckRule(
+            id="rule2",
+            metric="install_size",
+            measurement="relative_diff",
+            value=10,
+            unit="%",
+            filter_query="",
+        )
+
+        assert _evaluate_rule_threshold(rule_absolute_diff, size_metrics, None) is False
+        assert _evaluate_rule_threshold(rule_relative_diff, size_metrics, None) is False
+
+    def test_fetch_base_size_metrics_with_matching_build_config(self):
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_release,
+        )
+
+        base_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=head_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_release,
+        )
+
+        result = _fetch_base_size_metrics([head_artifact], self.project)
+
+        assert head_artifact.id in result
+        assert result[head_artifact.id].id == base_metrics.id
+
+    def test_fetch_base_size_metrics_with_different_build_config(self):
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_release,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=head_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_debug,
+        )
+
+        result = _fetch_base_size_metrics([head_artifact], self.project)
+
+        assert result == {}
+
+    def test_status_check_with_absolute_diff_rule(self):
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_release,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=head_commit_comparison,
+            app_id="com.example.app",
+            build_configuration=self.build_config_release,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=60 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            head_artifact.id: list(
+                PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=head_artifact)
+            )
+        }
+
+        base_size_metrics_map = _fetch_base_size_metrics([head_artifact], self.project)
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute_diff",
+            value=5,
+            unit="MB",
+            filter_query="",
+        )
+
+        status = _compute_overall_status(
+            [head_artifact],
+            size_metrics_map,
+            rules=[rule],
+            base_size_metrics_map=base_size_metrics_map,
+        )
+        assert status == StatusCheckStatus.FAILURE
+
+    def test_rules_only_evaluate_main_artifact_not_watch_app(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=150 * 1024 * 1024,
+            identifier="com.example.app.watchapp",
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            unit="MB",
+            filter_query="",
+        )
+
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
+        assert status == StatusCheckStatus.SUCCESS

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -64,7 +64,7 @@ class StatusCheckFiltersTest(TestCase):
         context = _get_artifact_filter_context(artifact)
 
         assert context["platform"] == "ios"
-        assert context["branch"] == "feature/test"
+        assert context["git_head_ref"] == "feature/test"
         assert context["app_id"] == "com.example.app"
         assert context["build_configuration"] == "Debug"
 
@@ -80,7 +80,7 @@ class StatusCheckFiltersTest(TestCase):
         context = _get_artifact_filter_context(artifact)
 
         assert context["platform"] == "android"
-        assert context["branch"] == "feature/test"
+        assert context["git_head_ref"] == "feature/test"
         assert context["app_id"] == "com.example.android"
         assert "build_configuration" not in context
 

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -240,9 +240,7 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="build_configuration:Debug",
         )
 
-        status, triggered_rules = _compute_overall_status(
-            [artifact], size_metrics_map, rules=[rule]
-        )
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
         assert status == StatusCheckStatus.FAILURE
 
     def test_status_check_succeeds_when_rule_matches_but_under_threshold(self):
@@ -277,9 +275,7 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="build_configuration:Debug",
         )
 
-        status, triggered_rules = _compute_overall_status(
-            [artifact], size_metrics_map, rules=[rule]
-        )
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
         assert status == StatusCheckStatus.SUCCESS
 
     def test_status_check_succeeds_when_rule_does_not_match(self):
@@ -314,9 +310,7 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="build_configuration:Debug",
         )
 
-        status, triggered_rules = _compute_overall_status(
-            [artifact], size_metrics_map, rules=[rule]
-        )
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
         assert status == StatusCheckStatus.SUCCESS
 
     def test_parse_rules_from_project_options(self):
@@ -729,7 +723,7 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="",
         )
 
-        status, triggered_rules = _compute_overall_status(
+        status = _compute_overall_status(
             [head_artifact],
             size_metrics_map,
             rules=[rule],
@@ -772,7 +766,5 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="",
         )
 
-        status, triggered_rules = _compute_overall_status(
-            [artifact], size_metrics_map, rules=[rule]
-        )
+        status = _compute_overall_status([artifact], size_metrics_map, rules=[rule])
         assert status == StatusCheckStatus.SUCCESS

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -30,6 +30,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         self.project = self.create_project(
             teams=[self.team], organization=self.organization, name="test_project"
         )
+        self.project.update_option("sentry:preprod_size_status_checks_enabled", True)
 
     def _create_preprod_artifact(
         self,

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -30,7 +30,6 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         self.project = self.create_project(
             teams=[self.team], organization=self.organization, name="test_project"
         )
-        self.project.update_option("sentry:preprod_size_status_checks_enabled", True)
 
     def _create_preprod_artifact(
         self,


### PR DESCRIPTION
Actually consider the two settings values ("is enabled" and the rules) during the trigger of a status check.

If they aren't enabled, then we shouldn't be sending them. If they are but any of the rules apply, we should fail that status check