### PR TITLE
fix(seer-slack): Update messages after autofix engagement to prevent duplicate triggers

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -147,6 +147,23 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         except SlackApiError as e:
             translate_slack_api_error(e)
 
+    def update_message(
+        self,
+        *,
+        channel_id: str,
+        message_ts: str,
+        renderable: SlackRenderable,
+    ) -> None:
+        client = self.get_client()
+        try:
+            client.chat_update(
+                channel=channel_id,
+                ts=message_ts,
+                blocks=renderable["blocks"],
+            )
+        except SlackApiError as e:
+            translate_slack_api_error(e)
+
 
 class SlackIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.SLACK.value

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -159,6 +159,7 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
             client.chat_update(
                 channel=channel_id,
                 ts=message_ts,
+                text=renderable["text"],
                 blocks=renderable["blocks"],
             )
         except SlackApiError as e:

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -26,7 +26,7 @@ class SeerAutofixTrigger(NotificationData):
     @property
     def label(self) -> str:
         if self.stopping_point == AutofixStoppingPoint.ROOT_CAUSE:
-            return "Start RCA"
+            return "Fix with Seer"
         elif self.stopping_point == AutofixStoppingPoint.SOLUTION:
             return "Plan a Solution"
         elif self.stopping_point == AutofixStoppingPoint.CODE_CHANGES:

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -122,7 +122,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                 channel_id=self.channel_id,
                 message_ts=self.thread_ts,
             )
