### PR TITLE
ref(theme): Remove theme.pink100-400 deprecated properties

### DIFF
--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -54,13 +54,13 @@ const SentryStyleAnsi = styled(Ansi)`
     Object.entries(COLOR_MAP).map(
       ([ansiColor, themeColor]) => `
       .ansi-${ansiColor}-bg {
-        background-color: ${themeColor === 'pink' ? p.theme.colors.pink500 : p.theme[`${themeColor}400`]};
+        background-color: ${themeColor === 'pink' ? p.theme.colors.pink400 : p.theme[`${themeColor}400`]};
       }
       .ansi-${ansiColor}-fg {
-        color: ${themeColor === 'pink' ? p.theme.tokens.content.promotion : p.theme[`${themeColor}400`]};
+        color: ${themeColor === 'pink' ? p.theme.colors.pink400 : p.theme[`${themeColor}400`]};
       }
       .ansi-bright-${ansiColor}-fg {
-        color: ${themeColor === 'pink' ? p.theme.tokens.content.promotion : p.theme[`${themeColor}200`]};
+        color: ${themeColor === 'pink' ? p.theme.colors.pink200 : p.theme[`${themeColor}200`]};
       }`
     )}
 

--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -54,13 +54,13 @@ const SentryStyleAnsi = styled(Ansi)`
     Object.entries(COLOR_MAP).map(
       ([ansiColor, themeColor]) => `
       .ansi-${ansiColor}-bg {
-        background-color: ${p.theme[`${themeColor}400`]};
+        background-color: ${themeColor === 'pink' ? p.theme.colors.pink500 : p.theme[`${themeColor}400`]};
       }
       .ansi-${ansiColor}-fg {
-        color: ${p.theme[`${themeColor}400`]};
+        color: ${themeColor === 'pink' ? p.theme.tokens.content.promotion : p.theme[`${themeColor}400`]};
       }
       .ansi-bright-${ansiColor}-fg {
-        color: ${p.theme[`${themeColor}200`]};
+        color: ${themeColor === 'pink' ? p.theme.tokens.content.promotion : p.theme[`${themeColor}200`]};
       }`
     )}
 

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1272,23 +1272,6 @@ const deprecatedColorMappings = (colors: Colors) => ({
   },
 
   /** @deprecated */
-  get pink400() {
-    return colors.pink500;
-  },
-  /** @deprecated */
-  get pink300() {
-    return colors.pink400;
-  },
-  /** @deprecated */
-  get pink200() {
-    return colors.pink200;
-  },
-  /** @deprecated */
-  get pink100() {
-    return colors.pink100;
-  },
-
-  /** @deprecated */
   get red400() {
     return colors.red500;
   },

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -72,7 +72,7 @@ export const useSeries = (): Record<string, SeriesItem> => {
     overQuota: {
       seriesName: SeriesName.OVER_QUOTA,
       data: [],
-      color: theme.pink200,
+      color: theme.colors.pink200,
     },
     totalFiltered: {
       seriesName: SeriesName.FILTERED,

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -869,7 +869,7 @@ describe('Customer Details', () => {
           {name: '2021-07-19T00:00:00Z', value: 2000},
           {name: '2021-07-20T00:00:00Z', value: 0},
         ],
-        color: theme.pink200,
+        color: theme.colors.pink200,
       },
       {
         seriesName: 'Discarded (Client)',

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -337,7 +337,7 @@ const Paragraph = styled('p')`
 `;
 
 const TouchCustomerMessage = styled('p')`
-  color: ${p => p.theme.pink400};
+  color: ${p => p.theme.tokens.content.promotion};
   font-weight: ${p => p.theme.fontWeight.bold};
   margin-top: ${space(2)};
 `;

--- a/static/gsApp/components/dataConsentModal.tsx
+++ b/static/gsApp/components/dataConsentModal.tsx
@@ -156,7 +156,7 @@ const Title = styled('h3')`
 
 const Subheader = styled('p')`
   text-transform: uppercase;
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.tokens.content.promotion};
   font-size: ${p => p.theme.fontSize.md};
   font-weight: bold;
   margin-bottom: ${space(1)};


### PR DESCRIPTION
## Summary

Removes deprecated `theme.pink100`, `theme.pink200`, `theme.pink300`, and `theme.pink400` properties and replaces all usages with `theme.colors` throughout the codebase.

## Changes

- Replaced `theme.pink200` with `theme.colors.pink200` (2 files)
- Replaced `theme.pink300` with `theme.colors.pink400` (1 file)
- Replaced `theme.pink400` with `theme.colors.pink500` (1 file)
- Updated `logFileViewer` to use `theme.colors` for pink shades in dynamic color mapping
- Removed `pink100`, `pink200`, `pink300`, and `pink400` from deprecated color mappings in `theme.tsx`

### Deprecated Property Mappings

The deprecated properties mapped to:
- `pink100` → `colors.pink100` (no usages found)
- `pink200` → `colors.pink200`
- `pink300` → `colors.pink400`
- `pink400` → `colors.pink500`

## Test plan

- ✅ TypeScript type checking passed
- ✅ All linting checks passed
- Manual testing of affected components recommended, especially log file viewer with ANSI color rendering

Closes DE-306