### PR TITLE
chore(dynamic-sampling): remove option for empty queries after rollout

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -284,7 +284,7 @@ def query_project_counts_by_org(
 
     Yields chunks of result rows, to allow timeouts to be handled in the caller.
     """
-    if not org_ids and options.get("dynamic-sampling.skip_snuba_query_for_empty_orgs"):
+    if not org_ids:
         return
 
     if query_interval is None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2244,13 +2244,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Skip Snuba query when there are no orgs to query for. This is a rollout flag for a fix
-# that prevents unnecessary Snuba queries.
-register(
-    "dynamic-sampling.skip_snuba_query_for_empty_orgs",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # === Hybrid cloud subsystem options ===
 # UI rollout

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -377,17 +377,16 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
     def test_query_skips_for_empty_org_ids_when_option_enabled(self) -> None:
         """
         Confirms that query_project_counts_by_org does NOT make a Snuba query
-        when called with an empty org_ids list and the option is enabled.
+        when called with an empty org_ids list.
         """
-        with self.options({"dynamic-sampling.skip_snuba_query_for_empty_orgs": True}):
-            with patch(
-                "sentry.dynamic_sampling.tasks.boost_low_volume_projects.raw_snql_query"
-            ) as mock_query:
-                mock_query.return_value = {"data": []}
+        with patch(
+            "sentry.dynamic_sampling.tasks.boost_low_volume_projects.raw_snql_query"
+        ) as mock_query:
+            mock_query.return_value = {"data": []}
 
-                list(query_project_counts_by_org([], SamplingMeasure.TRANSACTIONS))
+            list(query_project_counts_by_org([], SamplingMeasure.TRANSACTIONS))
 
-                assert mock_query.call_count == 0
+            assert mock_query.call_count == 0
 
     def test_fetch_projects_only_queries_measures_with_orgs(self) -> None:
         """
@@ -416,7 +415,6 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
                 {
                     "dynamic-sampling.check_span_feature_flag": True,
                     "dynamic-sampling.measure.spans": [org.id],
-                    "dynamic-sampling.skip_snuba_query_for_empty_orgs": True,
                 }
             ):
                 partitioned = partition_by_measure([org.id])
@@ -450,7 +448,6 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
                 {
                     "dynamic-sampling.check_span_feature_flag": True,
                     "dynamic-sampling.measure.spans": [org1.id, org2.id],
-                    "dynamic-sampling.skip_snuba_query_for_empty_orgs": True,
                 }
             ):
                 batches = [[org1.id], [org2.id]]


### PR DESCRIPTION
Everything went well - remove the option