### PR TITLE
ref(grouping): Fix single non-URL frame handling in new config

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -59,6 +59,9 @@ register_grouping_config(
     initial_context={
         # Shim to preserve hash values, since they're order-dependent
         "use_legacy_exception_subcomponent_order": True,
+        # Preserve a long-standing bug, wherein our "non-URL frame" test actually looks for frames
+        # *with* URLs
+        "handle_js_single_frame_url_origin_backwards": True,
     },
     enhancements_base="all-platforms:2023-01-11",
     fingerprinting_bases=["javascript@2024-02-02"],

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -72,6 +72,7 @@ register_grouping_config(
     base=WINTER_2023_GROUPING_CONFIG,
     initial_context={
         "use_legacy_exception_subcomponent_order": False,
+        "handle_js_single_frame_url_origin_backwards": False,
     },
     enhancements_base="all-platforms:2025-11-21",
 )

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -510,7 +510,13 @@ def _single_stacktrace_variant(
         and get_behavior_family_for_platform(frames[0].platform or event.platform) == "javascript"
         and not frames[0].function
     ):
-        should_ignore_frame = has_url_origin(frames[0].abs_path, files_count_as_urls=True)
+        # TODO: The `newstyle:2023-01-11` config has this backwards - it finds frames *with* URLs
+        # rather than frames without them. Once we've fully transitioned off of it, the
+        # `should_ignore_frame` condition can get moved to the main `if`.
+        should_ignore_frame = not has_url_origin(frames[0].abs_path, files_count_as_urls=True)
+        if context.get("handle_js_single_frame_url_origin_backwards"):
+            should_ignore_frame = not should_ignore_frame
+
         if should_ignore_frame:
             frame_components[0].update(
                 contributes=False, hint="ignored single non-URL JavaScript frame"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -1,33 +1,21 @@
 ---
 source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
 ---
-hash_basis: stacktrace
+hash_basis: fallback
 hashing_metadata: {
-  "num_stacktraces": 1,
-  "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "fallback_reason": "no_contributing_frames"
 }
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "stacktrace",
+    "hash_basis": "fallback",
     "is_hybrid_fingerprint": "False"
   },
-  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
-    "chained_exception": "False",
-    "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+  "grouping.grouphashmetadata.event_hashing_metadata.fallback": {
+    "fallback_reason": "no_contributing_frames"
   }
 }
 ---
 contributing variants:
-  system*
-    hash: "d2ab6870c762b8a67d831c2a608bbfb4"
-    contributing component: stacktrace
-    hint: None
-    root_component:
-      system*
-        stacktrace*
-          frame*
-            filename*
-              "great.js"
+  fallback*
+    hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
@@ -82,7 +82,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored single non-URL JavaScript frame",
+                "hint": null,
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
     "app_stacktrace": {
       "component": {
         "contributes": false,
-        "hint": "ignored because system stacktrace takes precedence",
+        "hint": null,
         "id": "app",
         "name": "in-app",
         "values": [
@@ -55,26 +55,34 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "contributes": false,
       "description": "event-level stacktrace — in-app frames",
       "hash": null,
-      "hint": "ignored because system stacktrace takes precedence",
+      "hint": null,
       "key": "app_stacktrace",
       "type": "component"
     },
+    "fallback": {
+      "contributes": true,
+      "description": "fallback grouping",
+      "hash": "d41d8cd98f00b204e9800998ecf8427e",
+      "hint": null,
+      "key": "fallback",
+      "type": "fallback"
+    },
     "system_stacktrace": {
       "component": {
-        "contributes": true,
+        "contributes": false,
         "hint": null,
         "id": "system",
         "name": null,
         "values": [
           {
-            "contributes": true,
-            "hint": null,
+            "contributes": false,
+            "hint": "ignored because it contains no contributing frames",
             "id": "stacktrace",
             "name": "stacktrace",
             "values": [
               {
-                "contributes": true,
-                "hint": null,
+                "contributes": false,
+                "hint": "ignored single non-URL JavaScript frame",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -107,9 +115,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           }
         ]
       },
-      "contributes": true,
+      "contributes": false,
       "description": "event-level stacktrace — all frames",
-      "hash": "d2ab6870c762b8a67d831c2a608bbfb4",
+      "hash": null,
       "hint": null,
       "key": "system_stacktrace",
       "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_single_url_frame.pysnap
@@ -82,7 +82,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored single non-URL JavaScript frame",
+                "hint": null,
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/frame_ignores_filename_if_blob.pysnap
@@ -22,6 +22,6 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored single non-URL JavaScript frame)
+        frame
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_non_url_frame.pysnap
@@ -4,21 +4,24 @@ source: tests/sentry/grouping/test_variants.py::test_variants
 app:
   hash: null
   contributing component: null
-  hint: ignored because system stacktrace takes precedence
+  hint: None
   root_component:
-    app (ignored because system stacktrace takes precedence)
+    app
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "great.js"
 --------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
 system:
-  hash: "d2ab6870c762b8a67d831c2a608bbfb4"
-  contributing component: stacktrace
+  hash: null
+  contributing component: null
   hint: None
   root_component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace (ignored because it contains no contributing frames)
+        frame (ignored single non-URL JavaScript frame)
           filename*
             "great.js"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_single_url_frame.pysnap
@@ -22,6 +22,6 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored single non-URL JavaScript frame)
+        frame
           filename (ignored because frame points to a URL)
             "great.js"


### PR DESCRIPTION
In our current grouping algorithm, one of the edge cases we handle is single-frame JavaScript stacks with no function name available. In cases where that single frame's `abs_path` isn't a URL, we choose to ignore the stack, because it's most often too low-quality to be usable. Or rather, that's what we intend to do. In reality, this check is implemented backwards, so that we end up ignoring such stacks when they _do_ come from a URL rather than when they don't.

This PR fixes that, and adds a new grouping config option (`handle_js_single_frame_url_origin_backwards`, defaulting to `True`) to preserve the current behavior until we switch to the new grouping config. (In the new config's snapshots, we can see that the URL case no longer gets the `ignored single non-URL JavaScript frame` hint, whereas the non-URL case now does get it where it didn't before.  Note that this also affects the blob `abs_path` case, since `blob:...` [counts as a URL for our purposes](https://github.com/getsentry/sentry/blob/d6959a82662060dcee15f43cd535fe4b7157c633/src/sentry/grouping/strategies/utils.py#L47-L57).)