### PR TITLE
SentryApps status fix

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
@@ -111,7 +111,8 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
         )
 
         # Must send to user & partners so that the reply-to email will be each other
-        recipients = ["integrations-platform@sentry.io", request.user.email]
+        # User is guaranteed to be authenticated since this endpoint requires org:admin
+        recipients = ["integrations-platform@sentry.io", request.user.email]  # type: ignore[union-attr]
         sent_messages = new_message.send(
             to=recipients,
         )

--- a/src/sentry/sentry_apps/logic.py
+++ b/src/sentry/sentry_apps/logic.py
@@ -167,13 +167,14 @@ class SentryAppUpdater:
             self.sentry_app.author = self.author
 
     def _update_status(self, user: User | RpcUser) -> None:
-        if self.status is not None:
-            if _is_elevated_user(user):
-                if self.status == SentryAppStatus.PUBLISHED_STR:
-                    self.sentry_app.status = SentryAppStatus.PUBLISHED
-                    self.sentry_app.date_published = timezone.now()
-                if self.status == SentryAppStatus.UNPUBLISHED_STR:
-                    self.sentry_app.status = SentryAppStatus.UNPUBLISHED
+        # All status changes require elevated permissions (superuser/staff).
+        # The publish request endpoint handles its own status change directly.
+        if self.status is not None and _is_elevated_user(user):
+            if self.status == SentryAppStatus.PUBLISHED_STR:
+                self.sentry_app.status = SentryAppStatus.PUBLISHED
+                self.sentry_app.date_published = timezone.now()
+            if self.status == SentryAppStatus.UNPUBLISHED_STR:
+                self.sentry_app.status = SentryAppStatus.UNPUBLISHED
             if self.status == SentryAppStatus.PUBLISH_REQUEST_INPROGRESS_STR:
                 self.sentry_app.status = SentryAppStatus.PUBLISH_REQUEST_INPROGRESS
 

--- a/tests/sentry/sentry_apps/test_sentry_app_updater.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_updater.py
@@ -218,6 +218,23 @@ class TestUpdater(TestCase):
         self.updater.run(self.user)
         assert self.sentry_app.status == SentryAppStatus.UNPUBLISHED
 
+    def test_update_status_to_publish_request_inprogress_if_superuser(self) -> None:
+        self.updater.status = "publish_request_inprogress"
+        self.user.is_superuser = True
+        self.updater.run(self.user)
+        assert self.sentry_app.status == SentryAppStatus.PUBLISH_REQUEST_INPROGRESS
+
+    def test_doesnt_update_status_to_publish_request_inprogress_if_not_superuser(self) -> None:
+        """Non-elevated users cannot set publish_request_inprogress via SentryAppUpdater.
+
+        The dedicated publish request endpoint sets status directly and has its own
+        permission checks (org:admin).
+        """
+        self.updater.status = "publish_request_inprogress"
+        self.updater.run(self.user)
+        # Status should remain unchanged (UNPUBLISHED)
+        assert self.sentry_app.status == SentryAppStatus.UNPUBLISHED
+
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_create_service_hook_on_update(self, mock_record: MagicMock) -> None:
         self.create_project(organization=self.org)


### PR DESCRIPTION
UI properly gates publish requests to org:write, but managers with org:write could set publish_request_inprogress status via PUT, bypassing the org:admin requirement. Fixes: 
- All status changes via SentryAppUpdater require elevated permissions (superuser/staff)
- Publish request endpoint sets status directly which already enforces org:admin
- Added regression tests

The broken access control didn't do much since changing the status would bypass SentryAppPublishRequestEndpoint entirely.  