### PR TITLE
ref(grouping): Remove space from "stack trace" in grouping info hints

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -191,7 +191,7 @@ def _add_rule_source_to_hint(hint: str | None, custom_rules: set[str]) -> str | 
     def _add_type_to_rule(rule_regex_match: re.Match) -> str:
         rule_str = rule_regex_match.group(1)
         rule_type = "custom" if rule_str in custom_rules else "built-in"
-        return f"{rule_type} stack trace rule ({rule_str})"
+        return f"{rule_type} stacktrace rule ({rule_str})"
 
     return HINT_STACKTRACE_RULE_REGEX.sub(_add_type_to_rule, hint)
 
@@ -252,7 +252,7 @@ def _get_hint_for_stacktrace(
         return None
 
     # Add 'custom' or 'built-in' to any stacktrace rule description as appropriate
-    return _add_rule_source_to_hint(raw_hint, custom_rules)
+    return _add_rule_source_to_hint(raw_hint, custom_rules).replace("stack trace", "stacktrace")
 
 
 def _split_rules(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -589,7 +589,7 @@ class EnhancementsConfig:
             rust_enhancements = _get_rust_enhancements("config_structure", pickled)
 
         except (LookupError, AttributeError, TypeError, ValueError) as e:
-            raise ValueError("invalid stack trace rule config: %s" % e)
+            raise ValueError("invalid stacktrace rule config: %s" % e)
 
         return EnhancementsConfigData(
             rules, [rule.text for rule in rules], rust_enhancements, version, bases

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -8,7 +8,7 @@ import zlib
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Literal
+from typing import Any, Literal, overload
 
 import msgpack
 import sentry_sdk
@@ -173,6 +173,14 @@ def _can_use_hint(
         return False
 
     return True
+
+
+@overload
+def _add_rule_source_to_hint(hint: str, custom_rules: set[str]) -> str: ...
+
+
+@overload
+def _add_rule_source_to_hint(hint: None, custom_rules: set[str]) -> None: ...
 
 
 def _add_rule_source_to_hint(hint: str | None, custom_rules: set[str]) -> str | None:

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -45,6 +45,8 @@ DEFAULT_ENHANCEMENTS_BASE = "all-platforms:2026-01-20"
 # base64 strings never contain '#')
 BASE64_ENHANCEMENTS_DELIMITER = b"#"
 
+# This has a space between "stack" and "trace" to match the way the hints come back from the rust
+# enhancer, even though that's not how it eventually gets rendered in grouping info
 HINT_STACKTRACE_RULE_REGEX = re.compile(r"stack trace rule \((.+)\)$")
 
 VALID_PROFILING_MATCHER_PREFIXES = (

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -142,7 +142,7 @@ class FlagAction(EnhancementAction):
         idx: int,
         rule: EnhancementRule | None = None,
     ) -> None:
-        rule_hint = "stack trace rule"
+        rule_hint = "stacktrace rule"
         if rule:
             rule_hint = f"{rule_hint} ({rule.text})"
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -854,7 +854,7 @@ def filter_exceptions_for_exception_groups(
     # When there's more than one distinct top-level exception, return one of each of them AND the root exception group.
     # NOTE: This deviates from the original RFC, because finding a common ancestor that shares
     # one of each top-level exception that is _not_ the root is overly complicated.
-    # Also, it's more likely the stack trace of the root exception will be more meaningful
+    # Also, it's more likely the stacktrace of the root exception will be more meaningful
     # than one of an inner exception group.
     if exception_tree[0].exception:
         distinct_top_level_exceptions.append(exception_tree[0].exception)

--- a/src/sentry/issues/auto_source_code_config/README.md
+++ b/src/sentry/issues/auto_source_code_config/README.md
@@ -10,7 +10,7 @@ If no previous code mappings were established for that project, the creation of 
 - Suspect commits will be created
 - Sentry comments on pull requests will be created [1]
 
-When a code mapping is created and the stack trace is not an in-app frame we can create a Sentry stack trace rule to mark them as in-app from then on [2]. Having at least one in-app frame is required to enable the features listed above.
+When a code mapping is created and the stacktrace is not an in-app frame we can create a Sentry stacktrace rule to mark them as in-app from then on [2]. Having at least one in-app frame is required to enable the features listed above.
 
 During the creation of the first code mapping we can also import a CODEOWNERS file [2], thus, the following features will be enabled:
 
@@ -30,7 +30,7 @@ Will you access or store my source code?
 
 Configurations:
 
-- Creating in-app stack trace rules
+- Creating in-app stacktrace rules
 - Importing CODEOWNERS
 - Keeping SCM Teams in sync with Sentry Teams
 

--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def save_in_app_stack_trace_rules(
     project: Project, code_mappings: Sequence[CodeMapping], platform_config: PlatformConfig
 ) -> list[str]:
-    """Save in app stack trace rules for a given project"""
+    """Save in app stacktrace rules for a given project"""
     rules_from_code_mappings = set()
     for code_mapping in code_mappings:
         try:

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -199,9 +199,9 @@ def create_configurations(
     platform_config: PlatformConfig,
 ) -> tuple[list[CodeMapping], list[str]]:
     """
-    Given a set of trees and frames to process, create code mappings & in-app stack trace rules.
+    Given a set of trees and frames to process, create code mappings & in-app stacktrace rules.
 
-    Returns a tuple of code mappings and in-app stack trace rules even when running in dry-run mode.
+    Returns a tuple of code mappings and in-app stacktrace rules even when running in dry-run mode.
     """
     org_integration = installation.org_integration
     if not org_integration:

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -158,7 +158,7 @@ PROFILE_FILTERS = {
 }
 
 
-# This support applying a subset of stack trace rules to the profile (matchers and actions).
+# This support applying a subset of stacktrace rules to the profile (matchers and actions).
 #
 # Matchers allowed:
 #

--- a/tests/sentry/grouping/enhancements/test_hints.py
+++ b/tests/sentry/grouping/enhancements/test_hints.py
@@ -357,6 +357,7 @@ def test_adds_rule_source_to_stacktrace_rule_hints() -> None:
     frame_component = FrameGroupingComponent(in_app=True, values=[])
     custom_rules = {"function:roll_over +app"}
 
+    # Here 'stack trace' has a space in it because that's how it comes back from the rust enhancer
     built_in_rule_rust_frame = DummyRustFrame(
         hint="marked in-app by stack trace rule (function:shake +app)"
     )
@@ -373,7 +374,7 @@ def test_adds_rule_source_to_stacktrace_rule_hints() -> None:
             "in-app",
             custom_rules,
         )
-        == "marked in-app by built-in stack trace rule (function:shake +app)"
+        == "marked in-app by built-in stacktrace rule (function:shake +app)"
     )
     assert (
         _get_hint_for_frame(
@@ -384,5 +385,5 @@ def test_adds_rule_source_to_stacktrace_rule_hints() -> None:
             "in-app",
             custom_rules,
         )
-        == "marked in-app by custom stack trace rule (function:roll_over +app)"
+        == "marked in-app by custom stacktrace rule (function:roll_over +app)"
     )

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -32,6 +32,6 @@ contributing variants:
             frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "__99+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -29,16 +29,16 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
             frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "FudgeLogTaggedError"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "SentrySetupInteractor.setupSentry"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -29,7 +29,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:playFetch +app))
+            frame* (marked in-app by custom stacktrace rule (function:playFetch +app))
               filename*
                 "dogpark.js"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -29,70 +29,70 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "child_process"
               context_line*
                 "run_worker("
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "run_worker"
               context_line*
                 "_execute_activation(task_func, inflight.activation)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "_execute_activation"
               context_line*
                 "task_func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.task"
               function*
                 "__call__"
               context_line*
                 "return self._func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.tasks.post_process"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -29,238 +29,238 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn._subprocess"
               function*
                 "subprocess_started"
               context_line*
                 "target(sockets=sockets)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.server"
               function*
                 "run"
               context_line*
                 "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.runners"
               function*
                 "run"
               context_line*
                 "return runner.run(main)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "asyncio.runners"
               function*
                 "run"
               context_line*
                 "return self._loop.run_until_complete(task)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "run_until_complete"
               context_line*
                 "self.run_forever()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "run_forever"
               context_line*
                 "self._run_once()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "_run_once"
               context_line*
                 "handle._run()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.events"
               function*
                 "_run"
               context_line*
                 "self._context.run(self._callback, *self._args)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.lifespan.on"
               function*
                 "main"
               context_line*
                 "await app(scope, self.receive, self.send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
                 "return await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.applications"
               function*
                 "__call__"
               context_line*
                 "await super().__call__(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.applications"
               function*
                 "__call__"
               context_line*
                 "await self.middleware_stack(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.errors"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.base"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.cors"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.exceptions"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.middleware.asyncexitstack"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "__call__"
               context_line*
                 "await self.middleware_stack(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "app"
               context_line*
                 "await self.lifespan(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "lifespan"
               context_line*
                 "async with self.lifespan_context(app) as maybe_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "app.main"
               function*
@@ -331,7 +331,7 @@ contributing variants:
                 "run"
               context_line*
                 "return runner.run(main)"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "asyncio.runners"
               function*
@@ -457,49 +457,49 @@ contributing variants:
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -29,7 +29,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+            frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -29,7 +29,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+            frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -29,79 +29,79 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::Terminate"
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -29,49 +29,49 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "android_main"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "AndroidMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UGameEngine::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UWorld::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "AActor::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::Terminate"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -29,93 +29,93 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "WinMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -29,73 +29,73 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -29,93 +29,93 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "WinMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -29,82 +29,82 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
@@ -29,16 +29,16 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
             frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "FudgeLogTaggedError"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "SentrySetupInteractor.setupSentry"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
@@ -31,7 +31,7 @@ contributing variants:
           type*
             "FailedToFetchError"
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:playFetch +app))
+            frame* (marked in-app by custom stacktrace rule (function:playFetch +app))
               filename*
                 "dogpark.js"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -31,70 +31,70 @@ contributing variants:
           type*
             "TimeoutError"
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app) and un-ignored by custom stacktrace rule (function:post_process_group +group v+group))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "child_process"
               context_line*
                 "run_worker("
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "run_worker"
               context_line*
                 "_execute_activation(task_func, inflight.activation)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.workerchild"
               function*
                 "_execute_activation"
               context_line*
                 "task_func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.taskworker.task"
               function*
                 "__call__"
               context_line*
                 "return self._func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
               module*
                 "sentry.tasks.post_process"
               function*
@@ -111,7 +111,7 @@ contributing variants:
           type*
             "TimeoutError"
           stacktrace*
-            frame* (un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:post_process_group +group v+group))
               module*
                 "__main__"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -29,238 +29,238 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn._subprocess"
               function*
                 "subprocess_started"
               context_line*
                 "target(sockets=sockets)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.server"
               function*
                 "run"
               context_line*
                 "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.runners"
               function*
                 "run"
               context_line*
                 "return runner.run(main)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "asyncio.runners"
               function*
                 "run"
               context_line*
                 "return self._loop.run_until_complete(task)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "run_until_complete"
               context_line*
                 "self.run_forever()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "run_forever"
               context_line*
                 "self._run_once()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.base_events"
               function*
                 "_run_once"
               context_line*
                 "handle._run()"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "asyncio.events"
               function*
                 "_run"
               context_line*
                 "self._context.run(self._callback, *self._args)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.lifespan.on"
               function*
                 "main"
               context_line*
                 "await app(scope, self.receive, self.send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
                 "return await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.applications"
               function*
                 "__call__"
               context_line*
                 "await super().__call__(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.applications"
               function*
                 "__call__"
               context_line*
                 "await self.middleware_stack(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.errors"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.base"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.cors"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.middleware.exceptions"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.middleware.asyncexitstack"
               function*
                 "__call__"
               context_line*
                 "await self.app(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "__call__"
               context_line*
                 "await self.middleware_stack(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "app"
               context_line*
                 "await self.lifespan(scope, receive, send)"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "starlette.routing"
               function*
                 "lifespan"
               context_line*
                 "async with self.lifespan_context(app) as maybe_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
               module*
                 "app.main"
               function*
@@ -275,7 +275,7 @@ contributing variants:
       system*
         threads*
           stacktrace*
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "__main__"
               function*
@@ -331,7 +331,7 @@ contributing variants:
                 "run"
               context_line*
                 "return runner.run(main)"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "asyncio.runners"
               function*
@@ -457,49 +457,49 @@ contributing variants:
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*
                 "merged_lifespan"
               context_line*
                 "async with original_context(app) as maybe_original_state:"
-            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
               module*
                 "fastapi.routing"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/stacktrace_rust.pysnap
@@ -31,7 +31,7 @@ contributing variants:
           type*
             "log_demo"
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+            frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/stacktrace_rust2.pysnap
@@ -31,7 +31,7 @@ contributing variants:
           type*
             "log_demo"
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+            frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assert_mac.pysnap
@@ -31,79 +31,79 @@ contributing variants:
           type*
             "EXC_BAD_ACCESS"
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::Terminate"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
@@ -29,49 +29,49 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "android_main"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "AndroidMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UGameEngine::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UWorld::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "AActor::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::Terminate"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
@@ -29,93 +29,93 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "WinMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
@@ -31,73 +31,73 @@ contributing variants:
           type*
             "Ensure failed"
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
   system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
