### PR TITLE
feat(seer): Auto-continue from solution to code changes

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -125,6 +125,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 ),
             ),
         ]
+        extra_footer_mrkdwn: str | None = None
         if data.current_point == AutofixStoppingPoint.ROOT_CAUSE:
             current_stage_mrkdwn = ":mag:  *Root Cause Analysis*"
             action_elements.append(
@@ -140,17 +141,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
             )
         elif data.current_point == AutofixStoppingPoint.SOLUTION:
             current_stage_mrkdwn = ":test_tube:  *Proposed Solution*"
-            action_elements.append(
-                cls.render_autofix_button(
-                    data=SeerAutofixTrigger(
-                        organization_id=data.organization_id,
-                        project_id=data.project_id,
-                        group_id=data.group_id,
-                        run_id=data.run_id,
-                        stopping_point=AutofixStoppingPoint.CODE_CHANGES,
-                    )
-                )
-            )
+            extra_footer_mrkdwn = "_Seer is writing the code..._"
         elif data.current_point == AutofixStoppingPoint.CODE_CHANGES:
             current_stage_mrkdwn = ":pencil2:  *Code Change Suggestions*"
             for change in data.changes:
@@ -217,5 +208,8 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 )
             )
         blocks.append(ActionsBlock(elements=action_elements))
-        blocks.append(ContextBlock(elements=[MarkdownTextObject(text=f"Run ID: {data.run_id}")]))
+        footer_mrkdwn = f"Run ID: {data.run_id}"
+        if extra_footer_mrkdwn:
+            footer_mrkdwn += f", {extra_footer_mrkdwn}"
+        blocks.append(ContextBlock(elements=[MarkdownTextObject(text=footer_mrkdwn)]))
         return SlackRenderable(blocks=blocks, text="Seer Autofix Update")

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class AutofixPostResponse(TypedDict):
@@ -18,7 +18,7 @@ class AutofixStateResponse(TypedDict):
 class AutofixSelectRootCausePayload(TypedDict):
     type: Literal["select_root_cause"]
     cause_id: int
-    stopping_point: Literal["solution", "code_changes", "open_pr"] | None = None
+    stopping_point: NotRequired[Literal["solution", "code_changes", "open_pr"]]
 
 
 class AutofixSelectSolutionPayload(TypedDict):

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -18,6 +18,7 @@ class AutofixStateResponse(TypedDict):
 class AutofixSelectRootCausePayload(TypedDict):
     type: Literal["select_root_cause"]
     cause_id: int
+    stopping_point: Literal["solution", "code_changes", "open_pr"] | None = None
 
 
 class AutofixSelectSolutionPayload(TypedDict):

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -85,7 +85,12 @@ class SeerOperator[CachePayloadT]:
             if stopping_point == AutofixStoppingPoint.SOLUTION:
                 # TODO(Leander): We need to figure out a way to get the real cause_id for this.
                 # Probably need to add it to the root cause webhook from seer's side.
-                payload = AutofixSelectRootCausePayload(type="select_root_cause", cause_id=0)
+                payload = AutofixSelectRootCausePayload(
+                    type="select_root_cause",
+                    cause_id=0,
+                    # XXX: Continue from solution to code changes automatically.
+                    stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+                )
             elif stopping_point == AutofixStoppingPoint.CODE_CHANGES:
                 payload = AutofixSelectSolutionPayload(type="select_solution")
             elif stopping_point == AutofixStoppingPoint.OPEN_PR:


### PR DESCRIPTION
When a user clicks "Plan a Solution" in Slack, Seer now automatically continues
to generate code changes instead of stopping and requiring a second button click.
This removes friction from the autofix flow.

The SOLUTION stopping point now passes `stopping_point="code_changes"` in the
payload to Seer, and the Slack UI shows "_Seer is writing the code..._" in the
footer while processing.

Refs ECO-1338

<img width="723" height="491" alt="image" src="https://github.com/user-attachments/assets/8b6fcd0c-0766-4f54-b85b-65d561e2583c" />
