### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for `Beacons` route

### DIFF
--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -56,7 +56,6 @@ function buildRoutes() {
           {
             index: true,
             component: Beacons,
-            deprecatedRouteProps: true,
           },
           {
             path: ':beaconId/',

--- a/static/gsAdmin/views/beacons.tsx
+++ b/static/gsAdmin/views/beacons.tsx
@@ -2,12 +2,9 @@ import moment from 'moment-timezone';
 
 import {Link} from 'sentry/components/core/link';
 import Truncate from 'sentry/components/truncate';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 
 import PageHeader from 'admin/components/pageHeader';
 import ResultGrid from 'admin/components/resultGrid';
-
-type Props = RouteComponentProps<unknown, unknown>;
 
 const getRow = (row: any) => [
   <td key="beacon">
@@ -38,7 +35,7 @@ const getRow = (row: any) => [
   </td>,
 ];
 
-function Beacons(props: Props) {
+export default function Beacons() {
   return (
     <div>
       <PageHeader title="Beacons" />
@@ -75,10 +72,7 @@ function Beacons(props: Props) {
           ['projects', 'Projects'],
         ]}
         defaultSort="date"
-        {...props}
       />
     </div>
   );
 }
-
-export default Beacons;


### PR DESCRIPTION
Migrates the `Beacons` admin route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7