### PR TITLE
fix(aci): set failure rate y-axis range based on seriesMax and threshold

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -250,7 +250,11 @@ export function useMetricDetectorChart({
     usePageDate: true,
   });
 
-  const {maxValue, minValue} = useDetectorChartAxisBounds({series, thresholdMaxValue});
+  const {maxValue, minValue} = useDetectorChartAxisBounds({
+    series,
+    thresholdMaxValue,
+    aggregate,
+  });
 
   const additionalSeries = useMemo(() => {
     const baseSeries = [...thresholdAdditionalSeries, ...filteredAnomalyThresholdSeries];

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -194,6 +194,7 @@ export function useMetricDetectorChart({
 
   const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =
     useMetricDetectorThresholdSeries({
+      aggregate,
       conditions: detector.conditionGroup?.conditions,
       detectionType,
       comparisonSeries,

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {GroupOpenPeriod} from 'sentry/types/group';
 import type {MetricDetector, SnubaQuery} from 'sentry/types/workflowEngine/detectors';
+import {axisLabelFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -195,7 +196,6 @@ export function useMetricDetectorChart({
     useMetricDetectorThresholdSeries({
       conditions: detector.conditionGroup?.conditions,
       detectionType,
-      aggregate,
       comparisonSeries,
     });
 
@@ -271,19 +271,33 @@ export function useMetricDetectorChart({
     });
 
     const isPercentage = outputType === 'percentage';
-    // For percentage aggregates, use fixed max of 1 (100%) and calculated min
-    const yAxisMax = isPercentage ? 1 : maxValue > 0 ? maxValue : undefined;
-    // Start charts at 0 for non-percentage aggregates
-    const yAxisMin = isPercentage ? minValue : 0;
+    // Use calculated max/min values from data and thresholds for appropriate scaling
+    const yAxisMax = maxValue > 0 ? maxValue : undefined;
+    const yAxisMin = minValue;
+
+    // For percentages, use 2 decimal places
+    const customFormatter = (value: number): string => {
+      if (isPercentage) {
+        return axisLabelFormatterUsingAggregateOutputType(
+          value,
+          outputType,
+          true,
+          undefined,
+          undefined,
+          2
+        );
+      }
+      return formatYAxisLabel(value);
+    };
 
     const mainYAxis: YAXisComponentOption = {
       max: yAxisMax,
       min: yAxisMin,
       axisLabel: {
-        // Show max label for percentage (100%) but hide for other types to avoid arbitrary values
+        // Show max label for percentage but hide for other types to avoid arbitrary values
         showMaxLabel: isPercentage,
         // Format the axis labels with units
-        formatter: formatYAxisLabel,
+        formatter: customFormatter,
       },
       // Disable the y-axis grid lines
       splitLine: {show: false},

--- a/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
@@ -1,10 +1,12 @@
 import {useMemo} from 'react';
 
 import type {Series} from 'sentry/types/echarts';
+import {aggregateOutputType} from 'sentry/utils/discover/fields';
 
 interface UseChartAxisBoundsProps {
   series: Series[];
   thresholdMaxValue: number | undefined;
+  aggregate?: string;
 }
 
 interface ChartAxisBounds {
@@ -19,6 +21,7 @@ interface ChartAxisBounds {
 export function useDetectorChartAxisBounds({
   series,
   thresholdMaxValue,
+  aggregate,
 }: UseChartAxisBoundsProps): ChartAxisBounds {
   return useMemo(() => {
     if (series.length === 0) {
@@ -49,6 +52,12 @@ export function useDetectorChartAxisBounds({
       maxValue = seriesMax + maxPadding;
     }
 
+    // Cap percentage metrics at 100% (1.0 in 0-1 scale)
+    const isPercentage = aggregate && aggregateOutputType(aggregate) === 'percentage';
+    if (isPercentage && maxValue > 1.0) {
+      maxValue = 1.0;
+    }
+
     // Add padding to min value
     const minPadding = seriesMin * 0.1;
     const minValue = Math.max(0, seriesMin - minPadding);
@@ -57,5 +66,5 @@ export function useDetectorChartAxisBounds({
       maxValue,
       minValue,
     };
-  }, [series, thresholdMaxValue]);
+  }, [series, thresholdMaxValue, aggregate]);
 }

--- a/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
@@ -38,20 +38,24 @@ export function useDetectorChartAxisBounds({
     const seriesMax = Math.max(...allSeriesValues);
     const seriesMin = Math.min(...allSeriesValues);
 
-    // Combine with threshold max and round to nearest whole number
-    const combinedMax = thresholdMaxValue
-      ? Math.max(seriesMax, thresholdMaxValue)
-      : seriesMax;
+    // Determine the max value: use threshold if it's higher than data, otherwise add padding to data
+    let maxValue: number;
+    if (thresholdMaxValue && thresholdMaxValue >= seriesMax) {
+      // Threshold is the limiting factor - use it as-is without padding
+      maxValue = thresholdMaxValue;
+    } else {
+      // Data exceeds threshold - add padding to show data clearly above threshold
+      const maxPadding = seriesMax * 0.1;
+      maxValue = seriesMax + maxPadding;
+    }
 
-    const roundedMax = Math.round(combinedMax);
-
-    // Add padding to the bounds
-    const maxPadding = roundedMax * 0.1;
+    // Add padding to min value
     const minPadding = seriesMin * 0.1;
+    const minValue = Math.max(0, seriesMin - minPadding);
 
     return {
-      maxValue: roundedMax + maxPadding,
-      minValue: Math.max(0, seriesMin - minPadding),
+      maxValue,
+      minValue,
     };
   }, [series, thresholdMaxValue]);
 }

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -195,6 +195,7 @@ export function MetricDetectorChart({
 
   const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =
     useMetricDetectorThresholdSeries({
+      aggregate,
       conditions,
       detectionType,
       comparisonSeries,

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -254,7 +254,11 @@ export function MetricDetectorChart({
     thresholdType,
   });
 
-  const {maxValue, minValue} = useDetectorChartAxisBounds({series, thresholdMaxValue});
+  const {maxValue, minValue} = useDetectorChartAxisBounds({
+    series,
+    thresholdMaxValue,
+    aggregate,
+  });
 
   const additionalSeries = useMemo(() => {
     const baseSeries = [...thresholdAdditionalSeries, ...filteredAnomalyThresholdSeries];

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -18,6 +18,7 @@ import type {
   MetricCondition,
   MetricDetectorConfig,
 } from 'sentry/types/workflowEngine/detectors';
+import {axisLabelFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
@@ -196,7 +197,6 @@ export function MetricDetectorChart({
     useMetricDetectorThresholdSeries({
       conditions,
       detectionType,
-      aggregate,
       comparisonSeries,
     });
 
@@ -278,18 +278,33 @@ export function MetricDetectorChart({
     });
 
     const isPercentage = outputType === 'percentage';
-    // For percentage aggregates, use fixed max of 1 (100%) and calculated min
-    const yAxisMax = isPercentage ? 1 : maxValue > 0 ? maxValue : undefined;
-    const yAxisMin = isPercentage ? minValue : 0;
+    // Use calculated max/min values from data and thresholds for appropriate scaling
+    const yAxisMax = maxValue > 0 ? maxValue : undefined;
+    const yAxisMin = minValue;
+
+    // For percentages, use 2 decimal places (consistent with metric alerts)
+    const customFormatter = (value: number): string => {
+      if (isPercentage) {
+        return axisLabelFormatterUsingAggregateOutputType(
+          value,
+          outputType,
+          true,
+          undefined,
+          undefined,
+          2 // Fixed 2 decimal places for percentages
+        );
+      }
+      return formatYAxisLabel(value);
+    };
 
     const mainYAxis: YAXisComponentOption = {
       max: yAxisMax,
       min: yAxisMin,
       axisLabel: {
-        // Show max label for percentage (100%) but hide for other types to avoid arbitrary values
+        // Show max label for percentage but hide for other types to avoid arbitrary values
         showMaxLabel: isPercentage,
         // Format the axis labels with units
-        formatter: formatYAxisLabel,
+        formatter: customFormatter,
       },
       // Disable the y-axis grid lines
       splitLine: {show: false},


### PR DESCRIPTION
we were hardcoding the y-axis max to be 100%, which makes it difficult to see small percentages. this change sets the max to the max between the seriesMax and the specified threshold.

before
<img width="1023" height="272" alt="Screenshot 2026-01-08 at 1 44 32 PM" src="https://github.com/user-attachments/assets/fb00ae4c-27e5-4361-9282-eca9f771379b" />

after
<img width="981" height="303" alt="Screenshot 2026-01-08 at 1 46 15 PM" src="https://github.com/user-attachments/assets/00873dd0-4cdb-4e2e-8cf5-34b593c75ec0" />
