### PR TITLE
fix(dashboard): use disabledKeys to prevent duplication and deletion of prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -143,8 +143,9 @@ function DashboardGrid({
       },
     ];
 
-    const disabledKeys =
-      (dashboards && dashboards.length <= 1) || disableDelete ? ['dashboard-delete'] : [];
+    const disabledKeys = [];
+    if ((dashboards && dashboards.length <= 1) || disableDelete)
+      disabledKeys.push('dashboard-delete');
     if (disableDuplicate) {
       disabledKeys.push('dashboard-duplicate');
     }

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -90,6 +90,9 @@ function DashboardGrid({
   }
 
   function renderDropdownMenu(dashboard: DashboardListItem, dashboardLimitData: any) {
+    const shouldDisablePrebuiltControls =
+      defined(dashboard.prebuiltId) &&
+      !organization.features.includes('dashboards-prebuilt-controls');
     const {
       hasReachedDashboardLimit,
       isLoading: isLoadingDashboardsLimit,
@@ -99,12 +102,9 @@ function DashboardGrid({
     const disableDuplicate =
       hasReachedDashboardLimit ||
       isLoadingDashboardsLimit ||
-      (defined(dashboard.prebuiltId) &&
-        !organization.features.includes('dashboards-prebuilt-controls'));
+      shouldDisablePrebuiltControls;
 
-    const disableDelete =
-      defined(dashboard.prebuiltId) ||
-      (dashboards !== undefined && dashboards.length <= 1);
+    const disableDelete = defined(dashboard.prebuiltId);
 
     const menuItems: MenuItemProps[] = [
       {
@@ -118,11 +118,9 @@ function DashboardGrid({
           });
         },
         disabled: disableDuplicate,
-        tooltip:
-          defined(dashboard.prebuiltId) &&
-          !organization.features.includes('dashboards-prebuilt-controls')
-            ? t('Prebuilt dashboards cannot be duplicated')
-            : limitMessage,
+        tooltip: shouldDisablePrebuiltControls
+          ? t('Prebuilt dashboards cannot be duplicated')
+          : limitMessage,
         tooltipOptions: {
           isHoverable: true,
         },
@@ -138,8 +136,8 @@ function DashboardGrid({
             onConfirm: () => handleDeleteDashboard(dashboard, 'grid'),
           });
         },
-        disabled: defined(dashboard.prebuiltId),
-        tooltip: defined(dashboard.prebuiltId)
+        disabled: disableDelete,
+        tooltip: shouldDisablePrebuiltControls
           ? t('Prebuilt dashboards cannot be deleted')
           : undefined,
       },

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -95,6 +95,17 @@ function DashboardGrid({
       isLoading: isLoadingDashboardsLimit,
       limitMessage,
     } = dashboardLimitData;
+
+    const disableDuplicate =
+      hasReachedDashboardLimit ||
+      isLoadingDashboardsLimit ||
+      (defined(dashboard.prebuiltId) &&
+        !organization.features.includes('dashboards-prebuilt-controls'));
+
+    const disableDelete =
+      defined(dashboard.prebuiltId) ||
+      (dashboards !== undefined && dashboards.length <= 1);
+
     const menuItems: MenuItemProps[] = [
       {
         key: 'dashboard-duplicate',
@@ -106,11 +117,7 @@ function DashboardGrid({
             onConfirm: () => handleDuplicateDashboard(dashboard, 'grid'),
           });
         },
-        disabled:
-          hasReachedDashboardLimit ||
-          isLoadingDashboardsLimit ||
-          (defined(dashboard.prebuiltId) &&
-            !organization.features.includes('dashboards-prebuilt-controls')),
+        disabled: disableDuplicate,
         tooltip:
           defined(dashboard.prebuiltId) &&
           !organization.features.includes('dashboards-prebuilt-controls')
@@ -138,6 +145,12 @@ function DashboardGrid({
       },
     ];
 
+    const disabledKeys =
+      (dashboards && dashboards.length <= 1) || disableDelete ? ['dashboard-delete'] : [];
+    if (disableDuplicate) {
+      disabledKeys.push('dashboard-duplicate');
+    }
+
     return (
       <DropdownMenu
         items={menuItems}
@@ -157,7 +170,7 @@ function DashboardGrid({
           />
         )}
         position="bottom-end"
-        disabledKeys={dashboards && dashboards.length <= 1 ? ['dashboard-delete'] : []}
+        disabledKeys={disabledKeys}
         offset={4}
       />
     );


### PR DESCRIPTION
Fixes a bug where the `Duplicate` and `Delete` on a prebuilt dashboard were still clickable and fired `onAction` even though they were disabled via the `disabled` property of `MenuItems`. Apparently we have to use `disabledKeys` as well to disable to `onAction`. Only putting disabled on menuItems would still grey it out and disable the click cursor, but the onAction would still fired on click. 

<img width="478" height="298" alt="image" src="https://github.com/user-attachments/assets/817fe4ae-b87b-4f4e-b7fc-2076371b11cf" />
