### PR TITLE
chore(aci): handle workflows or rules in digests sans feature flag

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -76,8 +76,11 @@ def unsplit_key(
     return f"mail:p:{project.id}:{target_type.value}:{target_str}:{fallthrough}"
 
 
-def split_rules_by_identifier_key(rules: Sequence[Rule]) -> dict[IdentifierKey, Rule]:
-    parsed_rules = {IdentifierKey.RULE: [], IdentifierKey.WORKFLOW: []}
+def split_rules_by_identifier_key(rules: Sequence[Rule]) -> dict[IdentifierKey, list[Rule]]:
+    parsed_rules: dict[IdentifierKey, list[Rule]] = {
+        IdentifierKey.RULE: [],
+        IdentifierKey.WORKFLOW: [],
+    }
     for rule in rules:
         try:
             key, _ = get_rule_or_workflow_id(rule)

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -208,7 +208,7 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
         workflow_ids
     )
 
-    # Try to fetch rules for workflows, if not use the rule_id
+    # Try to fetch rules for workflows, if not use the workflow id
     alert_rule_workflows = AlertRuleWorkflow.objects.filter(workflow_id__in=workflow_ids)
     alert_rule_workflows_map = {awf.workflow_id: awf for awf in alert_rule_workflows}
 

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -13,7 +13,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tsdb.base import TSDBModel
 from sentry.workflow_engine.models import Workflow
