### PR TITLE
feat(infra): Add backend tests workflow with coverage upload to GCS

### DIFF
--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -91,6 +91,10 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true'
     name: combine coverage
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      actions: read # used for DIM metadata
     needs: [backend-test-with-cov-context, calculate-shards, files-changed]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -7,14 +7,8 @@ jobs:
     name: detect what files changed
     runs-on: ubuntu-24.04
     timeout-minutes: 3
-    # Map a step output to a job output
     outputs:
-      api_docs: ${{ steps.changes.outputs.api_docs }}
       backend: ${{ steps.changes.outputs.backend_all }}
-      backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
-      backend_api_urls: ${{ steps.changes.outputs.backend_api_urls }}
-      backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
-      migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -34,7 +28,6 @@ jobs:
     outputs:
       shard-count: ${{ steps.calculate-shards.outputs.shard-count }}
       shard-indices: ${{ steps.calculate-shards.outputs.shard-indices }}
-
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -47,8 +40,7 @@ jobs:
 
       - name: Calculate test shards
         id: calculate-shards
-        run: |
-          python3 .github/workflows/scripts/calculate-backend-test-shards.py
+        run: python3 .github/workflows/scripts/calculate-backend-test-shards.py
 
   backend-test-with-cov-context:
     if: needs.files-changed.outputs.backend == 'true'
@@ -57,18 +49,12 @@ jobs:
     needs: [files-changed, calculate-shards]
     timeout-minutes: 60
     strategy:
-      # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
-      # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
       fail-fast: false
       matrix:
-        # Dynamic matrix from calculate-shards
         instance: ${{ fromJSON(needs.calculate-shards.outputs.shard-indices) }}
-
     env:
-      # Dynamic total from calculate-shards
       MATRIX_INSTANCE_TOTAL: ${{ needs.calculate-shards.outputs.shard-count }}
       TEST_GROUP_STRATEGY: roundrobin
