### PR TITLE
ref: bump react-router version

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "react-lazyload": "^3.2.1",
     "react-mentions": "4.4.10",
     "react-popper": "^2.3.0",
-    "react-router-dom": "6.30.1",
+    "react-router-dom": "6.30.3",
     "react-select": "4.3.1",
     "react-textarea-autosize": "8.5.7",
     "react-virtualized": "^9.22.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,7 +419,7 @@ importers:
         version: 0.6.0
       nuqs:
         specifier: 2.7.1
-        version: 2.7.1(react-router-dom@6.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@6.30.1(react@19.2.3))(react@19.2.3)
+        version: 2.7.1(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@6.30.3(react@19.2.3))(react@19.2.3)
       papaparse:
         specifier: ^5.3.2
         version: 5.3.2
@@ -472,8 +472,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0(@popperjs/core@2.11.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-router-dom:
-        specifier: 6.30.1
-        version: 6.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 6.30.3
+        version: 6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-select:
         specifier: 4.3.1
         version: 4.3.1(@types/react@19.2.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2958,6 +2958,10 @@ packages:
 
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
+
+  '@remix-run/router@1.23.2':
+    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
 
   '@rsdoctor/client@1.3.1':
@@ -7477,15 +7481,15 @@ packages:
     peerDependencies:
       react: '>= 16.3'
 
-  react-router-dom@6.30.1:
-    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+  react-router-dom@6.30.3:
+    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.1:
-    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+  react-router@6.30.3:
+    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -11761,6 +11765,8 @@ snapshots:
       react: 19.2.3
 
   '@remix-run/router@1.23.0': {}
+
+  '@remix-run/router@1.23.2': {}
 
   '@rsdoctor/client@1.3.1': {}
 
@@ -16910,13 +16916,13 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.1(react-router-dom@6.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@6.30.1(react@19.2.3))(react@19.2.3):
+  nuqs@2.7.1(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@6.30.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
-      react-router: 6.30.1(react@19.2.3)
-      react-router-dom: 6.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 6.30.3(react@19.2.3)
+      react-router-dom: 6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   nwsapi@2.2.20: {}
 
@@ -17450,16 +17456,16 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  react-router-dom@6.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.2
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 6.30.1(react@19.2.3)
+      react-router: 6.30.3(react@19.2.3)
 
-  react-router@6.30.1(react@19.2.3):
+  react-router@6.30.3(react@19.2.3):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.2
       react: 19.2.3
 
   react-select@4.3.1(@types/react@19.2.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):


### PR DESCRIPTION
Not sure if we are affected by the latest vulnerabilities, but upgrading to the recommended latest patch version seems like a good idea regardless.

The one that could affect us is likely this: https://github.com/remix-run/react-router/security/advisories/GHSA-9jcx-v3wj-wh4m