-        except IntegrationError:
+        except (IntegrationError, TypeError, KeyError):
             logger.exception(
                 "slack.autofix.update_message_failed",
                 extra={

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -282,7 +282,7 @@ def _send_thread_update(
         )
 
 
-def transform_block_actions(blocks, transform_fn):
+def _transform_block_actions(blocks, transform_fn):
     """
     Transform action elements within top-level action blocks. Does not traverse nested blocks.
     """
@@ -313,7 +313,7 @@ def _update_existing_message(
 ) -> None:
     from sentry.integrations.slack.message_builder.types import SlackAction
 
-    blocks = transform_block_actions(
+    blocks = _transform_block_actions(
         request.data["message"]["blocks"],
         lambda elem: (
             None

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
+
+from slack_sdk.models.blocks.blocks import Block
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration.service import integration_service
@@ -293,7 +296,10 @@ def _send_thread_update(
         )
 
 
-def _transform_block_actions(blocks, transform_fn):
+def _transform_block_actions(
+    blocks: Sequence[dict[str, Any]],
+    transform_fn: Callable[[dict[str, Any]], dict[str, Any] | None],
+) -> list[dict[str, Any]]:
     """
     Transform action elements within top-level action blocks. Does not traverse nested blocks.
     """
@@ -334,8 +340,9 @@ def _update_existing_message(
         ),
     )
 
+    parsed_blocks = [Block.parse(block) for block in blocks]
     renderable = SlackRenderable(
-        blocks=blocks,
+        blocks=[block for block in parsed_blocks if block is not None],
         text=request.data["message"]["text"],
     )
 

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -313,6 +313,7 @@ def _update_existing_message(
 ) -> None:
     from sentry.integrations.slack.message_builder.types import SlackAction
 
+    # Removes the autofix button to prevent repeated usage
     blocks = _transform_block_actions(
         request.data["message"]["blocks"],
         lambda elem: (

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -1,7 +1,6 @@
 from unittest.mock import ANY, Mock, patch
 
 from fixtures.seer.webhooks import MOCK_RUN_ID, MOCK_SEER_WEBHOOKS
-from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.notifications.platform.templates.seer import SeerAutofixUpdate
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.integrations.slack import (
@@ -23,7 +22,7 @@ class SlackEntrypointTest(TestCase):
             external_id="TXXXXXXXXX1",
             provider="slack",
         )
-        self.slack_request: SlackActionRequest = Mock()
+        self.slack_request = Mock()
         self.slack_request.integration = self.integration
         self.slack_request.channel_id = self.channel_id
         self.slack_request.user_id = self.slack_user_id

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -9,7 +9,6 @@ from sentry.seer.entrypoints.integrations.slack import (
     SlackEntrypointCachePayload,
     _send_thread_update,
     _update_existing_message,
-    transform_block_actions,
 )
 from sentry.testutils.cases import TestCase
 
@@ -145,51 +144,6 @@ class SlackEntrypointTest(TestCase):
             renderable=ANY,
             slack_user_id=self.slack_user_id,
         )
-
-    def test_transform_block_actions_removes_matching_elements(self):
-        blocks = [
-            {"type": "section", "text": {"type": "plain_text", "text": "Keep this"}},
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": "remove_me",
-                        "text": {"type": "plain_text", "text": "Remove"},
-                    },
-                    {
-                        "type": "button",
-                        "action_id": "keep_me",
-                        "text": {"type": "plain_text", "text": "Keep"},
-                    },
-                ],
-            },
-        ]
-
-        result = transform_block_actions(
-            blocks, lambda elem: None if elem.get("action_id") == "remove_me" else elem
-        )
-
-        assert len(result) == 2
-        assert result[0]["type"] == "section"
-        assert len(result[1]["elements"]) == 1
-        assert result[1]["elements"][0]["action_id"] == "keep_me"
-
-    def test_transform_block_actions_removes_empty_action_blocks(self):
-        blocks = [
-            {
-                "type": "actions",
-                "elements": [
-                    {"type": "button", "action_id": "remove_me"},
-                ],
-            },
-        ]
-
-        result = transform_block_actions(
-            blocks, lambda elem: None if elem.get("action_id") == "remove_me" else elem
-        )
-
-        assert len(result) == 0
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.update_message")
     def test_update_existing_message(self, mock_update_message):

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -155,8 +155,17 @@ class SlackEntrypointTest(TestCase):
                     {
                         "type": "actions",
                         "elements": [
-                            {"type": "button", "action_id": "seer_autofix_start_root_cause"},
-                            {"type": "button", "action_id": "other_action"},
+                            {
+                                "type": "button",
+                                "action_id": "seer_autofix_start",
+                                "value": AutofixStoppingPoint.SOLUTION.value,
+                                "text": {"type": "plain_text", "text": "Plan a Solution"},
+                            },
+                            {
+                                "type": "button",
+                                "action_id": "other_action",
+                                "text": {"type": "plain_text", "text": "Other Action"},
+                            },
                         ],
                     },
                 ],
@@ -177,8 +186,10 @@ class SlackEntrypointTest(TestCase):
         assert call_args.kwargs["message_ts"] == self.thread_ts
         renderable = call_args.kwargs["renderable"]
         assert len(renderable["blocks"]) == 2
-        assert len(renderable["blocks"][1]["elements"]) == 1
-        assert renderable["blocks"][1]["elements"][0]["action_id"] == "other_action"
+        # The second block is an ActionsBlock with only the non-autofix button remaining
+        actions_block = renderable["blocks"][1]
+        assert len(actions_block.elements) == 1
+        assert actions_block.elements[0].action_id == "other_action"
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.update_message")
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
@@ -193,7 +204,12 @@ class SlackEntrypointTest(TestCase):
                     {
                         "type": "actions",
                         "elements": [
-                            {"type": "button", "action_id": "seer_autofix_start_root_cause"}
+                            {
+                                "type": "button",
+                                "action_id": "seer_autofix_start",
+                                "value": AutofixStoppingPoint.SOLUTION.value,
+                                "text": {"type": "plain_text", "text": "Plan a Solution"},
+                            },
                         ],
                     }
                 ],

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -8,6 +8,8 @@ from sentry.seer.entrypoints.integrations.slack import (
     SlackEntrypoint,
     SlackEntrypointCachePayload,
     _send_thread_update,
+    _update_existing_message,
+    transform_block_actions,
 )
 from sentry.testutils.cases import TestCase
 
@@ -43,8 +45,18 @@ class SlackEntrypointTest(TestCase):
             slack_user_id=self.slack_request.user_id,
         )
 
+    @patch("sentry.integrations.slack.integration.SlackIntegration.update_message")
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
-    def test_on_trigger_autofix_success(self, mock_send_threaded_ephemeral_message):
+    def test_on_trigger_autofix_success(
+        self, mock_send_threaded_ephemeral_message, mock_update_message
+    ):
+        self.slack_request.data = {
+            "message": {
+                "ts": self.thread_ts,
+                "text": "Issue notification",
+                "blocks": [],
+            }
+        }
         ep = SlackEntrypoint(
             slack_request=self.slack_request,
             group=self.group,
@@ -57,6 +69,7 @@ class SlackEntrypointTest(TestCase):
             renderable=ANY,
             slack_user_id=self.slack_request.user_id,
         )
