### PR TITLE
chore: Assign taskworker modules to streaming-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -664,8 +664,8 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 
 
 # Taskbroker workers
-/src/sentry/taskworker/                                       @getsentry/taskbroker
-/tests/sentry/taskworker/                                     @getsentry/taskbroker
+/src/sentry/taskworker/                                       @getsentry/streaming-platform
+/tests/sentry/taskworker/                                     @getsentry/streaming-platform
 
 # Tempest
 /src/sentry/tempest/                                       @getsentry/gdx


### PR DESCRIPTION
With the taskbroker & streaming teams merged together there isn't much value in continuing to have the code ownership separated.
