### PR TITLE
chore(eap): bump max rollup in general sentry constants

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -82,7 +82,7 @@ PROJECT_SLUG_MAX_LENGTH = 100
 
 # Maximum number of results we are willing to fetch when calculating rollup
 # Clients should adapt the interval width based on their display width.
-MAX_ROLLUP_POINTS = 10000
+MAX_ROLLUP_POINTS = 10081
 
 
 # Organization slugs which may not be used. Generally these are top level URL patterns


### PR DESCRIPTION
We had bumped the constant in [EAP constants](https://github.com/getsentry/sentry/commit/17bcbb7d992e0456d1ff249f9c8b71fca2f24201) but forgot the sentry constants potentially causing some charts to return no data.
