### PR TITLE
fix(traces): react to theme changes

### DIFF
--- a/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
@@ -24,8 +24,9 @@ export function useTraceWaterfallModels() {
       theme
     );
     // We only care about initial state when we initialize the view manager
+    // but we need to stay reactive to theme changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [theme]);
 
   return {traceView, traceScheduler, viewManager};
 }


### PR DESCRIPTION
I noticed that text colors on the trace preview in issue details weren’t readable when switching themes. Turns out the `manager` was reading a stale theme value because we only initialize it once with the theme.

before:

https://github.com/user-attachments/assets/b5d39f07-756a-4499-8a4b-b73c152cd5dc

after:

https://github.com/user-attachments/assets/5a268bc8-211e-4d40-b30e-84624ccedc8b