### PR TITLE
fix(ui): Size leading items wrapper to height of input group

### DIFF
--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -31,9 +31,11 @@ const InputItemsWrap = styled('div')`
   align-items: center;
   gap: ${space(1)};
 
+  /* Do not use transform here to do alignment as it will create a new stacking
+   * context, breaking things like dropdown menus */
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
 `;
 
 const itemsPadding = {


### PR DESCRIPTION
Avoids creating a new stacking context due to the previously applied transform. This fixes dropdown menus inside the leading items.

I don't see a reason why this container needed to be sized to the content itself, especially given that it's already a center aligned grid inside

Fixes [DE-715: Investigate z-index issues with menus in stories](https://linear.app/getsentry/issue/DE-715/investigate-z-index-issues-with-menus-in-stories)