### PR TITLE
fix(dashboards): Consolidate network requests on Mobile Vitals page

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -308,9 +308,6 @@ class Referrer(StrEnum):
     API_INSIGHTS_MOBILE_SPARTUP_SPAN_TABLE = "api.insights.mobile-spartup-span-table"
     API_INSIGHTS_MOBILE_SCREENS_METRICS = "api.insights.mobile-screens-metrics"
     API_INSIGHTS_MOBILE_SCREENS_SPAN_METRICS = "api.insights.mobile-screens-span-metrics"
-    API_INSIGHTS_MOBILE_SCREENS_SCREEN_TABLE_METRICS = (
-        "api.insights.mobile-screens-screen-table-metrics"
-    )
     API_INSIGHTS_MOBILE_SCREENS_SCREEN_TABLE_SPAN_METRICS = (
         "api.insights.mobile-screens-screen-table-span-metrics"
     )

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -67,8 +67,8 @@ describe('ScreensOverview', () => {
     expect(await screen.findByRole('table')).toBeInTheDocument();
   });
 
-  it('queries both dataset correctly', async () => {
-    const transactionMetricsMock = MockApiClient.addMockResponse({
+  it('queries correctly', async () => {
+    const metricsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
         data: [
@@ -80,6 +80,9 @@ describe('ScreensOverview', () => {
             'count()': 10000,
             'avg(measurements.app_start_cold)': 300,
             'avg(measurements.app_start_warm)': 400,
+            'avg(mobile.frozen_frames)': 1,
+            'avg(mobile.frames_delay)': 2,
+            'avg(mobile.slow_frames)': 3,
           },
           {
             transaction: 'Screen B',
@@ -89,6 +92,9 @@ describe('ScreensOverview', () => {
             'count()': 5000,
             'avg(measurements.app_start_cold)': 700,
             'avg(measurements.app_start_warm)': 800,
+            'avg(mobile.frozen_frames)': 4,
+            'avg(mobile.frames_delay)': 5,
+            'avg(mobile.slow_frames)': 6,
           },
         ],
         meta: {
@@ -100,6 +106,9 @@ describe('ScreensOverview', () => {
             'count()': 'integer',
             'avg(measurements.app_start_cold)': 'duration',
             'avg(measurements.app_start_warm)': 'duration',
+            'avg(mobile.frozen_frames)': 'number',
+            'avg(mobile.frames_delay)': 'number',
+            'avg(mobile.slow_frames)': 'number',
           },
           units: {
             transaction: null,
@@ -109,56 +118,11 @@ describe('ScreensOverview', () => {
             'count()': null,
             'avg(measurements.app_start_cold)': 'millisecond',
             'avg(measurements.app_start_warm)': 'millisecond',
-          },
-          isMetricsData: true,
-          isMetricsExtractedData: false,
-          tips: {},
-          datasetReason: 'unchanged',
-          dataset: 'spans',
-        },
-      },
-      match: [
-        MockApiClient.matchQuery({
-          referrer: 'api.insights.mobile-screens-screen-table-metrics',
-        }),
-      ],
-    });
-
-    const spanMetricsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      body: {
-        data: [
-          {
-            'project.id': project.id,
-            transaction: 'Screen A',
-            'avg(mobile.frozen_frames)': 1,
-            'avg(mobile.frames_delay)': 2,
-            'avg(mobile.slow_frames)': 3,
-          },
-          {
-            'project.id': project.id,
-            transaction: 'Screen B',
-            'avg(mobile.frozen_frames)': 4,
-            'avg(mobile.frames_delay)': 5,
-            'avg(mobile.slow_frames)': 6,
-          },
-        ],
-        meta: {
-          fields: {
-            'project.id': 'integer',
-            transaction: 'string',
-            'avg(mobile.frozen_frames)': 'number',
-            'avg(mobile.frames_delay)': 'number',
-            'avg(mobile.slow_frames)': 'number',
-          },
-          units: {
-            'project.id': null,
-            transaction: null,
             'avg(mobile.frozen_frames)': null,
             'avg(mobile.frames_delay)': null,
             'avg(mobile.slow_frames)': null,
           },
-          isMetricsData: false,
+          isMetricsData: true,
           isMetricsExtractedData: false,
           tips: {},
           datasetReason: 'unchanged',
@@ -178,11 +142,9 @@ describe('ScreensOverview', () => {
     });
 
     render(<ScreensOverview />, {organization});
+
     await waitFor(() => {
-      expect(transactionMetricsMock).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(spanMetricsMock).toHaveBeenCalled();
+      expect(metricsMock).toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/insights/mobile/screens/referrers.tsx
+++ b/static/app/views/insights/mobile/screens/referrers.tsx
@@ -2,6 +2,5 @@ export enum Referrer {
   // based on https://github.com/getsentry/sentry/blob/1dd8b8de9a99672301ee8eb2f852ac42b3a87e62/src/sentry/snuba/referrer.py#L457-L458
   SCREENS_SPAN_METRICS = 'api.insights.mobile-screens-span-metrics',
   SCREENS_METRICS = 'api.insights.mobile-screens-metrics',
-  SCREENS_SCREEN_TABLE = 'api.insights.mobile-screens-screen-table-metrics',
   SCREENS_SCREEN_TABLE_SPAN_METRICS = 'api.insights.mobile-screens-screen-table-span-metrics',
 }


### PR DESCRIPTION
The Mobile Vitals page does a shenanigan: in order to render the table, it makes _two_ requests. One is for simple metrics like TTID and TTFD, and one for other metrics like Frozen Frame Rate. The component then stitches the data together.

This _used_ to be necessary because the former metrics were in the Transactions dataset, and the latter were in the Spans dataset. At some point the requests to Transactions was migrated to use the Spans dataset, but the requests were not combined. In this PR I combine them together, so only one request goes out.

No visual changes! This also prevents a gross bug where if the list of transactions was too long, the second request would fail because the `transaction:` filter would be too long.
