### PR TITLE
ref(explorer): error msg for empty state when state req fails

### DIFF
--- a/static/app/views/seerExplorer/emptyState.tsx
+++ b/static/app/views/seerExplorer/emptyState.tsx
@@ -1,23 +1,39 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSeer} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface EmptyStateProps {
+  isError?: boolean;
   isLoading?: boolean;
+  runId?: number | null;
 }
 
-function EmptyState({isLoading}: EmptyStateProps) {
+function EmptyState({isLoading = false, isError = false, runId}: EmptyStateProps) {
+  const runIdDisplay = runId?.toString() ?? 'null';
   return (
     <Container>
-      {isLoading ? (
-        <LoadingIndicator size={32} />
+      {isError ? (
+        <Fragment>
+          <IconSeer size="xl" />
+          <Text>
+            {tct('Error loading this session (ID=[runIdDisplay]).', {runIdDisplay})}
+          </Text>
+        </Fragment>
+      ) : isLoading ? (
+        <Fragment>
+          <LoadingIndicator size={32} />
+          <Text>{t('Ask Seer anything about your application.')}</Text>
+        </Fragment>
       ) : (
-        <IconSeer size="xl" animation="waiting" />
+        <Fragment>
+          <IconSeer size="xl" animation="waiting" />
+          <Text>{t('Ask Seer anything about your application.')}</Text>
+        </Fragment>
       )}
-      <Text>{!isLoading && t('Ask Seer anything about your application.')}</Text>
     </Container>
   );
 }

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -93,7 +93,7 @@ describe('ExplorerPanel', () => {
     MockApiClient.clearMockResponses();
     sessionStorage.clear();
 
-    // This matches the real behavior when no run ID is provided.
+    // This matches the real behavior when no run ID is provided to the endpoint.
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/explorer-chat/`,
       method: 'GET',
@@ -174,6 +174,38 @@ describe('ExplorerPanel', () => {
         screen.getByPlaceholderText('Type your message or / command and press Enter ↵')
       ).toBeInTheDocument();
     });
+
+    it('shows error when hook returns isError=true', () => {
+      const useSeerExplorerSpy = jest
+        .spyOn(useSeerExplorerModule, 'useSeerExplorer')
+        .mockReturnValue({
+          runId: 123,
+          sessionData: null, // should always be null when isError
+          sendMessage: jest.fn(),
+          deleteFromIndex: jest.fn(),
+          startNewSession: jest.fn(),
+          isPolling: false,
+          isError: true, // isError
+          isPending: false,
+          deletedFromIndex: null,
+          interruptRun: jest.fn(),
+          interruptRequested: false,
+          switchToRun: jest.fn(),
+          respondToUserInput: jest.fn(),
+          createPR: jest.fn(),
+        });
+
+      renderWithPanelContext(<ExplorerPanel />, true, {organization});
+
+      expect(
+        screen.getByText('Error loading this session (ID=123).')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Ask Seer anything about your application./)
+      ).not.toBeInTheDocument();
+
+      useSeerExplorerSpy.mockRestore();
+    });
   });
 
   describe('Messages Display', () => {
@@ -212,6 +244,7 @@ describe('ExplorerPanel', () => {
         deleteFromIndex: jest.fn(),
         startNewSession: jest.fn(),
         isPolling: false,
+        isError: false,
         isPending: false,
         deletedFromIndex: null,
         interruptRun: jest.fn(),

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -75,6 +75,7 @@ function ExplorerPanel() {
     deleteFromIndex,
     startNewSession,
     isPolling,
+    isError,
     interruptRun,
     interruptRequested,
     switchToRun,
@@ -589,7 +590,11 @@ function ExplorerPanel() {
       {menu}
       <BlocksContainer ref={scrollContainerRef} onClick={handlePanelBackgroundClick}>
         {isEmptyState ? (
-          <EmptyState isLoading={isWaitingForSessionData} />
+          <EmptyState
+            isLoading={isWaitingForSessionData}
+            isError={isError}
+            runId={runId}
+          />
         ) : (
           <Fragment>
             {blocks.map((block: Block, index: number) => (

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -152,7 +152,11 @@ export const useSeerExplorer = () => {
   } | null>(null);
   const previousPRStatesRef = useRef<Record<string, RepoPRState>>({});
 
-  const {data: apiData, isPending} = useApiQuery<SeerExplorerResponse>(
+  const {
+    data: apiData,
+    isPending,
+    isError,
+  } = useApiQuery<SeerExplorerResponse>(
     makeSeerExplorerQueryKey(orgSlug || '', runId || undefined),
     {
       staleTime: 0,
@@ -549,6 +553,7 @@ export const useSeerExplorer = () => {
     sessionData: filteredSessionData,
     isPolling: isPolling(filteredSessionData, waitingForResponse),
     isPending,
+    isError,
     sendMessage,
     runId,
     /** Switches to a different run and fetches its latest state. */


### PR DESCRIPTION
closes [AIML-2149: error states for chat panel](https://linear.app/getsentry/issue/AIML-2149/error-states-for-chat-panel)
<img width="377" height="275" alt="Screenshot 2026-01-09 at 3 05 11 PM" src="https://github.com/user-attachments/assets/9c5206f0-959b-44b9-8dda-0f84f73ad87a" />
