### PR TITLE
feat(ACI): Add documentation for OrganizationDetectorIndexEndpoint GET

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -1,0 +1,187 @@
+from drf_spectacular.utils import OpenApiExample
+
+
+class WorkflowEngineExamples:
+    LIST_ORG_DETECTORS = [
+        OpenApiExample(
+            "List all monitors in an organization",
+            value=[
+                {
+                    "id": "123",
+                    "projectId": "1",
+                    "name": "Error Monitor",
+                    "description": None,
+                    "type": "error",
+                    "workflowIds": ["12345"],
+                    "owner": None,
+                    "createdBy": None,
+                    "dateCreated": "2025-03-12T11:15:50.764865Z",
+                    "dateUpdated": "2025-06-17T14:04:02.485354Z",
+                    "dataSources": None,
+                    "conditionGroup": None,
+                    "config": {},
+                    "enabled": True,
+                    "latestGroup": {
+                        "id": "123456789",
+                        "title": "This is an example Python exception",
+                        "culprit": "/api/0/test/example/",
+                        "shortId": "SENTRY-ABC12",
+                        "level": "info",
+                        "status": "unresolved",
+                        "substatus": "escalating",
+                        "platform": "python",
+                        "project": {
+                            "id": "1",
+                            "name": "Example",
+                            "slug": "sentry",
+                            "platform": "python",
+                        },
+                        "type": "default",
+                        "issueType": "error",
+                        "issueCategory": "error",
+                        "metadata": {
+                            "title": "This is an example Python exception",
+                            "sdk": {
+                                "name": "sentry.python.django",
+                                "name_normalized": "sentry.python",
+                            },
+                            "severity": 0.0,
+                            "severity_reason": "log_level_info",
+                            "initial_priority": 25,
+                        },
+                        "numComments": 0,
+                        "firstSeen": "2026-01-08T21:00:59.737468Z",
+                        "lastSeen": "2026-01-08T21:23:45.723716Z",
+                    },
+                    "openIssues": 100,
+                },
+                {
+                    "id": "234567891",
+                    "projectId": "1",
+                    "name": "[us] Example",
+                    "description": None,
+                    "type": "uptime_domain_failure",
+                    "workflowIds": [],
+                    "owner": {"type": "team", "id": "1234", "name": "abc"},
+                    "createdBy": None,
+                    "dateCreated": "2025-04-21T21:56:32.445528Z",
+                    "dateUpdated": "2025-10-23T00:07:24.809466Z",
+                    "dataSources": [
+                        {
+                            "id": "271218",
+                            "organizationId": "1",
+                            "type": "uptime_subscription",
+                            "sourceId": "267409",
+                            "queryObj": {
+                                "url": "https://example.com",
+                                "method": "POST",
+                                "body": '{\n  "level": "info",\n  "message": "Test-Event",\n  "platform": "javascript"\n}',
+                                "headers": [
+                                    ["content-type", "application/json"],
+                                    ["user-agent", "Sentry Test"],
+                                ],
+                                "intervalSeconds": 60,
+                                "timeoutMs": 5000,
+                                "traceSampling": False,
+                            },
+                        }
+                    ],
+                    "conditionGroup": {
+                        "id": "56789",
+                        "organizationId": "1",
+                        "logicType": "any",
+                        "conditions": [
+                            {
+                                "id": "123456",
+                                "type": "eq",
+                                "comparison": "failure",
+                                "conditionResult": 75,
+                            },
+                            {
+                                "id": "234567",
+                                "type": "eq",
+                                "comparison": "success",
+                                "conditionResult": 0,
+                            },
+                        ],
+                        "actions": [],
+                    },
+                    "config": {
+                        "mode": 1,
+                        "environment": "us",
+                        "downtimeThreshold": 3,
+                        "recoveryThreshold": 1,
+                    },
+                    "enabled": True,
+                    "latestGroup": None,
+                    "openIssues": 0,
+                },
+                {
+                    "id": "1234567",
+                    "projectId": "123",
+                    "name": "Test Alert",
+                    "description": None,
+                    "type": "metric_issue",
+                    "workflowIds": ["1234567"],
+                    "owner": {
+                        "type": "user",
+                        "id": "12345",
+                        "name": "colleen@sentry.io",
+                        "email": "colleen@sentry.io",
+                    },
+                    "createdBy": "12345",
+                    "dateCreated": "2025-04-28T22:46:12.469771Z",
+                    "dateUpdated": "2025-07-29T20:57:06.680844Z",
+                    "dataSources": [
+                        {
+                            "id": "56789",
+                            "organizationId": "1",
+                            "type": "snuba_query_subscription",
+                            "sourceId": "45678",
+                            "queryObj": {
+                                "id": "34567",
+                                "status": 0,
+                                "subscription": "12/3456789",
+                                "snubaQuery": {
+                                    "id": "56789",
+                                    "dataset": "events_analytics_platform",
+                                    "query": "",
+                                    "aggregate": "avg(span.duration)",
+                                    "timeWindow": 14400,
+                                    "environment": None,
+                                    "eventTypes": ["trace_item_span"],
+                                    "extrapolationMode": "unknown",
+                                },
+                            },
+                        }
+                    ],
+                    "conditionGroup": {
+                        "id": "12345",
+                        "organizationId": "1",
+                        "logicType": "any",
+                        "conditions": [
+                            {
+                                "id": "456789",
+                                "type": "gt",
+                                "comparison": 1600.0,
+                                "conditionResult": 75,
+                            },
+                            {
+                                "id": "345678",
+                                "type": "lte",
+                                "comparison": 1600.0,
+                                "conditionResult": 0,
+                            },
+                        ],
+                        "actions": [],
+                    },
+                    "config": {"detectionType": "static", "comparisonDelta": None},
+                    "enabled": True,
+                    "latestGroup": None,
+                    "openIssues": 0,
+                },
+            ],
+            status_codes=["201"],
+            response_only=True,
+        )
+    ]

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -446,6 +446,8 @@ Available fields are:
 - `id`
 - `type`
 - `connectedWorkflows`
