### PR TITLE
feat(dashboards): add `excludePrebuilt` filter to dashboards endpoint

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -472,18 +472,17 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             return serialized
 
         render_pre_built_dashboard = True
-        if render_pre_built_dashboard:
-            if (
-                filter_by
-                and filter_by in {"onlyFavorites", "owned"}
-                or should_filter_by_prebuilt_ids
-                or filter_by == "excludePrebuilt"
-            ):
-                render_pre_built_dashboard = False
-            elif pin_by and pin_by == "favorites":
-                # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
-                # This allows the prebuilt dashboard to appear when users have no dashboards yet
-                render_pre_built_dashboard = not dashboards.exists()
+        if (
+            filter_by
+            and filter_by in {"onlyFavorites", "owned"}
+            or should_filter_by_prebuilt_ids
+            or filter_by == "excludePrebuilt"
+        ):
+            render_pre_built_dashboard = False
+        elif pin_by and pin_by == "favorites":
+            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+            # This allows the prebuilt dashboard to appear when users have no dashboards yet
+            render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -471,13 +471,18 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        render_pre_built_dashboard = True
-        if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
-            render_pre_built_dashboard = False
-        elif pin_by and pin_by == "favorites":
-            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
-            # This allows the prebuilt dashboard to appear when users have no dashboards yet
-            render_pre_built_dashboard = not dashboards.exists()
+        render_pre_built_dashboard = filter_by != "excludePrebuilt"
+        if render_pre_built_dashboard:
+            if (
+                filter_by
+                and filter_by in {"onlyFavorites", "owned"}
+                or should_filter_by_prebuilt_ids
+            ):
+                render_pre_built_dashboard = False
+            elif pin_by and pin_by == "favorites":
+                # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+                # This allows the prebuilt dashboard to appear when users have no dashboards yet
+                render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -471,12 +471,13 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        render_pre_built_dashboard = filter_by != "excludePrebuilt"
+        render_pre_built_dashboard = True
         if render_pre_built_dashboard:
             if (
                 filter_by
                 and filter_by in {"onlyFavorites", "owned"}
                 or should_filter_by_prebuilt_ids
+                or filter_by == "excludePrebuilt"
             ):
                 render_pre_built_dashboard = False
             elif pin_by and pin_by == "favorites":

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -301,6 +301,10 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             dashboards = Dashboard.objects.filter(organization_id=organization.id).exclude(
                 created_by_id=request.user.id
             )
+        elif filter_by == "excludePrebuilt":
+            dashboards = Dashboard.objects.filter(organization_id=organization.id).exclude(
+                prebuilt_id__isnull=False
+            )
         else:
             dashboards = Dashboard.objects.filter(organization_id=organization.id)
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -474,9 +474,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         render_pre_built_dashboard = True
         if (
             filter_by
-            and filter_by in {"onlyFavorites", "owned"}
+            and filter_by in {"onlyFavorites", "owned", "excludePrebuilt"}
             or should_filter_by_prebuilt_ids
-            or filter_by == "excludePrebuilt"
         ):
             render_pre_built_dashboard = False
         elif pin_by and pin_by == "favorites":

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2074,6 +2074,4 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 assert total_count == 5
 
                 assert response.status_code == 200
-                assert (
-                    len(response.data) == (total_count - prebuilt_dashboards_count) + 1
-                )  # +1 for general dashboard
+                assert len(response.data) == total_count - prebuilt_dashboards_count

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2060,3 +2060,20 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 assert response.status_code == 200
                 assert len(response.data) == 1
                 assert response.data[0]["prebuiltId"] == PrebuiltDashboardId.FRONTEND_SESSION_HEALTH
+
+    def test_get_with_exclude_prebuilt(self) -> None:
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            with override_options({"dashboards.prebuilt-dashboard-ids": [1, 2, 3]}):
+                response = self.do_request("get", self.url, {"filter": "excludePrebuilt"})
+
+                prebuilt_dashboards_count = Dashboard.objects.filter(
+                    organization=self.organization, prebuilt_id__isnull=False
+                ).count()
+                total_count = Dashboard.objects.filter(organization=self.organization).count()
+                assert prebuilt_dashboards_count == 3
+                assert total_count == 5
+
+                assert response.status_code == 200
+                assert (
+                    len(response.data) == (total_count - prebuilt_dashboards_count) + 1
+                )  # +1 for general dashboard


### PR DESCRIPTION
Adds a `excludePrebuilt` filter to the dashboard endpoint, this so the frontend can filter out prebuilt dashboards when it calculates the total dashboard and compares it to the dashboard limit.