### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for `Broadcasts` route

### DIFF
--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -70,7 +70,6 @@ function buildRoutes() {
           {
             index: true,
             component: Broadcasts,
-            deprecatedRouteProps: true,
           },
           {
             path: ':broadcastId/',

--- a/static/gsAdmin/views/broadcasts.spec.tsx
+++ b/static/gsAdmin/views/broadcasts.spec.tsx
@@ -1,7 +1,6 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -28,8 +27,6 @@ describe('Broadcasts', () => {
   });
 
   it('renders', async () => {
-    const {router} = initializeOrg();
-
     ConfigStore.loadInitialData(
       ConfigFixture({
         user: mockUser,
@@ -38,16 +35,7 @@ describe('Broadcasts', () => {
 
     renderMockRequests();
 
-    render(
-      <Broadcasts
-        location={router.location}
-        router={router}
-        params={router.params}
-        route={router.routes[0]!}
-        routeParams={router.params}
-        routes={router.routes}
-      />
-    );
+    render(<Broadcasts />);
 
     renderGlobalModal();
 

--- a/static/gsAdmin/views/broadcasts.tsx
+++ b/static/gsAdmin/views/broadcasts.tsx
@@ -5,14 +5,11 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {Link} from 'sentry/components/core/link';
 import ConfigStore from 'sentry/stores/configStore';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 
 import {CreateBroadcastModal} from 'admin/components/createBroadcastModal';
 import PageHeader from 'admin/components/pageHeader';
 import ResultGrid from 'admin/components/resultGrid';
 import {getBroadcastSchema} from 'admin/schemas/broadcasts';
-
-type Props = RouteComponentProps<unknown, unknown>;
 
 const getRow = (row: any) => [
   <td key="title">
@@ -38,7 +35,7 @@ const getRow = (row: any) => [
   </td>,
 ];
 
-function Broadcasts(props: Props) {
+export default function Broadcasts() {
   const hasPermission = ConfigStore.get('user').permissions.has('broadcasts.admin');
   const fields = getBroadcastSchema();
 
@@ -91,10 +88,7 @@ function Broadcasts(props: Props) {
           ['expires', 'Date Expires'],
         ]}
         defaultSort="created"
-        {...props}
       />
     </div>
   );
 }
-
-export default Broadcasts;


### PR DESCRIPTION
Migrates the `Broadcasts` admin route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7