### PR TITLE
fix(aci): Better handling for error monitor edit permissions

### DIFF
--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -4,10 +4,9 @@ import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconEdit} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -18,6 +17,10 @@ import {
   makeMonitorTypePathname,
 } from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
+import {
+  getManagedBySentryMonitorEditTooltip,
+  getNoPermissionToEditMonitorTooltip,
+} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 export function DisableDetectorAction({detector}: {detector: Detector}) {
@@ -54,30 +57,23 @@ export function DisableDetectorAction({detector}: {detector: Detector}) {
   );
 }
 
-export function EditDetectorAction({detector}: {detector: Detector}) {
+export function EditDetectorAction({
+  detector,
+  canEdit: canEditOverride,
+}: {
+  detector: Detector;
+  canEdit?: boolean;
+}) {
   const organization = useOrganization();
-  const canEdit = useCanEditDetector({
+  const canEditDetectorType = useCanEditDetector({
     detectorType: detector.type,
     projectId: detector.projectId,
   });
+  const canEdit = canEditOverride ?? canEditDetectorType;
 
   const permissionTooltipText = detectorTypeIsUserCreateable(detector.type)
-    ? tct(
-        'You do not have permission to edit this monitor. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
-        {
-          settingsLink: (
-            <Link
-              to={{
-                pathname: `/settings/${organization.slug}/`,
-                hash: 'alertsMemberWrite',
-              }}
-            />
-          ),
-        }
-      )
-    : t(
-        'This monitor is managed by Sentry. Only organization owners and managers can edit it.'
-      );
+    ? getNoPermissionToEditMonitorTooltip()
+    : getManagedBySentryMonitorEditTooltip();
 
   return (
     <Tooltip

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -20,32 +20,55 @@ type DetectorDetailsHeaderProps = {
   project: Project;
 };
 
-export function DetectorDetailsHeader({detector, project}: DetectorDetailsHeaderProps) {
+function DetectorDetailsBreadcrumbs({detector}: {detector: Detector}) {
   const organization = useOrganization();
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug),
+        },
+        {
+          label: getDetectorTypeLabel(detector.type),
+          to: makeMonitorTypePathname(organization.slug, detector.type),
+        },
+        {label: detector.name},
+      ]}
+    />
+  );
+}
 
+export function DetectorDetailsDefaultHeaderContent({
+  detector,
+  project,
+}: {
+  detector: Detector;
+  project: Project;
+}) {
+  return (
+    <DetailLayout.HeaderContent>
+      <DetectorDetailsBreadcrumbs detector={detector} />
+      <DetailLayout.Title title={detector.name} project={project} />
+    </DetailLayout.HeaderContent>
+  );
+}
+
+function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
+  return (
+    <DetailLayout.Actions>
+      <MonitorFeedbackButton />
+      <DisableDetectorAction detector={detector} />
+      <EditDetectorAction detector={detector} />
+    </DetailLayout.Actions>
+  );
+}
+
+export function DetectorDetailsHeader({detector, project}: DetectorDetailsHeaderProps) {
   return (
     <DetailLayout.Header>
-      <DetailLayout.HeaderContent>
-        <Breadcrumbs
-          crumbs={[
-            {
-              label: t('Monitors'),
-              to: makeMonitorBasePathname(organization.slug),
-            },
-            {
-              label: getDetectorTypeLabel(detector.type),
-              to: makeMonitorTypePathname(organization.slug, detector.type),
-            },
-            {label: detector.name},
-          ]}
-        />
-        <DetailLayout.Title title={detector.name} project={project} />
-      </DetailLayout.HeaderContent>
-      <DetailLayout.Actions>
-        <MonitorFeedbackButton />
-        <DisableDetectorAction detector={detector} />
-        <EditDetectorAction detector={detector} />
-      </DetailLayout.Actions>
+      <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+      <DetectorDetailsDefaultActions detector={detector} />
     </DetailLayout.Header>
   );
 }

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -9,11 +9,14 @@ import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
+import {EditDetectorAction} from 'sentry/views/detectors/components/details/common/actions';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
-import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {DetectorDetailsDefaultHeaderContent} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
+import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 type ErrorDetectorDetailsProps = {
   detector: Detector;
@@ -65,10 +68,17 @@ function ResolveSection({project}: {project: Project}) {
 
 export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsProps) {
   const organization = useOrganization();
+  const canEdit = useCanEditDetectorWorkflowConnections({projectId: project.id});
 
   return (
     <DetailLayout>
-      <DetectorDetailsHeader detector={detector} project={project} />
+      <DetailLayout.Header>
+        <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+        <DetailLayout.Actions>
+          <MonitorFeedbackButton />
+          <EditDetectorAction detector={detector} canEdit={canEdit} />
+        </DetailLayout.Actions>
+      </DetailLayout.Header>
       <DetailLayout.Body>
         <DetailLayout.Main>
           <DisabledAlert

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -18,6 +18,8 @@ import {AutomationFeedbackButton} from 'sentry/views/automations/components/auto
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {getNoPermissionToEditMonitorTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
+import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 type ErrorDetectorFormData = {
   workflowIds: string[];
@@ -114,6 +116,11 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
 
+  // Error monitors only allow editing workflow connections right now, so that's the only permission we need to check
+  const canEditWorkflowConnections = useCanEditDetectorWorkflowConnections({
+    projectId: detector.projectId,
+  });
+
   const handleFormSubmit = useEditDetectorFormSubmit({
     detector,
     formDataToEndpointPayload: (data: ErrorDetectorFormData) => ({
@@ -151,7 +158,15 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       </EditLayout.Body>
 
       <EditLayout.Footer maxWidth={maxWidth}>
-        <Button type="submit" priority="primary" size="sm">
+        <Button
+          type="submit"
+          priority="primary"
+          size="sm"
+          disabled={!canEditWorkflowConnections}
+          title={
+            canEditWorkflowConnections ? undefined : getNoPermissionToEditMonitorTooltip()
+          }
+        >
           {t('Save')}
         </Button>
       </EditLayout.Footer>

--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -1,11 +1,8 @@
-import {Link} from '@sentry/scraps/link';
-
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {IconAdd} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
+import {t} from 'sentry/locale';
 import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -15,6 +12,7 @@ import {
   makeMonitorCreateSettingsPathname,
 } from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
+import {getNoPermissionToCreateMonitorsTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanCreateDetector} from 'sentry/views/detectors/utils/useCanCreateDetector';
 
 interface DetectorListActionsProps {
@@ -22,26 +20,8 @@ interface DetectorListActionsProps {
   children?: React.ReactNode;
 }
 
-function getPermissionTooltipText({
-  organization,
-  detectorType,
-}: {
-  detectorType: DetectorType | null;
-  organization: Organization;
-}) {
-  const noPermissionText = tct(
-    'You do not have permission to create monitors. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
-    {
-      settingsLink: (
-        <Link
-          to={{
-            pathname: `/settings/${organization.slug}/`,
-            hash: 'alertsMemberWrite',
-          }}
-        />
-      ),
-    }
-  );
+function getPermissionTooltipText({detectorType}: {detectorType: DetectorType | null}) {
+  const noPermissionText = getNoPermissionToCreateMonitorsTooltip();
 
   if (!detectorType || detectorTypeIsUserCreateable(detectorType)) {
     return noPermissionText;
@@ -78,7 +58,6 @@ export function DetectorListActions({detectorType, children}: DetectorListAction
           canCreateDetector
             ? undefined
             : getPermissionTooltipText({
-                organization,
                 detectorType,
               })
         }

--- a/static/app/views/detectors/utils/monitorAccessMessages.tsx
+++ b/static/app/views/detectors/utils/monitorAccessMessages.tsx
@@ -1,0 +1,36 @@
+import {Link} from 'sentry/components/core/link';
+import {t, tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+function AlertsMemberWriteSettingsLink() {
+  const organization = useOrganization();
+
+  return (
+    <Link
+      to={{
+        hash: 'alertsMemberWrite',
+        pathname: `/settings/${organization.slug}/`,
+      }}
+    />
+  );
+}
+
+export function getNoPermissionToEditMonitorTooltip() {
+  return tct(
+    'You do not have permission to edit this monitor. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
+    {settingsLink: <AlertsMemberWriteSettingsLink />}
+  );
+}
+
+export function getNoPermissionToCreateMonitorsTooltip() {
+  return tct(
+    'You do not have permission to create monitors. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
+    {settingsLink: <AlertsMemberWriteSettingsLink />}
+  );
+}
+
+export function getManagedBySentryMonitorEditTooltip() {
+  return t(
+    'This monitor is managed by Sentry. Only organization owners and managers can edit it.'
+  );
+}


### PR DESCRIPTION
Currently, we are not allowing most users to click into the error monitor edit page. That's not really necessary since the edit page doesn't actually allow you to edit anything and gives you good information about the necessary settings pages.

In this PR I've opened up the edit button to anyone with ACI permissions. I've also done a little refactoring to make the detector header component more composable which allows us to modify the edit button behavior here.