+- `latestGroup`
+- `openIssues`
 
 Prefix with `-` to sort in descending order.
         """,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -30,7 +30,9 @@ from sentry.apidocs.constants import (
     RESPONSE_SUCCESS,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
 from sentry.apidocs.parameters import DetectorParams, GlobalParams, OrganizationParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.grouptype import MetricIssue
@@ -45,7 +47,10 @@ from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils.audit import create_audit_entry
-from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializer,
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
 from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
@@ -225,7 +230,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         return queryset
 
     @extend_schema(
-        operation_id="Fetch a Project's Detectors",
+        operation_id="Fetch a Organization's Monitors",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
@@ -234,18 +239,19 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             DetectorParams.ID,
         ],
         responses={
-            201: DetectorSerializer,
+            201: inline_sentry_response_serializer(
+                "ListDetectorSerializerResponse", list[DetectorSerializerResponse]
+            ),
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=WorkflowEngineExamples.LIST_ORG_DETECTORS,
     )
     def get(self, request: Request, organization: Organization) -> Response:
         """
-        List an Organization's Detectors
-        `````````````````````````````
-        Return a list of detectors for a given organization.
+        List an Organization's Monitors
         """
         if not request.user.is_authenticated:
             return self.respond(status=status.HTTP_401_UNAUTHORIZED)

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -230,7 +230,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         return queryset
 
     @extend_schema(
-        operation_id="Fetch a Organization's Monitors",
+        operation_id="Fetch an Organization's Monitors",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -179,9 +179,7 @@ class DetectorSerializer(Serializer):
 
         return attrs
 
-    def serialize(
-        self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs
-    ) -> DetectorSerializerResponse:
+    def serialize(self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
         alert_rule_mapping = attrs.get("alert_rule_mapping", {})
         return {
             "id": str(obj.id),

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, TypedDict
 
 from django.db.models import Count
 from drf_spectacular.utils import extend_schema_serializer
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.models.actor import ActorSerializer
+from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.api.serializers.models.group import SimpleGroupSerializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.grouping.grouptype import ErrorGroupType
@@ -24,15 +24,8 @@ from sentry.workflow_engine.models import (
 )
 
 
-class OwnerSerializerResponse(TypedDict):
-    type: str
-    id: str
-    name: str
-    email: NotRequired[str]
-
-
 class DetectorSerializerResponseOptional(TypedDict, total=False):
-    owner: OwnerSerializerResponse | None
+    owner: ActorSerializerResponse | None
     createdBy: str | None
     alertRuleId: int | None
     ruleId: int | None

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -42,7 +42,7 @@ class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     workflowIds: list[str]
     dateCreated: datetime
     dateUpdated: datetime
-    dataSources: list[dict] | None
+    dataSources: list[dict]
     conditionGroup: dict | None
     config: dict
     enabled: bool


### PR DESCRIPTION
Add documentation for the GET `OrganizationDetectorIndexEndpoint`.

This will not be published yet, but in order to deploy the workflow engine API documentation in pieces we'll set the `publish_status` to `PUBLIC` all at once and add the sidebar item for workflow engine.

<img width="1184" height="708" alt="Screenshot 2026-01-09 at 12 39 40 PM" src="https://github.com/user-attachments/assets/1455ce1b-3919-456a-ba6d-72491c7cfc26" />