-
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -79,35 +65,20 @@ jobs:
           mode: backend-ci
 
       - name: Run backend test with coverage (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
-        id: run_backend_tests
-        run: |
-          make test-python-ci-with-coverage
+        run: make test-python-ci-with-coverage
 
-      # Even if tests fail, gather the raw coverage sqlite DB(s)
-      - name: Collect raw coverage database files
-        if: ${{ always() }}
-        shell: bash
+      - name: Validate coverage database
+        if: always()
         run: |
           set -euxo pipefail
-
-          # List all coverage files before processing
-          echo "Coverage files before combining:"
-          ls -lah .coverage* 2>/dev/null || echo "No coverage files found"
-
-          # Ensure we have a .coverage file
           if [[ ! -f .coverage ]]; then
             echo "Error: No .coverage file found after tests"
             exit 1
           fi
-
-          # Verify the database is not corrupted
-          python -c "import sqlite3; con=sqlite3.connect('.coverage'); con.execute('SELECT COUNT(*) FROM file'); print('Coverage DB is valid')" || {
-            echo "Error: Coverage database is corrupted"
-            exit 1
-          }
+          python -c "import sqlite3; sqlite3.connect('.coverage').execute('SELECT COUNT(*) FROM file')"
 
       - name: Upload raw coverage sqlite as artifact
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pycoverage-sqlite-${{ github.run_id }}-${{ steps.setup.outputs.matrix-instance-number }}
@@ -124,6 +95,19 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Determine commit SHA
+        id: commit-info
+        run: |
+          # For PRs, use the head SHA (the actual commit being tested)
+          # For other events (workflow_dispatch, workflow_call), use github.sha
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            COMMIT_SHA="${{ github.sha }}"
+          fi
+          echo "sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${COMMIT_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
           version: '0.8.2'
@@ -134,9 +118,8 @@ jobs:
         with:
           python-version: '3.13.1'
 
-      - name: Install coverage and plugins
-        run: |
-          uv pip install --system coverage[toml] covdefaults sentry-covdefaults-disable-branch-coverage
+      - name: Install coverage
+        run: uv pip install --system coverage[toml] covdefaults sentry-covdefaults-disable-branch-coverage
 
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
@@ -150,20 +133,14 @@ jobs:
           ls -la .artifacts/all-coverage || true
           find .artifacts/all-coverage -type f || true
 
-      - name: Rename coverage files for combining
+      - name: Prepare coverage files for combining
         run: |
           set -euxo pipefail
           mkdir -p .artifacts/to-combine
 
-          # The download-artifact action creates a subdirectory for each artifact
-          # Find all .coverage files and rename them with unique identifiers
           find .artifacts/all-coverage -name ".coverage" -type f | while IFS= read -r file; do
-            # Get the parent directory name (artifact name)
             parent_dir=$(basename "$(dirname "$file")")
-            echo "Found coverage file: $file from $parent_dir"
-            # Extract the matrix instance number from the artifact name
             instance=$(echo "$parent_dir" | grep -oP '(?<=-)\d+$' || echo "unknown")
-            # Copy with a unique name for coverage combine
             cp -v "$file" ".artifacts/to-combine/.coverage.${instance}"
           done
 
@@ -173,36 +150,49 @@ jobs:
       - name: Combine all coverage databases
         run: |
           set -euxo pipefail
-          mkdir -p .artifacts/combined-coverage
-
-          # Combine all coverage files into a single database
-          # Don't use --keep so the sharded files are removed after combining
           coverage combine .artifacts/to-combine/.coverage.*
 
-          # Move the combined file to output directory
-          if [[ -f .coverage ]]; then
-            mv .coverage .artifacts/combined-coverage/.coverage.combined
-          else
+          if [[ ! -f .coverage ]]; then
             echo "Error: Combined coverage file was not created"
             exit 1
           fi
 
-      - name: Generate coverage report (debug)
-        run: |
-          if [[ -f .artifacts/combined-coverage/.coverage.combined ]]; then
-            python -c "import os,sqlite3; p='.artifacts/combined-coverage/.coverage.combined'; \
-              print('Combined coverage db:', p, os.path.getsize(p), 'bytes'); \
-              con=sqlite3.connect(p); cur=con.cursor(); \
-              print('tables:', [r[0] for r in cur.execute(\"select name from sqlite_master where type='table' order by 1\").fetchall()]); \
-              print('file rows:', cur.execute('select count(*) from file').fetchone()[0] if cur.execute(\"select count(*) from sqlite_master where type='table' and name='file'\").fetchone() else 'n/a'); \
-              print('context rows:', cur.execute('select count(*) from context').fetchone()[0] if cur.execute(\"select count(*) from sqlite_master where type='table' and name='context'\").fetchone() else 'n/a')"
-          fi
+          # Rename with commit SHA for identification
+          mv .coverage ".coverage.${{ steps.commit-info.outputs.short_sha }}"
 
-      - name: Upload combined coverage database
+      - name: Generate coverage summary (debug)
+        run: |
+          COVERAGE_FILE=".coverage.${{ steps.commit-info.outputs.short_sha }}"
+          python -c "
+          import os, sqlite3
+          p = '$COVERAGE_FILE'
+          print(f'Combined coverage db: {p} ({os.path.getsize(p)} bytes)')
+          con = sqlite3.connect(p)
+          cur = con.cursor()
+          tables = [r[0] for r in cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY 1\").fetchall()]
+          print(f'Tables: {tables}')
+          print(f'File rows: {cur.execute(\"SELECT COUNT(*) FROM file\").fetchone()[0]}')
+          print(f'Context rows: {cur.execute(\"SELECT COUNT(*) FROM context\").fetchone()[0]}')
+          "
+
+      - name: Upload combined coverage database (artifact)
         uses: actions/upload-artifact@v4
         with:
           name: pycoverage-sqlite-combined-${{ github.run_id }}
-          path: .artifacts/combined-coverage/.coverage.combined
+          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
           if-no-files-found: error
           retention-days: 30
           include-hidden-files: true
+
+      - name: Authenticate to Google Cloud
+        id: gcloud-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
+          service_account_email: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload coverage to GCS
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
+          destination: sentry-coverage-data/coverage/${{ steps.commit-info.outputs.sha }}

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -1,6 +1,11 @@
 name: backend - with test coverage
 
-on: [workflow_dispatch, workflow_call, pull_request]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+  schedule:
+    - cron: '0 * * * *'
 
 jobs:
   calculate-shards:

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -120,7 +120,8 @@ jobs:
 
   combine-coverage:
     name: combine coverage
-    if: needs.check-existing-coverage.outputs.has-coverage != 'true' && !cancelled()
+    # Only upload coverage if all test shards pass - incomplete coverage could cause selective testing to skip tests incorrectly
+    if: needs.check-existing-coverage.outputs.has-coverage != 'true'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -141,16 +142,24 @@ jobs:
           pattern: pycoverage-sqlite-${{ github.run_id }}-*
           path: .artifacts/all-coverage
 
-      - name: Prepare coverage files for combining
+      - name: Verify all shards produced coverage
+        env:
+          EXPECTED_SHARD_COUNT: ${{ needs.calculate-shards.outputs.shard-count }}
         run: |
           set -euxo pipefail
 
-          echo "Downloaded coverage files"
+          echo "Downloaded coverage artifacts:"
           ls -la .artifacts/all-coverage || true
-          find .artifacts/all-coverage -type f || true
 
-          echo "Files ready for combining:"
-          find .artifacts/all-coverage -name ".coverage" -type f
+          COVERAGE_FILE_COUNT=$(find .artifacts/all-coverage -name ".coverage" -type f | wc -l)
+          echo "Found ${COVERAGE_FILE_COUNT} coverage files, expected ${EXPECTED_SHARD_COUNT}"
+
+          if [[ "$COVERAGE_FILE_COUNT" -ne "$EXPECTED_SHARD_COUNT" ]]; then
+            echo "Error: Missing coverage files. Expected ${EXPECTED_SHARD_COUNT}, found ${COVERAGE_FILE_COUNT}"
+            echo "This indicates some test shards failed to produce coverage."
+            find .artifacts/all-coverage -name ".coverage" -type f
+            exit 1
+          fi
 
       - name: Combine all coverage databases
         run: |

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -3,6 +3,7 @@ name: backend - with test coverage
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
   # Every 30 minutes
   schedule:
     - cron: '0,30 * * * *'

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -88,10 +88,10 @@ jobs:
       - name: Determine commit SHA
         id: commit-info
         run: |
-          # For PRs, use the base SHA (the merge target commit)
+          # For PRs, use the head SHA (the actual commit being tested)
           # For other events (workflow_dispatch, workflow_call), use github.sha
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COMMIT_SHA="${{ github.event.pull_request.base.sha }}"
+            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
           else
             COMMIT_SHA="${{ github.sha }}"
           fi

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -3,13 +3,63 @@ name: backend - with test coverage
 on:
   workflow_dispatch:
   workflow_call:
-  pull_request:
+  # Once an hour
   schedule:
     - cron: '0 * * * *'
 
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
+  # Optimization to not generate coverage if it already exists in GCS
+  check-existing-coverage:
+    name: check for existing coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      has-coverage: ${{ steps.check-coverage.outputs.exists }}
+      commit-sha: ${{ steps.get-sha.outputs.sha }}
+    steps:
+      - name: Determine commit SHA
+        id: get-sha
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            COMMIT_SHA="${{ github.sha }}"
+          fi
+          echo "sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: sentry-dev-tooling
+          workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
+          service_account: ${{ secrets.COLLECT_TEST_DATA_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Check if coverage exists
+        id: check-coverage
+        env:
+          COMMIT_SHA: ${{ steps.get-sha.outputs.sha }}
+        run: |
+          if gcloud storage ls "gs://sentry-coverage-data/${COMMIT_SHA}/.coverage.combined" &>/dev/null; then
+            echo "Coverage already exists for commit ${COMMIT_SHA}, skipping test run"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No coverage found for commit ${COMMIT_SHA}, will run tests"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
   calculate-shards:
     name: calculate test shards
+    if: needs.check-existing-coverage.outputs.has-coverage != 'true'
+    needs: [check-existing-coverage]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -31,8 +81,9 @@ jobs:
 
   backend-test-with-cov-context:
     name: backend test
+    if: needs.check-existing-coverage.outputs.has-coverage != 'true'
     runs-on: ubuntu-24.04
-    needs: [calculate-shards]
+    needs: [check-existing-coverage, calculate-shards]
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -75,28 +126,15 @@ jobs:
 
   combine-coverage:
     name: combine coverage
-    if: '!cancelled()' # Always run this step, unless the workflow was cancelled
+    if: needs.check-existing-coverage.outputs.has-coverage != 'true' && !cancelled()
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
       actions: read # used for DIM metadata
-    needs: [backend-test-with-cov-context, calculate-shards]
+    needs: [check-existing-coverage, backend-test-with-cov-context, calculate-shards]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Determine commit SHA
-        id: commit-info
-        run: |
-          # For PRs, use the head SHA (the actual commit being tested)
-          # For other events (workflow_dispatch, workflow_call), use github.sha
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            COMMIT_SHA="${{ github.sha }}"
-          fi
-          echo "sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${COMMIT_SHA:0:12}" >> "$GITHUB_OUTPUT"
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
@@ -153,4 +191,4 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: .coverage.combined
-          destination: sentry-coverage-data/${{ steps.commit-info.outputs.sha }}
+          destination: sentry-coverage-data/${{ needs.check-existing-coverage.outputs.commit-sha }}

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -1,0 +1,206 @@
+name: backend - with test coverage
+
+on: [workflow_dispatch, workflow_call, pull_request]
+
+jobs:
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      api_docs: ${{ steps.changes.outputs.api_docs }}
+      backend: ${{ steps.changes.outputs.backend_all }}
+      backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
+      backend_api_urls: ${{ steps.changes.outputs.backend_api_urls }}
+      backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
+      migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Check for backend file changes
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  calculate-shards:
+    if: needs.files-changed.outputs.backend == 'true'
+    needs: files-changed
+    name: calculate test shards
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      shard-count: ${{ steps.calculate-shards.outputs.shard-count }}
+      shard-indices: ${{ steps.calculate-shards.outputs.shard-indices }}
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          mode: backend-ci
+          skip-devservices: true
+
+      - name: Calculate test shards
+        id: calculate-shards
+        run: |
+          python3 .github/workflows/scripts/calculate-backend-test-shards.py
+
+  backend-test-with-cov-context:
+    name: backend test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
+      # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
+      fail-fast: false
+      matrix:
+        # Dynamic matrix from calculate-shards
+        instance: ${{ fromJSON(needs.calculate-shards.outputs.shard-indices) }}
+
+    env:
+      # Dynamic total from calculate-shards
+      MATRIX_INSTANCE_TOTAL: ${{ needs.calculate-shards.outputs.shard-count }}
+      TEST_GROUP_STRATEGY: roundrobin
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          mode: backend-ci
+
+      - name: Run backend test with coverage (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
+        id: run_backend_tests
+        run: |
+          make test-python-ci-with-coverage
+
+      # Even if tests fail, gather the raw coverage sqlite DB(s)
+      - name: Collect raw coverage database files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          # List all coverage files before processing
+          echo "Coverage files before combining:"
+          ls -lah .coverage* 2>/dev/null || echo "No coverage files found"
+
+          # Ensure we have a .coverage file
+          if [[ ! -f .coverage ]]; then
+            echo "Error: No .coverage file found after tests"
+            exit 1
+          fi
+
+          # Verify the database is not corrupted
+          python -c "import sqlite3; con=sqlite3.connect('.coverage'); con.execute('SELECT COUNT(*) FROM file'); print('Coverage DB is valid')" || {
+            echo "Error: Coverage database is corrupted"
+            exit 1
+          }
+
+      - name: Upload raw coverage sqlite as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pycoverage-sqlite-${{ github.run_id }}-${{ steps.setup.outputs.matrix-instance-number }}
+          path: .coverage
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: true
+
+  combine-coverage:
+    name: Combine coverage from all test jobs
+    runs-on: ubuntu-24.04
+    needs: backend-test-with-cov-context
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+        with:
+          version: '0.8.2'
+          enable-cache: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13.1'
+
+      - name: Install coverage and plugins
+        run: |
+          uv pip install --system coverage[toml] covdefaults sentry-covdefaults-disable-branch-coverage
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pycoverage-sqlite-${{ github.run_id }}-*
+          path: .artifacts/all-coverage
+
+      - name: List downloaded artifacts (debug)
+        run: |
+          echo "=== Downloaded artifacts structure ==="
+          ls -la .artifacts/all-coverage || true
+          find .artifacts/all-coverage -type f || true
+
+      - name: Rename coverage files for combining
+        run: |
+          set -euxo pipefail
+          mkdir -p .artifacts/to-combine
+
+          # The download-artifact action creates a subdirectory for each artifact
+          # Find all .coverage files and rename them with unique identifiers
+          find .artifacts/all-coverage -name ".coverage" -type f | while IFS= read -r file; do
+            # Get the parent directory name (artifact name)
+            parent_dir=$(basename "$(dirname "$file")")
+            echo "Found coverage file: $file from $parent_dir"
+            # Extract the matrix instance number from the artifact name
+            instance=$(echo "$parent_dir" | grep -oP '(?<=-)\d+$' || echo "unknown")
+            # Copy with a unique name for coverage combine
+            cp -v "$file" ".artifacts/to-combine/.coverage.${instance}"
+          done
+
+          echo "=== Files ready for combining ==="
+          ls -la .artifacts/to-combine/
+
+      - name: Combine all coverage databases
+        run: |
+          set -euxo pipefail
+          mkdir -p .artifacts/combined-coverage
+
+          # Combine all coverage files into a single database
+          # Don't use --keep so the sharded files are removed after combining
+          coverage combine .artifacts/to-combine/.coverage.*
+
+          # Move the combined file to output directory
+          if [[ -f .coverage ]]; then
+            mv .coverage .artifacts/combined-coverage/.coverage.combined
+          else
+            echo "Error: Combined coverage file was not created"
+            exit 1
+          fi
+
+      - name: Generate coverage report (debug)
+        run: |
+          if [[ -f .artifacts/combined-coverage/.coverage.combined ]]; then
+            python -c "import os,sqlite3; p='.artifacts/combined-coverage/.coverage.combined'; \
+              print('Combined coverage db:', p, os.path.getsize(p), 'bytes'); \
+              con=sqlite3.connect(p); cur=con.cursor(); \
+              print('tables:', [r[0] for r in cur.execute(\"select name from sqlite_master where type='table' order by 1\").fetchall()]); \
+              print('file rows:', cur.execute('select count(*) from file').fetchone()[0] if cur.execute(\"select count(*) from sqlite_master where type='table' and name='file'\").fetchone() else 'n/a'); \
+              print('context rows:', cur.execute('select count(*) from context').fetchone()[0] if cur.execute(\"select count(*) from sqlite_master where type='table' and name='context'\").fetchone() else 'n/a')"
+          fi
+
+      - name: Upload combined coverage database
+        uses: actions/upload-artifact@v4
+        with:
+          name: pycoverage-sqlite-combined-${{ github.run_id }}
+          path: .artifacts/combined-coverage/.coverage.combined
+          if-no-files-found: error
+          retention-days: 30
+          include-hidden-files: true

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -88,10 +88,10 @@ jobs:
       - name: Determine commit SHA
         id: commit-info
         run: |
-          # For PRs, use the head SHA (the actual commit being tested)
+          # For PRs, use the base SHA (the merge target commit)
           # For other events (workflow_dispatch, workflow_call), use github.sha
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+            COMMIT_SHA="${{ github.event.pull_request.base.sha }}"
           else
             COMMIT_SHA="${{ github.sha }}"
           fi

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -3,9 +3,9 @@ name: backend - with test coverage
 on:
   workflow_dispatch:
   workflow_call:
-  # Once an hour
+  # Every 30 minutes
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0,30 * * * *'
 
 jobs:
   # Skip generating coverage if already exists in GCS
@@ -31,7 +31,7 @@ jobs:
           echo "sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.3
         with:
           project_id: sentry-dev-tooling
           workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
@@ -96,7 +96,7 @@ jobs:
           mode: backend-ci
 
       - name: Run backend test with coverage (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
-        run: make test-python-ci-with-coverage
+        run: make test-backend-ci-with-coverage
 
       - name: Validate coverage database
         if: always()
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload raw coverage sqlite as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pycoverage-sqlite-${{ github.run_id }}-${{ steps.setup.outputs.matrix-instance-number }}
           path: .coverage
@@ -137,7 +137,7 @@ jobs:
           enable-cache: false
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: pycoverage-sqlite-${{ github.run_id }}-*
           path: .artifacts/all-coverage
@@ -175,14 +175,14 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: gcloud-auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.3
         with:
           project_id: sentry-dev-tooling
           workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
           service_account: ${{ secrets.COLLECT_TEST_DATA_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Upload coverage to GCS
-        uses: google-github-actions/upload-cloud-storage@v2
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2.2.4
         with:
           path: .coverage.combined
           destination: sentry-coverage-data/${{ needs.check-existing-coverage.outputs.commit-sha }}

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -164,7 +164,8 @@ jobs:
       - name: Combine all coverage databases
         run: |
           set -euxo pipefail
-          uvx coverage combine $(find .artifacts/all-coverage -name ".coverage" -type f)
+          uvx --with covdefaults --with sentry-covdefaults-disable-branch-coverage \
+            coverage combine $(find .artifacts/all-coverage -name ".coverage" -type f)
 
           if [[ ! -f .coverage ]]; then
             echo "Error: Combined coverage file was not created"

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -196,3 +196,12 @@ jobs:
         with:
           path: .coverage.${{ steps.commit-info.outputs.short_sha }}
           destination: sentry-coverage-data/coverage/${{ steps.commit-info.outputs.sha }}
+      - name: Upload coverage  data
+        if: '!cancelled()' # Always run this step, unless the workflow was cancelled
+        uses: getsentry/action-collect-test-data@v0.3.0
+        with:
+          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
+          gcs_path: sentry-coverage-data/${{ steps.commit-info.outputs.sha }}
+          gcp_project_id: sentry-dev-tooling
+          workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
+          service_account_email: ${{ secrets.COLLECT_TEST_DATA_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -3,7 +3,6 @@ name: backend - with test coverage
 on:
   workflow_dispatch:
   workflow_call:
-  pull_request:
   # Every 30 minutes
   schedule:
     - cron: '0,30 * * * *'

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -7,14 +7,8 @@ on:
   schedule:
     - cron: '0 * * * *'
 
-# Cancel in progress workflows on pull_requests.
-# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
-  # Optimization to not generate coverage if it already exists in GCS
+  # Skip generating coverage if already exists in GCS
   check-existing-coverage:
     name: check for existing coverage
     runs-on: ubuntu-24.04
@@ -141,14 +135,6 @@ jobs:
           version: '0.8.2'
           enable-cache: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13.1'
-
-      - name: Install coverage
-        run: uv pip install --system coverage[toml] covdefaults sentry-covdefaults-disable-branch-coverage
-
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -169,14 +155,13 @@ jobs:
       - name: Combine all coverage databases
         run: |
           set -euxo pipefail
-          coverage combine $(find .artifacts/all-coverage -name ".coverage" -type f)
+          uvx coverage combine $(find .artifacts/all-coverage -name ".coverage" -type f)
 
           if [[ ! -f .coverage ]]; then
             echo "Error: Combined coverage file was not created"
             exit 1
           fi
 
-          # Rename to combined
           mv .coverage ".coverage.combined"
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -114,6 +114,7 @@ jobs:
           retention-days: 7
           include-hidden-files: true
 
+  # TODO: Skip this step if the no backend files changed
   combine-coverage:
     name: Combine coverage from all test jobs
     runs-on: ubuntu-24.04

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -189,7 +189,7 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
-          service_account_email: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
 
       - name: Upload coverage to GCS
         uses: google-github-actions/upload-cloud-storage@v2

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -3,25 +3,7 @@ name: backend - with test coverage
 on: [workflow_dispatch, workflow_call, pull_request]
 
 jobs:
-  files-changed:
-    name: detect what files changed
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    outputs:
-      backend: ${{ steps.changes.outputs.backend_all }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Check for backend file changes
-        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
   calculate-shards:
-    if: needs.files-changed.outputs.backend == 'true'
-    needs: files-changed
     name: calculate test shards
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -43,10 +25,9 @@ jobs:
         run: python3 .github/workflows/scripts/calculate-backend-test-shards.py
 
   backend-test-with-cov-context:
-    if: needs.files-changed.outputs.backend == 'true'
     name: backend test
     runs-on: ubuntu-24.04
-    needs: [files-changed, calculate-shards]
+    needs: [calculate-shards]
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -88,14 +69,14 @@ jobs:
           include-hidden-files: true
 
   combine-coverage:
-    if: needs.files-changed.outputs.backend == 'true'
     name: combine coverage
+    if: '!cancelled()' # Always run this step, unless the workflow was cancelled
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
       actions: read # used for DIM metadata
-    needs: [backend-test-with-cov-context, calculate-shards, files-changed]
+    needs: [backend-test-with-cov-context, calculate-shards]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -131,62 +112,29 @@ jobs:
           pattern: pycoverage-sqlite-${{ github.run_id }}-*
           path: .artifacts/all-coverage
 
-      - name: List downloaded artifacts (debug)
-        run: |
-          echo "=== Downloaded artifacts structure ==="
-          ls -la .artifacts/all-coverage || true
-          find .artifacts/all-coverage -type f || true
-
       - name: Prepare coverage files for combining
         run: |
           set -euxo pipefail
-          mkdir -p .artifacts/to-combine
 
-          find .artifacts/all-coverage -name ".coverage" -type f | while IFS= read -r file; do
-            parent_dir=$(basename "$(dirname "$file")")
-            instance=$(echo "$parent_dir" | grep -oP '(?<=-)\d+$' || echo "unknown")
-            cp -v "$file" ".artifacts/to-combine/.coverage.${instance}"
-          done
+          echo "Downloaded coverage files"
+          ls -la .artifacts/all-coverage || true
+          find .artifacts/all-coverage -type f || true
 
-          echo "=== Files ready for combining ==="
-          ls -la .artifacts/to-combine/
+          echo "Files ready for combining:"
+          find .artifacts/all-coverage -name ".coverage" -type f
 
       - name: Combine all coverage databases
         run: |
           set -euxo pipefail
-          coverage combine .artifacts/to-combine/.coverage.*
+          coverage combine $(find .artifacts/all-coverage -name ".coverage" -type f)
 
           if [[ ! -f .coverage ]]; then
             echo "Error: Combined coverage file was not created"
             exit 1
           fi
 
-          # Rename with commit SHA for identification
-          mv .coverage ".coverage.${{ steps.commit-info.outputs.short_sha }}"
-
-      - name: Generate coverage summary (debug)
-        run: |
-          COVERAGE_FILE=".coverage.${{ steps.commit-info.outputs.short_sha }}"
-          python -c "
-          import os, sqlite3
-          p = '$COVERAGE_FILE'
-          print(f'Combined coverage db: {p} ({os.path.getsize(p)} bytes)')
-          con = sqlite3.connect(p)
-          cur = con.cursor()
-          tables = [r[0] for r in cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY 1\").fetchall()]
-          print(f'Tables: {tables}')
-          print(f'File rows: {cur.execute(\"SELECT COUNT(*) FROM file\").fetchone()[0]}')
-          print(f'Context rows: {cur.execute(\"SELECT COUNT(*) FROM context\").fetchone()[0]}')
-          "
-
-      - name: Upload combined coverage database (artifact)
-        uses: actions/upload-artifact@v4
-        with:
-          name: pycoverage-sqlite-combined-${{ github.run_id }}
-          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
-          if-no-files-found: error
-          retention-days: 30
-          include-hidden-files: true
+          # Rename to combined
+          mv .coverage ".coverage.combined"
 
       - name: Authenticate to Google Cloud
         id: gcloud-auth
@@ -198,14 +146,6 @@ jobs:
       - name: Upload coverage to GCS
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
-          destination: sentry-coverage-data/coverage/${{ steps.commit-info.outputs.sha }}
-      - name: Upload coverage  data
-        if: '!cancelled()' # Always run this step, unless the workflow was cancelled
-        uses: getsentry/action-collect-test-data@v0.3.0
-        with:
-          path: .coverage.${{ steps.commit-info.outputs.short_sha }}
-          gcs_path: sentry-coverage-data/${{ steps.commit-info.outputs.sha }}
-          gcp_project_id: sentry-dev-tooling
-          workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
-          service_account_email: ${{ secrets.COLLECT_TEST_DATA_SERVICE_ACCOUNT_EMAIL }}
+          path: .coverage.combined
+          project_id: sentry-dev-tooling
+          destination: sentry-coverage-data/${{ steps.commit-info.outputs.sha }}

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -51,8 +51,10 @@ jobs:
           python3 .github/workflows/scripts/calculate-backend-test-shards.py
 
   backend-test-with-cov-context:
+    if: needs.files-changed.outputs.backend == 'true'
     name: backend test
     runs-on: ubuntu-24.04
+    needs: [files-changed, calculate-shards]
     timeout-minutes: 60
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
@@ -114,12 +116,11 @@ jobs:
           retention-days: 7
           include-hidden-files: true
 
-  # TODO: Skip this step if the no backend files changed
   combine-coverage:
-    name: Combine coverage from all test jobs
+    if: needs.files-changed.outputs.backend == 'true'
+    name: combine coverage
     runs-on: ubuntu-24.04
-    needs: backend-test-with-cov-context
-    if: ${{ always() }}
+    needs: [backend-test-with-cov-context, calculate-shards, files-changed]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -140,6 +140,7 @@ jobs:
         id: gcloud-auth
         uses: google-github-actions/auth@v2
         with:
+          project_id: sentry-dev-tooling
           workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
           service_account: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
 

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -142,11 +142,10 @@ jobs:
         with:
           project_id: sentry-dev-tooling
           workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
-          service_account: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.COLLECT_TEST_DATA_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Upload coverage to GCS
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: .coverage.combined
-          project_id: sentry-dev-tooling
           destination: sentry-coverage-data/${{ steps.commit-info.outputs.sha }}

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test-python-ci:
 
 test-python-ci-with-coverage:
 	@echo "--> Running CI Python tests with coverage"
-	python3 -b -m pytest \
+	COVERAGE_CORE=sysmon python3 -b -m pytest \
 		tests \
 		--ignore tests/acceptance \
 		--ignore tests/apidocs \

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ test-python-ci-with-coverage:
 	python3 -b -m pytest \
 		tests \
 		--ignore tests/acceptance \
+		--ignore tests/apidocs \
 		--ignore tests/js \
 		--ignore tests/tools \
 		--cov . \

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,22 @@ test-python-ci:
 		-o junit_suite_name=pytest
 	@echo ""
 
+test-python-ci-with-coverage:
+	@echo "--> Running CI Python tests with coverage"
+	python3 -b -m pytest \
+		tests \
+		--ignore tests/acceptance \
+		--ignore tests/js \
+		--ignore tests/tools \
+		--cov . \
+		--cov-context=test \
+		--json-report \
+		--json-report-file=".artifacts/pytest.json" \
+		--json-report-omit=log \
+		--junit-xml=.artifacts/pytest.junit.xml \
+		-o junit_suite_name=pytest
+	@echo ""
+
 # it's not possible to change settings.DATABASE after django startup, so
 # unfortunately these tests must be run in a separate pytest process. References:
 #   * https://docs.djangoproject.com/en/4.2/topics/testing/tools/#overriding-settings

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ test-python-ci:
 		-o junit_suite_name=pytest
 	@echo ""
 
-test-python-ci-with-coverage:
+test-backend-ci-with-coverage:
 	@echo "--> Running CI Python tests with coverage"
 	COVERAGE_CORE=sysmon python3 -b -m pytest \
 		tests \

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test-python-ci:
 
 test-backend-ci-with-coverage:
 	@echo "--> Running CI Python tests with coverage"
-	COVERAGE_CORE=sysmon python3 -b -m pytest \
+	python3 -b -m pytest \
 		tests \
 		--ignore tests/acceptance \
 		--ignore tests/apidocs \

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -29,7 +29,6 @@ from sentry.preprod.size_analysis.models import (
 logger = logging.getLogger(__name__)
 
 
-# Placeholder
 def compare_size_analysis(
     head_size_analysis: PreprodArtifactSizeMetrics,
     head_size_analysis_results: SizeAnalysisResults,

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -29,6 +29,7 @@ from sentry.preprod.size_analysis.models import (
 logger = logging.getLogger(__name__)
 
 
+# Placeholder
 def compare_size_analysis(
     head_size_analysis: PreprodArtifactSizeMetrics,
     head_size_analysis_results: SizeAnalysisResults,


### PR DESCRIPTION
In prep for selective testing, this creates a workflow to run all backend testing with full test coverage once every hour. The full coverage is then combined from all individual shards and uploaded to Gcloud, stored by `sha`.

The selective test workflow in #105500 will then find the best candidate from this job (working backwards in commits from the branch's base sha) and use that coverage for determining which tests to select based on the diff.

In the future, we can increase the frequency of this job, or run on all backend commits. I also already added a job to this workflow that will skip the rest of the workflow if we already have coverage for the given commit.