@@ -31,93 +31,93 @@ contributing variants:
           type*
             "Ensure failed"
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "WinMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
@@ -29,82 +29,82 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
               function*
                 "UFunction::Invoke"
   system*

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:alloc::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:alloc::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2630,7 +2630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2791,7 +2791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2824,7 +2824,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2923,7 +2923,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2956,7 +2956,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2989,7 +2989,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3187,7 +3187,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3352,7 +3352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3517,7 +3517,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3682,7 +3682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3979,7 +3979,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5068,7 +5068,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -3959,7 +3959,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3994,7 +3994,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4029,7 +4029,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4064,7 +4064,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4099,7 +4099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4134,7 +4134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4169,7 +4169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4204,7 +4204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4239,7 +4239,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4274,7 +4274,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4309,7 +4309,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4344,7 +4344,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4379,7 +4379,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4414,7 +4414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4449,7 +4449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4484,7 +4484,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4519,7 +4519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4554,7 +4554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4589,7 +4589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4624,7 +4624,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4659,7 +4659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4694,7 +4694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4729,7 +4729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4764,7 +4764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4799,7 +4799,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4834,7 +4834,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4869,7 +4869,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4904,7 +4904,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4939,7 +4939,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4974,7 +4974,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5009,7 +5009,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5044,7 +5044,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5079,7 +5079,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5114,7 +5114,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5149,7 +5149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5184,7 +5184,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5219,7 +5219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5254,7 +5254,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5289,7 +5289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5324,7 +5324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5359,7 +5359,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5394,7 +5394,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5429,7 +5429,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5464,7 +5464,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5499,7 +5499,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5534,7 +5534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5569,7 +5569,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5604,7 +5604,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5639,7 +5639,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5674,7 +5674,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5709,7 +5709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5744,7 +5744,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5779,7 +5779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5814,7 +5814,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5849,7 +5849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5884,7 +5884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5919,7 +5919,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5954,7 +5954,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5989,7 +5989,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6024,7 +6024,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6059,7 +6059,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6094,7 +6094,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6129,7 +6129,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6164,7 +6164,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6199,7 +6199,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6234,7 +6234,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6269,7 +6269,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6304,7 +6304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6339,7 +6339,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6374,7 +6374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6409,7 +6409,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6444,7 +6444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6479,7 +6479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6514,7 +6514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6549,7 +6549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6584,7 +6584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6619,7 +6619,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6654,7 +6654,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6689,7 +6689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6724,7 +6724,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6759,7 +6759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6794,7 +6794,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6829,7 +6829,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6864,7 +6864,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6899,7 +6899,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6934,7 +6934,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6969,7 +6969,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7004,7 +7004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7039,7 +7039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7074,7 +7074,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7109,7 +7109,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7144,7 +7144,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7179,7 +7179,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7214,7 +7214,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7249,7 +7249,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7284,7 +7284,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7319,7 +7319,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7354,7 +7354,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7389,7 +7389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7459,7 +7459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7494,7 +7494,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7529,7 +7529,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7564,7 +7564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7599,7 +7599,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7634,7 +7634,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7669,7 +7669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7704,7 +7704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7790,7 +7790,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -56,7 +56,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -237,7 +237,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -98,7 +98,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -408,7 +408,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -534,7 +534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -726,7 +726,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1151,7 +1151,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1182,7 +1182,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1244,7 +1244,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1275,7 +1275,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1306,7 +1306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1337,7 +1337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1368,7 +1368,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1430,7 +1430,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1461,7 +1461,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1587,7 +1587,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1684,7 +1684,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -366,7 +366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -459,7 +459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -640,7 +640,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -671,7 +671,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -702,7 +702,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -733,7 +733,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -857,7 +857,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -919,7 +919,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -950,7 +950,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -981,7 +981,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:runApp -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:runApp -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:handleRequest -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:handleRequest -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -127,7 +127,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -169,7 +169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:playFetch +app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:playFetch +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -261,7 +261,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:runApp -group)",
+                    "hint": "ignored by custom stacktrace rule (function:runApp -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -345,7 +345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:runApp -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:runApp -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:handleRequest -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:handleRequest -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -127,7 +127,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:runApp -group)",
+                    "hint": "ignored by custom stacktrace rule (function:runApp -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -303,7 +303,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -115,7 +115,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -829,7 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -860,7 +860,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -891,7 +891,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -953,7 +953,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -984,7 +984,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1015,7 +1015,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1046,7 +1046,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1077,7 +1077,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1108,7 +1108,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1139,7 +1139,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1170,7 +1170,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1201,7 +1201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1232,7 +1232,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1263,7 +1263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1294,7 +1294,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1325,7 +1325,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1356,7 +1356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1387,7 +1387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1418,7 +1418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:__*[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:__*[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1449,7 +1449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -275,7 +275,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -306,7 +306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -399,7 +399,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -group)",
+                "hint": "ignored by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (family:javascript module:**/packages/flutter/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (family:javascript module:**/packages/flutter/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_logging/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_logging/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -52,7 +52,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_dio/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_dio/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_file/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_file/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -118,7 +118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_hive/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_hive/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_isar/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_isar/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -184,7 +184,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_sqflite/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_sqflite/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -217,7 +217,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_drift/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_drift/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -282,7 +282,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_logging/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_logging/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -315,7 +315,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_dio/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_dio/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_file/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_file/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -381,7 +381,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_hive/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_hive/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -414,7 +414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_isar/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_isar/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -447,7 +447,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_sqflite/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_sqflite/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_drift/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_drift/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_flutter/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_flutter/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_flutter/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_flutter/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -52,7 +52,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/go/pkg/mod/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/go/pkg/mod/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -510,7 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1285,7 +1285,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1719,7 +1719,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1752,7 +1752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1785,7 +1785,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1818,7 +1818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1851,7 +1851,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1917,7 +1917,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2198,7 +2198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2229,7 +2229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2260,7 +2260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2322,7 +2322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2353,7 +2353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2384,7 +2384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2415,7 +2415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2446,7 +2446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -837,7 +837,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -868,7 +868,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -899,7 +899,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -930,7 +930,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -992,7 +992,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1023,7 +1023,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1054,7 +1054,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1085,7 +1085,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1147,7 +1147,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1240,7 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1426,7 +1426,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1457,7 +1457,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1488,7 +1488,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1519,7 +1519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -965,7 +965,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -996,7 +996,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1027,7 +1027,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1058,7 +1058,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1089,7 +1089,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1339,7 +1339,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1806,7 +1806,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -107,7 +107,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -702,7 +702,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -733,7 +733,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -845,7 +845,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -878,7 +878,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -909,7 +909,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -940,7 +940,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1068,7 +1068,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1256,7 +1256,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1287,7 +1287,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1318,7 +1318,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1380,7 +1380,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1442,7 +1442,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1473,7 +1473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -72,7 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -473,7 +473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -638,7 +638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -671,7 +671,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -704,7 +704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -737,7 +737,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1235,7 +1235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1343,7 +1343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1554,7 +1554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1649,7 +1649,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1744,7 +1744,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1777,7 +1777,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1876,7 +1876,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1942,7 +1942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1975,7 +1975,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2008,7 +2008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2289,7 +2289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2351,7 +2351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2382,7 +2382,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2413,7 +2413,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2444,7 +2444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2475,7 +2475,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -545,7 +545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -644,7 +644,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -677,7 +677,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -710,7 +710,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -743,7 +743,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -776,7 +776,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -809,7 +809,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1090,7 +1090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1121,7 +1121,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1152,7 +1152,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1183,7 +1183,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1214,7 +1214,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1245,7 +1245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1276,7 +1276,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1388,7 +1388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1419,7 +1419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1450,7 +1450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1481,7 +1481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1512,7 +1512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1605,7 +1605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1731,7 +1731,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1826,7 +1826,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1859,7 +1859,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1892,7 +1892,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1958,7 +1958,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2057,7 +2057,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2090,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2123,7 +2123,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2435,7 +2435,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2466,7 +2466,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2497,7 +2497,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2528,7 +2528,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2559,7 +2559,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2590,7 +2590,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -589,7 +589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -620,7 +620,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -651,7 +651,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1054,7 +1054,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -132,7 +132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -510,7 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1572,7 +1572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1601,7 +1601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1630,7 +1630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1688,7 +1688,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1717,7 +1717,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1748,7 +1748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1922,7 +1922,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2356,7 +2356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2389,7 +2389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2422,7 +2422,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2455,7 +2455,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2488,7 +2488,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2521,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2554,7 +2554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2959,7 +2959,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2990,7 +2990,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3021,7 +3021,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3052,7 +3052,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3083,7 +3083,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3362,7 +3362,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3596,7 +3596,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3627,7 +3627,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3689,7 +3689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3720,7 +3720,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -479,7 +479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -545,7 +545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1421,7 +1421,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1607,7 +1607,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1638,7 +1638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1669,7 +1669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1700,7 +1700,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1731,7 +1731,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1762,7 +1762,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1843,7 +1843,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2246,7 +2246,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2279,7 +2279,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2312,7 +2312,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2345,7 +2345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2378,7 +2378,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2411,7 +2411,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2444,7 +2444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2849,7 +2849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2880,7 +2880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2911,7 +2911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2942,7 +2942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2973,7 +2973,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3252,7 +3252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3283,7 +3283,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3314,7 +3314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3345,7 +3345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3376,7 +3376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3407,7 +3407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3438,7 +3438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3469,7 +3469,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3531,7 +3531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3562,7 +3562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1097,7 +1097,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1872,7 +1872,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1953,7 +1953,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2201,7 +2201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2232,7 +2232,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2263,7 +2263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2294,7 +2294,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2325,7 +2325,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2356,7 +2356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2387,7 +2387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2418,7 +2418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2449,7 +2449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2480,7 +2480,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2511,7 +2511,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2604,7 +2604,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2666,7 +2666,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2728,7 +2728,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2759,7 +2759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2790,7 +2790,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2821,7 +2821,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2852,7 +2852,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2914,7 +2914,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2945,7 +2945,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2976,7 +2976,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3038,7 +3038,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3069,7 +3069,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3100,7 +3100,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3193,7 +3193,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3224,7 +3224,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3255,7 +3255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3286,7 +3286,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3317,7 +3317,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3348,7 +3348,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3379,7 +3379,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3441,7 +3441,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3472,7 +3472,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3503,7 +3503,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3534,7 +3534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3565,7 +3565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3596,7 +3596,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3627,7 +3627,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3658,7 +3658,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3689,7 +3689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3720,7 +3720,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3751,7 +3751,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3782,7 +3782,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -465,7 +465,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -682,7 +682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1190,7 +1190,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1221,7 +1221,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1471,7 +1471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1661,7 +1661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1725,7 +1725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2161,7 +2161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2192,7 +2192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -452,7 +452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1190,7 +1190,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1221,7 +1221,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1471,7 +1471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1568,7 +1568,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1725,7 +1725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2161,7 +2161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2192,7 +2192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -268,7 +268,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -301,7 +301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -520,7 +520,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -584,7 +584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1264,7 +1264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1295,7 +1295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1326,7 +1326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1390,7 +1390,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1456,7 +1456,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1522,7 +1522,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1741,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1836,7 +1836,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2053,7 +2053,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2117,7 +2117,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2181,7 +2181,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2307,7 +2307,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2340,7 +2340,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2402,7 +2402,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -766,7 +766,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -931,7 +931,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1210,7 +1210,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1243,7 +1243,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1305,7 +1305,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1336,7 +1336,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1367,7 +1367,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1398,7 +1398,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1429,7 +1429,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1460,7 +1460,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1491,7 +1491,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1522,7 +1522,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1553,7 +1553,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1584,7 +1584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1615,7 +1615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1646,7 +1646,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1741,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1772,7 +1772,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1902,7 +1902,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2067,7 +2067,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1447,7 +1447,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                        "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -2020,7 +2020,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -2859,7 +2859,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -3418,7 +3418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -2043,7 +2043,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2078,7 +2078,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2113,7 +2113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2148,7 +2148,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3793,7 +3793,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3933,7 +3933,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:@babel/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:@babel/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:core-js/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:core-js/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -109,7 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:tslib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:tslib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:@babel/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:@babel/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -225,7 +225,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:core-js/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:core-js/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:tslib/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:tslib/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://unpkg.com/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://unpkg.com/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://cdnjs.cloudflare.com/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://cdnjs.cloudflare.com/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://cdn.jsdelivr.net/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://cdn.jsdelivr.net/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://esm.run/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://esm.run/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1496,7 +1496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1527,7 +1527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1608,7 +1608,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2073,7 +2073,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2104,7 +2104,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2135,7 +2135,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2166,7 +2166,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2197,7 +2197,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2848,7 +2848,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2879,7 +2879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2939,7 +2939,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2999,7 +2999,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3030,7 +3030,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3092,7 +3092,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -684,7 +684,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1118,7 +1118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1178,7 +1178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1860,7 +1860,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1891,7 +1891,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1972,7 +1972,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2251,7 +2251,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2282,7 +2282,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2313,7 +2313,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2344,7 +2344,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2375,7 +2375,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2551,7 +2551,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2644,7 +2644,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2768,7 +2768,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2799,7 +2799,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2830,7 +2830,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2861,7 +2861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2892,7 +2892,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2954,7 +2954,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2985,7 +2985,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3016,7 +3016,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3107,7 +3107,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3138,7 +3138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3231,7 +3231,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3262,7 +3262,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3293,7 +3293,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3324,7 +3324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3355,7 +3355,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3386,7 +3386,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3417,7 +3417,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3479,7 +3479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3510,7 +3510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3541,7 +3541,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3572,7 +3572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3603,7 +3603,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3634,7 +3634,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3665,7 +3665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3696,7 +3696,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3727,7 +3727,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3758,7 +3758,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3789,7 +3789,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3820,7 +3820,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1388,7 +1388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1481,7 +1481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1574,7 +1574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -401,7 +401,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -432,7 +432,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -463,7 +463,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -306,7 +306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -368,7 +368,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -430,7 +430,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -461,7 +461,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -521,7 +521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -186,7 +186,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored because only 1 frame is considered by custom stack trace rule (family:native max-frames=1)",
+                    "hint": "ignored because only 1 frame is considered by custom stacktrace rule (family:native max-frames=1)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -341,7 +341,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -589,7 +589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -682,7 +682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (function:processTicksAndRejections -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (function:processTicksAndRejections -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (function:runMicrotasks -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (function:runMicrotasks -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (function:processTicksAndRejections -group)",
+                    "hint": "ignored by built-in stacktrace rule (function:processTicksAndRejections -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -196,7 +196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (function:runMicrotasks -group)",
+                    "hint": "ignored by built-in stacktrace rule (function:runMicrotasks -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -577,7 +577,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -621,7 +621,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -665,7 +665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -709,7 +709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -753,7 +753,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -797,7 +797,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -395,7 +395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -665,7 +665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -709,7 +709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -753,7 +753,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -797,7 +797,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -841,7 +841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -885,7 +885,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -929,7 +929,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +131,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +175,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -307,7 +307,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -395,7 +395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -439,7 +439,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -835,7 +835,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -879,7 +879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -69,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -113,7 +113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -157,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -201,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -245,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -333,7 +333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -377,7 +377,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -421,7 +421,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -465,7 +465,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -509,7 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -553,7 +553,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -597,7 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -641,7 +641,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -685,7 +685,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -773,7 +773,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -817,7 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -861,7 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -905,7 +905,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -949,7 +949,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -993,7 +993,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1037,7 +1037,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1081,7 +1081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1169,7 +1169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1257,7 +1257,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1301,7 +1301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1389,7 +1389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1433,7 +1433,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1477,7 +1477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2194,7 +2194,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2986,7 +2986,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3030,7 +3030,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3074,7 +3074,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3118,7 +3118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3162,7 +3162,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3206,7 +3206,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3250,7 +3250,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -835,7 +835,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -879,7 +879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -245,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -597,7 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -641,7 +641,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -685,7 +685,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -773,7 +773,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -817,7 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -861,7 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -905,7 +905,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -949,7 +949,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -993,7 +993,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1037,7 +1037,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1081,7 +1081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1169,7 +1169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1257,7 +1257,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1301,7 +1301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1389,7 +1389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1433,7 +1433,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2)",
+                "hint": "discarded because stacktrace only contains 1 frame which is under the configured threshold by custom stacktrace rule (family:native min-frames=2)",
                 "id": "stacktrace",
                 "name": "stacktrace",
                 "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -310,7 +310,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -341,7 +341,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (family:native function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (family:native function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (family:native function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (family:native function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (family:native function:__* -group)",
