### PR TITLE
ref(unmerge): only do `MinHash` repair if not on AI grouping

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -458,8 +458,11 @@ def repair_denormalizations(
     repair_group_release_data(caches, project, events)
     repair_tsdb_data(caches, project, events)
 
-    for event in events:
-        similarity.record(project, [event])
+    # Skip MinHash similarity indexing for projects that have been backfilled to Seer.
+    # Those projects use Seer's embeddings-based similarity instead.
+    if not project.get_option("sentry:similarity_backfill_completed"):
+        for event in events:
+            similarity.record(project, [event])
 
 
 def lock_hashes(project_id: int, source_id: int, fingerprints: Sequence[str]) -> list[str]:


### PR DESCRIPTION
Refs SENTRY-4192

Unmerge seems to be taking a long time in repairing `MinHash` similarity scores. Since we don't use this feature for SaaS, we should skip this step if we're using Seer AI grouping.