### PR TITLE
feat(eco): Adds a way to surface debug data safely from integration metadata, while excluding sensitive information

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -425,6 +425,33 @@ class IntegrationInstallation(abc.ABC):
     def get_dynamic_display_information(self) -> Mapping[str, Any] | None:
         return None
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        """
+        Returns a list of metadata keys that are safe to expose for debugging purposes.
+
+        These keys should contain non-sensitive information like domain names,
+        installation IDs, webhook URLs (without secrets), etc. Never include
+        credentials, tokens, passwords, or API keys.
+
+        By default, returns an empty list (no metadata exposed).
+        Override in provider-specific IntegrationInstallation subclasses.
+        """
+        return []
+
+    def get_debug_metadata(self) -> dict[str, Any]:
+        """
+        Returns a filtered metadata dictionary containing only non-sensitive fields.
+
+        This method uses _get_debug_metadata_keys() to determine which metadata
+        fields are safe to expose for debugging purposes. Override _get_debug_metadata_keys()
+        in provider-specific subclasses to customize which fields are exposed.
+
+        Returns:
+            A dictionary containing only the allowlisted metadata fields.
+        """
+        allowed_keys = self._get_debug_metadata_keys()
+        return {key: value for key, value in self.model.metadata.items() if key in allowed_keys}
+
     @abc.abstractmethod
     def get_client(self) -> Any:
         """

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -444,7 +444,7 @@ class IntegrationInstallation(abc.ABC):
             A dictionary containing only the allowlisted metadata fields.
         """
         allowed_keys = self._get_debug_metadata_keys()
