### PR TITLE
fix(code-review): Disable direct-to-seer ghe on-prem flow

### DIFF
--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 
@@ -50,6 +51,10 @@ def handle_webhook_event(
         integration: The GitHub integration
         **kwargs: Additional keyword arguments
     """
+    # Skip GitHub Enterprise on-prem - code review is only supported for GitHub Cloud
+    if integration and integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE:
+        return
+
     handler = EVENT_TYPE_TO_HANDLER.get(github_event)
     if handler is None:
         logger.warning(

--- a/tests/sentry/seer/code_review/webhooks/test_handlers.py
+++ b/tests/sentry/seer/code_review/webhooks/test_handlers.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.integrations.github.webhook_types import GithubWebhookType
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.seer.code_review.webhooks.handlers import handle_webhook_event
+from sentry.testutils.cases import TestCase
+
+
+class TestHandleWebhookEvent(TestCase):
+    """Unit tests for handle_webhook_event."""
+
+    @patch("sentry.seer.code_review.webhooks.handlers.CodeReviewPreflightService")
+    def test_skips_github_enterprise_on_prem(self, mock_preflight: MagicMock) -> None:
+        """
+        Test that GitHub Enterprise on-prem webhooks are skipped.
+
+        Code review is only supported for GitHub Cloud, not GitHub Enterprise Server.
+        """
+        integration = MagicMock()
+        integration.provider = IntegrationProviderSlug.GITHUB_ENTERPRISE
+
+        handle_webhook_event(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": "opened", "pull_request": {}},
+            organization=self.organization,
+            repo=MagicMock(),
+            integration=integration,
+        )
+
+        # Preflight should never be called for GitHub Enterprise
+        mock_preflight.assert_not_called()
+
+    @patch("sentry.seer.code_review.webhooks.handlers.CodeReviewPreflightService")
+    def test_processes_github_com(self, mock_preflight: MagicMock) -> None:
+        """Test that GitHub Cloud webhooks are processed normally."""
+        integration = MagicMock()
+        integration.provider = IntegrationProviderSlug.GITHUB
+        integration.id = 123
+
+        mock_preflight_instance = MagicMock()
+        mock_preflight_instance.check.return_value.allowed = False
+        mock_preflight_instance.check.return_value.denial_reason = None
+        mock_preflight.return_value = mock_preflight_instance
+
+        handle_webhook_event(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": "opened", "pull_request": {}},
+            organization=self.organization,
+            repo=MagicMock(),
+            integration=integration,
+        )
+
+        # Preflight should be called for GitHub Cloud
+        mock_preflight.assert_called_once()


### PR DESCRIPTION
GitHub Enterprise on-prem webhooks are currently flowing through our new stuff for the overwatch migration project (getting filtered out, but still getting further than we want, so add this additional check upstream). 

inheritance chain
```
GitHubEnterprisePullRequestEventWebhook
    ├── GitHubEnterpriseWebhook (mixin - provides provider="github_enterprise")
    └── PullRequestEventWebhook (from github/webhook.py)
            └── GitHubWebhook (base class)
                    └── WEBHOOK_EVENT_PROCESSORS = (
                            _handle_pr_webhook_for_autofix_processor,
                            code_review_handle_webhook_event,  ← This is what got called and caused sentry issue SENTRY-5GEH
                        )
```

I saw an unexpected sentry [issue](https://sentry.sentry.io/issues/7173671530/?project=1&query=%21error.type%3AThreadLeakAssertionError%20code_review%20is%3Aunresolved&referrer=issue-stream) with this [PR](https://github.com/getsentry/sentry/pull/105587) because we assumed the github_event was `GitHubWebhookType` [here](https://github.com/getsentry/sentry/blob/08603c18d567309b7a8e9cb1132ee529467e1709/src/sentry/integrations/github/webhook.py#L169), but actually it's of type string for github enterprise on-prem inherited provider code [here](https://github.com/getsentry/sentry/blob/08603c18d567309b7a8e9cb1132ee529467e1709/src/sentry/integrations/github_enterprise/webhook.py#L293). So technically the type hint was wrong in the case of ghe on-prem.

When we go to support GitHub Enterprise on-prem provider we can make any necessary adjustments there and anywhere else needed to fully support that flow end-to-end.