### PR TITLE
feat(explorer): Add span.status_code to trace waterfall data

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -404,7 +404,12 @@ def get_trace_waterfall(trace_id: str, organization_id: int) -> EAPTrace | None:
         projects=projects,
         organization=organization,
     )
-    events = query_trace_data(snuba_params, full_trace_id, referrer=Referrer.SEER_EXPLORER_TOOLS)
+    events = query_trace_data(
+        snuba_params,
+        full_trace_id,
+        additional_attributes=["span.status_code"],
+        referrer=Referrer.SEER_EXPLORER_TOOLS,
+    )
 
     return EAPTrace(
         trace_id=full_trace_id,

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -802,6 +802,34 @@ class TestGetTraceWaterfall(APITransactionTestCase, SpanTestCase, SnubaTestCase)
         result = get_trace_waterfall(trace_id[:8], self.organization.id)
         assert result is None
 
+    def test_get_trace_waterfall_includes_status_code(self) -> None:
+        """Test that span.status_code is included in additional_attributes."""
+        transaction_name = "api/test/status"
+        trace_id = uuid.uuid4().hex
+
+        # Create a span with status_code
+        span = self.create_span(
+            {
+                "description": "http-request",
+                "sentry_tags": {
+                    "transaction": transaction_name,
+                    "status_code": "500",
+                },
+                "trace_id": trace_id,
+                "is_segment": True,
+            },
+            start_ts=self.ten_mins_ago,
+        )
+        self.store_spans([span], is_eap=True)
+
+        result = get_trace_waterfall(trace_id, self.organization.id)
+        assert isinstance(result, EAPTrace)
+
+        # Find the span and verify additional_attributes contains status_code
+        root_span = result.trace[0]
+        assert "additional_attributes" in root_span
+        assert root_span["additional_attributes"].get("span.status_code") == "500"
+
 
 class TestTraceTableQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Pass span.status_code as additional_attributes in get_trace_waterfall so Seer can highlight 4xx/5xx status codes in trace formatting.

Seer PR: https://github.com/getsentry/seer/pull/4443
Closes AIML-2146