### PR TITLE
feat(search-bar): Wrap selected filters in parentheses

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -464,7 +464,21 @@ function wrapTokensWithParentheses(
   const after = state.query.substring(lastToken.location.end.offset);
 
   const newQuery = removeExcessWhitespaceFromParts(before, '(', middle, ')', after);
-  const cursorPosition = firstToken.location.start.offset + middle.length + 2;
+  // Calculate cursor position in the new query: find the closing ')' that we just added.
+  const trimmedMiddle = middle.trim();
+  let cursorPosition = newQuery.length; // Fallback: position at end of query
+
+  if (trimmedMiddle.length > 0) {
+    const middleStartIndex = newQuery.indexOf(trimmedMiddle);
+    if (middleStartIndex >= 0) {
+      const middleEndIndex = middleStartIndex + trimmedMiddle.length;
+      // Find the ')' that comes after middle (there should be a space before it)
+      const closingParenIndex = newQuery.indexOf(')', middleEndIndex);
+      if (closingParenIndex >= 0) {
+        cursorPosition = closingParenIndex + 1;
+      }
+    }
+  }
   const newParsedQuery = parseQuery(newQuery);
 
   const focusedToken = newParsedQuery?.find(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -464,20 +464,22 @@ function wrapTokensWithParentheses(
   const after = state.query.substring(lastToken.location.end.offset);
 
   const newQuery = removeExcessWhitespaceFromParts(before, '(', middle, ')', after);
-  // Calculate cursor position in the new query: find the closing ')' that we just added.
-  const trimmedMiddle = middle.trim();
-  let cursorPosition = newQuery.length; // Fallback: position at end of query
 
-  if (trimmedMiddle.length > 0) {
-    const middleStartIndex = newQuery.indexOf(trimmedMiddle);
-    if (middleStartIndex >= 0) {
-      const middleEndIndex = middleStartIndex + trimmedMiddle.length;
-      // Find the ')' that comes after middle (there should be a space before it)
-      const closingParenIndex = newQuery.indexOf(')', middleEndIndex);
-      if (closingParenIndex >= 0) {
-        cursorPosition = closingParenIndex + 1;
-      }
-    }
+  // Calculate cursor position: position right after the closing ')' we just added.
+  let cursorPosition: number;
+  const trimmedBefore = before.trim();
+  const trimmedMiddle = middle.trim();
+  if (trimmedMiddle.length === 0) {
+    // Edge case: empty middle, position at end
+    cursorPosition = newQuery.length;
+  } else if (trimmedBefore.length > 0) {
+    // Format: "trimmedBefore ( trimmedMiddle ) ..."
+    // Position: trimmedBefore + " " + "(" + " " + trimmedMiddle + " " + ")" = len + 4 + len + 1
+    cursorPosition = trimmedBefore.length + trimmedMiddle.length + 5;
+  } else {
+    // Format: "( trimmedMiddle ) ..."
+    // Position: "(" + " " + trimmedMiddle + " " + ")" = 2 + len + 2
+    cursorPosition = trimmedMiddle.length + 4;
   }
   const newParsedQuery = parseQuery(newQuery);
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -488,16 +488,15 @@ function wrapTokensWithParentheses(
       token.type === Token.FREE_TEXT && token.location.start.offset >= cursorPosition
   );
 
-  const focusOverride = focusedToken
-    ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)}
-    : newParsedQuery?.length
-      ? {
-          itemKey: makeTokenKey(
-            newParsedQuery[newParsedQuery.length - 1]!,
-            newParsedQuery
-          ),
-        }
-      : null;
+  let focusOverride: FocusOverride | null = null;
+  if (focusedToken) {
+    focusOverride = {itemKey: makeTokenKey(focusedToken, newParsedQuery)};
+  } else if (newParsedQuery?.[newParsedQuery.length - 1]) {
+    focusOverride = {
+      // We know that the last token exists because of the check above, but TS isn't happy
+      itemKey: makeTokenKey(newParsedQuery[newParsedQuery.length - 1]!, newParsedQuery),
+    };
+  }
 
   return {
     ...state,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -463,7 +463,7 @@ function wrapTokensWithParentheses(
   );
   const after = state.query.substring(lastToken.location.end.offset);
 
-  const newQuery = `${before}(${middle})${after}`.trim();
+  const newQuery = `${before} ( ${middle} ) ${after}`.trim();
   const cursorPosition = firstToken.location.start.offset + middle.length + 2;
   const newParsedQuery = parseQuery(newQuery);
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -463,7 +463,7 @@ function wrapTokensWithParentheses(
   );
   const after = state.query.substring(lastToken.location.end.offset);
 
-  const newQuery = `${before} ( ${middle} ) ${after}`.trim();
+  const newQuery = removeExcessWhitespaceFromParts(before, '(', middle, ')', after);
   const cursorPosition = firstToken.location.start.offset + middle.length + 2;
   const newParsedQuery = parseQuery(newQuery);
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1803,6 +1803,106 @@ describe('SearchQueryBuilder', () => {
       expect(mockOnChange).toHaveBeenCalledWith('', expect.anything());
     });
 
+    it('wraps selected tokens in parentheses with ( key', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="is:unresolved browser.name:chrome"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Control>}a{/Control}');
+      await userEvent.keyboard('(');
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        '(is:unresolved browser.name:chrome)',
+        expect.anything()
+      );
+    });
+
+    it('wraps selected tokens in parentheses with ) key', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="is:unresolved browser.name:chrome"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Control>}a{/Control}');
+      await userEvent.keyboard(')');
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        '(is:unresolved browser.name:chrome)',
+        expect.anything()
+      );
+    });
+
+    it('wraps single selected token in parentheses', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="is:unresolved"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
+      await waitFor(() => {
+        expect(screen.getByRole('row', {name: 'is:unresolved'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+      await userEvent.keyboard('(');
+
+      expect(mockOnChange).toHaveBeenCalledWith('(is:unresolved)', expect.anything());
+    });
+
+    it('does not wrap when nothing is selected', async () => {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="is:unresolved" />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('(');
+
+      expect(await screen.findByRole('row', {name: '('})).toBeInTheDocument();
+    });
+
+    it('can undo wrapping with ctrl-z', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="is:unresolved browser.name:chrome"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Control>}a{/Control}');
+      await userEvent.keyboard('(');
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        '(is:unresolved browser.name:chrome)',
+        expect.anything()
+      );
+
+      await userEvent.keyboard('{Control>}z{/Control}');
+
+      expect(await screen.findByRole('row', {name: 'is:unresolved'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:chrome'})
+      ).toBeInTheDocument();
+      expect(screen.queryByText('(')).not.toBeInTheDocument();
+    });
+
     it('can undo last action with ctrl-z', async () => {
       render(
         <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1875,6 +1875,79 @@ describe('SearchQueryBuilder', () => {
       expect(await screen.findByRole('row', {name: '('})).toBeInTheDocument();
     });
 
+    it('wraps selected tokens correctly when existing parentheses are present', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="( is:unresolved ) browser.name:chrome"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      // Select only the browser.name token (shift+left)
+      await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
+      await waitFor(() => {
+        expect(screen.getByRole('row', {name: 'browser.name:chrome'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+      await userEvent.keyboard('(');
+
+      // Should wrap only the selected token, preserving existing parens
+      expect(mockOnChange).toHaveBeenCalledWith(
+        '( is:unresolved ) ( browser.name:chrome )',
+        expect.anything()
+      );
+    });
+
+    it('wraps selected tokens correctly when duplicate content appears earlier', async () => {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox browser.name:firefox"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      // Select only the last browser.name token (shift+left)
+      await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
+      await waitFor(() => {
+        // Both have the same name, so just check something is selected
+        const rows = screen.getAllByRole('row', {name: 'browser.name:firefox'});
+        expect(rows[1]).toHaveAttribute('aria-selected', 'true');
+      });
+      await userEvent.keyboard('(');
+
+      // Should wrap the second occurrence correctly
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'browser.name:firefox ( browser.name:firefox )',
+        expect.anything()
+      );
+    });
+
+    it('places focus after the closing paren when wrapping', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="is:unresolved browser.name:chrome"
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Control>}a{/Control}');
+      await userEvent.keyboard('(');
+
+      // After wrapping, focus should be at the end (last input)
+      await waitFor(() => {
+        expect(getLastInput()).toHaveFocus();
+      });
+    });
+
     it('can undo wrapping with ctrl-z', async () => {
       const mockOnChange = jest.fn();
       render(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1818,7 +1818,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('(');
 
       expect(mockOnChange).toHaveBeenCalledWith(
-        '(is:unresolved browser.name:chrome)',
+        '( is:unresolved browser.name:chrome )',
         expect.anything()
       );
     });
@@ -1838,7 +1838,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard(')');
 
       expect(mockOnChange).toHaveBeenCalledWith(
-        '(is:unresolved browser.name:chrome)',
+        '( is:unresolved browser.name:chrome )',
         expect.anything()
       );
     });
@@ -1863,7 +1863,7 @@ describe('SearchQueryBuilder', () => {
       });
       await userEvent.keyboard('(');
 
-      expect(mockOnChange).toHaveBeenCalledWith('(is:unresolved)', expect.anything());
+      expect(mockOnChange).toHaveBeenCalledWith('( is:unresolved )', expect.anything());
     });
 
     it('does not wrap when nothing is selected', async () => {
@@ -1890,7 +1890,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('(');
 
       expect(mockOnChange).toHaveBeenCalledWith(
-        '(is:unresolved browser.name:chrome)',
+        '( is:unresolved browser.name:chrome )',
         expect.anything()
       );
 

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -142,6 +142,18 @@ export function SelectionKeyHandler({
             return;
           }
 
+          // Wrap selected tokens in parentheses when ( or ) is pressed
+          if ((e.key === '(' || e.key === ')') && selectedTokens.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            dispatch({
+              type: 'WRAP_TOKENS_WITH_PARENTHESES',
+              tokens: selectedTokens,
+            });
+            state.selectionManager.clearSelection();
+            return;
+          }
+
           // If the key pressed will generate a symbol, replace the selection with it
           if (/^.$/u.test(e.key)) {
             dispatch({


### PR DESCRIPTION
Small tweak to the query builder logic to wrap selected filters in parens when hitting `(` or `)`, thought this would be nifty since it's similar to behavior in text editors.

Ticket: EXP-696

Before:

https://github.com/user-attachments/assets/336662be-fa1b-40ba-abc1-70bc4e85e173

After:

https://github.com/user-attachments/assets/3220b374-41a1-461f-b8af-5bb48febe683