### PR TITLE
fix(grouping): Add rule source to stacktrace hints

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 import msgpack
 import sentry_sdk
 import zstandard
+from sentry_ophio.enhancers import AssembleResult as RustStacktraceResult
 from sentry_ophio.enhancers import Cache as RustCache
 from sentry_ophio.enhancers import Component as RustFrame
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
@@ -229,6 +230,18 @@ def _get_hint_for_frame(
         can_use_rust_hint = False
 
     raw_hint = rust_hint if can_use_rust_hint else incoming_hint if can_use_incoming_hint else None
+
+    # Add 'custom' or 'built-in' to any stacktrace rule description as appropriate
+    return _add_rule_source_to_hint(raw_hint, custom_rules)
+
+
+def _get_hint_for_stacktrace(
+    rust_stacktrace_results: RustStacktraceResult, custom_rules: set[str]
+) -> str | None:
+    raw_hint = rust_stacktrace_results.hint
+
+    if not raw_hint:
+        return None
 
     # Add 'custom' or 'built-in' to any stacktrace rule description as appropriate
     return _add_rule_source_to_hint(raw_hint, custom_rules)

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -529,7 +529,7 @@ class EnhancementsConfig:
 
         stacktrace_component = StacktraceGroupingComponent(
             values=frame_components,
-            hint=rust_stacktrace_results.hint,
+            hint=_get_hint_for_stacktrace(rust_stacktrace_results, self.custom_rule_strings),
             contributes=rust_stacktrace_results.contributes,
         )
 

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2)",
+                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2)",
                 "id": "stacktrace",
                 "name": "stacktrace",
                 "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
               },
               {
                 "contributes": false,
-                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2)",
+                "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2)",
                 "id": "stacktrace",
                 "name": "stacktrace",
                 "values": [

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -8,7 +8,7 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2))
+        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2))
           frame (non app frame)
             function*
               "_main"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -12,7 +12,7 @@ app:
           "log_demo"
         value*
           "Holy shit everything is on fire!"
-        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2))
+        stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by custom stack trace rule (family:native min-frames=2))
           frame (non app frame)
             function*
               "_main"


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/103266, we added stacktrace rule source (custom or built-in) to frame hints in grouping info, but forgot to apply the same change to stacktrace hints. This PR fixes that, by adding a new helper, `_get_hint_for_stacktrace`, to live alongside the `_get_hint_for_frame` helper we already had.