+                    "hint": "ignored by custom stacktrace rule (family:native function:__* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (family:native function:*::__* -group)",
+                    "hint": "ignored by custom stacktrace rule (family:native function:*::__* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -911,7 +911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -942,7 +942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -973,7 +973,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1085,7 +1085,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1116,7 +1116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1767,7 +1767,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -165,7 +165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -196,7 +196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -227,7 +227,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -320,7 +320,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -382,7 +382,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -413,7 +413,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -444,7 +444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -475,7 +475,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -537,7 +537,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -599,7 +599,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -630,7 +630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -661,7 +661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -692,7 +692,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -723,7 +723,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -752,7 +752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -833,7 +833,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -864,7 +864,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -233,7 +233,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -264,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -295,7 +295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -326,7 +326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -357,7 +357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -450,7 +450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -481,7 +481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -667,7 +667,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -698,7 +698,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -760,7 +760,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -946,7 +946,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -977,7 +977,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1008,7 +1008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1039,7 +1039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1070,7 +1070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1101,7 +1101,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1132,7 +1132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1165,7 +1165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1229,7 +1229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1260,7 +1260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1291,7 +1291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1324,7 +1324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1355,7 +1355,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1436,7 +1436,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1467,7 +1467,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1498,7 +1498,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1781,7 +1781,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2060,7 +2060,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2401,7 +2401,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -909,7 +909,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -938,7 +938,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -967,7 +967,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -998,7 +998,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1029,7 +1029,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1060,7 +1060,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1091,7 +1091,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1149,7 +1149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1178,7 +1178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1209,7 +1209,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1240,7 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1333,7 +1333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1442,7 +1442,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1473,7 +1473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1504,7 +1504,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1597,7 +1597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1628,7 +1628,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1690,7 +1690,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1721,7 +1721,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1752,7 +1752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1783,7 +1783,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1814,7 +1814,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1845,7 +1845,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1876,7 +1876,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1907,7 +1907,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1938,7 +1938,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1969,7 +1969,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2000,7 +2000,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2031,7 +2031,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2062,7 +2062,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2093,7 +2093,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2124,7 +2124,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2155,7 +2155,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2186,7 +2186,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2217,7 +2217,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2248,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2279,7 +2279,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2308,7 +2308,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2337,7 +2337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2366,7 +2366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2397,7 +2397,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2428,7 +2428,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2459,7 +2459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2490,7 +2490,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2519,7 +2519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2548,7 +2548,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2577,7 +2577,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2608,7 +2608,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2639,7 +2639,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2670,7 +2670,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2701,7 +2701,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2732,7 +2732,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2763,7 +2763,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2794,7 +2794,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2875,7 +2875,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2906,7 +2906,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2937,7 +2937,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3588,7 +3588,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4010,7 +4010,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4041,7 +4041,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4072,7 +4072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4103,7 +4103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4134,7 +4134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4165,7 +4165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4196,7 +4196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4227,7 +4227,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4274,7 +4274,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4305,7 +4305,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4336,7 +4336,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4987,7 +4987,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5409,7 +5409,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5440,7 +5440,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5471,7 +5471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5502,7 +5502,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5533,7 +5533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5564,7 +5564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5595,7 +5595,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5626,7 +5626,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -233,7 +233,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -264,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -295,7 +295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -326,7 +326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -357,7 +357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -450,7 +450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -481,7 +481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -667,7 +667,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -698,7 +698,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -760,7 +760,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -946,7 +946,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -977,7 +977,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1008,7 +1008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1039,7 +1039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1070,7 +1070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1101,7 +1101,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1132,7 +1132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1165,7 +1165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1229,7 +1229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1260,7 +1260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1291,7 +1291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1322,7 +1322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1353,7 +1353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1386,7 +1386,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1419,7 +1419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1485,7 +1485,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1518,7 +1518,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1549,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1580,7 +1580,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1661,7 +1661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1692,7 +1692,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1723,7 +1723,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1756,7 +1756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2006,7 +2006,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2285,7 +2285,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2626,7 +2626,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3070,7 +3070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -56,7 +56,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -118,7 +118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -149,7 +149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -180,7 +180,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -211,7 +211,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -242,7 +242,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -366,7 +366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -397,7 +397,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -428,7 +428,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -459,7 +459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -490,7 +490,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -521,7 +521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -552,7 +552,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -583,7 +583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -614,7 +614,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -645,7 +645,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -676,7 +676,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -707,7 +707,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -738,7 +738,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -769,7 +769,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -800,7 +800,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -831,7 +831,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -862,7 +862,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -893,7 +893,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -924,7 +924,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -955,7 +955,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -986,7 +986,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1017,7 +1017,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1048,7 +1048,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1079,7 +1079,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1110,7 +1110,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1141,7 +1141,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1172,7 +1172,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1203,7 +1203,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1234,7 +1234,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1265,7 +1265,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1353,7 +1353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1384,7 +1384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1415,7 +1415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2066,7 +2066,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2407,7 +2407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2438,7 +2438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2469,7 +2469,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2500,7 +2500,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2531,7 +2531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2562,7 +2562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2593,7 +2593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/actix.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:alloc::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:alloc::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2630,7 +2630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2791,7 +2791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2824,7 +2824,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2923,7 +2923,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2956,7 +2956,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2989,7 +2989,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3187,7 +3187,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3352,7 +3352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3517,7 +3517,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3682,7 +3682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3979,7 +3979,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5068,7 +5068,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/android_anr.pysnap
@@ -3959,7 +3959,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3994,7 +3994,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4029,7 +4029,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4064,7 +4064,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4099,7 +4099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4134,7 +4134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4169,7 +4169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4204,7 +4204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4239,7 +4239,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4274,7 +4274,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4309,7 +4309,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4344,7 +4344,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4379,7 +4379,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4414,7 +4414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4449,7 +4449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4484,7 +4484,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4519,7 +4519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4554,7 +4554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4589,7 +4589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4624,7 +4624,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4659,7 +4659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4694,7 +4694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4729,7 +4729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4764,7 +4764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4799,7 +4799,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4834,7 +4834,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4869,7 +4869,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4904,7 +4904,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4939,7 +4939,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4974,7 +4974,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5009,7 +5009,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5044,7 +5044,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5079,7 +5079,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5114,7 +5114,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5149,7 +5149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5184,7 +5184,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5219,7 +5219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5254,7 +5254,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5289,7 +5289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5324,7 +5324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5359,7 +5359,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5394,7 +5394,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5429,7 +5429,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5464,7 +5464,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5499,7 +5499,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5534,7 +5534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5569,7 +5569,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5604,7 +5604,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5639,7 +5639,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5674,7 +5674,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5709,7 +5709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5744,7 +5744,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5779,7 +5779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5814,7 +5814,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5849,7 +5849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5884,7 +5884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5919,7 +5919,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5954,7 +5954,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5989,7 +5989,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6024,7 +6024,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6059,7 +6059,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6094,7 +6094,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6129,7 +6129,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6164,7 +6164,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6199,7 +6199,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6234,7 +6234,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6269,7 +6269,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6304,7 +6304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6339,7 +6339,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6374,7 +6374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6409,7 +6409,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6444,7 +6444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6479,7 +6479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6514,7 +6514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6549,7 +6549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6584,7 +6584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6619,7 +6619,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6654,7 +6654,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6689,7 +6689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6724,7 +6724,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6759,7 +6759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6794,7 +6794,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6829,7 +6829,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6864,7 +6864,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6899,7 +6899,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6934,7 +6934,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -6969,7 +6969,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7004,7 +7004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7039,7 +7039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7074,7 +7074,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7109,7 +7109,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7144,7 +7144,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7179,7 +7179,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7214,7 +7214,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7249,7 +7249,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7284,7 +7284,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7319,7 +7319,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7354,7 +7354,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7389,7 +7389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7459,7 +7459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7494,7 +7494,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7529,7 +7529,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7564,7 +7564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7599,7 +7599,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7634,7 +7634,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7669,7 +7669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7704,7 +7704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -7790,7 +7790,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/block_invoke.pysnap
@@ -206,7 +206,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -237,7 +237,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/callee_guaranteed.pysnap
@@ -98,7 +98,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -408,7 +408,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -534,7 +534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -567,7 +567,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -726,7 +726,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -759,7 +759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -792,7 +792,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -825,7 +825,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -858,7 +858,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1151,7 +1151,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1182,7 +1182,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1244,7 +1244,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1275,7 +1275,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1306,7 +1306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1337,7 +1337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1368,7 +1368,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1430,7 +1430,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1461,7 +1461,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1587,7 +1587,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1684,7 +1684,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -366,7 +366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -640,7 +640,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -671,7 +671,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -702,7 +702,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -733,7 +733,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -857,7 +857,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -919,7 +919,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -950,7 +950,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -981,7 +981,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:runApp -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:runApp -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:handleRequest -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:handleRequest -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -127,7 +127,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -169,7 +169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:playFetch +app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:playFetch +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -261,7 +261,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:runApp -group)",
+                    "hint": "ignored by custom stacktrace rule (function:runApp -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -345,7 +345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/contributing_system_frames.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:runApp -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:runApp -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by custom stack trace rule (function:handleRequest -app)",
+                    "hint": "marked out of app by custom stacktrace rule (function:handleRequest -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -127,7 +127,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:runApp -group)",
+                    "hint": "ignored by custom stacktrace rule (function:runApp -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -303,7 +303,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:recordMetrics -group)",
+                    "hint": "ignored by custom stacktrace rule (function:recordMetrics -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/exception_cocoa_nserror.pysnap
@@ -115,7 +115,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -829,7 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -860,7 +860,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -891,7 +891,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -953,7 +953,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -984,7 +984,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1015,7 +1015,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1046,7 +1046,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1077,7 +1077,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1108,7 +1108,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1139,7 +1139,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1170,7 +1170,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1201,7 +1201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1232,7 +1232,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1263,7 +1263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1294,7 +1294,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1325,7 +1325,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1356,7 +1356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1387,7 +1387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1418,7 +1418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:__*[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:__*[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1449,7 +1449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/fallback_prefix_level_1.pysnap
@@ -275,7 +275,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -306,7 +306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -399,7 +399,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_dartlang_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -group)",
+                "hint": "ignored by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_flutter_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (family:javascript module:**/packages/flutter/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (family:javascript module:**/packages/flutter/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_dart_packages.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_logging/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_logging/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -52,7 +52,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_dio/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_dio/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -85,7 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_file/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_file/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -118,7 +118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_hive/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_hive/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_isar/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_isar/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -184,7 +184,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_sqflite/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_sqflite/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -217,7 +217,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_drift/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_drift/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -282,7 +282,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_logging/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_logging/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -315,7 +315,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_dio/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_dio/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_file/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_file/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -381,7 +381,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_hive/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_hive/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -414,7 +414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_isar/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_isar/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -447,7 +447,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_sqflite/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_sqflite/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_drift/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_drift/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_dart_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sentry_flutter_sdk.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (path:package:sentry_flutter/** -app)",
+                "hint": "marked out of app by built-in stacktrace rule (path:package:sentry_flutter/** -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "ignored by built-in stack trace rule (path:package:sentry_flutter/** -group)",
+                "hint": "ignored by built-in stacktrace rule (path:package:sentry_flutter/** -group)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/frame_ignores_sun_java_generated_methods.pysnap
@@ -19,7 +19,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
             "values": [
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [
@@ -52,7 +52,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                 "id": "frame",
                 "name": null,
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/go_pkg_mod.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/go/pkg/mod/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/go/pkg/mod/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_125_event_126.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -510,7 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -987,7 +987,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1285,7 +1285,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1719,7 +1719,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1752,7 +1752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1785,7 +1785,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1818,7 +1818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1851,7 +1851,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1917,7 +1917,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2198,7 +2198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2229,7 +2229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2260,7 +2260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2322,7 +2322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2353,7 +2353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2384,7 +2384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2415,7 +2415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2446,7 +2446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_200_event_200.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -837,7 +837,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -868,7 +868,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -899,7 +899,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -930,7 +930,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -992,7 +992,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1023,7 +1023,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1054,7 +1054,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1085,7 +1085,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1147,7 +1147,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1240,7 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1426,7 +1426,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1457,7 +1457,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1488,7 +1488,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1519,7 +1519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_275_event_275.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -965,7 +965,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -996,7 +996,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1027,7 +1027,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1058,7 +1058,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1089,7 +1089,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1339,7 +1339,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1806,7 +1806,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_289_event_312.pysnap
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -107,7 +107,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -454,7 +454,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -485,7 +485,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -516,7 +516,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -547,7 +547,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -640,7 +640,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -702,7 +702,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -733,7 +733,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -845,7 +845,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -878,7 +878,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -909,7 +909,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -940,7 +940,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1068,7 +1068,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1256,7 +1256,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1287,7 +1287,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1318,7 +1318,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1380,7 +1380,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1442,7 +1442,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1473,7 +1473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1504,7 +1504,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_294_event_294.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -72,7 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -473,7 +473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -638,7 +638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -671,7 +671,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -704,7 +704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -737,7 +737,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1235,7 +1235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1343,7 +1343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1554,7 +1554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1649,7 +1649,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1744,7 +1744,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1777,7 +1777,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1876,7 +1876,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1942,7 +1942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1975,7 +1975,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2008,7 +2008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2289,7 +2289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2320,7 +2320,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2351,7 +2351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2382,7 +2382,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2413,7 +2413,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2444,7 +2444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2475,7 +2475,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_294_event_329.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -545,7 +545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -644,7 +644,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -677,7 +677,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -710,7 +710,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -743,7 +743,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -776,7 +776,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -809,7 +809,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1090,7 +1090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1121,7 +1121,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1152,7 +1152,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1183,7 +1183,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1214,7 +1214,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1245,7 +1245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1276,7 +1276,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1388,7 +1388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1419,7 +1419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1450,7 +1450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1481,7 +1481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1512,7 +1512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1605,7 +1605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1731,7 +1731,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1826,7 +1826,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1859,7 +1859,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1892,7 +1892,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1958,7 +1958,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2057,7 +2057,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2090,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2123,7 +2123,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2404,7 +2404,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2435,7 +2435,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2466,7 +2466,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2497,7 +2497,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2528,7 +2528,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2559,7 +2559,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2590,7 +2590,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_307_event_307.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -589,7 +589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -620,7 +620,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -651,7 +651,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1054,7 +1054,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_307_event_657.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -132,7 +132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_313_event_313.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -510,7 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1572,7 +1572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1601,7 +1601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1630,7 +1630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1688,7 +1688,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1717,7 +1717,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1748,7 +1748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1922,7 +1922,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2356,7 +2356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2389,7 +2389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2422,7 +2422,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2455,7 +2455,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2488,7 +2488,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2521,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2554,7 +2554,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2959,7 +2959,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2990,7 +2990,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3021,7 +3021,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3052,7 +3052,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3083,7 +3083,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3362,7 +3362,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3596,7 +3596,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3627,7 +3627,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3658,7 +3658,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3689,7 +3689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3720,7 +3720,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_313_event_333.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -479,7 +479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -545,7 +545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1421,7 +1421,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1607,7 +1607,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1638,7 +1638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1669,7 +1669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1700,7 +1700,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1731,7 +1731,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1762,7 +1762,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1843,7 +1843,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2246,7 +2246,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2279,7 +2279,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2312,7 +2312,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2345,7 +2345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2378,7 +2378,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2411,7 +2411,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2444,7 +2444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2849,7 +2849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2880,7 +2880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2911,7 +2911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2942,7 +2942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2973,7 +2973,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3252,7 +3252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3283,7 +3283,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3314,7 +3314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3345,7 +3345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3376,7 +3376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3407,7 +3407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3438,7 +3438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3469,7 +3469,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3500,7 +3500,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3531,7 +3531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3562,7 +3562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_319_event_321.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -911,7 +911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -942,7 +942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1097,7 +1097,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1128,7 +1128,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1190,7 +1190,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1221,7 +1221,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1283,7 +1283,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1314,7 +1314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1407,7 +1407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1438,7 +1438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1469,7 +1469,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1500,7 +1500,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1562,7 +1562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1593,7 +1593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1624,7 +1624,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1655,7 +1655,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1686,7 +1686,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1717,7 +1717,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1748,7 +1748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1872,7 +1872,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1953,7 +1953,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2201,7 +2201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2232,7 +2232,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2263,7 +2263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2294,7 +2294,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2325,7 +2325,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2356,7 +2356,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2387,7 +2387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2418,7 +2418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2449,7 +2449,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2480,7 +2480,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2511,7 +2511,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2604,7 +2604,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2666,7 +2666,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2728,7 +2728,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2759,7 +2759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2790,7 +2790,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2821,7 +2821,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2852,7 +2852,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2914,7 +2914,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2945,7 +2945,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2976,7 +2976,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3007,7 +3007,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3038,7 +3038,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3069,7 +3069,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3100,7 +3100,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3193,7 +3193,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3224,7 +3224,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3255,7 +3255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3286,7 +3286,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3317,7 +3317,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3348,7 +3348,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3379,7 +3379,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3441,7 +3441,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3472,7 +3472,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3503,7 +3503,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3534,7 +3534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3565,7 +3565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3596,7 +3596,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3627,7 +3627,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3658,7 +3658,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3689,7 +3689,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3720,7 +3720,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3751,7 +3751,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3782,7 +3782,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_389_event_389.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -465,7 +465,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -682,7 +682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_432_event_432.pysnap
@@ -1014,7 +1014,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1045,7 +1045,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1076,7 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1190,7 +1190,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1221,7 +1221,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1471,7 +1471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1661,7 +1661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1725,7 +1725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2130,7 +2130,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2161,7 +2161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2192,7 +2192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_432_event_453.pysnap
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -452,7 +452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1014,7 +1014,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1045,7 +1045,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1076,7 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1159,7 +1159,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1190,7 +1190,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1221,7 +1221,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1471,7 +1471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1568,7 +1568,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1725,7 +1725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2130,7 +2130,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2161,7 +2161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2192,7 +2192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/group_445_event_445.pysnap
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -268,7 +268,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -301,7 +301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -520,7 +520,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -584,7 +584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1119,7 +1119,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1150,7 +1150,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1181,7 +1181,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1264,7 +1264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1295,7 +1295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1326,7 +1326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1390,7 +1390,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1456,7 +1456,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1522,7 +1522,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1741,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1836,7 +1836,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2053,7 +2053,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2117,7 +2117,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2181,7 +2181,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2307,7 +2307,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2340,7 +2340,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2371,7 +2371,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2402,7 +2402,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/in_app_in_ui.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -766,7 +766,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -931,7 +931,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1210,7 +1210,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1243,7 +1243,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1305,7 +1305,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1336,7 +1336,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1367,7 +1367,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1398,7 +1398,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1429,7 +1429,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1460,7 +1460,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1491,7 +1491,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1522,7 +1522,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1553,7 +1553,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1584,7 +1584,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1615,7 +1615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1646,7 +1646,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1741,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1772,7 +1772,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1902,7 +1902,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2067,7 +2067,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/java_chained.pysnap
@@ -1447,7 +1447,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "marked out of app by built-in stack trace rule (category:framework -app)",
+                        "hint": "marked out of app by built-in stacktrace rule (category:framework -app)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -2020,7 +2020,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -2859,7 +2859,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [
@@ -3418,7 +3418,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     "values": [
                       {
                         "contributes": false,
-                        "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                        "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                         "id": "frame",
                         "name": null,
                         "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/java_minimal.pysnap
@@ -2043,7 +2043,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2078,7 +2078,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2113,7 +2113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2148,7 +2148,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3793,7 +3793,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3933,7 +3933,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:io.sentry.* -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:io.sentry.* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/javascript_polyfills.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:@babel/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:@babel/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:core-js/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:core-js/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -109,7 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (module:tslib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (module:tslib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:@babel/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:@babel/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -225,7 +225,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:core-js/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:core-js/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (module:tslib/** -group)",
+                    "hint": "ignored by built-in stacktrace rule (module:tslib/** -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/javascript_unpkg.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://unpkg.com/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://unpkg.com/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://cdnjs.cloudflare.com/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://cdnjs.cloudflare.com/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://cdn.jsdelivr.net/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://cdn.jsdelivr.net/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**https://esm.run/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**https://esm.run/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/macos_amd_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1283,7 +1283,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1314,7 +1314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1434,7 +1434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1496,7 +1496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1527,7 +1527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1608,7 +1608,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2073,7 +2073,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2104,7 +2104,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2135,7 +2135,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2166,7 +2166,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2197,7 +2197,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2848,7 +2848,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2879,7 +2879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2939,7 +2939,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2999,7 +2999,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3030,7 +3030,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3061,7 +3061,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3092,7 +3092,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/macos_intel_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -535,7 +535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -564,7 +564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -593,7 +593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -622,7 +622,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -684,7 +684,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -715,7 +715,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -839,7 +839,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -870,7 +870,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -901,7 +901,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -932,7 +932,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -963,7 +963,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1025,7 +1025,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1056,7 +1056,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1118,7 +1118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1149,7 +1149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1178,7 +1178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1209,7 +1209,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1240,7 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1333,7 +1333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1426,7 +1426,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1457,7 +1457,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1488,7 +1488,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1519,7 +1519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1581,7 +1581,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1612,7 +1612,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1643,7 +1643,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1674,7 +1674,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1705,7 +1705,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1736,7 +1736,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1767,7 +1767,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1798,7 +1798,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1829,7 +1829,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1860,7 +1860,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1891,7 +1891,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1972,7 +1972,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2251,7 +2251,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2282,7 +2282,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2313,7 +2313,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2344,7 +2344,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2375,7 +2375,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2551,7 +2551,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2644,7 +2644,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2768,7 +2768,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2799,7 +2799,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2830,7 +2830,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2861,7 +2861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2892,7 +2892,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2954,7 +2954,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2985,7 +2985,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:telemetry -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:telemetry -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3016,7 +3016,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3047,7 +3047,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3107,7 +3107,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3138,7 +3138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3231,7 +3231,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3262,7 +3262,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3293,7 +3293,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3324,7 +3324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3355,7 +3355,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3386,7 +3386,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3417,7 +3417,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3479,7 +3479,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3510,7 +3510,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3541,7 +3541,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3572,7 +3572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3603,7 +3603,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3634,7 +3634,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3665,7 +3665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3696,7 +3696,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3727,7 +3727,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3758,7 +3758,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3789,7 +3789,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3820,7 +3820,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/malloc_sentinel.pysnap
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1388,7 +1388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1481,7 +1481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1512,7 +1512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1574,7 +1574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_complex_function_names.pysnap
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash1.pysnap
@@ -401,7 +401,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -432,7 +432,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -463,7 +463,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash2.pysnap
@@ -306,7 +306,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -368,7 +368,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_driver_crash3.pysnap
@@ -430,7 +430,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -461,7 +461,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -521,7 +521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_limit_frames.pysnap
@@ -186,7 +186,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored because only 1 frame is considered by custom stack trace rule (family:native max-frames=1)",
+                    "hint": "ignored because only 1 frame is considered by custom stacktrace rule (family:native max-frames=1)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_malloc_chain.pysnap
@@ -341,7 +341,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_no_filenames.pysnap
@@ -589,7 +589,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -682,7 +682,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_unlimited_frames.pysnap
@@ -248,7 +248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/native_windows_anon_namespace.pysnap
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/node_low_level_async.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (function:processTicksAndRejections -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (function:processTicksAndRejections -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (function:runMicrotasks -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (function:runMicrotasks -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (function:processTicksAndRejections -group)",
+                    "hint": "ignored by built-in stacktrace rule (function:processTicksAndRejections -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -196,7 +196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (function:runMicrotasks -group)",
+                    "hint": "ignored by built-in stacktrace rule (function:runMicrotasks -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_grouping_enhancer_away_from_crash.pysnap
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -577,7 +577,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -621,7 +621,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -665,7 +665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -709,7 +709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -753,7 +753,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -797,7 +797,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (path:**/release_webhook.py v-group)",
+                    "hint": "ignored by custom stacktrace rule (path:**/release_webhook.py v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_grouping_enhancer_towards_crash.pysnap
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -395,7 +395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -665,7 +665,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -709,7 +709,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -753,7 +753,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -797,7 +797,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -841,7 +841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -885,7 +885,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -929,7 +929,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (function:wrapped_view ^-group -group)",
+                    "hint": "ignored by custom stacktrace rule (function:wrapped_view ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app) and un-ignored by custom stacktrace rule (function:post_process_group +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +131,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +175,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -263,7 +263,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -307,7 +307,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -395,7 +395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -439,7 +439,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:post_process_group +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -527,7 +527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -571,7 +571,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -659,7 +659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -703,7 +703,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -747,7 +747,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -835,7 +835,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -879,7 +879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -998,7 +998,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:post_process_group +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:post_process_group +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -69,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -113,7 +113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -157,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -201,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -245,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -333,7 +333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -377,7 +377,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -421,7 +421,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -465,7 +465,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -509,7 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -553,7 +553,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -597,7 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -641,7 +641,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -685,7 +685,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -773,7 +773,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -817,7 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -861,7 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -905,7 +905,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -949,7 +949,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -993,7 +993,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1037,7 +1037,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1081,7 +1081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1169,7 +1169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1257,7 +1257,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1301,7 +1301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1389,7 +1389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1433,7 +1433,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1477,7 +1477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1842,7 +1842,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2194,7 +2194,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2986,7 +2986,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3030,7 +3030,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3074,7 +3074,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3118,7 +3118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3162,7 +3162,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3206,7 +3206,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3250,7 +3250,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "hint": "un-ignored by custom stacktrace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +131,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +175,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -527,7 +527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -571,7 +571,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -659,7 +659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -703,7 +703,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -747,7 +747,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -835,7 +835,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -879,7 +879,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -998,7 +998,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -245,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -597,7 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -641,7 +641,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -685,7 +685,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -773,7 +773,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -817,7 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -861,7 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -905,7 +905,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -949,7 +949,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -993,7 +993,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1037,7 +1037,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1081,7 +1081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1169,7 +1169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1213,7 +1213,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1257,7 +1257,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1301,7 +1301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1389,7 +1389,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1433,7 +1433,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1842,7 +1842,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_enforce_min_frames.pysnap
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2)",
+                "hint": "discarded because stacktrace only contains 1 frame which is under the configured threshold by custom stacktrace rule (family:native min-frames=2)",
                 "id": "stacktrace",
                 "name": "stacktrace",
                 "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_negated_match.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -310,7 +310,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -341,7 +341,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -403,7 +403,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (!function:log_demo::* -group)",
