### PR TITLE
fix(seer): Disable formatting of save toasts for Code Review triggers…

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -67,6 +67,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
                   ['on_ready_for_review', t('On Ready for Review')],
                   ['on_new_commit', t('On New Commit')],
                 ],
+                formatMessageValue: false,
                 getData: data => ({
                   codeReviewTriggers: data.codeReviewTriggers,
                   repositoryIds: [repoWithSettings.id],

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -108,6 +108,7 @@ export default function SeerAutomationSettings() {
                     ['on_ready_for_review', t('On Ready for Review')],
                     ['on_new_commit', t('On New Commit')],
                   ],
+                  formatMessageValue: false,
                 },
               ],
             },


### PR DESCRIPTION
Having the list of values (there are only 2 possible values) is hard to read in the toast actually. The toast wants to show the enum values and it's just a bit annoying.

**Before**
<img width="1766" height="346" alt="Screenshot 2026-01-06 at 11 54 36 AM" src="https://github.com/user-attachments/assets/99fdad4f-944c-4eab-8f3f-bd0333b88d59" />


**After**
<img width="526" height="155" alt="SCR-20260108-mcsd" src="https://github.com/user-attachments/assets/b72e5f73-1e6d-4aa2-af61-62e98affd37a" />


Fixes https://www.notion.so/sentry/The-code-review-triggers-toast-is-a-bit-unreadable-2e08b10e4b5d808ea6ecda08f945d33d?pvs=23