### PR TITLE
chore(code-review): Hook up list of gh orgs to options-automator

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -694,6 +694,11 @@ register("overwatch.forward-webhooks.verbose", default=False, flags=FLAG_AUTOMAT
 register("github.webhook.issue-comment", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# List of GitHub org names that should always send directly to Seer (bypass Overwatch)
+register(
+    "seer.code-review.direct-to-seer-enabled-gh-orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -17,7 +17,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.overwatch_webhooks.types import OrganizationSummary, WebhookDetails
 from sentry.overwatch_webhooks.webhook_publisher import OverwatchWebhookPublisher
 from sentry.seer.code_review.utils import get_webhook_option_key
-from sentry.seer.code_review.webhooks.config import GH_ORGS_TO_ONLY_SEND_TO_SEER
+from sentry.seer.code_review.webhooks.config import get_direct_to_seer_gh_orgs
 from sentry.types.region import get_region_by_name
 from sentry.utils import metrics
 
@@ -151,12 +151,13 @@ class OverwatchGithubWebhookForwarder:
             if isinstance(repository, dict):
                 github_org = repository.get("owner", {}).get("login")
 
-            if github_org and github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
+            direct_to_seer_orgs = get_direct_to_seer_gh_orgs()
+            if github_org and github_org in direct_to_seer_orgs:
                 verbose_log(
                     "overwatch.debug.github_org_not_whitelisted",
                     extra={
                         "github_org": github_org,
-                        "whitelisted_orgs": list(GH_ORGS_TO_ONLY_SEND_TO_SEER),
+                        "direct_to_seer_orgs": direct_to_seer_orgs,
                     },
                 )
                 return

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -1,13 +1,15 @@
+from sentry import options
 from sentry.integrations.github.webhook_types import GithubWebhookType
-
-GH_ORGS_TO_ONLY_SEND_TO_SEER = {
-    "sentry-ecosystem",  # on s4s2 & us
-    "coding-workflows-s4s",  # on us
-    "sentry-coding-workflows",  # on us
-}
 
 # Mapping of webhook types to their corresponding option keys
 WEBHOOK_TYPE_TO_OPTION_KEY = {
     GithubWebhookType.ISSUE_COMMENT: "github.webhook.issue-comment",
     GithubWebhookType.PULL_REQUEST: "github.webhook.pr",
 }
+
+
+def get_direct_to_seer_gh_orgs() -> list[str]:
+    """
+    Returns the list of GitHub org names that should always send directly to Seer.
+    """
+    return options.get("seer.code-review.direct-to-seer-enabled-gh-orgs") or []

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -18,7 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
-from .config import GH_ORGS_TO_ONLY_SEND_TO_SEER
+from .config import get_direct_to_seer_gh_orgs
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def handle_issue_comment_event(
         return
 
     github_org = event.get("repository", {}).get("owner", {}).get("login")
-    if github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
+    if github_org in get_direct_to_seer_gh_orgs():
         if comment_id:
             _add_eyes_reaction_to_comment(integration, organization, repo, str(comment_id))
 

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -18,7 +18,7 @@ from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.utils import metrics
 
 from ..utils import _get_target_commit_sha
-from .config import GH_ORGS_TO_ONLY_SEND_TO_SEER
+from .config import get_direct_to_seer_gh_orgs
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ def handle_pull_request_event(
         return
 
     github_org = event.get("repository", {}).get("owner", {}).get("login")
-    if github_org in GH_ORGS_TO_ONLY_SEND_TO_SEER:
+    if github_org in get_direct_to_seer_gh_orgs():
         from .task import schedule_task
 
         schedule_task(

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -24,7 +24,7 @@ from sentry.taskworker.state import current_task
 from sentry.utils import metrics
 
 from ..utils import get_seer_endpoint_for_event, make_seer_request
-from .config import GH_ORGS_TO_ONLY_SEND_TO_SEER
+from .config import get_direct_to_seer_gh_orgs
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ def process_github_webhook_event(
     # Check if repo owner is in the whitelist (always send to Seer for these orgs)
     # Otherwise, check option key to see if Overwatch should handle this
     repo_owner = event_payload.get("data", {}).get("repo", {}).get("owner")
-    if repo_owner not in GH_ORGS_TO_ONLY_SEND_TO_SEER:
+    if repo_owner not in get_direct_to_seer_gh_orgs():
         # If option is True, Overwatch handles this - skip Seer processing
         if option_key and options.get(option_key):
             return

--- a/src/sentry/testutils/helpers/github.py
+++ b/src/sentry/testutils/helpers/github.py
@@ -138,13 +138,13 @@ class GitHubWebhookTestCase(APITestCase):
 
 class GitHubWebhookCodeReviewTestCase(GitHubWebhookTestCase):
     CODE_REVIEW_FEATURES = {"organizations:gen-ai-features", "organizations:code-review-beta"}
-    OPTIONS_TO_SET: dict[str, bool] = {}
+    OPTIONS_TO_SET: dict[str, Any] = {}
 
     @contextmanager
     def code_review_setup(
         self,
         features: Collection[str] | Mapping[str, Any] | None = None,
-        options: dict[str, bool] | None = None,
+        options: dict[str, Any] | None = None,
     ) -> Generator[None]:
         """Helper to set up code review test context."""
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)

--- a/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
+++ b/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
@@ -154,7 +154,12 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
             )
             mock_enqueue.assert_not_called()
 
-    @override_options({"overwatch.enabled-regions": ["us"]})
+    @override_options(
+        {
+            "overwatch.enabled-regions": ["us"],
+            "seer.code-review.direct-to-seer-enabled-gh-orgs": ["sentry-ecosystem"],
+        }
+    )
     def test_forward_if_applicable_skips_seer_only_orgs(self):
         organization = self.create_organization(name="Test Org", slug="test-org", region="us")
         self.create_organization_integration(

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -14,7 +14,10 @@ from sentry.testutils.helpers.github import GitHubWebhookCodeReviewTestCase
 class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
     """Integration tests for GitHub issue_comment webhook events."""
 
-    OPTIONS_TO_SET = {"github.webhook.issue-comment": False}
+    OPTIONS_TO_SET = {
+        "github.webhook.issue-comment": False,
+        "seer.code-review.direct-to-seer-enabled-gh-orgs": ["sentry-ecosystem"],
+    }
 
     @pytest.fixture(autouse=True)
     def mock_github_api_calls(self) -> Generator[None]:

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -13,7 +13,10 @@ from sentry.testutils.helpers.github import GitHubWebhookCodeReviewTestCase
 class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
     """Integration tests for GitHub pull_request webhook events."""
 
-    OPTIONS_TO_SET = {"github.webhook.pr": False}
+    OPTIONS_TO_SET = {
+        "github.webhook.pr": False,
+        "seer.code-review.direct-to-seer-enabled-gh-orgs": ["sentry-ecosystem"],
+    }
 
     @pytest.fixture(autouse=True)
     def mock_github_api_calls(self) -> Generator[None]:


### PR DESCRIPTION
Update to use options-automator like [here](https://github.com/getsentry/sentry-options-automator/pull/6079/files) instead of hardcode so we can have shorter deploy/test cycles