### PR TITLE
ref(slack): Compact Slack issue alert message layout

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -413,6 +413,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Workflows in Slack
     manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable new compact issue alert UI in Slack
+    manager.add("organizations:slack-compact-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query builder boolean operator select feature
     manager.add("organizations:search-query-builder-add-boolean-operator-select", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query builder conditionals in combobox menus

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -659,7 +659,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         text = description_text.lstrip(" ")
         # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")
-        return self.get_text_block(description_text) if text else None
+        return self.get_text_block(text) if text else None
 
     def build_group_context_block(self, suggested_assignees: list[str]) -> SlackBlock | None:
         """Combine stats (events, users, state, first seen) with suggested assignees in one context block."""
@@ -677,6 +677,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             suggested_text = ", ".join(truncated_assignees)
             context_text += f"   Suggested: {suggested_text}"
 
+        context_text = context_text.strip()
         if not context_text:
             return None
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -575,7 +575,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             return None
 
         if features.has("organizations:slack-compact-alerts", self.group.organization):
-            return f"*Initial Guess*: {escape_slack_markdown_text("  ".join(parts))}"
+            return f"*Initial Guess*: {escape_slack_markdown_text('  '.join(parts))}"
         else:
             return escape_slack_markdown_text("\n\n".join(parts))
 
@@ -584,7 +584,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             return self.get_context_block(event_or_group.culprit)
         return None
 
-    # 'small' param be removed when 'slack-compact-alerts' is GA
+    # 'small' param can be removed when 'slack-compact-alerts' is GA
     def get_text_block(self, text, small: bool = False) -> SlackBlock:
         if self.group.issue_category == GroupCategory.FEEDBACK:
             max_block_text_length = USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH
@@ -605,10 +605,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
     def get_group_context_block(self, suggested_assignees: list[str]) -> SlackBlock:
         """Combine stats (events, users, state, first seen) with suggested assignees in one context block."""
-        # Get the stats context text
         context_text = get_context(self.group, self.rules)
 
-        # Append suggested assignees if available
         if suggested_assignees:
             suggested_text = ", ".join(suggested_assignees)
             context_text += f"   Suggested: {suggested_text}"

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -606,13 +606,16 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             suggested_assignee_text += assignee + ", "
         return self.get_context_block(suggested_assignee_text[:-2])  # get rid of comma at the end
 
-    def get_group_context_block(self, suggested_assignees: list[str]) -> SlackBlock:
+    def get_group_context_block(self, suggested_assignees: list[str]) -> SlackBlock | None:
         """Combine stats (events, users, state, first seen) with suggested assignees in one context block."""
         context_text = get_context(self.group, self.rules)
 
         if suggested_assignees:
             suggested_text = ", ".join(suggested_assignees)
             context_text += f"   Suggested: {suggested_text}"
+
+        if not context_text:
+            return None
 
         return self.get_context_block(context_text)
 
@@ -773,7 +776,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )
 
         if self._is_compact:
-            blocks.append(self.get_group_context_block(suggested_assignees=suggested_assignees))
+            if group_context_block := self.get_group_context_block(
+                suggested_assignees=suggested_assignees
+            ):
+                blocks.append(group_context_block)
         else:
             # add event count, user count, substate, first seen
             context = get_context(self.group, self.rules)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -683,21 +683,22 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         return self.get_context_block(context_text)
 
-    def build_pre_footer_context_block(self, suggested_assignees: list[str]) -> SlackBlock | None:
+    def build_pre_footer_context_blocks(self, suggested_assignees: list[str]) -> list[SlackBlock]:
+        blocks = []
         summary_text: str | None = self.get_issue_summary_text()
         if self._is_compact and summary_text:
-            return self.get_context_block(summary_text)
+            blocks.append(self.get_context_block(summary_text))
 
         if not self._is_compact and len(suggested_assignees) > 0:
-            return self.get_suggested_assignees_block(suggested_assignees)
+            blocks.append(self.get_suggested_assignees_block(suggested_assignees))
 
         if not self._is_compact:
             # add suspect commit info
             suspect_commit_text = get_suspect_commit_text(self.group)
             if suspect_commit_text:
-                return self.get_context_block(suspect_commit_text)
+                blocks.append(self.get_context_block(suspect_commit_text))
 
-        return None
+        return blocks
 
     def build(self, notification_uuid: str | None = None) -> SlackBlock:
         self.issue_summary = fetch_issue_summary(self.group)
@@ -849,8 +850,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
 
-        if pre_footer_context_block := self.build_pre_footer_context_block(suggested_assignees):
-            blocks.append(pre_footer_context_block)
+        if pre_footer_context_block := self.build_pre_footer_context_blocks(suggested_assignees):
+            blocks.extend(pre_footer_context_block)
 
         # add notes
         if self.notes:

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1139,6 +1139,123 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         blocks = SlackIssuesMessageBuilder(group).build()
         assert "IntegrationError" in blocks["blocks"][0]["text"]["text"]
 
+    @with_feature("organizations:slack-compact-alerts")
+    @override_options({"alerts.issue_summary_timeout": 5})
+    @with_feature({"organizations:gen-ai-features"})
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    def test_compact_alerts_with_ai_summary(self, mock_get_seer_org_acknowledgement) -> None:
+        """
+        Test that with the slack-compact-alerts flag enabled and AI summary available:
+        - Title uses build_attachment_title() (not AI headline)
+        - Issue summary appears after action buttons as context with "Initial Guess:" prefix
+        """
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "IntegrationError",
+                "fingerprint": ["group-1"],
+                "exception": {
+                    "values": [
+                        {
+                            "type": "IntegrationError",
+                            "value": "Identity not found.",
+                        }
+                    ]
+                },
+                "level": "error",
+            },
+            project_id=self.project.id,
+        )
+        assert event.group
+        group = event.group
+        group.type = ErrorGroupType.type_id
+        group.save()
+
+        self.project.flags.has_releases = True
+        self.project.save(update_fields=["flags"])
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
+
+        mock_summary = {
+            "headline": "Custom AI Title",
+            "whatsWrong": "This is what's wrong with the issue",
+            "trace": "This is trace information",
+            "possibleCause": "This is a possible cause",
+        }
+        patch_path = "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary"
+        serializer_path = "sentry.api.serializers.models.event.EventSerializer.serialize"
+        serializer_mock = Mock(return_value={})
+
+        with (
+            patch(patch_path) as mock_get_summary,
+            patch(serializer_path, serializer_mock),
+        ):
+            mock_get_summary.return_value = (mock_summary, 200)
+
+            blocks = SlackIssuesMessageBuilder(group).build()
+
+            title_block = blocks["blocks"][0]["text"]["text"]
+            assert "IntegrationError" in title_block
+            assert "Custom AI Title" not in title_block
+
+            found_initial_guess = False
+            for block in blocks["blocks"]:
+                if block.get("type") == "context":
+                    elements = block.get("elements", [])
+                    for element in elements:
+                        if "Initial Guess" in element.get("text", ""):
+                            found_initial_guess = True
+                            assert "This is a possible cause" in element["text"]
+                            break
+
+            assert found_initial_guess, "Initial Guess context block not found"
+            assert blocks["blocks"][-1]["type"] != "divider"
+
+    @with_feature("organizations:slack-compact-alerts")
+    def test_compact_alerts_context_includes_suggested_assignees(self) -> None:
+        """
+        Test that with compact alerts, suggested assignees are included in the context block
+        rather than in a separate block.
+        """
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "Hello world",
+                "fingerprint": ["group-1"],
+                "level": "error",
+                "stacktrace": {"frames": [{"filename": "foo.py"}]},
+            },
+            project_id=self.project.id,
+        )
+        assert event.group
+        group = event.group
+
+        # Set up ownership to create suggested assignees
+        rule = Rule(Matcher("path", "*"), [Owner("team", self.team.slug)])
+        ProjectOwnership.objects.create(project_id=self.project.id, schema=dump_schema([rule]))
+
+        blocks = SlackIssuesMessageBuilder(group, event).build()
+
+        found_suggested_in_context = False
+        found_old_suggested_assignees = False
+        for block in blocks["blocks"]:
+            if block.get("type") == "context":
+                elements = block.get("elements", [])
+                for element in elements:
+                    text = element.get("text", "")
+                    if "Suggested:" in text:
+                        found_suggested_in_context = True
+                    if "Suggested Assignees:" in text:
+                        found_old_suggested_assignees = True
+
+        assert found_suggested_in_context, "Suggested assignees should be in context block"
+        assert (
+            not found_old_suggested_assignees
+        ), "Old 'Suggested Assignees:' format should not appear"
+
 
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -262,7 +262,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
         assert "via" not in blocks[4]["elements"][0]["text"]
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
@@ -288,7 +288,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_until_condition_met(self, mock_tags: MagicMock) -> None:
@@ -306,7 +306,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_until_condition_met_through_unfurl(self, mock_tags: MagicMock) -> None:
@@ -327,7 +327,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_forever(self, mock_tags: MagicMock) -> None:
@@ -343,7 +343,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.models.organization.Organization.has_access", return_value=False)
     def test_archive_issue_forever_error(self, mock_access: MagicMock) -> None:
