### PR TITLE
fix(ai-trace): turn off autogrouping for gen_ai spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -808,6 +808,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
         tail.children[0]!.canAutogroup &&
         // skip `op: default` spans as `default` is added to op-less spans:
         tail.children[0]!.op !== 'default' &&
+        // skip gen_ai spans from autogrouping
+        !tail.children[0]!.op?.startsWith('gen_ai') &&
         tail.children[0]!.op === head.op
       ) {
         start = Math.min(start, tail.space[0]);
@@ -947,6 +949,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
           current.children.length === 0 &&
           // skip `op: default` spans as `default` is added to op-less spans
           next.op !== 'default' &&
+          // skip gen_ai spans from autogrouping
+          !next.op?.startsWith('gen_ai') &&
           next.op === current.op &&
           next.description === current.description
           // next.value.description === current.value.description


### PR DESCRIPTION
closes [TET-1700: Turn off autogrouping for gen ai spans](https://linear.app/getsentry/issue/TET-1700/turn-off-autogrouping-for-gen-ai-spans)