### PR TITLE
fix(dashboards): prebuilt backend dashboard no data for cache

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -271,6 +271,8 @@ const THIRD_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
             `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
           ],
           aggregates: [
+            'equation|count_if(cache.hit,equals,false)',
+            `count(${SpanFields.SPAN_DURATION})`,
             `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
           ],
           columns: [SpanFields.TRANSACTION],


### PR DESCRIPTION
Before
<img width="489" height="242" alt="image" src="https://github.com/user-attachments/assets/a22cb492-68e3-4d8f-ab80-ae3050bf20c6" />

After
<img width="442" height="209" alt="image" src="https://github.com/user-attachments/assets/c3764523-bc16-4440-844b-096a833c0a26" />