@@ -374,7 +374,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue_with_additional_user_auth(self) -> None:
         """
@@ -397,7 +397,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue_with_additional_user_auth_through_unfurl(self) -> None:
         """
@@ -420,7 +420,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_unarchive_issue(self, mock_tags: MagicMock) -> None:
@@ -445,7 +445,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_unarchive_issue_through_unfurl(self, mock_tags: MagicMock) -> None:
@@ -471,7 +471,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_assign_issue(self, mock_tags: MagicMock) -> None:
@@ -488,7 +488,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assign to team
@@ -500,7 +500,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assert group assignment activity recorded
@@ -543,7 +543,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][3]["text"]["text"].endswith(expect_status), resp.data["text"]
         assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
         # Assert group assignment activity recorded
@@ -569,7 +569,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
         # Assign to team
         self.assign_issue(original_message, self.team, payload_data)
@@ -578,7 +578,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
         # Assert group assignment activity recorded
         group_activity = list(Activity.objects.filter(group=self.group))
@@ -643,7 +643,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
     def test_assign_issue_user_has_identity_through_unfurl(self) -> None:
         user2 = self.create_user(is_superuser=False)
@@ -665,7 +665,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
     def test_assign_user_with_multiple_identities(self) -> None:
         org2 = self.create_organization(owner=None)
