### PR TITLE
feat(tasks) Add application to taskbroker requests

### DIFF
--- a/src/sentry/taskworker/app.py
+++ b/src/sentry/taskworker/app.py
@@ -16,13 +16,14 @@ class TaskworkerApp:
     Container for an application's task setup and configuration.
     """
 
-    def __init__(self, taskregistry: TaskRegistry | None = None) -> None:
+    def __init__(self, name: str, taskregistry: TaskRegistry | None = None) -> None:
         self._config = {
             "rpc_secret": None,
             "at_most_once_timeout": None,
         }
+        self.name = name
         self._modules: Iterable[str] = []
-        self._taskregistry = taskregistry or TaskRegistry(application="default")
+        self._taskregistry = taskregistry or TaskRegistry(application=name)
         self._at_most_once_store: AtMostOnceStore | None = None
 
     @property

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -273,4 +273,5 @@ class TaskRegistry:
         return namespace
 
 
+# TODO(mark) replace usage of this with `sentry.taskworker.runtime.app`
 taskregistry = TaskRegistry(application="sentry")

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -4,7 +4,7 @@ from django.core.cache import cache
 from sentry.taskworker.app import TaskworkerApp
 from sentry.taskworker.registry import taskregistry
 
-app = TaskworkerApp(taskregistry=taskregistry)
+app = TaskworkerApp(name="sentry", taskregistry=taskregistry)
 app.set_config(
     {
         "rpc_secret": settings.TASKWORKER_SHARED_SECRET,

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -74,6 +74,7 @@ class TaskWorker:
 
         self.client = TaskworkerClient(
             hosts=broker_hosts,
+            application=app.name,
             max_tasks_before_rebalance=rebalance_after,
             health_check_settings=(
                 None

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -15,7 +15,7 @@ from sentry.utils.redis import redis_clusters
 
 @pytest.fixture
 def task_app() -> TaskworkerApp:
-    app = TaskworkerApp()
+    app = TaskworkerApp(name="sentry")
     namespace = app.taskregistry.create_namespace("test")
 
     @namespace.register(name="valid")
@@ -534,7 +534,7 @@ def test_schedulerunner_tick_stale_lock_doesnt_starve_other_tasks(
 
 @pytest.mark.django_db
 def test_schedulerunner_silo_limited_task_has_task_properties() -> None:
-    app = TaskworkerApp()
+    app = TaskworkerApp(name="sentry")
     namespace = app.taskregistry.create_namespace("test")
 
     @namespace.register(

--- a/tests/sentry/taskworker/test_app.py
+++ b/tests/sentry/taskworker/test_app.py
@@ -13,19 +13,19 @@ def clear_cache():
 
 def test_taskregistry_param_and_property():
     registry = TaskRegistry(application="sentry")
-    app = TaskworkerApp(taskregistry=registry)
+    app = TaskworkerApp(name="sentry", taskregistry=registry)
     assert app.taskregistry == registry
 
 
-def test_default_application_name():
-    app = TaskworkerApp()
+def test_namespace_inherit_application_name():
+    app = TaskworkerApp(name="sentry")
     ns = app.taskregistry.create_namespace(name="testing")
-    assert ns.application == "default"
+    assert ns.application == "sentry"
     assert ns.name == "testing"
 
 
 def test_set_config():
-    app = TaskworkerApp()
+    app = TaskworkerApp(name="sentry")
     app.set_config({"rpc_secret": "testing", "ignored": "key"})
     assert app.config["rpc_secret"] == "testing"
     assert "ignored" not in app.config
@@ -39,7 +39,7 @@ def test_should_attempt_at_most_once(clear_cache):
         parameters='{"args": [], "kwargs": {}}',
         processing_deadline_duration=2,
     )
-    app = TaskworkerApp()
+    app = TaskworkerApp(name="sentry")
     app.at_most_once_store(cache)
     assert app.should_attempt_at_most_once(activation)
     assert not app.should_attempt_at_most_once(activation)


### PR DESCRIPTION
Now that sentry is producing all activations with `application` populated, the worker can start requesting activations from only its application name.

Refs STREAM-665