### PR TITLE
feat(replays): Add REPLAYS dataset to ExploreSavedQueryDataset

### DIFF
--- a/src/sentry/explore/models.py
+++ b/src/sentry/explore/models.py
@@ -20,6 +20,7 @@ class ExploreSavedQueryDataset(TypesClass):
     SPANS = 0
     OURLOGS = 1
     METRICS = 2
+    REPLAYS = 3
     # This is a temporary dataset to be used for the discover -> explore migration.
     # It will track which queries are generated from discover queries.
     SEGMENT_SPANS = 101
@@ -29,6 +30,7 @@ class ExploreSavedQueryDataset(TypesClass):
         (OURLOGS, "logs"),
         (SEGMENT_SPANS, "segment_spans"),
         (METRICS, "metrics"),
+        (REPLAYS, "replays"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1334,3 +1334,4 @@ class ExploreSavedQueriesTest(APITestCase):
         assert response.status_code == 201, response.content
         data = response.data
         assert data["query"]["query"] == "user.email:*@sentry.io"
+        assert data["query"]["mode"] == "samples"

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1325,6 +1325,7 @@ class ExploreSavedQueriesTest(APITestCase):
                     "query": [
                         {
                             "query": "user.email:*@sentry.io",
+                            "mode": "samples",
                         }
                     ],
                     "range": "48h",

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1333,5 +1333,5 @@ class ExploreSavedQueriesTest(APITestCase):
             )
         assert response.status_code == 201, response.content
         data = response.data
-        assert data["query"]["query"] == "user.email:*@sentry.io"
-        assert data["query"]["mode"] == "samples"
+        assert data["query"][0]["query"] == "user.email:*@sentry.io"
+        assert data["query"][0]["mode"] == "samples"

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1313,3 +1313,23 @@ class ExploreSavedQueriesTest(APITestCase):
         assert response.status_code == 201, response.content
         data = response.data
         assert data["query"][0]["caseInsensitive"] is True
+
+    def test_save_replay_query(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Replay dataset",
+                    "projects": self.project_ids,
+                    "dataset": "replays",
+                    "query": [
+                        {
+                            "query": "user.email:*@sentry.io",
+                        }
+                    ],
+                    "range": "48h",
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["query"]["query"] == "user.email:*@sentry.io"


### PR DESCRIPTION
Add REPLAYS as a new dataset type to the ExploreSavedQueryDataset enum.
This allows replay queries to be saved using the ExploreSavedQuery system.

Refs REPLAY-140