@@ -691,7 +691,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             assignee=self.external_id
         )
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
     def test_assign_user_with_multiple_identities_through_unfurl(self) -> None:
         org2 = self.create_organization(owner=None)
@@ -718,7 +718,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             assignee=self.external_id
         )
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert blocks[3]["text"]["text"].endswith(expect_status), text
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
@@ -735,7 +735,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"] == expect_status
+        assert blocks[3]["text"]["text"] == expect_status
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
@@ -757,7 +757,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"] == expect_status
+        assert blocks[3]["text"]["text"] == expect_status
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -791,7 +791,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
             in blocks[2]["text"]["text"]
         )
-        assert blocks[3]["text"]["text"] == expect_status
+        assert blocks[4]["text"]["text"] == expect_status
         assert ":white_circle: :chart_with_upwards_trend:" in blocks[0]["text"]["text"]
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
@@ -809,7 +809,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"] == expect_status
+        assert blocks[3]["text"]["text"] == expect_status
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
@@ -836,7 +836,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_resolve_issue_in_current_release_through_unfurl(self, mock_tags: MagicMock) -> None:
@@ -861,7 +861,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
@@ -885,7 +885,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_resolve_in_next_release_through_unfurl(self, mock_tags: MagicMock) -> None:
@@ -909,7 +909,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch(
         "slack_sdk.web.WebClient.views_update",
@@ -960,7 +960,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
-        assert blocks[2]["text"]["text"].endswith(expect_status)
+        assert blocks[3]["text"]["text"].endswith(expect_status)
 
     @patch(
         "slack_sdk.web.WebClient.views_update",


### PR DESCRIPTION
Adds a slack-compact-alerts flag for the new alert layout. The compact layout won't affect most customers, key differences are 
- the AI summary is moved 
- title will not vary by your access to Seer
- suggested assignee is moved to the context stats
- suspect commit removed

<img width="652" height="454" alt="image" src="https://github.com/user-attachments/assets/24ea61b5-3f76-4555-a9fd-7ab49ca6bb43" />

Hard to display all the differences without setting them up each feature and preventing race conditions (i.e. alert fires before suggested assignee is determined), so we can verify with tests and in production via the flag.