### PR TITLE
feat(preprod): Support configuring filters for `size` and `distribution` in project settings

### DIFF
--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -2,13 +2,19 @@ import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {Stack} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
+import {FeatureFilter} from './featureFilter';
 import {StatusCheckRules} from './statusCheckRules';
+
+const SIZE_ENABLED_QUERY_KEY = 'sentry:preprod_size_enabled_query';
+const DISTRIBUTION_ENABLED_QUERY_KEY = 'sentry:preprod_distribution_enabled_query';
 
 export default function PreprodSettings() {
   return (
@@ -28,7 +34,31 @@ export default function PreprodSettings() {
             'Configure status checks and thresholds for your mobile build size analysis.'
           )}
         </TextBlock>
-        <StatusCheckRules />
+        <Stack gap="lg">
+          <StatusCheckRules />
+          <FeatureFilter
+            settingsKey={SIZE_ENABLED_QUERY_KEY}
+            title={t('Size Analysis')}
+            successMessage={t('Size filter updated')}
+          >
+            <Text>
+              {t(
+                "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
+              )}
+            </Text>
+          </FeatureFilter>
+          <FeatureFilter
+            settingsKey={DISTRIBUTION_ENABLED_QUERY_KEY}
+            title={t('Build Distribution')}
+            successMessage={t('Distribution filter updated')}
+          >
+            <Text>
+              {t(
+                'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
+              )}
+            </Text>
+          </FeatureFilter>
+        </Stack>
       </Feature>
     </Fragment>
   );

--- a/static/app/views/settings/project/preprod/useFeatureFilter.ts
+++ b/static/app/views/settings/project/preprod/useFeatureFilter.ts
@@ -1,0 +1,42 @@
+import {useCallback} from 'react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+
+export function useFeatureFilter(
+  project: Project,
+  settingsKey: string,
+  successMessage: string
+) {
+  const updateProject = useUpdateProject(project);
+
+  const filterQuery = String(project.options?.[settingsKey] ?? '');
+
+  const setFilterQuery = useCallback(
+    (query: string) => {
+      addLoadingMessage(t('Saving...'));
+      updateProject.mutate(
+        {
+          options: {[settingsKey]: query},
+        },
+        {
+          onSuccess: () => {
+            addSuccessMessage(successMessage);
+          },
+          onError: () => {
+            addErrorMessage(t('Failed to save changes. Please try again.'));
+          },
+        }
+      );
+    },
+    [updateProject, settingsKey, successMessage]
+  );
+
+  return [filterQuery, setFilterQuery] as const;
+}


### PR DESCRIPTION
Support configuring filters for `size` and `distribution` in project settings.
These filters are synced to the backend where they can be used to decide which builds get which analyses.