### PR TITLE
fix(seer): Only show one tooltip to explain delegating background agents

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -37,7 +37,7 @@ const COLUMNS = [
         {t('Background Agent')}
         <QuestionTooltip
           title={t(
-            'Background Agent delegation can only be enabled on the individual project settings page. Backgroud agents can have their own settings that are not shown here.'
+            'Background agent delegation can only be enabled on the individual project settings page. Background agents can have their own settings that are not shown here.'
           )}
           size="xs"
         />

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -8,6 +8,7 @@ import {Flex} from '@sentry/scraps/layout/flex';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import type {useUpdateBulkAutofixAutomationSettings} from 'sentry/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -30,7 +31,20 @@ const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
   {title: t('Auto Fix'), key: 'fixes'},
   {title: t('PR Creation'), key: 'pr_creation'},
-  {title: t('Background Agent'), key: 'is_delegated'},
+  {
+    title: (
+      <Flex gap="sm">
+        {t('Background Agent')}
+        <QuestionTooltip
+          title={t(
+            'Background Agent delegation can only be enabled on the individual project settings page. Backgroud agents can have their own settings that are not shown here.'
+          )}
+          size="xs"
+        />
+      </Flex>
+    ),
+    key: 'is_delegated',
+  },
   {title: t('Repos'), key: 'repos'},
 ];
 

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -165,14 +165,6 @@ export default function SeerProjectTableRow({
                 );
               }}
             />
-            {hasDelegationEnabled ? null : (
-              <QuestionTooltip
-                title={t(
-                  'Enable delegation to a background agent on the project settings page.'
-                )}
-                size="xs"
-              />
-            )}
           </Flex>
         )}
       </SimpleTable.RowCell>


### PR DESCRIPTION
Enabling backgruond agents can't be done in bulk because there could be multiple agents to choose from, and each could have a different set of options. So you've gotta do it on the Settings > Project > Seer page, for each project.

The little checkbox isn't enough to capture all that, maybe in a future iteration we can do something else, like a little dropdown+form with the sub-options in there.... but another thing that's troublesome is we're not showing the current agent or it's settings in this table either... so when you're selecting items in the list you won't know what the current options are.


Anyway, this replaces an icon+tooltip on each row with a single icon+tooltip in the table header.
Could probably use some better copywriting at this point.

**Before**
<img width="166" height="183" alt="Screenshot 2025-12-17 at 10 11 42 AM" src="https://github.com/user-attachments/assets/3a24c16a-8151-4f93-95e3-ee6cc2d7a489" />
<img width="286" height="215" alt="Screenshot 2025-12-17 at 10 11 40 AM" src="https://github.com/user-attachments/assets/9c7974b2-cc6e-490e-9020-861005982e0c" />



**After**
<img width="317" height="279" alt="Screenshot 2026-01-08 at 2 25 47 PM" src="https://github.com/user-attachments/assets/18d61267-8d6d-4216-94f6-830a8e52f0a3" />

