### PR TITLE
chore(aci): handle workflows or rules in integrations sans feature flag

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -65,7 +65,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
             try:
                 key, rule_id = get_rule_or_workflow_id(self.rules[0])
             except AssertionError:
-                rule_id = self.rules[0].id
+                rule_id = str(self.rules[0].id)
 
         url = None
 
@@ -77,7 +77,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
                 self.issue_details,
                 self.notification,
                 ExternalProviders.DISCORD,
-                rule_id,
+                int(rule_id) if rule_id else None,
                 rule_environment_id,
                 notification_uuid=notification_uuid,
             )
@@ -89,7 +89,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
                 self.issue_details,
                 self.notification,
                 ExternalProviders.DISCORD,
-                rule_id,
+                int(rule_id) if rule_id else None,
                 rule_environment_id,
                 notification_uuid=notification_uuid,
             )

--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -59,9 +59,9 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         obj: Group | GroupEvent = self.event if self.event is not None else self.group
         rule_id = None
         rule_environment_id = None
+        key = "legacy_rule_id"
         if self.rules:
             rule_environment_id = self.rules[0].environment_id
-            key = "legacy_rule_id"
             try:
                 key, rule_id = get_rule_or_workflow_id(self.rules[0])
             except AssertionError:

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -292,10 +292,11 @@ def build_footer(
     footer = f"{group.qualified_short_id}"
     if rules:
         key, value = get_rule_or_workflow_id(rules[0])
-        if key == "workflow_id":
-            rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
-        else:
-            rule_url = build_rule_url(rules[0], group, project)
+        match key:
+            case "workflow_id":
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+            case "legacy_rule_id":
+                rule_url = build_rule_url(rules[0], group, project)
 
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -15,7 +15,7 @@ from sentry.models.team import Team
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data, get_rule_or_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.users.services.user import RpcUser
 from sentry.utils.http import absolute_uri
@@ -291,12 +291,9 @@ def build_footer(
 ) -> str:
     footer = f"{group.qualified_short_id}"
     if rules:
-        if features.has("organizations:workflow-engine-ui-links", group.organization):
-            rule_url = absolute_uri(
-                create_link_to_workflow(
-                    group.organization.id, get_key_from_rule_data(rules[0], "workflow_id")
-                )
-            )
+        key, value = get_rule_or_workflow_id(rules[0])
+        if key == "workflow_id":
+            rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
         else:
             rule_url = build_rule_url(rules[0], group, project)
 

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-from sentry import features
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.on_call.metrics import OnCallInteractionType
@@ -12,7 +11,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data, split_rules_by_rule_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -91,19 +90,30 @@ class OpsgenieClient(ApiClient):
             group_params = {"referrer": IntegrationProviderSlug.OPSGENIE.value}
             if notification_uuid:
                 group_params["notification_uuid"] = notification_uuid
+
+            rules_and_workflows = split_rules_by_rule_workflow_id(rules)
+            workflow_urls = self._get_workflow_urls(group, rules_and_workflows.workflow_rules)
+            rule_urls = self._get_rule_urls(group, rules_and_workflows.rules)
             rule_workflow_context = {}
-            if features.has("organizations:workflow-engine-ui-links", group.project.organization):
-                workflow_urls = self._get_workflow_urls(group, rules)
-                rule_workflow_context = {
-                    "Triggering Workflows": ", ".join([rule.label for rule in rules]),
-                    "Triggering Workflow URLs": "\n".join(workflow_urls),
-                }
-            else:
-                rule_urls = self._get_rule_urls(group, rules)
-                rule_workflow_context = {
-                    "Triggering Rules": ", ".join([rule.label for rule in rules]),
-                    "Triggering Rule URLs": "\n".join(rule_urls),
-                }
+            if rule_urls:
+                rule_workflow_context.update(
+                    {
+                        "Triggering Rules": ", ".join(
+                            [rule.label for rule in rules_and_workflows.rules]
+                        ),
+                        "Triggering Rule URLs": "\n".join(rule_urls),
+                    }
+                )
+            if workflow_urls:
+                rule_workflow_context.update(
+                    {
+                        "Triggering Workflows": ", ".join(
+                            [workflow.label for workflow in rules_and_workflows.workflow_rules]
+                        ),
+                        "Triggering Workflow URLs": "\n".join(workflow_urls),
+                    }
+                )
+
             payload["details"] = {
                 "Sentry ID": str(group.id),
                 "Sentry Group": getattr(group, "title", group.message).encode("utf-8"),

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -55,7 +55,6 @@ from sentry.models.release import Release
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.platform.slack.renderers.seer import SeerSlackRenderer
 from sentry.notifications.platform.templates.seer import SeerAutofixTrigger
@@ -64,7 +63,7 @@ from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
     get_suspect_commit_users,
 )
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
@@ -669,18 +668,22 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         rule_id = None
         rule_environment_id = None
+        key = "legacy_rule_id"
         if self.rules:
-            if features.has("organizations:workflow-engine-ui-links", self.group.organization):
-                rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
-                workflow = Workflow.objects.filter(id=rule_id).first()
-                rule_environment_id = workflow.environment_id if workflow else None
-            elif should_fire_workflow_actions(self.group.organization, self.group.type):
-                rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
-                rule = Rule.objects.filter(id=rule_id).first()
-                rule_environment_id = rule.environment_id if rule else None
-            else:
+            try:
+                key, value = get_rule_or_workflow_id(self.rules[0])
+            except AssertionError:
                 rule_id = self.rules[0].id
                 rule_environment_id = self.rules[0].environment_id
+            else:
+                if key == "workflow_id":
+                    rule_id = int(value)
+                    workflow = Workflow.objects.filter(id=rule_id).first()
+                    rule_environment_id = workflow.environment_id if workflow else None
+                else:
+                    rule_id = int(value)
+                    rule = Rule.objects.filter(id=rule_id).first()
+                    rule_environment_id = rule.environment_id if rule else None
 
         # build up actions text
         if self.actions and self.identity and not action_text:
@@ -689,7 +692,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             has_action = True
 
         title_link = None
-        if features.has("organizations:workflow-engine-ui-links", self.group.organization):
+        if key == "workflow_id":
             title_link = get_title_link_workflow_engine_ui(
                 self.group,
                 self.event,

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -19,10 +19,11 @@ def build_slack_footer(
 
     if rules:
         key, value = get_rule_or_workflow_id(rules[0])
-        if key == "legacy_rule_id":
-            rule_url = build_rule_url(rules[0], group, project)
-        else:
-            rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+        match key:
+            case "workflow_id":
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+            case "legacy_rule_id":
+                rule_url = build_rule_url(rules[0], group, project)
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -1,13 +1,12 @@
 from collections.abc import Sequence
 
-from sentry import features
 from sentry.integrations.messaging.message_builder import build_rule_url
 from sentry.integrations.slack.message_builder.types import SLACK_URL_FORMAT
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.utils.http import absolute_uri
 
 
@@ -19,14 +18,11 @@ def build_slack_footer(
     footer = f"{group.qualified_short_id}"
 
     if rules:
-        if features.has("organizations:workflow-engine-ui-links", group.organization):
-            rule_url = absolute_uri(
-                create_link_to_workflow(
-                    group.organization.id, get_key_from_rule_data(rules[0], "workflow_id")
-                )
-            )
-        else:
+        key, value = get_rule_or_workflow_id(rules[0])
+        if key == "legacy_rule_id":
             rule_url = build_rule_url(rules[0], group, project)
+        else:
+            rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -298,15 +298,13 @@ class AlertRuleNotification(ProjectNotification):
         title_str = "Alert triggered"
 
         if self.rules:
-            rule_url = build_rule_url(self.rules[0], self.group, self.project)
-            key = "legacy_rule_id"
-            try:
-                key, value = get_rule_or_workflow_id(self.rules[0])
-            except AssertionError:
-                pass
+            key, value = get_rule_or_workflow_id(self.rules[0])
 
-            if key == "workflow_id":
-                rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+            match key:
+                case "workflow_id":
+                    rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+                case "legacy_rule_id":
+                    rule_url = build_rule_url(self.rules[0], self.group, self.project)
 
             title_str += (
                 f" {self.format_url(text=self.rules[0].label, url=rule_url, provider=provider)}"

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -19,7 +19,7 @@ We can use this as a basepoint to build out our templating system in the future
 """
 
 
-def create_link_to_workflow(organization_id: int, workflow_id: int) -> str:
+def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -19,7 +19,7 @@ We can use this as a basepoint to build out our templating system in the future
 """
 
 
-def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
+def create_link_to_workflow(organization_id: int, workflow_id: int) -> str:
     """
     Create a link to a workflow
     """

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -31,13 +31,13 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
     return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
-def get_rule_or_workflow_id(rule: Rule) -> tuple[str, int]:
+def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:
     try:
-        return ("legacy_rule_id", int(get_key_from_rule_data(rule, "legacy_rule_id")))
+        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
     except AssertionError:
         pass
 
     try:
-        return ("workflow_id", int(get_key_from_rule_data(rule, "workflow_id")))
+        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
     except AssertionError:
-        return ("legacy_rule_id", rule.id)
+        return ("legacy_rule_id", str(rule.id))

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -31,8 +31,13 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
     return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
-def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:
+def get_rule_or_workflow_id(rule: Rule) -> tuple[str, int]:
     try:
-        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
+        return ("legacy_rule_id", int(get_key_from_rule_data(rule, "legacy_rule_id")))
     except AssertionError:
-        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
+        pass
+
+    try:
+        return ("workflow_id", int(get_key_from_rule_data(rule, "workflow_id")))
+    except AssertionError:
+        return ("legacy_rule_id", rule.id)

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -1,7 +1,10 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 from sentry.models.rule import Rule
+
+RuleIdType = Literal["workflow_id", "legacy_rule_id"]
 
 
 def get_key_from_rule_data(rule: Rule, key: str) -> str:
@@ -20,18 +23,16 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
     parsed_rules = []
     workflow_rules = []
     for rule in rules:
-        try:
-            key, _ = get_rule_or_workflow_id(rule)
-            if key == "workflow_id":
+        key, _ = get_rule_or_workflow_id(rule)
+        match key:
+            case "workflow_id":
                 workflow_rules.append(rule)
-            else:
+            case "legacy_rule_id":
                 parsed_rules.append(rule)
-        except AssertionError:
-            parsed_rules.append(rule)
     return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
-def get_rule_or_workflow_id(rule: Rule) -> tuple[str, str]:
+def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
     try:
         return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
     except AssertionError:

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Sequence
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.integrations.base import IntegrationInstallation
@@ -143,9 +142,9 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             installation, IssueBasicIntegration
         ), "Installation must be an IssueBasicIntegration to create a ticket"
         data["title"] = installation.get_group_title(event.group, event)
-        if features.has("organizations:workflow-engine-ui-links", organization):
-            workflow_id = data.get("workflow_id")
-            assert workflow_id is not None
+
+        workflow_id = data.get("workflow_id")
+        if workflow_id is not None:
             data["description"] = build_description_workflow_engine_ui(
                 event, workflow_id, installation, generate_footer
             )

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -740,10 +740,7 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         # if we are using the new workflow engine, we need to use the legacy rule id
         # Ignore test notifications
         if int(id) != -1:
-            try:
-                _, id = get_rule_or_workflow_id(f.rule)
-            except AssertionError:
-                pass
+            _, id = get_rule_or_workflow_id(f.rule)
 
         settings = f.kwargs.get("schema_defined_settings")
         if settings:

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -749,7 +749,7 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         if settings:
             extra_kwargs["additional_payload_key"] = "issue_alert"
             extra_kwargs["additional_payload"] = {
-                "id": id,
+                "id": int(id),
                 "title": f.rule.label,
                 "sentry_app_id": f.kwargs["sentry_app"].id,
                 "settings": settings,

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from requests import HTTPError, Timeout
 from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestException
 
-from sentry import analytics, features, nodestore
+from sentry import analytics, nodestore
 from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
     AlertRuleUiComponentWebhookSentEvent,
 )
@@ -40,7 +40,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
-from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -720,8 +720,6 @@ def send_resource_change_webhook(
 
 
 def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     for f in futures:
         if not f.kwargs.get("sentry_app"):
             logger.info(
@@ -742,10 +740,10 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         # if we are using the new workflow engine, we need to use the legacy rule id
         # Ignore test notifications
         if int(id) != -1:
-            if features.has("organizations:workflow-engine-ui-links", event.group.organization):
-                id = get_key_from_rule_data(f.rule, "workflow_id")
-            elif should_fire_workflow_actions(event.group.organization, event.group.type):
-                id = get_key_from_rule_data(f.rule, "legacy_rule_id")
+            try:
+                _, id = get_rule_or_workflow_id(f.rule)
+            except AssertionError:
+                pass
 
         settings = f.kwargs.get("schema_defined_settings")
         if settings:

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -380,7 +380,7 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
         assert payload["data"]["triggered_rule"] == rule.label
         assert payload["data"]["issue_alert"] == {
             # Use the legacy rule id
-            "id": 123,
+            "id": "123",
             "title": rule.label,
             "sentry_app_id": self.sentry_app.id,
             "settings": settings,

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -380,7 +380,7 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
         assert payload["data"]["triggered_rule"] == rule.label
         assert payload["data"]["issue_alert"] == {
             # Use the legacy rule id
-            "id": "123",
+            "id": 123,
             "title": rule.label,
             "sentry_app_id": self.sentry_app.id,
             "settings": settings,


### PR DESCRIPTION
Update integrations code to handle using legacy_rule_id or workflow_id depending on if it exists. We prefer using legacy_rule_id if available, otherwise try workflow_id, then finally use rule.id

Builds on https://github.com/getsentry/sentry/pull/105999