### PR TITLE
chore(uptime): Increase backlog queue max wait time from 3 minutes to 5 minutes.

### DIFF
--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.models.detector import Detector
 logger = logging.getLogger(__name__)
 
 # 7 attempts over 180 seconds
-BACKOFF_SCHEDULE = [10, 20, 30, 30, 30, 30, 30]
+BACKOFF_SCHEDULE = [10, 20, 30, 30, 30, 30, 30, 30, 30, 30, 30]
 
 
 @instrumented_task(


### PR DESCRIPTION
Give us a little more time to get missing checks from delayed regions through
