### PR TITLE
fix(spans-migration): add tooltip to open in explore with different extrapolation modes

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -388,8 +388,8 @@ function OpenInButton({detector}: OpenInButtonProps) {
   const snubaQuery = detector.dataSources[0]?.queryObj?.snubaQuery;
 
   const isUsingMigratedExtrapolationMode = useIsMigratedExtrapolation({
-    dataset: getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes),
-    extrapolationMode: snubaQuery.extrapolationMode,
+    dataset: getDetectorDataset(snubaQuery?.dataset, snubaQuery?.eventTypes),
+    extrapolationMode: snubaQuery?.extrapolationMode,
   });
 
   if (!snubaQuery) {

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -28,6 +28,7 @@ import {
 } from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
 import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/details/metric/getDetectorOpenInDestination';
 import {useDetectorChartAxisBounds} from 'sentry/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds';
+import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {useFilteredAnomalyThresholdSeries} from 'sentry/views/detectors/hooks/useFilteredAnomalyThresholdSeries';
@@ -386,6 +387,11 @@ function OpenInButton({detector}: OpenInButtonProps) {
   const location = useLocation();
   const snubaQuery = detector.dataSources[0]?.queryObj?.snubaQuery;
 
+  const isUsingMigratedExtrapolationMode = useIsMigratedExtrapolation({
+    dataset: getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes),
+    extrapolationMode: snubaQuery.extrapolationMode,
+  });
+
   if (!snubaQuery) {
     return null;
   }
@@ -404,9 +410,20 @@ function OpenInButton({detector}: OpenInButtonProps) {
     return null;
   }
 
+  const disabledTooltip = isUsingMigratedExtrapolationMode
+    ? t(
+        'This detector cannot be opened in Explore until you update thresholds and resave.'
+      )
+    : undefined;
+
   return (
     <Feature features="visibility-explore-view">
-      <LinkButton size="xs" to={destination.to}>
+      <LinkButton
+        size="xs"
+        to={destination.to}
+        disabled={isUsingMigratedExtrapolationMode}
+        title={disabledTooltip}
+      >
         {destination.buttonText}
       </LinkButton>
     </Feature>


### PR DESCRIPTION
Adding the tooltip on detectors when it's using one of the migrated extrapolation modes because it is not supported in explore. We haven't added it in since the `Open in Explore` button got added onto the UI

<img width="320" height="192" alt="image" src="https://github.com/user-attachments/assets/5a0bcd06-3294-4a19-bd6f-a477b30ab097" />

