### PR TITLE
feat(toolbar): Bump the version of the toolbar that we load up for employees

### DIFF
--- a/static/app/utils/useInitSentryToolbar.tsx
+++ b/static/app/utils/useInitSentryToolbar.tsx
@@ -16,6 +16,7 @@ export default function useInitSentryToolbar(organization: null | Organization) 
 
   useSentryToolbar({
     enabled: showDevToolbar && isEmployee && isEnvEnabled,
+    version: '1.0.0-beta.22',
     initProps: {
       organizationSlug: organization?.slug ?? 'sentry',
       projectIdOrSlug: 'javascript',


### PR DESCRIPTION
This version has a few package bumps (react 19!). The most visible change is that the logged-out styling is the same as when someone is logged-in, allowing the Feature Flag panel to be accessible all the time.

We're bumping the version manually here, and weren't doing that before, because I changed the publishing strategy.
- Before we would push the newest code to a `latest.js` file on the CDN, and all users would just get it automatically. Evergreen SDK users was the goal. 
- As of today we should be doing staged rollouts. So the code that's published as `1.0.0-beta.22` is not pushed to `latest` yet. But once we've tested it in the wild we can publish against the latest tag too!

| Unauth | Auth |
| --- | --- |
| <img width="406" height="572" alt="Screenshot 2026-01-02 at 10 25 31 AM" src="https://github.com/user-attachments/assets/2dd6e4d4-97ae-4e0b-9532-f7b72fb396c4" /> | <img width="406" height="572" alt="Screenshot 2026-01-02 at 10 25 26 AM" src="https://github.com/user-attachments/assets/957e2fb8-fdf8-4b8b-9470-6044507bad6a" />


You can also see this version of the toolbar in action over here: https://pokemon-market.sentry.dev/
- Click "log in" in the top-right corner of the site (this is only to enable the toolbar into the site)
- Login to the toolbar with a sentry account that has access to the org `sentry-test.sentry.io`
