### PR TITLE
fix(dashboards): dashboards frontend should filter out prebuilt dashboards when calculating limit

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -467,6 +467,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
+        render_pre_built_dashboard = True
         if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
             render_pre_built_dashboard = False
         elif pin_by and pin_by == "favorites":

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -467,18 +467,13 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        render_pre_built_dashboard = filter_by != "excludePrebuilt"
-        if render_pre_built_dashboard:
-            if (
-                filter_by
-                and filter_by in {"onlyFavorites", "owned"}
-                or should_filter_by_prebuilt_ids
-            ):
-                render_pre_built_dashboard = False
-            elif pin_by and pin_by == "favorites":
-                # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
-                # This allows the prebuilt dashboard to appear when users have no dashboards yet
-                render_pre_built_dashboard = not dashboards.exists()
+        render_pre_built_dashboard = True
+        if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
+            render_pre_built_dashboard = False
+        elif pin_by and pin_by == "favorites":
+            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+            # This allows the prebuilt dashboard to appear when users have no dashboards yet
+            render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -467,13 +467,18 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        render_pre_built_dashboard = True
-        if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
-            render_pre_built_dashboard = False
-        elif pin_by and pin_by == "favorites":
-            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
-            # This allows the prebuilt dashboard to appear when users have no dashboards yet
-            render_pre_built_dashboard = not dashboards.exists()
+        render_pre_built_dashboard = filter_by != "excludePrebuilt"
+        if render_pre_built_dashboard:
+            if (
+                filter_by
+                and filter_by in {"onlyFavorites", "owned"}
+                or should_filter_by_prebuilt_ids
+            ):
+                render_pre_built_dashboard = False
+            elif pin_by and pin_by == "favorites":
+                # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+                # This allows the prebuilt dashboard to appear when users have no dashboards yet
+                render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -467,18 +467,12 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        render_pre_built_dashboard = filter_by != "excludePrebuilt"
-        if render_pre_built_dashboard:
-            if (
-                filter_by
-                and filter_by in {"onlyFavorites", "owned"}
-                or should_filter_by_prebuilt_ids
-            ):
-                render_pre_built_dashboard = False
-            elif pin_by and pin_by == "favorites":
-                # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
-                # This allows the prebuilt dashboard to appear when users have no dashboards yet
-                render_pre_built_dashboard = not dashboards.exists()
+        if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
+            render_pre_built_dashboard = False
+        elif pin_by and pin_by == "favorites":
+            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+            # This allows the prebuilt dashboard to appear when users have no dashboards yet
+            render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -107,7 +107,7 @@ describe('useDashboardsLimit', () => {
         {id: '2', title: 'Dashboard 2'},
         {id: '3', title: 'Dashboard 3'},
       ],
-      match: [MockApiClient.matchQuery({per_page: 11})],
+      match: [MockApiClient.matchQuery({per_page: 10, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
@@ -149,7 +149,7 @@ describe('useDashboardsLimit', () => {
         {id: '2', title: 'Dashboard 2'},
         {id: '3', title: 'Dashboard 3'},
       ],
-      match: [MockApiClient.matchQuery({per_page: 4})],
+      match: [MockApiClient.matchQuery({per_page: 3, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
@@ -195,7 +195,7 @@ describe('useDashboardsLimit', () => {
         {id: '2', title: 'Dashboard 2'},
         {id: '3', title: 'Dashboard 3'},
       ],
-      match: [MockApiClient.matchQuery({per_page: 3})],
+      match: [MockApiClient.matchQuery({per_page: 2, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
@@ -237,7 +237,7 @@ describe('useDashboardsLimit', () => {
     const dashboardsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
       body: [],
-      match: [MockApiClient.matchQuery({per_page: 11})],
+      match: [MockApiClient.matchQuery({per_page: 10, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
@@ -271,7 +271,7 @@ describe('useDashboardsLimit', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
       statusCode: 500,
-      match: [MockApiClient.matchQuery({per_page: 11})],
+      match: [MockApiClient.matchQuery({per_page: 10, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -36,7 +36,7 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
           query: {
             filter: 'excludePrebuilt',
             // We only need to know there are at most the limited # of dashboards.
-            per_page: dashboardsLimit + 1, // +1 to account for the General dashboard
+            per_page: dashboardsLimit,
           },
         },
       ],

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -34,6 +34,7 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
         `/organizations/${organization.slug}/dashboards/`,
         {
           query: {
+            filter: 'excludePrebuilt',
             // We only need to know there are at most the limited # of dashboards.
             per_page: dashboardsLimit + 1, // +1 to account for the General dashboard
           },

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -46,9 +46,8 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
       }
     );
 
-  // Add 1 to dashboardsLimit to account for the General dashboard
   const hasReachedDashboardLimit =
-    ((dashboardsTotalCount?.length ?? 0) >= dashboardsLimit + 1 &&
+    ((dashboardsTotalCount?.length ?? 0) >= dashboardsLimit &&
       dashboardsLimit !== UNLIMITED_DASHBOARDS_LIMIT) ||
     dashboardsLimit === 0;
   const limitMessage = hasReachedDashboardLimit


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/105946 to merge

Updates the frontend to exclude prebuilt dashboards in the total count, so the user doesn't get incorrect dashboard limit issues.