### PR TITLE
feat(issueList): Add clickable column headers to change sort order

### DIFF
--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {COLUMN_BREAKPOINTS} from 'sentry/views/issueList/actions/utils';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 type Props = {
   isReprocessingQuery: boolean;
@@ -15,6 +16,8 @@ type Props = {
   selection: PageFilters;
   statsPeriod: string;
   isSavedSearchesOpen?: boolean;
+  onSortChange?: (sort: string) => void;
+  sort?: string;
 };
 
 function Headers({
@@ -22,6 +25,8 @@ function Headers({
   statsPeriod,
   onSelectStatsPeriod,
   isReprocessingQuery,
+  onSortChange,
+  sort,
 }: Props) {
   return (
     <Fragment>
@@ -33,15 +38,33 @@ function Headers({
         </Fragment>
       ) : (
         <Fragment>
-          <LastSeenLabel breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
-            {t('Last Seen')}
-          </LastSeenLabel>
-          <FirstSeenLabel breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
-            {t('Age')}
-          </FirstSeenLabel>
+          <SortableHeader
+            breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN}
+            align="right"
+            sortOption={IssueSortOptions.DATE}
+            currentSort={sort}
+            onSortChange={onSortChange}
+            label={t('Last Seen')}
+            width="86px"
+          />
+          <SortableHeader
+            breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN}
+            align="right"
+            sortOption={IssueSortOptions.NEW}
+            currentSort={sort}
+            onSortChange={onSortChange}
+            label={t('Age')}
+            width="50px"
+          />
           <GraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
             <Flex flex="1" justify="between">
-              {t('Trend')}
+              <SortableHeaderText
+                sortOption={IssueSortOptions.TRENDS}
+                currentSort={sort}
+                onSortChange={onSortChange}
+              >
+                {t('Trend')}
+              </SortableHeaderText>
               <GraphToggles>
                 {selection.datetime.period !== '24h' && (
                   <GraphToggle
@@ -60,12 +83,24 @@ function Headers({
               </GraphToggles>
             </Flex>
           </GraphLabel>
-          <EventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.EVENTS} align="right">
-            {t('Events')}
-          </EventsOrUsersLabel>
-          <EventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.USERS} align="right">
-            {t('Users')}
-          </EventsOrUsersLabel>
+          <SortableHeader
+            breakpoint={COLUMN_BREAKPOINTS.EVENTS}
+            align="right"
+            sortOption={IssueSortOptions.FREQ}
+            currentSort={sort}
+            onSortChange={onSortChange}
+            label={t('Events')}
+            width="60px"
+          />
+          <SortableHeader
+            breakpoint={COLUMN_BREAKPOINTS.USERS}
+            align="right"
+            sortOption={IssueSortOptions.USER}
+            currentSort={sort}
+            onSortChange={onSortChange}
+            label={t('Users')}
+            width="60px"
+          />
           <PriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY} align="left">
             {t('Priority')}
           </PriorityLabel>
@@ -75,6 +110,65 @@ function Headers({
         </Fragment>
       )}
     </Fragment>
+  );
+}
+
+function SortableHeader({
+  breakpoint,
+  align,
+  sortOption,
+  currentSort,
+  onSortChange,
+  label,
+  width,
+}: {
+  align: 'left' | 'right';
+  label: string;
+  sortOption: IssueSortOptions;
+  width: string;
+  breakpoint?: string;
+  currentSort?: string;
+  onSortChange?: (sort: string) => void;
+}) {
+  const isActive = currentSort === sortOption;
+  const isClickable = !!onSortChange;
+
+  return (
+    <SortableLabel
+      breakpoint={breakpoint}
+      align={align}
+      isActive={isActive}
+      isClickable={isClickable}
+      onClick={isClickable ? () => onSortChange(sortOption) : undefined}
+      style={{width}}
+    >
+      {label}
+    </SortableLabel>
+  );
+}
+
+function SortableHeaderText({
+  sortOption,
+  currentSort,
+  onSortChange,
+  children,
+}: {
+  children: React.ReactNode;
+  sortOption: IssueSortOptions;
+  currentSort?: string;
+  onSortChange?: (sort: string) => void;
+}) {
+  const isActive = currentSort === sortOption;
+  const isClickable = !!onSortChange;
+
+  return (
+    <SortableText
+      isActive={isActive}
+      isClickable={isClickable}
+      onClick={isClickable ? () => onSortChange(sortOption) : undefined}
+    >
+      {children}
+    </SortableText>
   );
 }
 
@@ -106,16 +200,41 @@ const GraphToggle = styled('a')<{active: boolean}>`
   }
 `;
 
-const LastSeenLabel = styled(IssueStreamHeaderLabel)`
-  width: 86px;
+const SortableLabel = styled(IssueStreamHeaderLabel)<{
+  isActive: boolean;
+  isClickable: boolean;
+}>`
+  ${p =>
+    p.isClickable &&
+    `
+    cursor: pointer;
+    user-select: none;
+    &:hover {
+      color: ${p.theme.tokens.content.primary};
+    }
+  `}
+  ${p =>
+    p.isActive &&
+    `
+    color: ${p.theme.tokens.content.primary};
+  `}
 `;
 
-const FirstSeenLabel = styled(IssueStreamHeaderLabel)`
-  width: 50px;
-`;
-
-const EventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
-  width: 60px;
+const SortableText = styled('span')<{isActive: boolean; isClickable: boolean}>`
+  ${p =>
+    p.isClickable &&
+    `
+    cursor: pointer;
+    user-select: none;
+    &:hover {
+      color: ${p.theme.tokens.content.primary};
+    }
+  `}
+  ${p =>
+    p.isActive &&
+    `
+    color: ${p.theme.tokens.content.primary};
+  `}
 `;
 
 const PriorityLabel = styled(IssueStreamHeaderLabel)`

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -48,6 +48,8 @@ type IssueListActionsProps = {
   selection: PageFilters;
   statsPeriod: string;
   onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
+  onSortChange?: (sort: string) => void;
+  sort?: string;
 };
 
 const animationProps: MotionNodeAnimationOptions = {
@@ -75,6 +77,8 @@ function ActionsBarPriority({
   isSavedSearchesOpen,
   statsPeriod,
   selection,
+  onSortChange,
+  sort,
 }: {
   allInQuerySelected: boolean;
   anySelected: boolean;
@@ -93,6 +97,8 @@ function ActionsBarPriority({
   selectedProjectSlug: string | undefined;
   selection: PageFilters;
   statsPeriod: string;
+  onSortChange?: (sort: string) => void;
+  sort?: string;
 }) {
   const shouldDisplayActions = anySelected && !narrowViewport;
 
@@ -140,6 +146,8 @@ function ActionsBarPriority({
               statsPeriod={statsPeriod}
               isReprocessingQuery={displayReprocessingActions}
               isSavedSearchesOpen={isSavedSearchesOpen}
+              onSortChange={onSortChange}
+              sort={sort}
             />
           </AnimatedHeaderItemsContainer>
         )}
@@ -159,6 +167,8 @@ function IssueListActions({
   query,
   selection,
   statsPeriod,
+  onSortChange,
+  sort,
 }: IssueListActionsProps) {
   const api = useApi();
   const queryClient = useQueryClient();
@@ -367,6 +377,8 @@ function IssueListActions({
         isSavedSearchesOpen={isSavedSearchesOpen}
         anySelected={anySelected}
         onSelectStatsPeriod={onSelectStatsPeriod}
+        onSortChange={onSortChange}
+        sort={sort}
       />
       {!allResultsVisible && pageSelected && (
         <Alert system variant="warning" showIcon={false}>

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -39,6 +39,8 @@ interface IssueListTableProps {
   selection: PageFilters;
   statsLoading: boolean;
   statsPeriod: string;
+  onSortChange?: (sort: string) => void;
+  sort?: string;
 }
 
 function IssueListTable({
@@ -63,6 +65,8 @@ function IssueListTable({
   paginationAnalyticsEvent,
   issuesSuccessfullyLoaded,
   pageSize,
+  onSortChange,
+  sort,
 }: IssueListTableProps) {
   const location = useLocation();
 
@@ -99,6 +103,8 @@ function IssueListTable({
               groupIds={groupIds}
               allResultsVisible={allResultsVisible}
               displayReprocessingActions={displayReprocessingActions}
+              onSortChange={onSortChange}
+              sort={sort}
             />
           )}
           <PanelBody>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -917,6 +917,8 @@ function IssueListOverview({
             paginationAnalyticsEvent={paginationAnalyticsEvent}
             issuesSuccessfullyLoaded={issuesSuccessfullyLoaded}
             pageSize={MAX_ITEMS}
+            onSortChange={onSortChange}
+            sort={sort}
           />
         </StyledMain>
       </StyledBody>


### PR DESCRIPTION
## Summary

- Add ability to click on issue stream column headers (Last Seen, Age, Trend, Events, Users) to update the sort order
- Clicking a header updates the sort selector dropdown automatically (both use the same `onSortChange` callback)
- Active sort column is visually highlighted with primary content color
- Clickable headers show pointer cursor and hover state