### PR TITLE
fix(aci): Add ongoing issues list to uptime monitor page

### DIFF
--- a/static/app/views/detectors/components/details/uptime/index.spec.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.spec.tsx
@@ -37,6 +37,10 @@ describe('UptimeDetectorDetails', () => {
       url: `/organizations/org-slug/workflows/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [],
+    });
   });
 
   it('renders the detector details sections', async () => {

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -25,6 +25,7 @@ import {DetectorDetailsDescription} from 'sentry/views/detectors/components/deta
 import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
 import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
 import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
 import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
@@ -65,6 +66,7 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
             message={t('This monitor is disabled and not recording uptime checks.')}
           />
           <DetailsTimeline uptimeDetector={detector} onStatsLoaded={checkHasUnknown} />
+          <DetectorDetailsOngoingIssues detector={detector} />
           <Section title={t('Recent Check-Ins')}>
             <div>
               <UptimeChecksTable

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -85,6 +85,10 @@ describe('DetectorDetails', () => {
       },
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20detector%3A1&statsPeriod=14d',
       body: [GroupFixture()],
     });


### PR DESCRIPTION
Tiny change, we weren't rendering the ongoing issues component for the uptime monitor page but should be.