-        return {key: value for key, value in self.model.metadata.items() if key in allowed_keys}
+        return {key: self.model.metadata.get(key) for key in allowed_keys}
 
     @abc.abstractmethod
     def get_client(self) -> Any:

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -427,24 +427,18 @@ class IntegrationInstallation(abc.ABC):
 
     def _get_debug_metadata_keys(self) -> list[str]:
         """
-        Returns a list of metadata keys that are safe to expose for debugging purposes.
+        Override this method in integration subclasses to expose additional
+        non-sensitive metadata fields via admin endpoints and logging.
 
-        These keys should contain non-sensitive information like domain names,
-        installation IDs, webhook URLs (without secrets), etc. Never include
-        credentials, tokens, passwords, or API keys.
-
-        By default, returns an empty list (no metadata exposed).
-        Override in provider-specific IntegrationInstallation subclasses.
+        Returns:
+            A list of keys that are safe to expose for debugging purposes.
         """
         return []
 
     def get_debug_metadata(self) -> dict[str, Any]:
         """
-        Returns a filtered metadata dictionary containing only non-sensitive fields.
-
-        This method uses _get_debug_metadata_keys() to determine which metadata
-        fields are safe to expose for debugging purposes. Override _get_debug_metadata_keys()
-        in provider-specific subclasses to customize which fields are exposed.
+        Returns a dictionary containing key value pairs of metadata useful for
+        debugging. These fields should be safe to log.
 
         Returns:
             A dictionary containing only the allowlisted metadata fields.

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -252,7 +252,7 @@ class GitHubIntegration(
         return GitHubApiClient(integration=self.model, org_integration_id=self.org_integration.id)
 
     def _get_debug_metadata_keys(self) -> list[str]:
-        return ["installation_id", "account_type", "domain_name"]
+        return ["account_type", "domain_name", "permissions"]
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -251,6 +251,9 @@ class GitHubIntegration(
             raise IntegrationError("Organization Integration does not exist")
         return GitHubApiClient(integration=self.model, org_integration_id=self.org_integration.id)
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["installation_id", "account_type", "domain_name"]
+
     # IntegrationInstallation methods
 
     def is_rate_limited_error(self, exc: ApiError) -> bool:

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -263,6 +263,9 @@ class GitHubEnterpriseIntegration(
 
         return False
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["domain_name", "installation_id", "account_type"]
+
 
 class InstallationForm(forms.Form):
     url = forms.CharField(

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -189,6 +189,9 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
 
         return False
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["domain_name", "group_id", "include_subgroups", "verify_ssl", "base_url"]
+
     # Gitlab only functions
 
     def get_group_id(self):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -517,7 +517,7 @@ class JiraIntegration(IssueSyncIntegration):
         )
 
     def _get_debug_metadata_keys(self) -> list[str]:
-        return ["base_url", "domain_name", "installation_id"]
+        return ["base_url", "domain_name"]
 
     def get_issue(self, issue_id, **kwargs):
         """

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -516,6 +516,9 @@ class JiraIntegration(IssueSyncIntegration):
             logging_context=logging_context,
         )
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["base_url", "domain_name", "installation_id"]
+
     def get_issue(self, issue_id, **kwargs):
         """
         Jira installation's implementation of IssueSyncIntegration's `get_issue`.

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1378,6 +1378,9 @@ class JiraServerIntegration(IssueSyncIntegration):
             }
         )
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["base_url", "domain_name", "verify_ssl"]
+
 
 class JiraServerIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.JIRA_SERVER.value

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -236,6 +236,9 @@ class OpsgenieIntegration(IntegrationInstallation):
 
         return super().update_organization_config(data)
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["base_url", "domain_name"]
+
     def schedule_migrate_opsgenie_plugin(self):
         migrate_opsgenie_plugin.apply_async(
             kwargs={

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -177,7 +177,7 @@ class PagerDutyIntegration(IntegrationInstallation):
         return {"service_table": service_list}
 
     def _get_debug_metadata_keys(self) -> list[str]:
-        return ["domain_name", "services"]
+        return ["domain_name"]
 
     @property
     def services(self) -> list[PagerDutyServiceDict]:

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -176,6 +176,9 @@ class PagerDutyIntegration(IntegrationInstallation):
             )
         return {"service_table": service_list}
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["domain_name", "services"]
+
     @property
     def services(self) -> list[PagerDutyServiceDict]:
         if self.org_integration:

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -525,6 +525,9 @@ class PerforceIntegration(RepositoryIntegration, CommitContextIntegration):
         # Invalidate cached client so it gets recreated with new credentials
         self._client = None
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["p4port", "user", "auth_type", "web_url"]
+
 
 class PerforceIntegrationProvider(IntegrationProvider):
     """Provider for Perforce integration."""

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -90,6 +90,9 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         )
         return {"installationType": metadata_.get("installation_type", default_installation)}
 
+    def _get_debug_metadata_keys(self) -> list[str]:
+        return ["workspace_name", "team_id", "webhook_channel", "webhook_channel_id"]
+
     def send_message(self, channel_id: str, message: str) -> None:
         client = self.get_client()
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -91,7 +91,7 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         return {"installationType": metadata_.get("installation_type", default_installation)}
 
     def _get_debug_metadata_keys(self) -> list[str]:
-        return ["workspace_name", "team_id", "webhook_channel", "webhook_channel_id"]
+        return ["domain_name", "installation_type"]
 
     def send_message(self, channel_id: str, message: str) -> None:
         client = self.get_client()

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -2186,3 +2186,28 @@ class GitHubIntegrationTest(IntegrationTestCase):
                     "body": "**** wrote:\n\n> hello world\n> This is a comment.\n> \n> \n>     I've changed it"
                 },
             )
+
+    @responses.activate
+    def test_get_debug_metadata(self) -> None:
+        installation = self.get_installation_helper()
+        metadata = installation.get_debug_metadata()
+
+        assert metadata == {
+            "account_type": "Organization",
+            "domain_name": "github.com/Test-Organization",
+            "permissions": {
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            },
+        }
+
+        del installation.model.metadata["permissions"]
+        metadata = installation.get_debug_metadata()
+        assert metadata == {
+            "account_type": "Organization",
+            "domain_name": "github.com/Test-Organization",
+            "permissions": None,
+        }


### PR DESCRIPTION
Adds a new method called `get_debug_metadata`, which returns a filtered metadata field, dictated by the child class's `_get_debug_metadata_keys`. The latter method acts as an allow list for non-sensitive fields to be logged or surfaced via admin APIs