+                    "hint": "ignored by custom stacktrace rule (!function:log_demo::* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_rust.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (family:native function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (family:native function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/stacktrace_rust2.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:std::* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (family:native function:log_demo::* +app)",
+                    "hint": "marked in-app by custom stacktrace rule (family:native function:log_demo::* +app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (family:native function:__* -group)",
+                    "hint": "ignored by custom stacktrace rule (family:native function:__* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -434,7 +434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by custom stack trace rule (family:native function:*::__* -group)",
+                    "hint": "ignored by custom stacktrace rule (family:native function:*::__* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assert_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -911,7 +911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -942,7 +942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -973,7 +973,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1085,7 +1085,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1116,7 +1116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1767,7 +1767,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -165,7 +165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -196,7 +196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -227,7 +227,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -258,7 +258,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -320,7 +320,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -351,7 +351,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -382,7 +382,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -413,7 +413,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -444,7 +444,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -475,7 +475,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -537,7 +537,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -599,7 +599,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -630,7 +630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -661,7 +661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -692,7 +692,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -723,7 +723,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -752,7 +752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -833,7 +833,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -864,7 +864,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -233,7 +233,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -264,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -295,7 +295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -326,7 +326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -357,7 +357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -450,7 +450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -481,7 +481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -667,7 +667,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -698,7 +698,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -760,7 +760,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -946,7 +946,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -977,7 +977,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1008,7 +1008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1039,7 +1039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1070,7 +1070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1101,7 +1101,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1132,7 +1132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1165,7 +1165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1229,7 +1229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1260,7 +1260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1291,7 +1291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1324,7 +1324,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1355,7 +1355,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:throw ^-app -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1436,7 +1436,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1467,7 +1467,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1498,7 +1498,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1781,7 +1781,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2060,7 +2060,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2401,7 +2401,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2748,7 +2748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:throw ^-group -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:throw ^-group -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -909,7 +909,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -938,7 +938,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -967,7 +967,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -998,7 +998,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1029,7 +1029,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1060,7 +1060,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1091,7 +1091,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1149,7 +1149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1178,7 +1178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1209,7 +1209,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1240,7 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1333,7 +1333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1442,7 +1442,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1473,7 +1473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1504,7 +1504,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1566,7 +1566,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1597,7 +1597,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1628,7 +1628,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1690,7 +1690,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1721,7 +1721,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1752,7 +1752,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1783,7 +1783,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1814,7 +1814,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1845,7 +1845,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1876,7 +1876,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1907,7 +1907,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1938,7 +1938,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1969,7 +1969,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2000,7 +2000,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2031,7 +2031,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2062,7 +2062,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2093,7 +2093,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2124,7 +2124,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2155,7 +2155,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2186,7 +2186,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2217,7 +2217,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2248,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2279,7 +2279,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2308,7 +2308,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2337,7 +2337,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2366,7 +2366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2397,7 +2397,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2428,7 +2428,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2459,7 +2459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2490,7 +2490,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2519,7 +2519,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2548,7 +2548,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2577,7 +2577,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2608,7 +2608,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2639,7 +2639,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2670,7 +2670,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2701,7 +2701,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2732,7 +2732,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2763,7 +2763,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2794,7 +2794,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2875,7 +2875,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2906,7 +2906,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2937,7 +2937,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3588,7 +3588,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4010,7 +4010,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4041,7 +4041,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4072,7 +4072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4103,7 +4103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4134,7 +4134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4165,7 +4165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4196,7 +4196,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4227,7 +4227,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4274,7 +4274,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4305,7 +4305,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4336,7 +4336,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -4987,7 +4987,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5409,7 +5409,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5440,7 +5440,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5471,7 +5471,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5502,7 +5502,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5533,7 +5533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5564,7 +5564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5595,7 +5595,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -5626,7 +5626,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -233,7 +233,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -264,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -295,7 +295,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -326,7 +326,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -357,7 +357,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:system -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:system -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -450,7 +450,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -481,7 +481,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -667,7 +667,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -698,7 +698,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -760,7 +760,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -946,7 +946,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -977,7 +977,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1008,7 +1008,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1039,7 +1039,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1070,7 +1070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1101,7 +1101,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1132,7 +1132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1165,7 +1165,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1229,7 +1229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1260,7 +1260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1291,7 +1291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1322,7 +1322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1353,7 +1353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1386,7 +1386,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1419,7 +1419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1485,7 +1485,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1518,7 +1518,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1549,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1580,7 +1580,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1661,7 +1661,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1692,7 +1692,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1723,7 +1723,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1756,7 +1756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2006,7 +2006,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2285,7 +2285,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2626,7 +2626,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -3070,7 +3070,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -56,7 +56,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -118,7 +118,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -149,7 +149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -180,7 +180,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -211,7 +211,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -242,7 +242,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -366,7 +366,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -397,7 +397,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -428,7 +428,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -459,7 +459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -490,7 +490,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -521,7 +521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -552,7 +552,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -583,7 +583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -614,7 +614,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -645,7 +645,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -676,7 +676,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -707,7 +707,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -738,7 +738,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -769,7 +769,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -800,7 +800,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -831,7 +831,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -862,7 +862,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -893,7 +893,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -924,7 +924,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -955,7 +955,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -986,7 +986,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1017,7 +1017,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1048,7 +1048,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1079,7 +1079,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1110,7 +1110,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1141,7 +1141,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1172,7 +1172,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1203,7 +1203,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1234,7 +1234,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1265,7 +1265,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app)",
+                    "hint": "marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1353,7 +1353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1384,7 +1384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "ignored by built-in stacktrace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1415,7 +1415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2066,7 +2066,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (category:indirection -group)",
+                    "hint": "ignored by built-in stacktrace rule (category:indirection -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2407,7 +2407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2438,7 +2438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2469,7 +2469,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2500,7 +2500,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2531,7 +2531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2562,7 +2562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -2593,7 +2593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group)",
+                    "hint": "ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame* (marked in-app by the client)
@@ -20,7 +20,7 @@ app:
               "thread.rs"
             function*
               "std::sys::unix::thread::Thread::new::thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:alloc::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:alloc::* -app))
             filename*
               "boxed.rs"
             function*
@@ -403,7 +403,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*
@@ -424,12 +424,12 @@ system:
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::catch_unwind"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panicking.rs"
             function*
@@ -444,17 +444,17 @@ system:
               "panicking.rs"
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::AssertUnwindSafe<T>::call_once"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "backtrace.rs"
             function*
@@ -484,7 +484,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -509,7 +509,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -534,7 +534,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -559,7 +559,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -604,7 +604,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -769,7 +769,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -794,693 +794,693 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit"
             filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
             filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.app.ActivityThread"
             filename (ignored because module takes precedence)
               "activitythread.java"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Looper"
             filename (ignored because module takes precedence)
               "looper.java"
             function*
               "loop"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (ignored because module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (ignored because module takes precedence)
               "handler.java"
             function*
               "handleCallback"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$CallbackRecord"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
@@ -1494,56 +1494,56 @@ system:
               "sourcefile"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.AdapterHelper"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.ChildHelper"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
             filename (ignored because module takes precedence)
@@ -1563,7 +1563,7 @@ system:
               "thread.java"
             function*
               "getStackTrace"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "dalvik.system.VMStack"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -12,7 +12,7 @@ app:
           frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (marked out of app by the client)
@@ -42,6 +42,6 @@ system:
           frame*
             function*
               "__99+[Something else]_block_invoke_2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -12,7 +12,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame (marked out of app by the client)
@@ -42,7 +42,7 @@ app:
           frame (marked out of app by the client)
             function*
               "_dispatch_call_block_and_release"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -56,7 +56,7 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -69,7 +69,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -80,7 +80,7 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -136,40 +136,40 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_main_queue_callback_4CF"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_call_block_and_release"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -183,7 +183,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -196,7 +196,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -207,7 +207,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
           frame (marked out of app by the client)
@@ -36,13 +36,13 @@ app:
           frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "FudgeLogTaggedError"
-          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
           frame (marked out of app by the client)
@@ -51,7 +51,7 @@ app:
           frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"
 --------------------------------------------------------------------------
@@ -78,22 +78,22 @@ system:
           frame*
             function*
               "UIApplicationMain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_main_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_block_async_invoke2"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "-[NSBlockOperation main]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
           frame*
@@ -102,18 +102,18 @@ system:
           frame*
             function*
               "FudgeLogTaggedError"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"
           frame*
             function*
               "SentrySetupInteractor.setupSentry"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_lane_barrier_sync_invoke_and_complete"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -9,28 +9,28 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by custom stack trace rule (function:runApp -app))
+          frame (marked out of app by custom stacktrace rule (function:runApp -app))
             filename*
               "app.js"
             function*
               "runApp"
             context_line*
               "return server.serve(port);"
-          frame (marked out of app by custom stack trace rule (function:handleRequest -app))
+          frame (marked out of app by custom stacktrace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
             context_line*
               "return withMetrics(handler, metricName, tags);"
-          frame* (marked in-app by custom stack trace rule (function:playFetch +app))
+          frame* (marked in-app by custom stacktrace rule (function:playFetch +app))
             filename*
               "dogpark.js"
             function*
@@ -50,7 +50,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by custom stack trace rule (function:runApp -group))
+          frame (ignored by custom stacktrace rule (function:runApp -group))
             filename*
               "app.js"
             function*
@@ -64,7 +64,7 @@ system:
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -9,21 +9,21 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
-          frame (marked out of app by custom stack trace rule (function:runApp -app))
+          frame (marked out of app by custom stacktrace rule (function:runApp -app))
             filename*
               "app.js"
             function*
               "runApp"
             context_line*
               "return server.serve(port);"
-          frame (marked out of app by custom stack trace rule (function:handleRequest -app))
+          frame (marked out of app by custom stacktrace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
@@ -43,7 +43,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by custom stack trace rule (function:runApp -group))
+          frame (ignored by custom stacktrace rule (function:runApp -group))
             filename*
               "app.js"
             function*
@@ -57,7 +57,7 @@ system:
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "main"
           frame (marked out of app by the client)
@@ -97,67 +97,67 @@ system:
     system (ignored because app exception takes precedence)
       threads (ignored because app exception takes precedence)
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__eventFetcherSourceCallback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__processEventQueue"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplicationAccessibility sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIWindow sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIWindow _sendTouchesForEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl touchesEnded:withEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl _sendActionsForEvents:withEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:__*[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:__*[[]Sentry* -group))
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -38,19 +38,19 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -app))
+        frame (marked out of app by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -app))
           filename*
             "async_patch.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -group))
+        frame (ignored by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -group))
           filename*
             "async_patch.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (family:javascript module:**/packages/flutter/** -app))
