### PR TITLE
fix(auth): Pass organization context to resolve_email_to_user

### DIFF
--- a/src/sentry/auth/email.py
+++ b/src/sentry/auth/email.py
@@ -5,7 +5,7 @@ from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 
 from sentry.models.organization import Organization
-from sentry.organizations.services.organization import organization_service
+from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.users.models.user import User
 from sentry.users.models.useremail import UserEmail
 from sentry.utils import metrics
@@ -18,7 +18,9 @@ class AmbiguousUserFromEmail(Exception):
         self.users = tuple(users)
 
 
-def resolve_email_to_user(email: str, organization: Organization | None = None) -> User | None:
+def resolve_email_to_user(
+    email: str, organization: Organization | RpcOrganization | None = None
+) -> User | None:
     candidates = tuple(UserEmail.objects.filter(email__iexact=email, user__is_active=True))
     if not candidates:
         return None
@@ -28,7 +30,7 @@ def resolve_email_to_user(email: str, organization: Organization | None = None) 
 @dataclass
 class _EmailResolver:
     email: str
-    organization: Organization | None
+    organization: Organization | RpcOrganization | None
 
     def resolve(self, candidates: Collection[UserEmail]) -> User:
         """Pick the user best matching the email address."""

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -100,7 +100,7 @@ class AuthIdentityHandler:
         email = self.identity.get("email")
         if email:
             try:
-                user = resolve_email_to_user(email)
+                user = resolve_email_to_user(email, organization=self.organization)
             except AmbiguousUserFromEmail as e:
                 user = e.users[0]
                 self.warn_about_ambiguous_email(email, e.users, user)


### PR DESCRIPTION
Found a bug that caused infinite loops when a logged-in org member tried to link an SSO identity that matched another user's primary email. PR #30926 added org membership as a tiebreaker when resolving ambiguous emails, but we never started using it to pass org context. Now we do.

Changes:
- Pass organization to resolve_email_to_user() in AuthIdentityHandler.user
- Add RpcOrganization to type signature in email.py
- Add integration test in test_helper.py for regression
- Add edge case unit tests in test_email.py for resolution chain