### PR TITLE
fix(dashboards): Add to dashboard persists page selection for create

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -15,6 +15,7 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import {Select} from 'sentry/components/core/select';
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
@@ -196,7 +197,9 @@ function AddToDashboardModal({
           title: newWidgetTitle,
           sort: orderBy ?? widgetAsQueryParams.sort,
           source,
-          ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
+          ...(selectedDashboard
+            ? getSavedPageFilters(selectedDashboard)
+            : pageFiltersToQueryParams(selection)),
         },
       })
     );


### PR DESCRIPTION
When "Create a new dashboard" is selected for the "Add to Dashboard" flow, the page filters should persist from the user's current page selections. Currently, the selections are dropped which means charts look slightly different since they're looking at different time ranges and projects.

The fix is to prioritize the saved dashboard's filters, but if the user is creating, pass along the params for their current selection.