### PR TITLE
feat(aci): Implement new table design for connected alerts

### DIFF
--- a/static/app/views/alerts/rules/crons/details.spec.tsx
+++ b/static/app/views/alerts/rules/crons/details.spec.tsx
@@ -45,6 +45,10 @@ describe('Monitor Details', () => {
       url: `/projects/${organization.slug}/${project.slug}/monitors/${monitor.slug}/processing-errors/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/detectors/`,
+      body: [],
+    });
   });
 
   it('renders', async () => {

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -37,7 +37,7 @@ export const makeAutomationsQueryKey = ({
 }: {
   orgSlug: string;
   cursor?: string;
-  detector?: number[];
+  detector?: string[];
   ids?: string[];
   limit?: number;
   projects?: number[];
@@ -54,7 +54,7 @@ const makeAutomationQueryKey = (orgSlug: string, automationId: string): ApiQuery
 
 interface UseAutomationsQueryOptions {
   cursor?: string;
-  detector?: number[];
+  detector?: string[];
   ids?: string[];
   limit?: number;
   projects?: number[];

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -33,9 +33,11 @@ export const makeAutomationsQueryKey = ({
   limit,
   cursor,
   projects,
+  detector,
 }: {
   orgSlug: string;
   cursor?: string;
+  detector?: number[];
   ids?: string[];
   limit?: number;
   projects?: number[];
@@ -43,7 +45,7 @@ export const makeAutomationsQueryKey = ({
   sortBy?: string;
 }): ApiQueryKey => [
   `/organizations/${orgSlug}/workflows/`,
-  {query: {query, sortBy, id: ids, per_page: limit, cursor, project: projects}},
+  {query: {query, sortBy, id: ids, per_page: limit, cursor, project: projects, detector}},
 ];
 
 const makeAutomationQueryKey = (orgSlug: string, automationId: string): ApiQueryKey => [
@@ -52,6 +54,7 @@ const makeAutomationQueryKey = (orgSlug: string, automationId: string): ApiQuery
 
 interface UseAutomationsQueryOptions {
   cursor?: string;
+  detector?: number[];
   ids?: string[];
   limit?: number;
   projects?: number[];

--- a/static/app/views/detectors/components/details/common/automations.spec.tsx
+++ b/static/app/views/detectors/components/details/common/automations.spec.tsx
@@ -39,6 +39,11 @@ describe('DetectorDetailsAutomations', () => {
         }),
       ],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      method: 'GET',
+      body: [],
+    });
   });
 
   it('renders connected alerts list', async () => {

--- a/static/app/views/detectors/components/details/common/automations.spec.tsx
+++ b/static/app/views/detectors/components/details/common/automations.spec.tsx
@@ -1,5 +1,8 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
-import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {
+  IssueStreamDetectorFixture,
+  UptimeDetectorFixture,
+} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -19,10 +22,23 @@ import {DetectorDetailsAutomations} from './automations';
 describe('DetectorDetailsAutomations', () => {
   const organization = OrganizationFixture();
   const automation1 = AutomationFixture({id: '1', name: 'Alert 1'});
+  const issueStreamDetector = IssueStreamDetectorFixture({id: 'issue-stream-1'});
 
   beforeEach(() => {
     jest.resetAllMocks();
     MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: [issueStreamDetector],
+      match: [
+        MockApiClient.matchQuery({
+          query: 'type:issue_stream',
+          project: [1],
+        }),
+      ],
+    });
   });
 
   it('renders connected alerts list', async () => {
@@ -30,7 +46,7 @@ describe('DetectorDetailsAutomations', () => {
       workflowIds: [automation1.id],
     });
 
-    MockApiClient.addMockResponse({
+    const workflowsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
       method: 'GET',
       body: [automation1],
@@ -40,6 +56,16 @@ describe('DetectorDetailsAutomations', () => {
 
     expect(screen.getByText('Connected Alerts')).toBeInTheDocument();
     expect(await screen.findByText(automation1.name)).toBeInTheDocument();
+
+    expect(workflowsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          // Should query for both the issue stream detector of the project and the detector itself
+          detector: [detector.id, issueStreamDetector.id],
+        }),
+      })
+    );
   });
 
   it('renders empty state when no alerts are connected', async () => {
@@ -56,10 +82,7 @@ describe('DetectorDetailsAutomations', () => {
     render(<DetectorDetailsAutomations detector={detector} />, {organization});
 
     expect(
-      await screen.findByText('No alerts are connected to this monitor.')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Connect Existing Alerts'})
+      await screen.findByRole('button', {name: 'Connect Existing Alerts'})
     ).toBeInTheDocument();
 
     // Shows create new alert link to new alert page and a prefilled connectedIds
@@ -76,17 +99,20 @@ describe('DetectorDetailsAutomations', () => {
       workflowIds: [],
     });
 
+    // Mock the table query (has detector param) to return empty
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
       method: 'GET',
-      match: [MockApiClient.matchQuery({ids: []})],
       body: [],
+      match: [(_url, options) => options.query?.detector !== undefined],
     });
 
+    // Mock the drawer's all automations query (no detector param)
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
       method: 'GET',
       body: [automation1],
+      match: [(_url, options) => options.query?.detector === undefined],
     });
 
     const updateRequest = MockApiClient.addMockResponse({
@@ -97,12 +123,16 @@ describe('DetectorDetailsAutomations', () => {
 
     render(<DetectorDetailsAutomations detector={detector} />, {organization});
 
-    await userEvent.click(screen.getByRole('button', {name: 'Connect Existing Alerts'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Connect Existing Alerts'})
+    );
 
     const drawer = await screen.findByRole('complementary', {name: 'Connect Alerts'});
 
     const allAutomationsList = await screen.findByTestId('drawer-all-automations-list');
-    expect(within(allAutomationsList).getByText(automation1.name)).toBeInTheDocument();
+    expect(
+      await within(allAutomationsList).findByText(automation1.name)
+    ).toBeInTheDocument();
 
     await userEvent.click(within(drawer).getByRole('button', {name: 'Connect'}));
 
@@ -137,7 +167,9 @@ describe('DetectorDetailsAutomations', () => {
 
     render(<DetectorDetailsAutomations detector={detector} />, {organization});
 
-    await userEvent.click(screen.getByRole('button', {name: 'Edit Connected Alerts'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Edit Connected Alerts'})
+    );
 
     const connectedAutomationsList = await screen.findByTestId(
       'drawer-connected-automations-list'
@@ -164,7 +196,7 @@ describe('DetectorDetailsAutomations', () => {
   });
 
   describe('permissions', () => {
-    it('disables edit button when user lacks alerts:write permission', () => {
+    it('disables edit button when user lacks alerts:write permission', async () => {
       const orgWithoutAlertsWrite = OrganizationFixture({
         access: [],
       });
@@ -189,11 +221,13 @@ describe('DetectorDetailsAutomations', () => {
         organization: orgWithoutAlertsWrite,
       });
 
-      const editButton = screen.getByRole('button', {name: 'Edit Connected Alerts'});
+      const editButton = await screen.findByRole('button', {
+        name: 'Edit Connected Alerts',
+      });
       expect(editButton).toBeDisabled();
     });
 
-    it('disables connect and create buttons in empty state when user lacks permission', () => {
+    it('disables connect and create buttons in empty state when user lacks permission', async () => {
       const orgWithoutAlertsWrite = OrganizationFixture({
         access: [],
       });
@@ -218,7 +252,9 @@ describe('DetectorDetailsAutomations', () => {
         organization: orgWithoutAlertsWrite,
       });
 
-      const connectButton = screen.getByRole('button', {name: 'Connect Existing Alerts'});
+      const connectButton = await screen.findByRole('button', {
+        name: 'Connect Existing Alerts',
+      });
       const createButton = screen.getByRole('button', {name: 'Create a New Alert'});
 
       expect(connectButton).toBeDisabled();

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -1,28 +1,153 @@
-import {useCallback, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
 import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
 
 import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import useDrawer from 'sentry/components/globalDrawer';
+import LoadingError from 'sentry/components/loadingError';
+import type {CursorHandler} from 'sentry/components/pagination';
+import Pagination from 'sentry/components/pagination';
+import Placeholder from 'sentry/components/placeholder';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
+import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
+import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {IconAdd} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {parseCursor} from 'sentry/utils/cursor';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useAutomationsQuery} from 'sentry/views/automations/hooks';
+import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationCreatePathname} from 'sentry/views/automations/pathnames';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
-import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
+
+const DEFAULT_AUTOMATIONS_PER_PAGE = 10;
 
 type Props = {
   detector: Detector;
 };
+
+interface DetectorAutomationsTableProps {
+  cursor: string | undefined;
+  detectorId: string;
+  emptyMessage: React.ReactNode;
+  onCursor: CursorHandler;
+  limit?: number;
+}
+
+function Skeletons({numberOfRows}: {numberOfRows: number}) {
+  return (
+    <Fragment>
+      {Array.from({length: numberOfRows}).map((_, index) => (
+        <SimpleTable.Row key={index}>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell data-column-name="last-triggered">
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell data-column-name="action-filters">
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+        </SimpleTable.Row>
+      ))}
+    </Fragment>
+  );
+}
+
+function DetectorAutomationsTable({
+  detectorId,
+  cursor,
+  onCursor,
+  emptyMessage,
+  limit = DEFAULT_AUTOMATIONS_PER_PAGE,
+}: DetectorAutomationsTableProps) {
+  const {
+    data: automations,
+    isLoading,
+    isError,
+    isSuccess,
+    getResponseHeader,
+  } = useAutomationsQuery({
+    detector: [Number(detectorId)],
+    limit,
+    cursor,
+  });
+
+  const pageLinks = getResponseHeader?.('Link');
+  const totalCount = getResponseHeader?.('X-Hits');
+  const totalCountInt = totalCount ? parseInt(totalCount, 10) : 0;
+
+  const paginationCaption = useMemo(() => {
+    if (!automations || automations.length === 0 || isLoading) {
+      return undefined;
+    }
+
+    const currentCursor = parseCursor(cursor);
+    const offset = currentCursor?.offset ?? 0;
+    const startCount = offset * limit + 1;
+    const endCount = startCount + automations.length - 1;
+
+    return tct('[start]-[end] of [total]', {
+      start: startCount.toLocaleString(),
+      end: endCount.toLocaleString(),
+      total: totalCountInt.toLocaleString(),
+    });
+  }, [automations, isLoading, cursor, limit, totalCountInt]);
+
+  return (
+    <Container>
+      <SimpleTableWithColumns>
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="last-triggered">
+            {t('Last Triggered')}
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="action-filters">
+            {t('Actions')}
+          </SimpleTable.HeaderCell>
+        </SimpleTable.Header>
+        {isLoading && <Skeletons numberOfRows={limit} />}
+        {isError && <LoadingError />}
+        {isSuccess && automations.length === 0 && (
+          <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>
+        )}
+        {isSuccess &&
+          automations.map(automation => (
+            <SimpleTable.Row
+              key={automation.id}
+              variant={automation.enabled ? 'default' : 'faded'}
+            >
+              <SimpleTable.RowCell>
+                <AutomationTitleCell automation={automation} />
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell data-column-name="last-triggered">
+                <TimeAgoCell date={automation.lastTriggered} />
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell data-column-name="action-filters">
+                <ActionCell actions={getAutomationActions(automation)} />
+              </SimpleTable.RowCell>
+            </SimpleTable.Row>
+          ))}
+      </SimpleTableWithColumns>
+      <Pagination
+        onCursor={onCursor}
+        pageLinks={pageLinks}
+        caption={totalCountInt > limit ? paginationCaption : null}
+      />
+    </Container>
+  );
+}
 
 export function DetectorDetailsAutomations({detector}: Props) {
   const organization = useOrganization();
@@ -99,23 +224,15 @@ export function DetectorDetailsAutomations({detector}: Props) {
       }
     >
       <ErrorBoundary mini>
-        <ConnectedAutomationsList
-          automationIds={detector.workflowIds}
+        <DetectorAutomationsTable
+          detectorId={detector.id}
           cursor={cursor}
           onCursor={setCursor}
           emptyMessage={
             <Stack gap="xl" align="center">
               <Stack gap="sm" align="center">
-                <Text as="p" align="center" variant="muted">
-                  {t('No alerts are connected to this monitor.')}
-                </Text>
-                <Text as="p" align="center" variant="muted">
-                  {t('You will not be notified when this monitor triggers.')}
-                </Text>
-              </Stack>
-              <Stack gap="sm" align="center">
                 <Button
-                  size="xs"
+                  size="sm"
                   onClick={toggleDrawer}
                   disabled={!canEditWorkflowConnections}
                   title={permissionTooltipText}
@@ -127,7 +244,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
                     connectedIds: [detector.id],
                   })}
                   external
-                  size="xs"
+                  size="sm"
                   icon={<IconAdd />}
                   disabled={!canEditWorkflowConnections}
                   title={permissionTooltipText}
@@ -142,3 +259,29 @@ export function DetectorDetailsAutomations({detector}: Props) {
     </Section>
   );
 }
+
+const Container = styled('div')`
+  container-type: inline-size;
+`;
+
+const SimpleTableWithColumns = styled(SimpleTable)`
+  grid-template-columns: 1fr 200px 180px;
+
+  margin-bottom: ${space(2)};
+
+  @container (max-width: ${p => p.theme.breakpoints.sm}) {
+    grid-template-columns: 1fr 180px;
+
+    [data-column-name='last-triggered'] {
+      display: none;
+    }
+  }
+
+  @container (max-width: ${p => p.theme.breakpoints.xs}) {
+    grid-template-columns: 1fr;
+
+    [data-column-name='action-filters'] {
+      display: none;
+    }
+  }
+`;

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -54,10 +54,10 @@ function Skeletons({numberOfRows}: {numberOfRows: number}) {
           <SimpleTable.RowCell>
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell data-column-name="last-triggered">
+          <SimpleTable.RowCell data-column-name="action-filters">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell data-column-name="action-filters">
+          <SimpleTable.RowCell data-column-name="triggered-by">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
         </SimpleTable.Row>

--- a/static/app/views/detectors/components/details/cron/index.spec.tsx
+++ b/static/app/views/detectors/components/details/cron/index.spec.tsx
@@ -79,6 +79,10 @@ describe('CronDetectorDetails - check-ins', () => {
       url: `/organizations/org-slug/detectors/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/workflows/`,
+      body: [],
+    });
   });
 
   it('should show onboarding when the monitor has never checked in', async () => {

--- a/static/app/views/detectors/components/details/cron/index.spec.tsx
+++ b/static/app/views/detectors/components/details/cron/index.spec.tsx
@@ -75,6 +75,10 @@ describe('CronDetectorDetails - check-ins', () => {
       url: `/projects/org-slug/${project.id}/monitors/${cronDataSource.queryObj.slug}/processing-errors/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/detectors/`,
+      body: [],
+    });
   });
 
   it('should show onboarding when the monitor has never checked in', async () => {

--- a/static/app/views/detectors/components/details/error/index.spec.tsx
+++ b/static/app/views/detectors/components/details/error/index.spec.tsx
@@ -42,6 +42,10 @@ describe('ErrorDetectorDetails', () => {
       url: `/organizations/org-slug/issues/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/detectors/`,
+      body: [],
+    });
   });
 
   describe('Resolve section', () => {

--- a/static/app/views/detectors/components/details/error/index.spec.tsx
+++ b/static/app/views/detectors/components/details/error/index.spec.tsx
@@ -46,6 +46,10 @@ describe('ErrorDetectorDetails', () => {
       url: `/organizations/org-slug/detectors/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/workflows/`,
+      body: [],
+    });
   });
 
   describe('Resolve section', () => {

--- a/static/app/views/detectors/components/details/uptime/index.spec.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.spec.tsx
@@ -33,6 +33,10 @@ describe('UptimeDetectorDetails', () => {
       url: `/organizations/org-slug/detectors/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/workflows/`,
+      body: [],
+    });
   });
 
   it('renders the detector details sections', async () => {

--- a/static/app/views/detectors/components/details/uptime/index.spec.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.spec.tsx
@@ -29,6 +29,10 @@ describe('UptimeDetectorDetails', () => {
       url: '/organizations/org-slug/uptime-summary/',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/detectors/`,
+      body: [],
+    });
   });
 
   it('renders the detector details sections', async () => {

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -4,6 +4,7 @@ import {
   CronDetectorFixture,
   CronMonitorDataSourceFixture,
   CronMonitorEnvironmentFixture,
+  IssueStreamDetectorFixture,
   MetricDetectorFixture,
   SnubaQueryDataSourceFixture,
   UptimeDetectorFixture,
@@ -50,6 +51,11 @@ describe('DetectorDetails', () => {
     route: '/organizations/:orgId/issues/detectors/:detectorId/',
   };
 
+  const issueStreamDetector = IssueStreamDetectorFixture({
+    id: 'issue-stream-1',
+    projectId: project.id,
+  });
+
   beforeEach(() => {
     ProjectsStore.loadInitialData([project]);
     TeamStore.loadInitialData([ownerTeam]);
@@ -59,7 +65,6 @@ describe('DetectorDetails', () => {
         AutomationFixture({id: '1', name: 'Automation 1'}),
         AutomationFixture({id: '2', name: 'Automation 2'}),
       ],
-      match: [MockApiClient.matchQuery({id: ['1', '2']})],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,
@@ -89,6 +94,16 @@ describe('DetectorDetails', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/1/`,
       body: GroupFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/detectors/`,
+      body: [issueStreamDetector],
+      match: [
+        MockApiClient.matchQuery({
+          query: 'type:issue_stream',
+          project: [Number(project.id)],
+        }),
+      ],
     });
   });
 

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -65,6 +65,7 @@ describe('DetectorDetails', () => {
         AutomationFixture({id: '1', name: 'Automation 1'}),
         AutomationFixture({id: '2', name: 'Automation 2'}),
       ],
+      match: [(_url, options) => options.query?.detector !== undefined],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,
@@ -104,6 +105,11 @@ describe('DetectorDetails', () => {
           project: [Number(project.id)],
         }),
       ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/workflows/`,
+      body: [],
+      match: [(_url, options) => options.query?.detector === undefined],
     });
   });
 

--- a/static/app/views/detectors/utils/useIssueStreamDetectorId.tsx
+++ b/static/app/views/detectors/utils/useIssueStreamDetectorId.tsx
@@ -1,0 +1,15 @@
+import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
+
+/**
+ * Returns the ID of the issue stream detector for a given project.
+ * Issue stream detectors are used to connect automations to "all issues in a project".
+ */
+export function useIssueStreamDetectorId(projectId: string | undefined): string | null {
+  const {data: issueStreamDetectors} = useDetectorsQuery({
+    query: 'type:issue_stream',
+    projects: [Number(projectId)],
+    includeIssueStreamDetectors: true,
+  });
+
+  return issueStreamDetectors?.[0]?.id ?? null;
+}

--- a/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
+++ b/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
@@ -4,12 +4,10 @@ import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
  * Returns the ID of the issue stream detector for a given project.
  * Issue stream detectors are used to connect automations to "all issues in a project".
  */
-export function useIssueStreamDetectorId(projectId: string | undefined): string | null {
-  const {data: issueStreamDetectors} = useDetectorsQuery({
+export function useIssueStreamDetectorsForProject(projectId: string | undefined) {
+  return useDetectorsQuery({
     query: 'type:issue_stream',
     projects: [Number(projectId)],
     includeIssueStreamDetectors: true,
   });
-
-  return issueStreamDetectors?.[0]?.id ?? null;
 }


### PR DESCRIPTION
On the monitor details page, uses the new table design. Changes include:

- The list queries for project alerts as well as directly connected ones
- Adds a new column "triggered by issues" to describe which kind of connection it is

Still TODO in followup PRs:

- Add sorting and filtering to the details list
- Improve the connected alerts drawer so it's less confusing that project alerts aren't shown

<img width="1686" height="748" alt="CleanShot 2026-01-08 at 11 04 50@2x" src="https://github.com/user-attachments/assets/6c376542-b5be-44ad-beeb-b42741461bcb" />
