### PR TITLE
fix(seer): Update copy and add more help text to explain default settings

### DIFF
--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -1,7 +1,9 @@
-import {ExternalLink} from '@sentry/scraps/link/link';
+import {Flex} from '@sentry/scraps/layout/flex';
+import {ExternalLink, Link} from '@sentry/scraps/link/link';
 
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
@@ -41,7 +43,24 @@ export default function SeerAutomationSettings() {
           disabled={!canWrite}
           forms={[
             {
-              title: t('Default automations for new projects'),
+              title: (
+                <Flex gap="md">
+                  <span>{t('Default automations for new projects')}</span>
+                  <QuestionTooltip
+                    isHoverable
+                    title={tct(
+                      'These settings apply as new projects are created. Any [link:existing projects] will not be affected.',
+                      {
+                        link: (
+                          <Link to={`/settings/${organization.slug}/seer/projects/`} />
+                        ),
+                      }
+                    )}
+                    size="xs"
+                    icon="info"
+                  />
+                </Flex>
+              ),
               fields: [
                 {
                   name: 'defaultAutofixAutomationTuning',
@@ -64,7 +83,7 @@ export default function SeerAutomationSettings() {
                   name: 'autoOpenPrs',
                   label: t('Enable Autofix PR Creation by Default'),
                   help: t(
-                    'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+                    'For all new projects with connected repositories, Seer will be able to make pull requests for highly actionable issues.'
                   ),
                   type: 'boolean',
                 },
@@ -85,13 +104,29 @@ export default function SeerAutomationSettings() {
               ],
             },
             {
-              title: t('Default Code Review for New Repos'),
+              // title: t('Default Code Review for New Repos'),
+              title: (
+                <Flex gap="md">
+                  <span>{t('Default Code Review for New Repos')}</span>
+                  <QuestionTooltip
+                    isHoverable
+                    title={tct(
+                      'These settings apply as repositories are newly connected. Any [link:existing repositories] will not be affected.',
+                      {
+                        link: <Link to={`/settings/${organization.slug}/seer/repos/`} />,
+                      }
+                    )}
+                    size="xs"
+                    icon="info"
+                  />
+                </Flex>
+              ),
               fields: [
                 {
                   name: 'autoEnableCodeReview',
                   label: t('Enable Code Review by Default'),
                   help: t(
-                    'For all new repos connected, Seer will review your PRs and flag potential bugs'
+                    'For all new repos connected, Seer will review your PRs and flag potential bugs.'
                   ),
                   type: 'boolean',
                 },

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -110,7 +110,7 @@ export default function SeerAutomationSettings() {
                   <QuestionTooltip
                     isHoverable
                     title={tct(
-                      'These settings apply as repositories are newly connected. Any [link:existing repositories] will not be affected.',
+                      'These settings apply as repos are newly connected. Any [link:existing repos] will not be affected.',
                       {
                         link: <Link to={`/settings/${organization.slug}/seer/repos/`} />,
                       }

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -83,7 +83,7 @@ export default function SeerAutomationSettings() {
                   name: 'autoOpenPrs',
                   label: t('Enable Autofix PR Creation by Default'),
                   help: t(
-                    'For all new projects with connected repositories, Seer will be able to make pull requests for highly actionable issues.'
+                    'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
                   ),
                   type: 'boolean',
                 },

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -104,7 +104,6 @@ export default function SeerAutomationSettings() {
               ],
             },
             {
-              // title: t('Default Code Review for New Repos'),
               title: (
                 <Flex gap="md">
                   <span>{t('Default Code Review for New Repos')}</span>


### PR DESCRIPTION
This improves the help text that we have on the main Org > Settings > Seer page. 
To reduce confusion, without adding more words to the screen, i added some info-icon that try to explain these settings will apply to new projects & repos, but anything that's already setup will have their existing settings remain the same.

Fixes https://www.notion.so/sentry/Switching-a-toggle-in-Seer-settings-going-to-projects-then-back-to-settings-doesn-t-show-the-updat-2cc8b10e4b5d8080a789f586fdf64c2e

New Tooltips:

<img width="1024" height="611" alt="Screenshot 2026-01-08 at 1 50 38 PM" src="https://github.com/user-attachments/assets/106fdf12-8fa0-4252-9056-140d661aaf8e" />
<img width="1024" height="611" alt="Screenshot 2026-01-08 at 1 50 40 PM" src="https://github.com/user-attachments/assets/e793845d-7654-4de5-beaa-5b5c6ec7e968" />
