### PR TITLE
fix(arithmetic-equations): Set constrained max width

### DIFF
--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -765,7 +765,7 @@ const ArgumentGridCell = styled('div')`
   max-width: fit-content;
 
   > div input {
-    max-width: fit-content !important;
+    max-width: 130px !important;
     min-width: 0 !important;
     white-space: nowrap !important;
   }


### PR DESCRIPTION
Change max width from `fit-content` to `130px` so that it doesn't expand incorrectly.

Before:
<img width="325" height="211" alt="Screenshot 2026-01-08 at 10 13 51" src="https://github.com/user-attachments/assets/4400e46c-e1df-47a3-b54c-145fd2286e2a" />

After:
<img width="320" height="208" alt="Screenshot 2026-01-08 at 10 14 06" src="https://github.com/user-attachments/assets/93945a9e-db95-46f4-adda-7486e5e2791a" />