+        frame (marked out of app by built-in stacktrace rule (family:javascript module:**/packages/flutter/** -app))
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -8,37 +8,37 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_logging/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_logging/** -app))
           filename*
             "sentry_logging.dart"
           function*
             "SentryLogging.log"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_dio/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_dio/** -app))
           filename*
             "sentry_dio.dart"
           function*
             "SentryDio.dio"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_file/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_file/** -app))
           filename*
             "sentry_file.dart"
           function*
             "SentryFile.file"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_hive/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_hive/** -app))
           filename*
             "sentry_hive.dart"
           function*
             "SentryHive.hive"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_isar/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_isar/** -app))
           filename*
             "sentry_isar.dart"
           function*
             "SentryIsar.isar"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_sqflite/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_sqflite/** -app))
           filename*
             "sentry_sqflite.dart"
           function*
             "SentrySqflite.sqflite"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_drift/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_drift/** -app))
           filename*
             "sentry_drift.dart"
           function*
@@ -54,37 +54,37 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry_logging/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_logging/** -group))
           filename*
             "sentry_logging.dart"
           function*
             "SentryLogging.log"
-        frame (ignored by built-in stack trace rule (path:package:sentry_dio/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_dio/** -group))
           filename*
             "sentry_dio.dart"
           function*
             "SentryDio.dio"
-        frame (ignored by built-in stack trace rule (path:package:sentry_file/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_file/** -group))
           filename*
             "sentry_file.dart"
           function*
             "SentryFile.file"
-        frame (ignored by built-in stack trace rule (path:package:sentry_hive/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_hive/** -group))
           filename*
             "sentry_hive.dart"
           function*
             "SentryHive.hive"
-        frame (ignored by built-in stack trace rule (path:package:sentry_isar/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_isar/** -group))
           filename*
             "sentry_isar.dart"
           function*
             "SentryIsar.isar"
-        frame (ignored by built-in stack trace rule (path:package:sentry_sqflite/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_sqflite/** -group))
           filename*
             "sentry_sqflite.dart"
           function*
             "SentrySqflite.sqflite"
-        frame (ignored by built-in stack trace rule (path:package:sentry_drift/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_drift/** -group))
           filename*
             "sentry_drift.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry/** -app))
           filename*
             "sentry_exception_factory.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry/** -group))
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_flutter/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_flutter/** -app))
           filename*
             "sentry_exception_factory.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry_flutter/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_flutter/** -group))
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -8,12 +8,12 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"
           function*
             "invoke"
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed reflection marker)
             "jdk.internal.reflect.GeneratedMethodAccessor"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (path:**/go/pkg/mod/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/go/pkg/mod/** -app))
             module*
               "github.com/robfig/cron/v3"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -9,10 +9,10 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -51,32 +51,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "type_traits"
             function*
@@ -119,22 +119,22 @@ app:
           frame (non app frame)
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dyld::link"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoader::link"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoader::recursiveRebase"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoaderMachOCompressed::rebase"
         type (ignored because exception is synthetic)
@@ -150,7 +150,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -192,37 +192,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -251,31 +251,31 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFBundleGetFunctionPointerForName"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_CFBundleLoadExecutableAndReturnError"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_CFBundleDlfcnLoadBundle"
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dyld::link"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::link"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::recursiveRebase"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachOCompressed::rebase"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -21,7 +21,7 @@ app:
           frame (non app frame)
             function*
               "TppWorkpExecuteCallback"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
           frame (non app frame)
@@ -94,37 +94,37 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkpExecuteCallback"
           frame*
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "WEBIO_REQUEST::OnIoComplete"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_USER_REQUEST::OnSendRequest"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_BASE_OBJECT::Dereference"
           frame*
             function*
               "destructor'"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "HTTP_USER_REQUEST::~HTTP_USER_REQUEST"
           frame*
@@ -133,37 +133,37 @@ system:
           frame*
             function*
               "RtlFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "memset"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeUserBlock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeUserBlockToHeap"
           frame*
             function*
               "RtlFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeHeapInternal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlEnterCriticalSection"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpEnterCriticalSectionContended"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpWaitOnCriticalSection"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpWaitOnAddress"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -9,22 +9,22 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -110,22 +110,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_root_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -134,7 +134,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -148,7 +148,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -195,7 +195,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -14,10 +14,10 @@ app:
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -80,13 +80,13 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -102,18 +102,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
@@ -121,7 +121,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -129,7 +129,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -149,37 +149,37 @@ system:
           frame*
             function*
               "glDeleteTextures_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleUnbindDeleteHashNamesAndObjects"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleUnbindTextureObject"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldUpdateDispatch"
           frame (ignored due to recursion)
             function*
               "gldUpdateDispatch"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
           frame*
             function*
               "gldCreateDevice"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -9,16 +9,16 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -47,47 +47,47 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "utility"
             function*
@@ -116,28 +116,28 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::__1::thread::~thread"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "default_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value* (stripped event-specific values)
@@ -152,10 +152,10 @@ system:
       exception*
         stacktrace*
           frame
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
           frame
@@ -167,7 +167,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -178,7 +178,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -189,17 +189,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -209,7 +209,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -219,17 +219,17 @@ system:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -258,25 +258,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::__1::thread::~thread"
           frame*
             function*
               "std::terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "std::__terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "default_terminate_handler"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort_message"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__abort"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -9,22 +9,22 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -58,52 +58,52 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "utility"
             function*
@@ -132,25 +132,25 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "demangling_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -166,22 +166,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_root_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -190,7 +190,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -204,7 +204,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -215,17 +215,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -235,7 +235,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -250,17 +250,17 @@ system:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -292,22 +292,22 @@ system:
           frame*
             function*
               "std::terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "std::__terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "demangling_terminate_handler"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort_message"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -12,10 +12,10 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -54,7 +54,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__dynamic_cast"
         type (ignored because exception is synthetic)
@@ -70,13 +70,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -115,7 +115,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "__dynamic_cast"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -12,9 +12,9 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -51,7 +51,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value*
@@ -65,7 +65,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -9,10 +9,10 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -51,32 +51,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "type_traits"
             function*
@@ -122,19 +122,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -158,32 +158,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -199,7 +199,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -241,37 +241,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -312,19 +312,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -351,7 +351,7 @@ system:
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "dlopen_internal"
           frame
@@ -361,19 +361,19 @@ system:
           frame (ignored due to recursion)
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__report_load"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "__report_load.cold.1"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -9,7 +9,7 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -48,32 +48,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "type_traits"
             function*
@@ -119,19 +119,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -155,40 +155,40 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "dyld::runInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoader::runInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoader::processInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -204,7 +204,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -243,37 +243,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -314,19 +314,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -353,37 +353,37 @@ system:
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dyld::runInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::runInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::processInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__report_load"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -9,7 +9,7 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -30,7 +30,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (non app frame)
@@ -69,7 +69,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (non app frame)
@@ -111,13 +111,13 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_sigtramp"
           frame (non app frame)
@@ -183,10 +183,10 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -202,7 +202,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -226,37 +226,37 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -265,55 +265,55 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "-[NSOpenGLContext flushBuffer]"
           frame*
             function*
               "CGLFlushDrawable"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "glSwap_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldPresentFramebufferData"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "SwapFlush"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
           frame*
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "_sigtramp"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -322,64 +322,64 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "_NSTryRunModal"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -12,13 +12,13 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_body"
           frame (non app frame)
@@ -36,7 +36,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_testcancel"
         type (ignored because exception is synthetic)
@@ -52,16 +52,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_body"
           frame*
@@ -79,7 +79,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_pthread_testcancel"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -136,16 +136,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -157,7 +157,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -168,7 +168,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -179,7 +179,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -190,7 +190,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -198,7 +198,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -242,10 +242,10 @@ system:
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -49,12 +49,12 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xtree"
             function*
@@ -136,16 +136,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -157,7 +157,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -168,7 +168,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -176,12 +176,12 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xtree"
             function*
@@ -198,7 +198,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -242,10 +242,10 @@ system:
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -28,22 +28,22 @@ app:
               "winmain.cpp"
             function*
               "wWinMain"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xstring"
             function*
@@ -66,7 +66,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
@@ -74,7 +74,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
           frame (non app frame)
@@ -157,21 +157,21 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "winmain.cpp"
             function*
@@ -181,7 +181,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -191,7 +191,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -214,7 +214,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
@@ -225,7 +225,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -246,7 +246,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -254,7 +254,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -262,7 +262,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -276,18 +276,18 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "purevirt.cpp"
             function*
               "_purecall"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "abort"
           frame*
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -12,7 +12,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
@@ -88,7 +88,7 @@ app:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -113,7 +113,7 @@ app:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -156,54 +156,54 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoObservers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Transaction::observer_callback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Layer::layout_and_display_if_needed"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Layer::layout_if_needed"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[CALayer layoutSublayers]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
           frame*
@@ -214,10 +214,10 @@ system:
           frame*
             function*
               "-[UITableView layoutSubviews]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UITableView _updateVisibleCellsNow:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
           frame*
@@ -235,7 +235,7 @@ system:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -260,7 +260,7 @@ system:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -288,7 +288,7 @@ app:
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (marked out of app by built-in stack trace rule (category:framework -app))
+            frame (marked out of app by built-in stacktrace rule (category:framework -app))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -409,7 +409,7 @@ system:
       chained_exception*
         exception*
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -576,7 +576,7 @@ system:
             "Address already in use"
         exception*
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -687,7 +687,7 @@ system:
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -416,28 +416,28 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.Thread"
             filename (ignored because module takes precedence)
               "thread.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (ignored because module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (ignored because module takes precedence)
@@ -766,7 +766,7 @@ system:
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
@@ -794,7 +794,7 @@ system:
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+          frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
             module*
               "io.sentry.example.Application"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -9,17 +9,17 @@ app:
     app*
       exception*
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (module:@babel/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:@babel/** -app))
             module*
               "@babel/runtime/helpers/asyncToGenerator"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (marked out of app by built-in stack trace rule (module:core-js/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:core-js/** -app))
             module*
               "core-js/internals/task"
             function*
               "listener"
-          frame (marked out of app by built-in stack trace rule (module:tslib/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:tslib/** -app))
             module*
               "tslib/tslib.es6"
             function* (trimmed javascript function)
@@ -37,17 +37,17 @@ system:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by built-in stack trace rule (module:@babel/** -group))
+          frame (ignored by built-in stacktrace rule (module:@babel/** -group))
             module*
               "@babel/runtime/helpers/asyncToGenerator"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (ignored by built-in stack trace rule (module:core-js/** -group))
+          frame (ignored by built-in stacktrace rule (module:core-js/** -group))
             module*
               "core-js/internals/task"
             function*
               "listener"
-          frame (ignored by built-in stack trace rule (module:tslib/** -group))
+          frame (ignored by built-in stacktrace rule (module:tslib/** -group))
             module*
               "tslib/tslib.es6"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -9,24 +9,24 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (path:**https://unpkg.com/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://unpkg.com/** -app))
             module*
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "unpkg"
-          frame (marked out of app by built-in stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://cdnjs.cloudflare.com/** -app))
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "cdnjs"
-          frame (marked out of app by built-in stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://cdn.jsdelivr.net/** -app))
             filename (ignored because frame points to a URL)
               "jquery.min.js"
             function*
               "jsdelivr"
-          frame (marked out of app by built-in stack trace rule (path:**https://esm.run/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://esm.run/** -app))
             filename (ignored because frame points to a URL)
               "d3@7.6.1"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -9,7 +9,7 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -51,7 +51,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
           frame (non app frame)
@@ -146,10 +146,10 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -165,7 +165,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -210,19 +210,19 @@ system:
           frame*
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
           frame*
@@ -285,27 +285,27 @@ system:
           frame*
             function*
               "glTexSubImage2D"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "glTexSubImage2D_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleTextureImagePut"
           frame
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
           frame
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -9,10 +9,10 @@ app:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (non app frame)
@@ -62,7 +62,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (non app frame)
@@ -104,11 +104,11 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (non app frame)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_sigtramp"
           frame (non app frame)
@@ -174,10 +174,10 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)
@@ -193,7 +193,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -220,19 +220,19 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
           frame
@@ -240,7 +240,7 @@ system:
           frame (ignored due to recursion)
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -249,7 +249,7 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
@@ -261,41 +261,41 @@ system:
           frame*
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
           frame*
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
           frame*
             function*
               "abort"
           frame
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "_sigtramp"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -304,64 +304,64 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "_NSTryRunModal"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -106,7 +106,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -169,7 +169,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
           frame*
@@ -178,16 +178,16 @@ system:
           frame*
             function*
               "malloc_report"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "malloc_vreport"
           frame*
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "pthread_kill"
-          frame (ignored by built-in stack trace rule (category:throw ^-group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -37,7 +37,7 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -50,13 +50,13 @@ system:
           frame*
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter10"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -39,13 +39,13 @@ system:
           frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter10"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -51,14 +51,14 @@ system:
           frame*
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
           frame
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter12"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -31,13 +31,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored because only 1 frame is considered by custom stack trace rule (family:native max-frames=1))
+          frame (ignored because only 1 frame is considered by custom stacktrace rule (family:native max-frames=1))
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -46,16 +46,16 @@ system:
           frame*
             function*
               "malloc_zone_malloc"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_malloc"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_allocate"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_allocate_from_block"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "nanov2_allocate_from_block.cold.1"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -70,7 +70,7 @@ system:
           frame*
             function*
               "std::rt::lang_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start_internal"
           frame*
@@ -79,7 +79,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -37,7 +37,7 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -47,12 +47,12 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -9,14 +9,14 @@ app:
     app*
       exception*
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (function:processTicksAndRejections -app))
+          frame (marked out of app by built-in stacktrace rule (function:processTicksAndRejections -app))
             module*
               "task_queues"
             filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"
-          frame (marked out of app by built-in stack trace rule (function:runMicrotasks -app))
+          frame (marked out of app by built-in stacktrace rule (function:runMicrotasks -app))
             filename*
               "axiosinterceptor.js"
             function*
@@ -34,14 +34,14 @@ system:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by built-in stack trace rule (function:processTicksAndRejections -group))
+          frame (ignored by built-in stacktrace rule (function:processTicksAndRejections -group))
             module*
               "task_queues"
             filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"
-          frame (ignored by built-in stack trace rule (function:runMicrotasks -group))
+          frame (ignored by built-in stacktrace rule (function:runMicrotasks -group))
             filename*
               "axiosinterceptor.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -54,7 +54,7 @@ app:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -112,7 +112,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.core.handlers.base"
             filename (ignored because module takes precedence)
@@ -121,7 +121,7 @@ system:
               "get_response"
             context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)
@@ -130,7 +130,7 @@ system:
               "view"
             context_line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -139,7 +139,7 @@ system:
               "_wrapper"
             context_line*
               "return bound_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.decorators.csrf"
             filename (ignored because module takes precedence)
@@ -148,7 +148,7 @@ system:
               "wrapped_view"
             context_line*
               "return view_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -157,7 +157,7 @@ system:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -166,7 +166,7 @@ system:
               "dispatch"
             context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -54,7 +54,7 @@ app:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -72,7 +72,7 @@ app:
               "dispatch"
             context_line*
               "return handler(request, *args, **kwargs)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -81,7 +81,7 @@ app:
               "post"
             context_line*
               "hook.handle(request)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
             filename (ignored because module takes precedence)
@@ -139,7 +139,7 @@ system:
               "_wrapper"
             context_line*
               "return bound_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.decorators.csrf"
             filename (ignored because module takes precedence)
@@ -148,7 +148,7 @@ system:
               "wrapped_view"
             context_line*
               "return view_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -157,7 +157,7 @@ system:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -166,7 +166,7 @@ system:
               "dispatch"
             context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)
@@ -175,7 +175,7 @@ system:
               "dispatch"
             context_line*
               "return handler(request, *args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -184,7 +184,7 @@ system:
               "post"
             context_line*
               "hook.handle(request)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
             filename (ignored because module takes precedence)
@@ -193,7 +193,7 @@ system:
               "handle"
             context_line*
               "email = request.POST['user']"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.datastructures"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -18,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -27,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -36,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -45,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -54,7 +54,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -63,7 +63,7 @@ app:
               "child_process"
             context_line*
               "run_worker("
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -72,7 +72,7 @@ app:
               "run_worker"
             context_line*
               "_execute_activation(task_func, inflight.activation)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -81,7 +81,7 @@ app:
               "_execute_activation"
             context_line*
               "task_func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.task"
             filename (ignored because module takes precedence)
@@ -90,7 +90,7 @@ app:
               "__call__"
             context_line*
               "return self._func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.tasks.post_process"
             filename (ignored because module takes precedence)
@@ -162,7 +162,7 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "connect"
             context_line*
               "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "_connect"
             context_line*
               "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -18,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -27,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -36,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -45,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -54,7 +54,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn._subprocess"
             filename (ignored because module takes precedence)
@@ -63,7 +63,7 @@ app:
               "subprocess_started"
             context_line*
               "target(sockets=sockets)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.server"
             filename (ignored because module takes precedence)
@@ -72,7 +72,7 @@ app:
               "run"
             context_line*
               "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -81,7 +81,7 @@ app:
               "run"
             context_line*
               "return runner.run(main)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -90,7 +90,7 @@ app:
               "run"
             context_line*
               "return self._loop.run_until_complete(task)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -99,7 +99,7 @@ app:
               "run_until_complete"
             context_line*
               "self.run_forever()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -108,7 +108,7 @@ app:
               "run_forever"
             context_line*
               "self._run_once()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -117,7 +117,7 @@ app:
               "_run_once"
             context_line*
               "handle._run()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.events"
             filename (ignored because module takes precedence)
@@ -126,7 +126,7 @@ app:
               "_run"
             context_line*
               "self._context.run(self._callback, *self._args)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.lifespan.on"
             filename (ignored because module takes precedence)
@@ -135,7 +135,7 @@ app:
               "main"
             context_line*
               "await app(scope, self.receive, self.send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.middleware.proxy_headers"
             filename (ignored because module takes precedence)
@@ -144,7 +144,7 @@ app:
               "__call__"
             context_line*
               "return await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.applications"
             filename (ignored because module takes precedence)
@@ -153,7 +153,7 @@ app:
               "__call__"
             context_line*
               "await super().__call__(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.applications"
             filename (ignored because module takes precedence)
@@ -162,7 +162,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.errors"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.base"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.cors"
             filename (ignored because module takes precedence)
@@ -189,7 +189,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.exceptions"
             filename (ignored because module takes precedence)
@@ -198,7 +198,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.middleware.asyncexitstack"
             filename (ignored because module takes precedence)
@@ -207,7 +207,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -216,7 +216,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -225,7 +225,7 @@ app:
               "app"
             context_line*
               "await self.lifespan(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -234,7 +234,7 @@ app:
               "lifespan"
             context_line*
               "async with self.lifespan_context(app) as maybe_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -243,7 +243,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -252,7 +252,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -261,7 +261,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -270,7 +270,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -279,7 +279,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -288,7 +288,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -297,7 +297,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -306,7 +306,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "app.main"
             filename (ignored because module takes precedence)
@@ -459,7 +459,7 @@ system:
               "run"
             context_line*
               "return runner.run(main)"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -621,7 +621,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -630,7 +630,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -639,7 +639,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -648,7 +648,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -657,7 +657,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -666,7 +666,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -675,7 +675,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -162,7 +162,7 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "connect"
             context_line*
               "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "_connect"
             context_line*
               "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -54,7 +54,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn._subprocess"
             filename (ignored because module takes precedence)
@@ -63,7 +63,7 @@ app:
               "subprocess_started"
             context_line*
               "target(sockets=sockets)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.server"
             filename (ignored because module takes precedence)
@@ -126,7 +126,7 @@ app:
               "_run"
             context_line*
               "self._context.run(self._callback, *self._args)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.lifespan.on"
             filename (ignored because module takes precedence)
@@ -135,7 +135,7 @@ app:
               "main"
             context_line*
               "await app(scope, self.receive, self.send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.middleware.proxy_headers"
             filename (ignored because module takes precedence)
@@ -144,7 +144,7 @@ app:
               "__call__"
             context_line*
               "return await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.applications"
             filename (ignored because module takes precedence)
@@ -153,7 +153,7 @@ app:
               "__call__"
             context_line*
               "await super().__call__(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.applications"
             filename (ignored because module takes precedence)
@@ -162,7 +162,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.errors"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.base"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.cors"
             filename (ignored because module takes precedence)
@@ -189,7 +189,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.exceptions"
             filename (ignored because module takes precedence)
@@ -198,7 +198,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.middleware.asyncexitstack"
             filename (ignored because module takes precedence)
@@ -207,7 +207,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -216,7 +216,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -225,7 +225,7 @@ app:
               "app"
             context_line*
               "await self.lifespan(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -234,7 +234,7 @@ app:
               "lifespan"
             context_line*
               "async with self.lifespan_context(app) as maybe_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -243,7 +243,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -252,7 +252,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -261,7 +261,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -270,7 +270,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -279,7 +279,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -288,7 +288,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -297,7 +297,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -8,23 +8,23 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2))
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by custom stacktrace rule (family:native min-frames=2))
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -55,7 +55,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -12,16 +12,16 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame (non app frame)
@@ -43,25 +43,25 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -12,19 +12,19 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -55,7 +55,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -12,19 +12,19 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -49,19 +49,19 @@ system:
           frame*
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by custom stack trace rule (family:native function:__* -group))
+          frame (ignored by custom stacktrace rule (family:native function:__* -group))
             function*
               "___rust_maybe_catch_panic"
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by custom stack trace rule (family:native function:*::__* -group))
+          frame (ignored by custom stacktrace rule (family:native function:*::__* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -9,100 +9,100 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FGenericPlatformMisc::RaiseException"
         type*
@@ -118,10 +118,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -184,7 +184,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -9,72 +9,72 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "__start_thread"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "android_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "AndroidMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UGameEngine::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UWorld::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "AActor::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "tgkill"
         type (ignored because exception is synthetic)
@@ -90,10 +90,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__start_thread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -9,143 +9,143 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "WinMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::AssertFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "RaiseException"
         type (ignored because exception is synthetic)
@@ -161,18 +161,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -198,7 +198,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -225,7 +225,7 @@ system:
           frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame*
@@ -258,7 +258,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -9,127 +9,127 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
         type*
@@ -138,127 +138,127 @@ app:
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -270,13 +270,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -339,7 +339,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -369,28 +369,28 @@ system:
           frame
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
         type*
@@ -399,13 +399,13 @@ system:
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -468,7 +468,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -498,27 +498,27 @@ system:
           frame
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -9,172 +9,172 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "WinMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "CheckVerifyImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_value_set_stacktrace"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_value_new_stacktrace"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_unwind_stack_from_ucontext"
         type*
@@ -190,18 +190,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -227,7 +227,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -254,7 +254,7 @@ system:
           frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame*
@@ -287,7 +287,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame*
@@ -339,7 +339,7 @@ system:
               "invoke.h"
             function*
               "Invoke"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "sentrysubsystem.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -9,127 +9,127 @@ app:
     app*
       threads*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -150,13 +150,13 @@ system:
     system*
       threads*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -219,7 +219,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -252,24 +252,24 @@ system:
           frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/actix.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
         stacktrace*
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame* (marked in-app by the client)
@@ -24,7 +24,7 @@ app:
               "thread.rs"
             function*
               "std::sys::unix::thread::Thread::new::thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:alloc::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:alloc::* -app))
             filename*
               "boxed.rs"
             function*
@@ -407,7 +407,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*
@@ -428,12 +428,12 @@ system:
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::catch_unwind"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panicking.rs"
             function*
@@ -448,17 +448,17 @@ system:
               "panicking.rs"
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::AssertUnwindSafe<T>::call_once"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "backtrace.rs"
             function*
@@ -488,7 +488,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -513,7 +513,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -538,7 +538,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -563,7 +563,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -608,7 +608,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -773,7 +773,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "local.rs"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/android_anr.pysnap
@@ -798,693 +798,693 @@ system:
         value (ignored because stacktrace takes precedence)
           "Application Not Responding for at least <int> ms."
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit"
             filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
             filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.app.ActivityThread"
             filename (ignored because module takes precedence)
               "activitythread.java"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Looper"
             filename (ignored because module takes precedence)
               "looper.java"
             function*
               "loop"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (ignored because module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (ignored because module takes precedence)
               "handler.java"
             function*
               "handleCallback"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$CallbackRecord"
             filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (ignored because module takes precedence)
@@ -1498,56 +1498,56 @@ system:
               "sourcefile"
             function*
               "onLayout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.AdapterHelper"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.ChildHelper"
             filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
             filename (ignored because module takes precedence)
@@ -1563,7 +1563,7 @@ system:
               "thread.java"
             function*
               "getStackTrace"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "dalvik.system.VMStack"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/block_invoke.pysnap
@@ -39,9 +39,9 @@ system:
           frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__99+[Something else]_block_invoke_2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/callee_guaranteed.pysnap
@@ -19,7 +19,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame (marked out of app by the client)
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             function*
               "_dispatch_call_block_and_release"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -63,12 +63,12 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -76,7 +76,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -87,27 +87,27 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -143,40 +143,40 @@ system:
           code*
             2
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_main_queue_callback_4CF"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_call_block_and_release"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -190,7 +190,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -203,7 +203,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -214,7 +214,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/cocoa_dispatch_client_callout.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
           frame (marked out of app by the client)
@@ -36,13 +36,13 @@ app:
           frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "FudgeLogTaggedError"
           frame (marked out of app by the client)
             function*
               "closure"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by built-in stacktrace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
           frame (marked out of app by the client)
@@ -78,22 +78,22 @@ system:
           frame*
             function*
               "UIApplicationMain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_main_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_block_async_invoke2"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "-[NSBlockOperation main]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
           frame*
@@ -102,18 +102,18 @@ system:
           frame*
             function*
               "FudgeLogTaggedError"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"
           frame*
             function*
               "SentrySetupInteractor.setupSentry"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_lane_barrier_sync_invoke_and_complete"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "closure"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/contributing_system_and_app_frames.pysnap
@@ -13,28 +13,28 @@ app:
         value (ignored because stacktrace takes precedence)
           "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
-          frame (marked out of app by custom stack trace rule (function:runApp -app))
+          frame (marked out of app by custom stacktrace rule (function:runApp -app))
             filename*
               "app.js"
             function*
               "runApp"
             context_line*
               "return server.serve(port);"
-          frame (marked out of app by custom stack trace rule (function:handleRequest -app))
+          frame (marked out of app by custom stacktrace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
             context_line*
               "return withMetrics(handler, metricName, tags);"
-          frame* (marked in-app by custom stack trace rule (function:playFetch +app))
+          frame* (marked in-app by custom stacktrace rule (function:playFetch +app))
             filename*
               "dogpark.js"
             function*
@@ -54,7 +54,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
-          frame (ignored by custom stack trace rule (function:runApp -group))
+          frame (ignored by custom stacktrace rule (function:runApp -group))
             filename*
               "app.js"
             function*
@@ -68,7 +68,7 @@ system:
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/contributing_system_frames.pysnap
@@ -13,21 +13,21 @@ app:
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace (ignored because it contains no contributing frames)
-          frame (marked out of app by custom stack trace rule (function:runApp -app))
+          frame (marked out of app by custom stacktrace rule (function:runApp -app))
             filename*
               "app.js"
             function*
               "runApp"
             context_line*
               "return server.serve(port);"
-          frame (marked out of app by custom stack trace rule (function:handleRequest -app))
+          frame (marked out of app by custom stacktrace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (marked in-app by custom stack trace rule (function:recordMetrics +app) but ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (marked in-app by custom stacktrace rule (function:recordMetrics +app) but ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
@@ -47,7 +47,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
-          frame (ignored by custom stack trace rule (function:runApp -group))
+          frame (ignored by custom stacktrace rule (function:runApp -group))
             filename*
               "app.js"
             function*
@@ -61,7 +61,7 @@ system:
               "handleRequest"
             context_line*
               "return handler(request);"
-          frame (ignored by custom stack trace rule (function:recordMetrics -group))
+          frame (ignored by custom stacktrace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/exception_cocoa_nserror.pysnap
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "main"
           frame (marked out of app by the client)
@@ -97,67 +97,67 @@ system:
     system (ignored because app exception takes precedence)
       threads (ignored because app exception takes precedence)
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__eventFetcherSourceCallback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__processEventQueue"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplicationAccessibility sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIWindow sendEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIWindow _sendTouchesForEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl touchesEnded:withEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl _sendActionsForEvents:withEvent:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:__*[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:__*[[]Sentry* -group))
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/fallback_prefix_level_1.pysnap
@@ -40,19 +40,19 @@ system:
         type*
           "EXC_BAD_ACCESS"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_dartlang_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -app))
+        frame (marked out of app by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -app))
           filename*
             "async_patch.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (family:javascript path:org-dartlang-sdk:///** -group))
+        frame (ignored by built-in stacktrace rule (family:javascript path:org-dartlang-sdk:///** -group))
           filename*
             "async_patch.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_flutter_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (family:javascript module:**/packages/flutter/** -app))
+        frame (marked out of app by built-in stacktrace rule (family:javascript module:**/packages/flutter/** -app))
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_dart_packages.pysnap
@@ -8,37 +8,37 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_logging/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_logging/** -app))
           filename*
             "sentry_logging.dart"
           function*
             "SentryLogging.log"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_dio/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_dio/** -app))
           filename*
             "sentry_dio.dart"
           function*
             "SentryDio.dio"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_file/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_file/** -app))
           filename*
             "sentry_file.dart"
           function*
             "SentryFile.file"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_hive/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_hive/** -app))
           filename*
             "sentry_hive.dart"
           function*
             "SentryHive.hive"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_isar/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_isar/** -app))
           filename*
             "sentry_isar.dart"
           function*
             "SentryIsar.isar"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_sqflite/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_sqflite/** -app))
           filename*
             "sentry_sqflite.dart"
           function*
             "SentrySqflite.sqflite"
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_drift/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_drift/** -app))
           filename*
             "sentry_drift.dart"
           function*
@@ -54,37 +54,37 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry_logging/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_logging/** -group))
           filename*
             "sentry_logging.dart"
           function*
             "SentryLogging.log"
-        frame (ignored by built-in stack trace rule (path:package:sentry_dio/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_dio/** -group))
           filename*
             "sentry_dio.dart"
           function*
             "SentryDio.dio"
-        frame (ignored by built-in stack trace rule (path:package:sentry_file/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_file/** -group))
           filename*
             "sentry_file.dart"
           function*
             "SentryFile.file"
-        frame (ignored by built-in stack trace rule (path:package:sentry_hive/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_hive/** -group))
           filename*
             "sentry_hive.dart"
           function*
             "SentryHive.hive"
-        frame (ignored by built-in stack trace rule (path:package:sentry_isar/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_isar/** -group))
           filename*
             "sentry_isar.dart"
           function*
             "SentryIsar.isar"
-        frame (ignored by built-in stack trace rule (path:package:sentry_sqflite/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_sqflite/** -group))
           filename*
             "sentry_sqflite.dart"
           function*
             "SentrySqflite.sqflite"
-        frame (ignored by built-in stack trace rule (path:package:sentry_drift/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_drift/** -group))
           filename*
             "sentry_drift.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_dart_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry/** -app))
           filename*
             "sentry_exception_factory.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry/** -group))
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sentry_flutter_sdk.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (path:package:sentry_flutter/** -app))
+        frame (marked out of app by built-in stacktrace rule (path:package:sentry_flutter/** -app))
           filename*
             "sentry_exception_factory.dart"
           function*
@@ -24,7 +24,7 @@ system:
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
-        frame (ignored by built-in stack trace rule (path:package:sentry_flutter/** -group))
+        frame (ignored by built-in stacktrace rule (path:package:sentry_flutter/** -group))
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/frame_ignores_sun_java_generated_methods.pysnap
@@ -8,12 +8,12 @@ app:
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"
           function*
             "invoke"
-        frame (marked out of app by built-in stack trace rule (category:framework -app))
+        frame (marked out of app by built-in stacktrace rule (category:framework -app))
           module* (removed reflection marker)
             "jdk.internal.reflect.GeneratedMethodAccessor"
           function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/go_pkg_mod.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "pq: cannot cast jsonb null to type integer"
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (path:**/go/pkg/mod/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/go/pkg/mod/** -app))
             module*
               "github.com/robfig/cron/v3"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_125_event_126.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: EXC_BAD_ACCESS / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -55,32 +55,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -117,28 +117,28 @@ app:
           frame (non app frame)
             function*
               "CFBundleGetFunctionPointerForName"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_CFBundleLoadExecutableAndReturnError"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "dyld::link"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoader::link"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoader::recursiveRebase"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoaderMachOCompressed::rebase"
 --------------------------------------------------------------------------
@@ -154,7 +154,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXC_BAD_ACCESS / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -196,37 +196,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -255,30 +255,30 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFBundleGetFunctionPointerForName"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_CFBundleLoadExecutableAndReturnError"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_CFBundleDlfcnLoadBundle"
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dyld::link"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::link"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::recursiveRebase"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachOCompressed::rebase"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_200_event_200.pysnap
@@ -25,19 +25,19 @@ app:
           frame (non app frame)
             function*
               "TppWorkpExecuteCallback"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "WEBIO_REQUEST::OnIoComplete"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "HTTP_USER_REQUEST::OnSendRequest"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "HTTP_BASE_OBJECT::Dereference"
           frame (non app frame)
@@ -52,37 +52,37 @@ app:
           frame (non app frame)
             function*
               "RtlFreeHeap"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "memset"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpFreeUserBlock"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpFreeUserBlockToHeap"
           frame (non app frame)
             function*
               "RtlFreeHeap"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpFreeHeapInternal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpFreeHeap"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlEnterCriticalSection"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpEnterCriticalSectionContended"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpWaitOnCriticalSection"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpWaitOnAddress"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
 --------------------------------------------------------------------------
@@ -98,37 +98,37 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkpExecuteCallback"
           frame*
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "WEBIO_REQUEST::OnIoComplete"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_USER_REQUEST::OnSendRequest"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "HTTP_BASE_OBJECT::Dereference"
           frame*
             function*
               "destructor'"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "HTTP_USER_REQUEST::~HTTP_USER_REQUEST"
           frame*
@@ -137,36 +137,36 @@ system:
           frame*
             function*
               "RtlFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "memset"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeUserBlock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeUserBlockToHeap"
           frame*
             function*
               "RtlFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeHeapInternal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpFreeHeap"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlEnterCriticalSection"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpEnterCriticalSectionContended"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpWaitOnCriticalSection"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpWaitOnAddress"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_275_event_275.pysnap
@@ -13,22 +13,22 @@ app:
         value*
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -98,7 +98,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
 --------------------------------------------------------------------------
@@ -114,22 +114,22 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_root_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -138,7 +138,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -152,7 +152,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -199,6 +199,6 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_289_event_312.pysnap
@@ -18,10 +18,10 @@ app:
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -60,37 +60,37 @@ app:
           frame (non app frame)
             function*
               "glDeleteTextures_Exec"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gleUnbindDeleteHashNamesAndObjects"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gleUnbindTextureObject"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldUpdateDispatch"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldUpdateDispatch"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
             function*
               "gldCreateDevice"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -106,18 +106,18 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
@@ -125,7 +125,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -133,7 +133,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -153,36 +153,36 @@ system:
           frame*
             function*
               "glDeleteTextures_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleUnbindDeleteHashNamesAndObjects"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleUnbindTextureObject"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldUpdateDispatch"
           frame (ignored due to recursion)
             function*
               "gldUpdateDispatch"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
           frame*
             function*
               "gldCreateDevice"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_294_event_294.pysnap
@@ -13,16 +13,16 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -51,47 +51,47 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "utility"
             function*
@@ -120,28 +120,28 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::__1::thread::~thread"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "default_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "abort_message"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
 --------------------------------------------------------------------------
 system:
   hash: "12f18dcb1efe33b32c7afe5004addaaa"
@@ -156,10 +156,10 @@ system:
           "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
           frame
@@ -171,7 +171,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -182,7 +182,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -193,17 +193,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -213,7 +213,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -223,17 +223,17 @@ system:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -262,25 +262,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::__1::thread::~thread"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "std::terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "std::__terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "default_terminate_handler"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort_message"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__abort"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_294_event_329.pysnap
@@ -13,22 +13,22 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -62,52 +62,52 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "utility"
             function*
@@ -136,25 +136,25 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "demangling_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "abort_message"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -170,22 +170,22 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_root_queue_drain"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -194,7 +194,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -208,7 +208,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -219,17 +219,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -239,7 +239,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -254,17 +254,17 @@ system:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -293,24 +293,24 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "std::terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "std::__terminate"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "demangling_terminate_handler"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort_message"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_307_event_307.pysnap
@@ -16,10 +16,10 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -58,7 +58,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "__dynamic_cast"
 --------------------------------------------------------------------------
@@ -74,13 +74,13 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -119,6 +119,6 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "__dynamic_cast"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_307_event_657.pysnap
@@ -16,9 +16,9 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -55,7 +55,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
@@ -69,7 +69,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_313_event_313.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -55,32 +55,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -126,19 +126,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -162,32 +162,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__report_load"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "__report_load.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -203,7 +203,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -245,37 +245,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -316,19 +316,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -355,7 +355,7 @@ system:
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "dlopen_internal"
           frame
@@ -365,18 +365,18 @@ system:
           frame (ignored due to recursion)
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__report_load"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "__report_load.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_313_event_333.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -52,32 +52,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -123,19 +123,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -159,40 +159,40 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "dyld::runInitializers"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoader::runInitializers"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoader::processInitializers"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__report_load"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -208,7 +208,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -247,37 +247,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -318,19 +318,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -357,36 +357,36 @@ system:
           frame*
             function*
               "dlopen"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "dyld::runInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::runInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::processInitializers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__report_load"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_319_event_321.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -34,49 +34,49 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSApplication run]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_DPSNextEvent"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ReceiveNextEventCommon"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RunCurrentEventLoopInMode"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CFRunLoopRunSpecific"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopRun"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopDoSources0"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopDoSource0"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThreadPerformPerform"
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (non app frame)
@@ -88,109 +88,109 @@ app:
           frame (non app frame)
             function*
               "CGLFlushDrawable"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "glSwap_Exec"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldPresentFramebufferData"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "SwapFlush"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "_sigtramp"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "NSRunAlertPanel"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_NSTryRunModal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Transaction::commit"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Context::commit_transaction"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Layer::display_if_needed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "CGLTexImageIOSurface2D"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -206,7 +206,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -230,37 +230,37 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -269,55 +269,55 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "-[NSOpenGLContext flushBuffer]"
           frame*
             function*
               "CGLFlushDrawable"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "glSwap_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldPresentFramebufferData"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "SwapFlush"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
           frame*
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "_sigtramp"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -326,63 +326,63 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "_NSTryRunModal"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_389_event_389.pysnap
@@ -16,13 +16,13 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_body"
           frame (non app frame)
@@ -40,7 +40,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_pthread_testcancel"
 --------------------------------------------------------------------------
@@ -56,16 +56,16 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_body"
           frame*
@@ -83,6 +83,6 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_pthread_testcancel"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_432_event_432.pysnap
@@ -116,13 +116,13 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*
@@ -140,16 +140,16 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -161,7 +161,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -172,7 +172,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -183,7 +183,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -194,7 +194,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -202,7 +202,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -243,13 +243,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_432_event_453.pysnap
@@ -53,12 +53,12 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "xtree"
             function*
@@ -116,13 +116,13 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*
@@ -140,16 +140,16 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -161,7 +161,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -172,7 +172,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -180,12 +180,12 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xtree"
             function*
@@ -202,7 +202,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -243,13 +243,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/group_445_event_445.pysnap
@@ -32,22 +32,22 @@ app:
               "winmain.cpp"
             function*
               "wWinMain"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "xstring"
             function*
@@ -70,7 +70,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             filename*
               "functional"
             function*
@@ -78,10 +78,10 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
           frame (non app frame)
@@ -137,13 +137,13 @@ app:
               "purevirt.cpp"
             function*
               "_purecall"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*
@@ -161,21 +161,21 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "winmain.cpp"
             function*
@@ -185,7 +185,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -195,7 +195,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -218,7 +218,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "functional"
             function*
@@ -229,7 +229,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -250,7 +250,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -258,7 +258,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -266,7 +266,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -280,18 +280,18 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "purevirt.cpp"
             function*
               "_purecall"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "raise"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/in_app_in_ui.pysnap
@@ -16,7 +16,7 @@ app:
           frame (marked out of app by the client)
             function*
               "start"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by the client but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
@@ -92,7 +92,7 @@ app:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -117,7 +117,7 @@ app:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -160,54 +160,54 @@ system:
         value (ignored because stacktrace takes precedence)
           "autoplayOption"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
               "main"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
           frame*
             function*
               "-[UIApplication _run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoObservers"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Transaction::observer_callback"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Layer::layout_and_display_if_needed"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CA::Layer::layout_if_needed"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[CALayer layoutSublayers]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
           frame*
@@ -218,10 +218,10 @@ system:
           frame*
             function*
               "-[UITableView layoutSubviews]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UITableView _updateVisibleCellsNow:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
           frame*
@@ -239,7 +239,7 @@ system:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -264,7 +264,7 @@ system:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/java_chained.pysnap
@@ -292,7 +292,7 @@ app:
           value* (stripped event-specific values)
             "Failed to start component [Connector[HTTP/<float><int>]]"
           stacktrace (ignored because it contains no in-app frames)
-            frame (marked out of app by built-in stack trace rule (category:framework -app))
+            frame (marked out of app by built-in stacktrace rule (category:framework -app))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -413,7 +413,7 @@ system:
           value (ignored because stacktrace takes precedence)
             "Address already in use"
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -580,7 +580,7 @@ system:
           value (ignored because stacktrace takes precedence)
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)
@@ -691,7 +691,7 @@ system:
           value (ignored because stacktrace takes precedence)
             "Failed to start component [Connector[HTTP/<float><int>]]"
           stacktrace*
-            frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+            frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
               filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/java_minimal.pysnap
@@ -420,28 +420,28 @@ system:
         value (ignored because stacktrace takes precedence)
           "/ by zero"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.lang.Thread"
             filename (ignored because module takes precedence)
               "thread.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (ignored because module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (ignored because module takes precedence)
@@ -770,7 +770,7 @@ system:
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             module*
               "java.lang.reflect.Method"
             filename (ignored because module takes precedence)
@@ -798,7 +798,7 @@ system:
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame (ignored by built-in stack trace rule (module:io.sentry.* -group))
+          frame (ignored by built-in stacktrace rule (module:io.sentry.* -group))
             module*
               "io.sentry.example.Application"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/javascript_polyfills.pysnap
@@ -13,17 +13,17 @@ app:
         value*
           "bad"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (module:@babel/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:@babel/** -app))
             module*
               "@babel/runtime/helpers/asyncToGenerator"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (marked out of app by built-in stack trace rule (module:core-js/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:core-js/** -app))
             module*
               "core-js/internals/task"
             function*
               "listener"
-          frame (marked out of app by built-in stack trace rule (module:tslib/** -app))
+          frame (marked out of app by built-in stacktrace rule (module:tslib/** -app))
             module*
               "tslib/tslib.es6"
             function* (trimmed javascript function)
@@ -41,17 +41,17 @@ system:
         value*
           "bad"
         stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by built-in stack trace rule (module:@babel/** -group))
+          frame (ignored by built-in stacktrace rule (module:@babel/** -group))
             module*
               "@babel/runtime/helpers/asyncToGenerator"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (ignored by built-in stack trace rule (module:core-js/** -group))
+          frame (ignored by built-in stacktrace rule (module:core-js/** -group))
             module*
               "core-js/internals/task"
             function*
               "listener"
-          frame (ignored by built-in stack trace rule (module:tslib/** -group))
+          frame (ignored by built-in stacktrace rule (module:tslib/** -group))
             module*
               "tslib/tslib.es6"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/javascript_unpkg.pysnap
@@ -13,24 +13,24 @@ app:
         value*
           "bad"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (path:**https://unpkg.com/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://unpkg.com/** -app))
             module*
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "unpkg"
-          frame (marked out of app by built-in stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://cdnjs.cloudflare.com/** -app))
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "cdnjs"
-          frame (marked out of app by built-in stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://cdn.jsdelivr.net/** -app))
             filename (ignored because frame points to a URL)
               "jquery.min.js"
             function*
               "jsdelivr"
-          frame (marked out of app by built-in stack trace rule (path:**https://esm.run/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**https://esm.run/** -app))
             filename (ignored because frame points to a URL)
               "d3@7.6.1"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/macos_amd_driver.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -55,22 +55,22 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CFRunLoopRunSpecific"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopRun"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopDoSources0"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRunLoopDoSource0"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
           frame (non app frame)
@@ -133,27 +133,27 @@ app:
           frame (non app frame)
             function*
               "glTexSubImage2D"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "glTexSubImage2D_Exec"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gleTextureImagePut"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -169,7 +169,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -214,19 +214,19 @@ system:
           frame*
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
           frame*
@@ -289,26 +289,26 @@ system:
           frame*
             function*
               "glTexSubImage2D"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "glTexSubImage2D_Exec"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gleTextureImagePut"
           frame
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
           frame
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/macos_intel_driver.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -37,39 +37,39 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSApplication run]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_DPSNextEvent"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "ReceiveNextEventCommon"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "RunCurrentEventLoopInMode"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThreadPerformPerform"
           frame (non app frame)
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (non app frame)
@@ -81,107 +81,107 @@ app:
           frame (non app frame)
             function*
               "CGLTexImageIOSurface2D"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "_sigtramp"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "NSRunAlertPanel"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "_NSTryRunModal"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Transaction::commit"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Context::commit_transaction"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CA::Layer::display_if_needed"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "code"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "CGLTexImageIOSurface2D"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
+          frame (marked out of app by built-in stacktrace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------
@@ -197,7 +197,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (ignored due to recursion)
@@ -224,19 +224,19 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
           frame
@@ -244,7 +244,7 @@ system:
           frame (ignored due to recursion)
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -253,7 +253,7 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
@@ -265,41 +265,41 @@ system:
           frame*
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
           frame*
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:telemetry -group))
+          frame (ignored by built-in stacktrace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
           frame
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "_sigtramp"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -308,63 +308,63 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "_NSTryRunModal"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gliSetInteger"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gldFlushObject"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/malloc_sentinel.pysnap
@@ -110,7 +110,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "<redacted>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -173,7 +173,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
           frame*
@@ -182,15 +182,15 @@ system:
           frame*
             function*
               "malloc_report"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "malloc_vreport"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "abort"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "pthread_kill"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_complex_function_names.pysnap
@@ -41,6 +41,6 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash1.pysnap
@@ -54,13 +54,13 @@ system:
           frame*
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter10"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash2.pysnap
@@ -43,13 +43,13 @@ system:
           frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter10"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_driver_crash3.pysnap
@@ -55,14 +55,14 @@ system:
           frame*
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
           frame
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "OpenAdapter12"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_limit_frames.pysnap
@@ -35,12 +35,12 @@ system:
         value (ignored because stacktrace takes precedence)
           "Holy shit everything is on fire!"
         stacktrace*
-          frame (ignored because only 1 frame is considered by custom stack trace rule (family:native max-frames=1))
+          frame (ignored because only 1 frame is considered by custom stacktrace rule (family:native max-frames=1))
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_malloc_chain.pysnap
@@ -50,15 +50,15 @@ system:
           frame*
             function*
               "malloc_zone_malloc"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_malloc"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_allocate"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "nanov2_allocate_from_block"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "nanov2_allocate_from_block.cold.1"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_no_filenames.pysnap
@@ -74,7 +74,7 @@ system:
           frame*
             function*
               "std::rt::lang_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start_internal"
           frame*
@@ -83,7 +83,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_unlimited_frames.pysnap
@@ -41,6 +41,6 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "<lambda>::operator()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/native_windows_anon_namespace.pysnap
@@ -51,12 +51,12 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/node_low_level_async.pysnap
@@ -13,14 +13,14 @@ app:
         value*
           "bad"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (function:processTicksAndRejections -app))
+          frame (marked out of app by built-in stacktrace rule (function:processTicksAndRejections -app))
             module*
               "task_queues"
             filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"
-          frame (marked out of app by built-in stack trace rule (function:runMicrotasks -app))
+          frame (marked out of app by built-in stacktrace rule (function:runMicrotasks -app))
             filename*
               "axiosinterceptor.js"
             function*
@@ -38,14 +38,14 @@ system:
         value*
           "bad"
         stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by built-in stack trace rule (function:processTicksAndRejections -group))
+          frame (ignored by built-in stacktrace rule (function:processTicksAndRejections -group))
             module*
               "task_queues"
             filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"
-          frame (ignored by built-in stack trace rule (function:runMicrotasks -group))
+          frame (ignored by built-in stacktrace rule (function:runMicrotasks -group))
             filename*
               "axiosinterceptor.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_grouping_enhancer_away_from_crash.pysnap
@@ -58,7 +58,7 @@ app:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -116,7 +116,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "\"'user'\""
         stacktrace*
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.core.handlers.base"
             filename (ignored because module takes precedence)
@@ -125,7 +125,7 @@ system:
               "get_response"
             context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)
@@ -134,7 +134,7 @@ system:
               "view"
             context_line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -143,7 +143,7 @@ system:
               "_wrapper"
             context_line*
               "return bound_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.decorators.csrf"
             filename (ignored because module takes precedence)
@@ -152,7 +152,7 @@ system:
               "wrapped_view"
             context_line*
               "return view_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -161,7 +161,7 @@ system:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -170,7 +170,7 @@ system:
               "dispatch"
             context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (path:**/release_webhook.py v-group))
