### PR TITLE
fix(seer): Show "Previous Step" during step 5 of seer onboarding

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/wrapUpStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/wrapUpStep.tsx
@@ -108,15 +108,10 @@ export function WrapUpStep() {
         </MaxWidthPanel>
 
         <ActionSection>
-          {!hasCompletedAnySteps && (
-            <Button
-              size="md"
-              onClick={handlePreviousStep}
-              aria-label={t('Previous Step')}
-            >
-              {t('Previous Step')}
-            </Button>
-          )}
+          <Button size="md" onClick={handlePreviousStep} aria-label={t('Previous Step')}>
+            {t('Previous Step')}
+          </Button>
+
           <LinkButton
             priority="primary"
             size="md"


### PR DESCRIPTION
If people get to the summary, but still want to go back and tweak things they should do that... moving through the wizard again will overrride their previous wizard settings, but that's ok because this person is literally the only one who setup the original values, they should have chances to fix mis-clicks and other problems.

But if they reload the page at that point then they'll actually be brought into the normal settings page, because everything is already saved and ready to go.

Fixes https://www.notion.so/sentry/No-prev-step-button-on-step-5-of-wizard-2cc8b10e4b5d80de8d26fdbe8ad41c9e