+        mock_update_message.assert_called_once()
 
     def test_create_autofix_cache_payload(self):
         ep = SlackEntrypoint(
@@ -132,3 +145,114 @@ class SlackEntrypointTest(TestCase):
             renderable=ANY,
             slack_user_id=self.slack_user_id,
         )
+
+    def test_transform_block_actions_removes_matching_elements(self):
+        blocks = [
+            {"type": "section", "text": {"type": "plain_text", "text": "Keep this"}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "remove_me",
+                        "text": {"type": "plain_text", "text": "Remove"},
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "keep_me",
+                        "text": {"type": "plain_text", "text": "Keep"},
+                    },
+                ],
+            },
+        ]
+
+        result = transform_block_actions(
+            blocks, lambda elem: None if elem.get("action_id") == "remove_me" else elem
+        )
+
+        assert len(result) == 2
+        assert result[0]["type"] == "section"
+        assert len(result[1]["elements"]) == 1
+        assert result[1]["elements"][0]["action_id"] == "keep_me"
+
+    def test_transform_block_actions_removes_empty_action_blocks(self):
+        blocks = [
+            {
+                "type": "actions",
+                "elements": [
+                    {"type": "button", "action_id": "remove_me"},
+                ],
+            },
+        ]
+
+        result = transform_block_actions(
+            blocks, lambda elem: None if elem.get("action_id") == "remove_me" else elem
+        )
+
+        assert len(result) == 0
+
+    @patch("sentry.integrations.slack.integration.SlackIntegration.update_message")
+    def test_update_existing_message(self, mock_update_message):
+        self.slack_request.data = {
+            "message": {
+                "ts": self.thread_ts,
+                "text": "Issue notification",
+                "blocks": [
+                    {"type": "section", "text": {"type": "plain_text", "text": "Issue found"}},
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {"type": "button", "action_id": "seer_autofix_start_root_cause"},
+                            {"type": "button", "action_id": "other_action"},
+                        ],
+                    },
+                ],
+            }
+        }
+
+        install = self.integration.get_installation(organization_id=self.organization.id)
+        _update_existing_message(
+            request=self.slack_request,
+            install=install,
+            channel_id=self.channel_id,
+            message_ts=self.thread_ts,
+        )
+
+        mock_update_message.assert_called_once()
+        call_args = mock_update_message.call_args
+        assert call_args.kwargs["channel_id"] == self.channel_id
+        assert call_args.kwargs["message_ts"] == self.thread_ts
+        renderable = call_args.kwargs["renderable"]
+        assert len(renderable["blocks"]) == 2
+        assert len(renderable["blocks"][1]["elements"]) == 1
+        assert renderable["blocks"][1]["elements"][0]["action_id"] == "other_action"
+
+    @patch("sentry.integrations.slack.integration.SlackIntegration.update_message")
+    @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
+    def test_on_trigger_autofix_success_updates_message(
+        self, mock_send_threaded_ephemeral_message, mock_update_message
+    ):
+        self.slack_request.data = {
+            "message": {
+                "ts": self.thread_ts,
+                "text": "Issue notification",
+                "blocks": [
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {"type": "button", "action_id": "seer_autofix_start_root_cause"}
+                        ],
+                    }
+                ],
+            }
+        }
+
+        ep = SlackEntrypoint(
+            slack_request=self.slack_request,
+            group=self.group,
+            organization_id=self.organization.id,
+        )
+        ep.on_trigger_autofix_success(run_id=MOCK_RUN_ID)
+
+        mock_send_threaded_ephemeral_message.assert_called_once()
+        mock_update_message.assert_called_once()


### PR DESCRIPTION
Update Slack messages after autofix is triggered to remove the autofix button from the original notification.

When users click the autofix button in Slack, the original message remains unchanged with the button still present. This can lead to confusion and potential duplicate autofix runs if users click again.

This PR adds an `update_message()` method to `SlackIntegration` and calls it after successful autofix trigger to update the original message. A new `transform_block_actions()` helper function handles filtering out specific action elements from BlockKit messages, making it reusable for future message manipulation needs.

Also includes a button label update from "Start RCA" to "Fix with Seer" for clearer UX.

Refs ECO-1334