+          frame (ignored by custom stacktrace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_grouping_enhancer_towards_crash.pysnap
@@ -58,7 +58,7 @@ app:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -76,7 +76,7 @@ app:
               "dispatch"
             context_line*
               "return handler(request, *args, **kwargs)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -85,7 +85,7 @@ app:
               "post"
             context_line*
               "hook.handle(request)"
-          frame (marked in-app by the client but ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (marked in-app by the client but ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
             filename (ignored because module takes precedence)
@@ -143,7 +143,7 @@ system:
               "_wrapper"
             context_line*
               "return bound_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.decorators.csrf"
             filename (ignored because module takes precedence)
@@ -152,7 +152,7 @@ system:
               "wrapped_view"
             context_line*
               "return view_func(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.decorators"
             filename (ignored because module takes precedence)
@@ -161,7 +161,7 @@ system:
               "bound_func"
             context_line*
               "return func(self, *args2, **kwargs2)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -170,7 +170,7 @@ system:
               "dispatch"
             context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.generic.base"
             filename (ignored because module takes precedence)
@@ -179,7 +179,7 @@ system:
               "dispatch"
             context_line*
               "return handler(request, *args, **kwargs)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
             filename (ignored because module takes precedence)
@@ -188,7 +188,7 @@ system:
               "post"
             context_line*
               "hook.handle(request)"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
             filename (ignored because module takes precedence)
@@ -197,7 +197,7 @@ system:
               "handle"
             context_line*
               "email = request.POST['user']"
-          frame (ignored by custom stack trace rule (function:wrapped_view ^-group -group))
+          frame (ignored by custom stacktrace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.datastructures"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "timed out"
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app) and un-ignored by custom stacktrace rule (function:post_process_group +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -22,7 +22,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -31,7 +31,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -40,7 +40,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -49,7 +49,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -58,7 +58,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -67,7 +67,7 @@ app:
               "child_process"
             context_line*
               "run_worker("
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -76,7 +76,7 @@ app:
               "run_worker"
             context_line*
               "_execute_activation(task_func, inflight.activation)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.workerchild"
             filename (ignored because module takes precedence)
@@ -85,7 +85,7 @@ app:
               "_execute_activation"
             context_line*
               "task_func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.taskworker.task"
             filename (ignored because module takes precedence)
@@ -94,7 +94,7 @@ app:
               "__call__"
             context_line*
               "return self._func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:post_process_group +app v+app))
             module*
               "sentry.tasks.post_process"
             filename (ignored because module takes precedence)
@@ -112,7 +112,7 @@ app:
               "run_post_process_job"
             context_line*
               "logger.exception("
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -121,7 +121,7 @@ app:
               "exception"
             context_line*
               "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -130,7 +130,7 @@ app:
               "error"
             context_line*
               "self._log(ERROR, msg, args, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -139,7 +139,7 @@ app:
               "_log"
             context_line*
               "self.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -148,7 +148,7 @@ app:
               "handle"
             context_line*
               "self.callHandlers(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -157,7 +157,7 @@ app:
               "callHandlers"
             context_line*
               "hdlr.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -166,7 +166,7 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -175,7 +175,7 @@ app:
               "connect"
             context_line*
               "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -184,7 +184,7 @@ app:
               "_connect"
             context_line*
               "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -215,7 +215,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "timed out"
         stacktrace*
-          frame* (un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:post_process_group +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -9,7 +9,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -18,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -27,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -36,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -45,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -54,7 +54,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn._subprocess"
             filename (ignored because module takes precedence)
@@ -63,7 +63,7 @@ app:
               "subprocess_started"
             context_line*
               "target(sockets=sockets)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.server"
             filename (ignored because module takes precedence)
@@ -72,7 +72,7 @@ app:
               "run"
             context_line*
               "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -81,7 +81,7 @@ app:
               "run"
             context_line*
               "return runner.run(main)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -90,7 +90,7 @@ app:
               "run"
             context_line*
               "return self._loop.run_until_complete(task)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -99,7 +99,7 @@ app:
               "run_until_complete"
             context_line*
               "self.run_forever()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -108,7 +108,7 @@ app:
               "run_forever"
             context_line*
               "self._run_once()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.base_events"
             filename (ignored because module takes precedence)
@@ -117,7 +117,7 @@ app:
               "_run_once"
             context_line*
               "handle._run()"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "asyncio.events"
             filename (ignored because module takes precedence)
@@ -126,7 +126,7 @@ app:
               "_run"
             context_line*
               "self._context.run(self._callback, *self._args)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.lifespan.on"
             filename (ignored because module takes precedence)
@@ -135,7 +135,7 @@ app:
               "main"
             context_line*
               "await app(scope, self.receive, self.send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "uvicorn.middleware.proxy_headers"
             filename (ignored because module takes precedence)
@@ -144,7 +144,7 @@ app:
               "__call__"
             context_line*
               "return await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.applications"
             filename (ignored because module takes precedence)
@@ -153,7 +153,7 @@ app:
               "__call__"
             context_line*
               "await super().__call__(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.applications"
             filename (ignored because module takes precedence)
@@ -162,7 +162,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.errors"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.base"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.cors"
             filename (ignored because module takes precedence)
@@ -189,7 +189,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.middleware.exceptions"
             filename (ignored because module takes precedence)
@@ -198,7 +198,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.middleware.asyncexitstack"
             filename (ignored because module takes precedence)
@@ -207,7 +207,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -216,7 +216,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -225,7 +225,7 @@ app:
               "app"
             context_line*
               "await self.lifespan(scope, receive, send)"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -234,7 +234,7 @@ app:
               "lifespan"
             context_line*
               "async with self.lifespan_context(app) as maybe_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -243,7 +243,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -252,7 +252,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -261,7 +261,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -270,7 +270,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -279,7 +279,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -288,7 +288,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -297,7 +297,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app) and un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -306,7 +306,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+          frame* (marked in-app by custom stacktrace rule (function:run_app +app v+app))
             module*
               "app.main"
             filename (ignored because module takes precedence)
@@ -387,7 +387,7 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -459,7 +459,7 @@ system:
               "run"
             context_line*
               "return runner.run(main)"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "asyncio.runners"
             filename (ignored because module takes precedence)
@@ -621,7 +621,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -630,7 +630,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -639,7 +639,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -648,7 +648,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -657,7 +657,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -666,7 +666,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -675,7 +675,7 @@ system:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+          frame* (un-ignored by custom stacktrace rule (function:run_app +group v+group))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -13,7 +13,7 @@ app:
         value*
           "timed out"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -22,7 +22,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -31,7 +31,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -40,7 +40,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -49,7 +49,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -112,7 +112,7 @@ app:
               "run_post_process_job"
             context_line*
               "logger.exception("
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -121,7 +121,7 @@ app:
               "exception"
             context_line*
               "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -130,7 +130,7 @@ app:
               "error"
             context_line*
               "self._log(ERROR, msg, args, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -139,7 +139,7 @@ app:
               "_log"
             context_line*
               "self.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -148,7 +148,7 @@ app:
               "handle"
             context_line*
               "self.callHandlers(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -157,7 +157,7 @@ app:
               "callHandlers"
             context_line*
               "hdlr.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -166,7 +166,7 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -175,7 +175,7 @@ app:
               "connect"
             context_line*
               "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -184,7 +184,7 @@ app:
               "_connect"
             context_line*
               "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "redis.connection"
             filename (ignored because module takes precedence)
@@ -215,7 +215,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "timed out"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "__main__"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -9,7 +9,7 @@ app:
     app (ignored because system threads take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -54,7 +54,7 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn._subprocess"
             filename (ignored because module takes precedence)
@@ -63,7 +63,7 @@ app:
               "subprocess_started"
             context_line*
               "target(sockets=sockets)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.server"
             filename (ignored because module takes precedence)
@@ -126,7 +126,7 @@ app:
               "_run"
             context_line*
               "self._context.run(self._callback, *self._args)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.lifespan.on"
             filename (ignored because module takes precedence)
@@ -135,7 +135,7 @@ app:
               "main"
             context_line*
               "await app(scope, self.receive, self.send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "uvicorn.middleware.proxy_headers"
             filename (ignored because module takes precedence)
@@ -144,7 +144,7 @@ app:
               "__call__"
             context_line*
               "return await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.applications"
             filename (ignored because module takes precedence)
@@ -153,7 +153,7 @@ app:
               "__call__"
             context_line*
               "await super().__call__(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.applications"
             filename (ignored because module takes precedence)
@@ -162,7 +162,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.errors"
             filename (ignored because module takes precedence)
@@ -171,7 +171,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.base"
             filename (ignored because module takes precedence)
@@ -180,7 +180,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.cors"
             filename (ignored because module takes precedence)
@@ -189,7 +189,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.middleware.exceptions"
             filename (ignored because module takes precedence)
@@ -198,7 +198,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.middleware.asyncexitstack"
             filename (ignored because module takes precedence)
@@ -207,7 +207,7 @@ app:
               "__call__"
             context_line*
               "await self.app(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -216,7 +216,7 @@ app:
               "__call__"
             context_line*
               "await self.middleware_stack(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -225,7 +225,7 @@ app:
               "app"
             context_line*
               "await self.lifespan(scope, receive, send)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "starlette.routing"
             filename (ignored because module takes precedence)
@@ -234,7 +234,7 @@ app:
               "lifespan"
             context_line*
               "async with self.lifespan_context(app) as maybe_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -243,7 +243,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -252,7 +252,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -261,7 +261,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -270,7 +270,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -279,7 +279,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -288,7 +288,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -297,7 +297,7 @@ app:
               "merged_lifespan"
             context_line*
               "async with original_context(app) as maybe_original_state:"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by built-in stacktrace rule (path:**/site-packages/** -app))
             module*
               "fastapi.routing"
             filename (ignored because module takes precedence)
@@ -387,7 +387,7 @@ system:
     system*
       threads*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             module*
               "__main__"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_enforce_min_frames.pysnap
@@ -12,23 +12,23 @@ app:
           "log_demo"
         value*
           "Holy shit everything is on fire!"
-        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2))
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by custom stacktrace rule (family:native min-frames=2))
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -59,7 +59,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_negated_match.pysnap
@@ -16,16 +16,16 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame (non app frame)
@@ -47,24 +47,24 @@ system:
         value (ignored because stacktrace takes precedence)
           "Holy shit everything is on fire!"
         stacktrace*
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by custom stack trace rule (!function:log_demo::* -group))
+          frame (ignored by custom stacktrace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_rust.pysnap
@@ -16,19 +16,19 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -59,7 +59,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/stacktrace_rust2.pysnap
@@ -16,19 +16,19 @@ app:
           frame (non app frame)
             function*
               "_main"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::rt::lang_start_internal"
           frame (non app frame)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))
+          frame* (marked in-app by custom stacktrace rule (family:native function:log_demo::* +app))
             function*
               "log_demo::main"
           frame (non app frame)
@@ -53,18 +53,18 @@ system:
           frame*
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by custom stack trace rule (family:native function:__* -group))
+          frame (ignored by custom stacktrace rule (family:native function:__* -group))
             function*
               "___rust_maybe_catch_panic"
           frame*
             function*
               "std::panicking::try::do_call"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by custom stack trace rule (family:native function:*::__* -group))
+          frame (ignored by custom stacktrace rule (family:native function:*::__* -group))
             function*
               "log::__private_api_log"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assert_mac.pysnap
@@ -13,100 +13,100 @@ app:
         value (ignored because stacktrace takes precedence)
           "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FGenericPlatformMisc::RaiseException"
 --------------------------------------------------------------------------
@@ -122,10 +122,10 @@ system:
         value (ignored because stacktrace takes precedence)
           "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -188,7 +188,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assertion_check_fail_android.pysnap
@@ -13,72 +13,72 @@ app:
         value (ignored because stacktrace takes precedence)
           "Trap"
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__start_thread"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "android_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "AndroidMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UGameEngine::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UWorld::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "AActor::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "tgkill"
 --------------------------------------------------------------------------
@@ -94,10 +94,10 @@ system:
         value (ignored because stacktrace takes precedence)
           "Trap"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__start_thread"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_assertion_check_fail_on_windows.pysnap
@@ -13,143 +13,143 @@ app:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: unknown <hex> / <hex>"
         stacktrace*
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "WinMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FDebug::AssertFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stacktrace rule (category:throw ^-app -app))
             function*
               "RaiseException"
 --------------------------------------------------------------------------
@@ -165,18 +165,18 @@ system:
         value (ignored because stacktrace takes precedence)
           "Fatal Error: unknown <hex> / <hex>"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -202,7 +202,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -229,7 +229,7 @@ system:
           frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame*
@@ -262,7 +262,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame*
@@ -301,6 +301,6 @@ system:
           frame*
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (ignored by built-in stack trace rule (category:throw ^-group -group))
+          frame (ignored by built-in stacktrace rule (category:throw ^-group -group))
             function*
               "RaiseException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_mac.pysnap
@@ -13,252 +13,252 @@ app:
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored due to recursion)
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -274,13 +274,13 @@ system:
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -343,7 +343,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -373,39 +373,39 @@ system:
           frame
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -468,7 +468,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -498,27 +498,27 @@ system:
           frame
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient captureException:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_ensure_check_fail_on_windows.pysnap
@@ -13,172 +13,172 @@ app:
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "WinMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (marked out of app by built-in stack trace rule (category:system -app))
+          frame (marked out of app by built-in stacktrace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "CheckVerifyImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_value_set_stacktrace"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_value_new_stacktrace"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_unwind_stack_from_ucontext"
 --------------------------------------------------------------------------
@@ -194,18 +194,18 @@ system:
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -231,7 +231,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -258,7 +258,7 @@ system:
           frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame*
@@ -291,7 +291,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame*
@@ -343,7 +343,7 @@ system:
               "invoke.h"
             function*
               "Invoke"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             filename*
               "sentrysubsystem.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/unreal_event_capture_mac.pysnap
@@ -9,127 +9,127 @@ app:
     app*
       threads*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stacktrace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stacktrace rule (category:internals -app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "GuardedMain"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:indirection -group))
+          frame (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame* (marked in-app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "UFunction::Invoke"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by built-in stack trace rule (family:native function:?[[]Sentry* -app))
+          frame (marked out of app by built-in stacktrace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -150,13 +150,13 @@ system:
     system*
       threads*
         stacktrace*
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (ignored by built-in stacktrace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (ignored by built-in stack trace rule (category:internals -group))
+          frame (ignored by built-in stacktrace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame*
@@ -219,7 +219,7 @@ system:
           frame*
             function*
               "ProcessLocalFunction"
-          frame (ignored by built-in stack trace rule (category:indirection -group))
+          frame (ignored by built-in stacktrace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
           frame*
@@ -252,24 +252,24 @@ system:
           frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by built-in stack trace rule (family:native function:?[[]Sentry* -group))
+          frame (ignored by built-in stacktrace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -325,7 +325,7 @@ class GetStacktraceStringTest(TestCase):
                                         "id": "frame",
                                         "name": None,
                                         "contributes": True,
-                                        "hint": "marked out of app by stack trace rule (function:dbx v-group -group v-app -app)",
+                                        "hint": "marked out of app by stacktrace rule (function:dbx v-group -group v-app -app)",
                                         "values": [
                                             {
                                                 "id": "module",

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -569,7 +569,7 @@ def test_apply_new_stack_trace_rules(
     process_and_save,
 ):
     """
-    Assert that after changing stack trace rules, the new grouping config
+    Assert that after changing stacktrace rules, the new grouping config
     is respected by reprocessing.
     """
 
@@ -623,7 +623,7 @@ def test_apply_new_stack_trace_rules(
 
     original_grouping_config = event1.data["grouping_config"]
 
-    # Different group, because different stack trace
+    # Different group, because different stacktrace
     assert event1.group.id != event2.group.id
     original_issue_id = event1.group.id
 
@@ -650,7 +650,7 @@ def test_apply_new_stack_trace_rules(
     assert is_group_finished(event1.group_id)
     assert is_group_finished(event2.group_id)
 
-    # Events should now be in same group because of stack trace rule
+    # Events should now be in same group because of stacktrace rule
     event1 = eventstore.backend.get_event_by_id(default_project.id, event_id1)
     event2 = eventstore.backend.get_event_by_id(default_project.id, event_id2)
     assert event1 is not None


### PR DESCRIPTION
This is a small fix similar to the one done in https://github.com/getsentry/sentry/pull/100251, to standardize our styling of the word "stacktrace" in the grouping info section. It also makes the same change to a few docstrings/comments in the grouping code, primarily as a convenience so that searching for "stacktrace" doesn't miss anything.