### PR TITLE
Add project access to check to OrganizationDetectorDetailsEndpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -79,6 +79,10 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         except Detector.DoesNotExist:
             raise ResourceDoesNotExist
 
+        # Verify user has access to the detector's project (respects Open Membership setting)
+        if not request.access.has_project_access(detector.project):
+            raise PermissionDenied
+
         return args, kwargs
 
     publish_status = {


### PR DESCRIPTION
Currently we allow org members to view detector details for projects they don't have access to. Added a project access check in convert_args() to ensure the requestor has permissions when open membership is disabled. 