### PR TITLE
ref(container) add ellipsis support

### DIFF
--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -8,6 +8,7 @@ resources:
 ---
 
 import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
 import documentation from '!!type-loader!@sentry/scraps/layout/container';
@@ -184,7 +185,35 @@ The `2xs` breakpoint is a breakpoint that applies from 0 to the smallest defined
 </Container>
 ```
 
-### Grid Integration
+#### Truncating Text within a Container
+
+In most case, it is recommended to use the `Text` component with the `ellipsis` prop to truncate text inside a container while using the parent `Container` component to set the actual boundary box for the text.
+
+<Storybook.Demo>
+  <Container maxWidth="200px">
+    <Text ellipsis>This content is hidden and ellipsed</Text>
+  </Container>
+</Storybook.Demo>
+```jsx
+<Container maxWidth="200px">
+  <Text ellipsis>This content is hidden and ellipsed</Text>
+</Container>
+```
+
+There is however another way to truncate text within a container by using the `ellipsis` prop on the parent `Container` component. This way, if you have multiple lines of text, they will all be truncated with an ellipsis.
+
+<Storybook.Demo>
+  <Container ellipsis maxWidth="200px">
+    <Text as="span">This content is hidden and ellipsed</Text>
+    <Text as="span">This content is hidden and ellipsed</Text>
+  </Container>
+</Storybook.Demo>
+```jsx
+<Container ellipsis maxWidth="200px">
+  <div>This content is hidden and ellipsed</div>
+  <div>This content is hidden and ellipsed</div>
+</Container>
+``` ### Grid Integration
 
 The `area` prop supports CSS Grid integration:
 

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -22,6 +22,13 @@ import {
 
 /* eslint-disable typescript-sort-keys/interface */
 interface ContainerLayoutProps {
+  /**
+   * When true, overflow is set to hidden, text-overflow is set to ellipsis, and white-space is set to nowrap.
+   * Individual properties can be overridden by setting the corresponding property (e.g. overflow, text-overflow, white-space).
+   * @default undefined
+   */
+  ellipsis?: Responsive<boolean>;
+
   background?: Responsive<SurfaceVariant>;
   display?: Responsive<
     | 'block'
@@ -81,6 +88,9 @@ interface ContainerLayoutProps {
   flexBasis?: Responsive<React.CSSProperties['flexBasis']>;
   alignSelf?: Responsive<React.CSSProperties['alignSelf']>;
   justifySelf?: Responsive<React.CSSProperties['justifySelf']>;
+
+  textOverflow?: Responsive<React.CSSProperties['textOverflow']>;
+  whiteSpace?: Responsive<React.CSSProperties['whiteSpace']>;
 
   /**
    * Prefer using Flex or Grid gap as opposed to margin.
@@ -167,6 +177,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'bottom',
   'column',
   'display',
+  'ellipsis',
   'flex',
   'flexBasis',
   'flexGrow',
@@ -197,8 +208,10 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'radius',
   'right',
   'row',
+  'textOverflow',
   'top',
   'width',
+  'whiteSpace',
 ]);
 
 export const Container = styled(
@@ -276,6 +289,19 @@ export const Container = styled(
   ${p => rc('border-bottom', p.borderBottom, p.theme, getBorder)};
   ${p => rc('border-left', p.borderLeft, p.theme, getBorder)};
   ${p => rc('border-right', p.borderRight, p.theme, getBorder)};
+
+  ${p =>
+    rc(
+      'text-overflow',
+      p.textOverflow ? p.textOverflow : p.ellipsis ? 'ellipsis' : undefined,
+      p.theme
+    )};
+  ${p =>
+    rc(
+      'white-space',
+      p.whiteSpace ? p.whiteSpace : p.ellipsis ? 'nowrap' : undefined,
+      p.theme
+    )};
 
   /**
    * This cast is required because styled-components does not preserve the generic signature of the wrapped component.

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -243,7 +243,12 @@ export const Container = styled(
   ${p => rc('left', p.left, p.theme)};
   ${p => rc('right', p.right, p.theme)};
 
-  ${p => rc('overflow', p.overflow, p.theme)};
+  ${p =>
+    p.overflow
+      ? rc('overflow', p.overflow, p.theme)
+      : p.ellipsis
+        ? rc('overflow', p.ellipsis, p.theme, v => (v ? 'hidden' : ''))
+        : undefined};
   ${p => rc('overflow-x', p.overflowX, p.theme)};
   ${p => rc('overflow-y', p.overflowY, p.theme)};
 


### PR DESCRIPTION
Adds container ellipsis support for Container. This is an alternative pattern to using

```
<Container width={...}>
  <Text ellipsis>Overflowing Text...</Text>
</Container>


<Container ellipsis width={...}>
  Overflowing Text...
</Container>
```