@@ -88,19 +88,7 @@ def event_to_record(
     # TODO(iamrajjoshi): The typing on this function is wrong, the type should be GroupEvent
     # TODO(iamrajjoshi): Creating a PR to fix this
     assert event.group is not None
-    rule_ids = []
-    if identifier_key == IdentifierKey.RULE:
-        for rule in rules:
-            try:
-                rule_ids.append(int(get_key_from_rule_data(rule, "legacy_rule_id")))
-            except AssertionError:
-                rule_ids.append(rule.id)
-    elif identifier_key == IdentifierKey.WORKFLOW:
-        for rule in rules:
-            try:
-                rule_ids.append(int(get_key_from_rule_data(rule, "workflow_id")))
-            except AssertionError:
-                rule_ids.append(rule.id)
+    rule_ids = [int(get_rule_or_workflow_id(rule)[1]) for rule in rules]
     return Record(
         event.event_id,
         Notification(event, rule_ids, notification_uuid, identifier_key),

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -13,7 +13,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
-from sentry.notifications.utils.rules import get_key_from_rule_data, get_rule_or_workflow_id
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tsdb.base import TSDBModel
 from sentry.workflow_engine.models import Workflow
@@ -74,23 +74,6 @@ def unsplit_key(
     target_str = target_identifier if target_identifier is not None else ""
     fallthrough = fallthrough_choice.value if fallthrough_choice is not None else ""
     return f"mail:p:{project.id}:{target_type.value}:{target_str}:{fallthrough}"
-
-
-def split_rules_by_identifier_key(rules: Sequence[Rule]) -> dict[IdentifierKey, list[Rule]]:
-    parsed_rules: dict[IdentifierKey, list[Rule]] = {
-        IdentifierKey.RULE: [],
-        IdentifierKey.WORKFLOW: [],
-    }
-    for rule in rules:
-        try:
-            key, _ = get_rule_or_workflow_id(rule)
-            if key == "workflow_id":
-                parsed_rules[IdentifierKey.WORKFLOW].append(rule)
-            else:
-                parsed_rules[IdentifierKey.RULE].append(rule)
-        except AssertionError:
-            parsed_rules[IdentifierKey.RULE].append(rule)
-    return parsed_rules
 
 
 def event_to_record(

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -15,7 +15,7 @@ from sentry.models.team import Team
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data, get_rule_or_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.users.services.user import RpcUser
 from sentry.utils.http import absolute_uri
@@ -291,14 +291,12 @@ def build_footer(
 ) -> str:
     footer = f"{group.qualified_short_id}"
     if rules:
-        if features.has("organizations:workflow-engine-ui-links", group.organization):
-            rule_url = absolute_uri(
-                create_link_to_workflow(
-                    group.organization.id, get_key_from_rule_data(rules[0], "workflow_id")
-                )
-            )
-        else:
-            rule_url = build_rule_url(rules[0], group, project)
+        key, value = get_rule_or_workflow_id(rules[0])
+        match key:
+            case "workflow_id":
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+            case "legacy_rule_id":
+                rule_url = build_rule_url(rules[0], group, project)
 
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-from sentry import features
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.on_call.metrics import OnCallInteractionType
@@ -12,7 +11,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data, split_rules_by_rule_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -91,19 +90,30 @@ class OpsgenieClient(ApiClient):
             group_params = {"referrer": IntegrationProviderSlug.OPSGENIE.value}
             if notification_uuid:
                 group_params["notification_uuid"] = notification_uuid
+
+            rules_and_workflows = split_rules_by_rule_workflow_id(rules)
+            workflow_urls = self._get_workflow_urls(group, rules_and_workflows.workflow_rules)
+            rule_urls = self._get_rule_urls(group, rules_and_workflows.rules)
             rule_workflow_context = {}
-            if features.has("organizations:workflow-engine-ui-links", group.project.organization):
-                workflow_urls = self._get_workflow_urls(group, rules)
-                rule_workflow_context = {
-                    "Triggering Workflows": ", ".join([rule.label for rule in rules]),
-                    "Triggering Workflow URLs": "\n".join(workflow_urls),
-                }
-            else:
-                rule_urls = self._get_rule_urls(group, rules)
-                rule_workflow_context = {
-                    "Triggering Rules": ", ".join([rule.label for rule in rules]),
-                    "Triggering Rule URLs": "\n".join(rule_urls),
-                }
+            if rule_urls:
+                rule_workflow_context.update(
+                    {
+                        "Triggering Rules": ", ".join(
+                            [rule.label for rule in rules_and_workflows.rules]
+                        ),
+                        "Triggering Rule URLs": "\n".join(rule_urls),
+                    }
+                )
+            if workflow_urls:
+                rule_workflow_context.update(
+                    {
+                        "Triggering Workflows": ", ".join(
+                            [workflow.label for workflow in rules_and_workflows.workflow_rules]
+                        ),
+                        "Triggering Workflow URLs": "\n".join(workflow_urls),
+                    }
+                )
+
             payload["details"] = {
                 "Sentry ID": str(group.id),
                 "Sentry Group": getattr(group, "title", group.message).encode("utf-8"),

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -1,13 +1,12 @@
 from collections.abc import Sequence
 
-from sentry import features
 from sentry.integrations.messaging.message_builder import build_rule_url
 from sentry.integrations.slack.message_builder.types import SLACK_URL_FORMAT
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.utils.http import absolute_uri
 
 
@@ -19,14 +18,12 @@ def build_slack_footer(
     footer = f"{group.qualified_short_id}"
 
     if rules:
-        if features.has("organizations:workflow-engine-ui-links", group.organization):
-            rule_url = absolute_uri(
-                create_link_to_workflow(
-                    group.organization.id, get_key_from_rule_data(rules[0], "workflow_id")
-                )
-            )
-        else:
-            rule_url = build_rule_url(rules[0], group, project)
+        key, value = get_rule_or_workflow_id(rules[0])
+        match key:
+            case "workflow_id":
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+            case "legacy_rule_id":
+                rule_url = build_rule_url(rules[0], group, project)
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -5,12 +5,8 @@ from typing import Any
 
 from sentry import digests
 from sentry.digests import get_option_key as get_digest_option_key
-from sentry.digests.notifications import (
-    DigestInfo,
-    event_to_record,
-    split_rules_by_identifier_key,
-    unsplit_key,
-)
+from sentry.digests.notifications import DigestInfo, event_to_record, unsplit_key
+from sentry.digests.types import IdentifierKey
 from sentry.integrations.types import ExternalProviders
 from sentry.models.activity import Activity
 from sentry.models.options.project_option import ProjectOption
@@ -25,6 +21,7 @@ from sentry.notifications.types import (
     NotificationSettingEnum,
 )
 from sentry.notifications.utils.participants import get_notification_recipients
+from sentry.notifications.utils.rules import split_rules_by_rule_workflow_id
 from sentry.plugins.base.structs import Notification
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.digests import deliver_digest
@@ -88,7 +85,11 @@ class MailAdapter:
 
             digest_key = unsplit_key(project, target_type, target_identifier, fallthrough_choice)
             extra["digest_key"] = digest_key
-            rules_by_identifier_key = split_rules_by_identifier_key(rules)
+            rules_and_workflows = split_rules_by_rule_workflow_id(rules)
+            rules_by_identifier_key = {
+                IdentifierKey.RULE: rules_and_workflows.rules,
+                IdentifierKey.WORKFLOW: rules_and_workflows.workflow_rules,
+            }
             immediate_delivery = False
             for identifier_key, parsed_rules in rules_by_identifier_key.items():
                 # If any of the records are added immediately, we can deliver the digest immediately

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -148,7 +148,7 @@ class DigestNotification(ProjectNotification):
 
         sentry_query_params = self.get_sentry_query_params(ExternalProviders.EMAIL)
 
-        if not features.has("organizations:workflow-engine-ui-links", self.project.organization):
+        if not features.has("organizations:workflow-engine-ui", self.project.organization):
             # TODO(iamrajjoshi): This actually mutes a rule for a user, something we have not ported over in the new system
             # By not including this context, the template will not show the mute button
             snooze_alert = len(rule_details) > 0

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -298,15 +298,13 @@ class AlertRuleNotification(ProjectNotification):
         title_str = "Alert triggered"
 
         if self.rules:
-            rule_url = build_rule_url(self.rules[0], self.group, self.project)
-            key = "legacy_rule_id"
-            try:
-                key, value = get_rule_or_workflow_id(self.rules[0])
-            except AssertionError:
-                pass
+            key, value = get_rule_or_workflow_id(self.rules[0])
 
-            if key == "workflow_id":
-                rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+            match key:
+                case "workflow_id":
+                    rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+                case "legacy_rule_id":
+                    rule_url = build_rule_url(self.rules[0], self.group, self.project)
 
             title_str += (
                 f" {self.format_url(text=self.rules[0].label, url=rule_url, provider=provider)}"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -49,7 +49,7 @@ from sentry.notifications.utils.links import (
     get_snooze_url,
 )
 from sentry.notifications.utils.participants import get_owner_reason, get_send_to
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.plugins.base.structs import Notification
 from sentry.services.eventstore.models import GroupEvent
 from sentry.types.actor import Actor
@@ -259,9 +259,8 @@ class AlertRuleNotification(ProjectNotification):
                 },
             )
 
-        # We don't show the snooze alert if the organization has not enabled the workflow engine UI links
-        # This is because in the new UI/system a user can't individually disable a workflow
-        if not features.has("organizations:workflow-engine-ui-links", self.organization):
+        # We don't show the snooze alert if the organization has not enabled the workflow engine UI because in the new UI/system a user can't individually disable a workflow
+        if not features.has("organizations:workflow-engine-ui", self.organization):
             if len(self.rules) > 0:
                 context["snooze_alert"] = True
                 context["snooze_alert_url"] = get_snooze_url(
@@ -299,14 +298,15 @@ class AlertRuleNotification(ProjectNotification):
         title_str = "Alert triggered"
 
         if self.rules:
-            if features.has("organizations:workflow-engine-ui-links", self.organization):
-                rule_url = absolute_uri(
-                    create_link_to_workflow(
-                        self.organization.id, get_key_from_rule_data(self.rules[0], "workflow_id")
-                    )
-                )
-            else:
-                rule_url = build_rule_url(self.rules[0], self.group, self.project)
+            rule_url = build_rule_url(self.rules[0], self.group, self.project)
+            try:
+                key, value = get_rule_or_workflow_id(self.rules[0])
+            except AssertionError:
+                pass
+
+            if key == "workflow_id":
+                rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+
             title_str += (
                 f" {self.format_url(text=self.rules[0].label, url=rule_url, provider=provider)}"
             )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -299,6 +299,7 @@ class AlertRuleNotification(ProjectNotification):
 
         if self.rules:
             rule_url = build_rule_url(self.rules[0], self.group, self.project)
+            key = "legacy_rule_id"
             try:
                 key, value = get_rule_or_workflow_id(self.rules[0])
             except AssertionError:

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -104,7 +104,7 @@ def get_issue_replay_link(group: Group, sentry_query_params: str = "") -> str:
 
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project, type_id: int | None = None
-) -> Sequence[NotificationRuleDetails]:
+) -> list[NotificationRuleDetails]:
     rules_and_workflows = split_rules_by_rule_workflow_id(rules)
 
     return get_workflow_links(
@@ -123,7 +123,7 @@ def _fetch_rule_id(rule: Rule, type_id: int | None = None) -> int:
 
 def get_rules_with_legacy_ids(
     rules: Sequence[Rule], organization: Organization, project: Project
-) -> Sequence[NotificationRuleDetails]:
+) -> list[NotificationRuleDetails]:
     rules_with_legacy_ids = []
     for rule in rules:
         rule_id = _fetch_rule_id(rule)
@@ -140,7 +140,7 @@ def get_rules_with_legacy_ids(
 
 def get_workflow_links(
     rules: Sequence[Rule], organization: Organization, project: Project
-) -> Sequence[NotificationRuleDetails]:
+) -> list[NotificationRuleDetails]:
     workflow_links = []
     for rule in rules:
         workflow_id = get_key_from_rule_data(rule, "workflow_id")

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -9,7 +9,11 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils.rules import get_key_from_rule_data, split_rules_by_rule_workflow_id
+from sentry.notifications.utils.rules import (
+    get_key_from_rule_data,
+    get_rule_or_workflow_id,
+    split_rules_by_rule_workflow_id,
+)
 from sentry.types.rules import NotificationRuleDetails
 
 """
@@ -163,8 +167,8 @@ def get_snooze_url(
     sentry_query_params: str,
     type_id: int,
 ) -> str:
-    try:
-        rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
-    except AssertionError:
-        rule_id = rule.id
+    key, rule_id = get_rule_or_workflow_id(rule)
+    # should only be using rule
+    if key == "workflow_id":
+        rule_id = str(rule.id)
     return f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/details/{sentry_query_params}&{urlencode({'mute': '1'})}"

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -174,10 +174,8 @@ def get_snooze_url(
     sentry_query_params: str,
     type_id: int,
 ) -> str:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
-    if should_fire_workflow_actions(organization, type_id):
+    try:
         rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
-    else:
+    except AssertionError:
         rule_id = rule.id
     return f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/details/{sentry_query_params}&{urlencode({'mute': '1'})}"

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -4,13 +4,12 @@ from typing import Any
 
 from django.utils.http import urlencode
 
-from sentry import features
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data, get_rule_or_workflow_id
 from sentry.types.rules import NotificationRuleDetails
 
 """
@@ -106,21 +105,22 @@ def get_issue_replay_link(group: Group, sentry_query_params: str = "") -> str:
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project, type_id: int | None = None
 ) -> Sequence[NotificationRuleDetails]:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+    rules_with_workflows = []
+    workflows_without_rules = []
+    for rule in rules:
+        key = "legacy_rule_id"
+        try:
+            key, _ = get_rule_or_workflow_id(rule)
+        except AssertionError:
+            pass
+        if key == "workflow_id":
+            workflows_without_rules.append(rule)
+        else:
+            rules_with_workflows.append(rule)
 
-    if features.has("organizations:workflow-engine-ui-links", organization):
-        return get_workflow_links(rules, organization, project)
-    elif type_id is None or should_fire_workflow_actions(organization, type_id):
-        return get_rules_with_legacy_ids(rules, organization, project)
-    return [
-        NotificationRuleDetails(
-            rule.id,
-            rule.label,
-            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/",
-            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/details/",
-        )
-        for rule in rules
-    ]
+    return get_workflow_links(
+        workflows_without_rules, organization, project
+    ) + get_rules_with_legacy_ids(rules_with_workflows, organization, project)
 
 
 def _fetch_rule_id(rule: Rule, type_id: int | None = None) -> int:

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -5,3 +5,10 @@ def get_key_from_rule_data(rule: Rule, key: str) -> str:
     value = rule.data.get("actions", [{}])[0].get(key)
     assert value is not None
     return value
+
+
+def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:
+    try:
+        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
+    except AssertionError:
+        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
 from sentry.models.rule import Rule
 
 
@@ -5,6 +8,27 @@ def get_key_from_rule_data(rule: Rule, key: str) -> str:
     value = rule.data.get("actions", [{}])[0].get(key)
     assert value is not None
     return value
+
+
+@dataclass
+class RulesAndWorkflows:
+    rules: list[Rule]
+    workflow_rules: list[Rule]  # workflows as fake Rules
+
+
+def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
+    parsed_rules = []
+    workflow_rules = []
+    for rule in rules:
+        try:
+            key, _ = get_rule_or_workflow_id(rule)
+            if key == "workflow_id":
+                workflow_rules.append(rule)
+            else:
+                parsed_rules.append(rule)
+        except AssertionError:
+            parsed_rules.append(rule)
+    return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
 def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -1,7 +1,10 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 from sentry.models.rule import Rule
+
+RuleIdType = Literal["workflow_id", "legacy_rule_id"]
 
 
 def get_key_from_rule_data(rule: Rule, key: str) -> str:
@@ -20,19 +23,22 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
     parsed_rules = []
     workflow_rules = []
     for rule in rules:
-        try:
-            key, _ = get_rule_or_workflow_id(rule)
-            if key == "workflow_id":
+        key, _ = get_rule_or_workflow_id(rule)
+        match key:
+            case "workflow_id":
                 workflow_rules.append(rule)
-            else:
+            case "legacy_rule_id":
                 parsed_rules.append(rule)
-        except AssertionError:
-            parsed_rules.append(rule)
     return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
-def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:
+def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
     try:
         return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
     except AssertionError:
+        pass
+
+    try:
         return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
+    except AssertionError:
+        return ("legacy_rule_id", str(rule.id))

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Sequence
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.integrations.base import IntegrationInstallation
@@ -143,9 +142,9 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             installation, IssueBasicIntegration
         ), "Installation must be an IssueBasicIntegration to create a ticket"
         data["title"] = installation.get_group_title(event.group, event)
-        if features.has("organizations:workflow-engine-ui-links", organization):
-            workflow_id = data.get("workflow_id")
-            assert workflow_id is not None
+
+        workflow_id = data.get("workflow_id")
+        if workflow_id is not None:
             data["description"] = build_description_workflow_engine_ui(
                 event, workflow_id, installation, generate_footer
             )

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 
 from sentry.digests.notifications import (
     Digest,
@@ -19,6 +19,7 @@ from sentry.digests.utils import (
 from sentry.issues.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
+from sentry.models.rule import Rule as RuleModel
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import SnubaTestCase, TestCase
@@ -26,8 +27,8 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.types.actor import ActorType
 
 
-def _get_records(project: Project, rules: Sequence[Rule], event: Event) -> list[Record]:
-    split_rules = split_rules_by_identifier_key(rules)
+def _get_records(project: Project, rules: Collection[RuleModel], event: Event) -> list[Record]:
+    split_rules = split_rules_by_identifier_key(list(rules))
     return [
         event_to_record(event, parsed_rules, identifier_key=identifier_key)
         for identifier_key, parsed_rules in split_rules.items()

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -466,60 +466,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         self._assert_issue_owners_env_block(rule, environment)
 
-    @override_options({"workflow_engine.issue_alert.group.type_id.ga": [1]})
-    @with_feature("organizations:workflow-engine-ui-links")
-    def test_issue_alert_issue_owners_environment_block__workflow_engine_ui_links(self) -> None:
-        environment = self.create_environment(self.project, name="production")
-        ProjectOwnership.objects.create(project_id=self.project.id)
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = self.create_project_rule(
-            project=self.project,
-            action_data=[action_data],
-            name="ja rule",
-            environment_id=environment.id,
-        )
-        # attach legacy_rule_id to the rule
-        rule.data["actions"][0]["legacy_rule_id"] = rule.id
-        workflow = IssueAlertMigrator(rule).run()
-
-        rule.data["actions"][0]["workflow_id"] = workflow.id
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error", "environment": environment.name},
-            project_id=self.project.id,
-        )
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule),
-            ActionTargetType.ISSUE_OWNERS,
-            self.user.id,
-            FallthroughChoiceType.ACTIVE_MEMBERS,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = notification.notification_uuid
-        assert (
-            fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.id}/monitors/alerts/{workflow.id}/|ja rule>"
-        )
-        assert blocks[0]["text"]["text"] == fallback_text
-        assert event.group
-        assert (
-            blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&workflow_id={workflow.id}&alert_type=issue|*Hello world*>"
-        )
-        assert (
-            blocks[4]["elements"][0]["text"]
-            == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
-        )
-
     @responses.activate
     def test_issue_alert_team_issue_owners_block(self) -> None:
         """

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -581,8 +581,8 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
 
     @mock_notify
     @mock.patch("sentry.notifications.notifications.rules.logger")
-    @with_feature("organizations:workflow-engine-ui-links")
-    def test_notify_users_does_email_workflow_engine_ui_links(self, mock_logger, mock_func) -> None:
+    @with_feature("organizations:workflow-engine-ui")  # snooze
+    def test_notify_users_does_email_workflow_engine_ui(self, mock_logger, mock_func) -> None:
         self.create_user_option(user=self.user, key="timezone", value="Europe/Vienna")
         event_manager = EventManager({"message": "hello world", "level": "error"})
         event_manager.normalize()

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -380,7 +380,7 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
         assert payload["data"]["triggered_rule"] == rule.label
         assert payload["data"]["issue_alert"] == {
             # Use the legacy rule id
-            "id": "123",
+            "id": 123,
             "title": rule.label,
             "sentry_app_id": self.sentry_app.id,
             "settings": settings,


### PR DESCRIPTION
We want to remove the `workflow-engine-ui-links` flag because redirection will happen on the FE. This involves several parts, but we can first merge PRs that handle the existence of either `workflow_id` or `legacy_rule_id` in a list of Rules. Here I update the implementation for digests.

Rather than depending on the feature flag, we check for the existence of `legacy_rule_id`, if so we should handle all Rules like that the same, similarly for rules with `workflow_id`. Put them into a nice dataclass so we can do different things with them.