### PR TITLE
o11y(explorer): add thumbs up/down feedback for chat responses

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -24,6 +24,14 @@ export type SeerAnalyticsEventsParameters = {
     step_type: 'root_cause' | 'solution' | 'changes';
     user_id: string;
   };
+  'seer.explorer.feedback_submitted': {
+    block_index: number;
+    block_message: string;
+    explorer_url: string | undefined;
+    langfuse_url: string | undefined;
+    run_id: number | undefined;
+    type: 'positive' | 'negative';
+  };
   'seer.explorer.global_panel.opened': {
     referrer: string;
   };
@@ -52,6 +60,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
   'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',
+  'seer.explorer.feedback_submitted': 'Seer Explorer: Feedback Submitted',
   'seer.explorer.global_panel.opened': 'Seer Explorer: Global Panel Opened',
   'seer.explorer.global_panel.tool_link_navigation': 'Seer Explorer: Tool Link Visited',
   'seer.explorer.message_sent': 'Seer Explorer: Message Sent',

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -9,7 +9,6 @@ import {Button} from 'sentry/components/core/button';
 import {Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
-import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {IconChevron, IconLink, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -18,10 +17,13 @@ import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 import type {Block, TodoItem} from './types';
 import {
   buildToolLinkUrl,
+  getExplorerUrl,
+  getLangfuseUrl,
   getToolsStringFromBlock,
   getValidToolLinks,
   postProcessLLMMarkdown,
@@ -30,7 +32,6 @@ import {
 interface BlockProps {
   block: Block;
   blockIndex: number;
-  feedbackTags?: Record<string, unknown>;
   getPageReferrer?: () => string;
   isAwaitingFileApproval?: boolean;
   isAwaitingQuestion?: boolean;
@@ -48,6 +49,7 @@ interface BlockProps {
   ) => void;
   readOnly?: boolean;
   ref?: React.Ref<HTMLDivElement>;
+  runId?: number;
 }
 
 function hasValidContent(content: string): boolean {
@@ -136,8 +138,8 @@ function getToolStatus(
 
 function BlockComponent({
   block,
-  blockIndex: _blockIndex,
-  feedbackTags = {},
+  blockIndex,
+  runId,
   getPageReferrer,
   isAwaitingFileApproval,
   isAwaitingQuestion,
@@ -276,36 +278,61 @@ function BlockComponent({
     navigateToToolLink,
   ]);
 
-  const feedbackThumbButton = (type: 'positive' | 'negative') => {
+  // Allow 1 feedback per session. This only writes to session storage on change, not init.
+  const [feedbackSubmitted, setFeedbackSubmitted] = useSessionStorage(
+    `seer-explorer-feedback:run-${runId ?? 'null'}:block-${block.id}`,
+    false
+  );
+
+  const trackThumbsFeedback = useCallback(
+    (type: 'positive' | 'negative') => {
+      if (!feedbackSubmitted) {
+        trackAnalytics('seer.explorer.feedback_submitted', {
+          organization,
+          type,
+          run_id: runId,
+          block_index: blockIndex,
+          block_message: block.message.content.slice(0, 100),
+          langfuse_url: runId ? getLangfuseUrl(runId) : undefined,
+          explorer_url: runId ? getExplorerUrl(runId) : undefined,
+        });
+        setFeedbackSubmitted(true); // disable button for rest of the session
+      }
+    },
+    [
+      organization,
+      blockIndex,
+      runId,
+      block.message.content,
+      feedbackSubmitted,
+      setFeedbackSubmitted,
+    ]
+  );
+
+  const thumbsFeedbackButton = (type: 'positive' | 'negative') => {
     const ariaLabel =
-      type === 'positive'
-        ? t('Seer Explorer Feedback Positive')
-        : t('Seer Explorer Feedback Negative');
+      type === 'positive' ? t('Seer Explorer Thumbs Up') : t('Seer Explorer Thumbs Down');
     return (
-      <FeedbackButton
+      <Button
         aria-label={ariaLabel}
         icon={<IconThumb direction={type === 'positive' ? 'up' : 'down'} />}
+        disabled={feedbackSubmitted}
         priority="transparent"
         size="xs"
         title={
-          type === 'positive'
-            ? t('I like this response')
-            : t("I don't like this response")
+          feedbackSubmitted
+            ? t('Feedback submitted')
+            : type === 'positive'
+              ? t('I like this response')
+              : t("I don't like this response")
         }
-        feedbackOptions={{
-          formTitle: t('Seer Explorer Feedback'),
-          messagePlaceholder:
-            type === 'positive'
-              ? t('What did you like about this response?')
-              : t('How can we improve this response?'),
-          tags: {
-            ...feedbackTags,
-            ['feedback.type']: type,
-          },
+        onClick={e => {
+          e.stopPropagation();
+          trackThumbsFeedback(type);
         }}
       >
         {undefined}
-      </FeedbackButton>
+      </Button>
     );
   };
 
@@ -455,8 +482,8 @@ function BlockComponent({
         )}
         {showActions && !isPolling && (
           <ActionButtonBar gap="xs">
-            {showFeedbackButtons && feedbackThumbButton('positive')}
-            {showFeedbackButtons && feedbackThumbButton('negative')}
+            {showFeedbackButtons && thumbsFeedbackButton('positive')}
+            {showFeedbackButtons && thumbsFeedbackButton('negative')}
             <Button
               size="xs"
               priority="transparent"

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -607,6 +607,7 @@ function ExplorerPanel() {
                 }}
                 block={block}
                 blockIndex={index}
+                feedbackTags={feedbackTags}
                 getPageReferrer={getPageReferrer}
                 isAwaitingFileApproval={isFileApprovalPending}
                 isAwaitingQuestion={isQuestionPending}

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -320,6 +320,7 @@ function ExplorerPanel() {
     [runId, langfuseUrl]
   );
 
+  // Generic feedback handler. Block components have separate thumbs up/down buttons.
   const handleFeedback = useCallback(() => {
     if (openFeedbackForm) {
       openFeedbackForm({

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -28,6 +28,7 @@ import type {Block} from 'sentry/views/seerExplorer/types';
 import {useExplorerPanel} from 'sentry/views/seerExplorer/useExplorerPanel';
 import {
   getExplorerUrl,
+  getLangfuseUrl,
   useCopySessionDataToClipboard,
   usePageReferrer,
 } from 'sentry/views/seerExplorer/utils';
@@ -295,9 +296,7 @@ function ExplorerPanel() {
     setIsMinimized(false);
   }, [setFocusedBlockIndex, textareaRef, setIsMinimized]);
 
-  const langfuseUrl = runId
-    ? `https://langfuse.getsentry.net/project/clx9kma1k0001iebwrfw4oo0z/traces?filter=sessionId%3Bstring%3B%3B%3D%3B${runId}`
-    : undefined;
+  const langfuseUrl = runId ? getLangfuseUrl(runId) : undefined;
 
   const handleOpenLangfuse = useCallback(() => {
     // Command handler. Disabled in slash command menu for non-employees
@@ -308,28 +307,22 @@ function ExplorerPanel() {
 
   const openFeedbackForm = useFeedbackForm();
 
-  // Tags shared by all feedback entrypoints in the panel.
-  const feedbackTags = useMemo(
-    () => ({
-      ['feedback.source']: 'seer_explorer',
-      ['feedback.owner']: 'ml-ai',
-      ...(runId === null ? {} : {['seer.run_id']: runId}),
-      ...(runId === null ? {} : {['explorer_url']: getExplorerUrl(runId)}),
-      ...(langfuseUrl ? {['langfuse_url']: langfuseUrl} : {}),
-    }),
-    [runId, langfuseUrl]
-  );
-
-  // Generic feedback handler. Block components have separate thumbs up/down buttons.
+  // Generic feedback handler
   const handleFeedback = useCallback(() => {
     if (openFeedbackForm) {
       openFeedbackForm({
         formTitle: 'Seer Explorer Feedback',
         messagePlaceholder: 'How can we make Seer Explorer better for you?',
-        tags: {...feedbackTags},
+        tags: {
+          ['feedback.source']: 'seer_explorer',
+          ['feedback.owner']: 'ml-ai',
+          ...(runId === null ? {} : {['seer.run_id']: runId}),
+          ...(runId === null ? {} : {['explorer_url']: getExplorerUrl(runId)}),
+          ...(langfuseUrl ? {['langfuse_url']: langfuseUrl} : {}),
+        },
       });
     }
-  }, [openFeedbackForm, feedbackTags]);
+  }, [openFeedbackForm, runId, langfuseUrl]);
 
   const {menu, isMenuOpen, menuMode, closeMenu, openSessionHistory, openPRWidget} =
     useExplorerMenu({
@@ -607,7 +600,7 @@ function ExplorerPanel() {
                 }}
                 block={block}
                 blockIndex={index}
-                feedbackTags={feedbackTags}
+                runId={runId ?? undefined}
                 getPageReferrer={getPageReferrer}
                 isAwaitingFileApproval={isFileApprovalPending}
                 isAwaitingQuestion={isQuestionPending}

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -908,3 +908,7 @@ export function getExplorerUrl(runId: number | string): string {
   url.searchParams.set(RUN_ID_QUERY_PARAM, String(runId));
   return url.toString();
 }
+
+export function getLangfuseUrl(runId: number | string): string {
+  return `https://langfuse.getsentry.net/project/clx9kma1k0001iebwrfw4oo0z/traces?filter=sessionId%3Bstring%3B%3B%3D%3B${runId}`;
+}

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -899,3 +899,12 @@ function locationToUrl(location: LocationDescriptor): string | null {
 }
 
 export const RUN_ID_QUERY_PARAM = 'explorerRunId';
+
+/**
+ * Returns the URL of the current window with the run ID query param set.
+ */
+export function getExplorerUrl(runId: number | string): string {
+  const url = new URL(window.location.href);
+  url.searchParams.set(RUN_ID_QUERY_PARAM, String(runId));
+  return url.toString();
+}


### PR DESCRIPTION
closes [AIML-2170: Add thumbs up/down feedback to Seer Explorer responses](https://linear.app/getsentry/issue/AIML-2170/add-thumbs-updown-feedback-to-seer-explorer-responses)
closes [AIML-2184: o11y: link to chat in feedback (explorer url)](https://linear.app/getsentry/issue/AIML-2184/o11y-link-to-chat-in-feedback-explorer-url)

instead of opening the feedback form, log an analytic and disable the buttons for the rest of the browser session. This is a session storage state unique for each run ID + block ID. 
<img width="175" height="108" alt="Screenshot 2026-01-08 at 11 41 54 AM" src="https://github.com/user-attachments/assets/75bc715e-7627-4de4-9cfe-bae8ebc907de" />
