### PR TITLE
Handle resolved condition in the frontend

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -31,6 +31,7 @@ export enum DataConditionType {
   NEW_HIGH_PRIORITY_ISSUE = 'new_high_priority_issue',
   REGRESSION_EVENT = 'regression_event',
   REAPPEARED_EVENT = 'reappeared_event',
+  ISSUE_RESOLVED_TRIGGER = 'issue_resolved_trigger',
   TAGGED_EVENT = 'tagged_event',
   ISSUE_PRIORITY_EQUALS = 'issue_priority_equals',
   ISSUE_PRIORITY_GREATER_OR_EQUAL = 'issue_priority_greater_or_equal',

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -191,6 +191,7 @@ const initialAutomationBuilderState: AutomationBuilderState = {
     logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
     conditions: [
       createWhenCondition(DataConditionType.FIRST_SEEN_EVENT),
+      createWhenCondition(DataConditionType.ISSUE_RESOLVED_TRIGGER),
       createWhenCondition(DataConditionType.REAPPEARED_EVENT),
       createWhenCondition(DataConditionType.REGRESSION_EVENT),
     ],

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -124,6 +124,13 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     },
   ],
   [
+    DataConditionType.ISSUE_RESOLVED_TRIGGER,
+    {
+      label: t('An issue is resolved'),
+      validate: undefined,
+    },
+  ],
+  [
     DataConditionType.REGRESSION_EVENT,
     {
       label: t('A resolved issue becomes unresolved'),

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -154,6 +154,7 @@ export function findConflictingConditions(
 
 const conflictingTriggers = new Set<DataConditionType>([
   DataConditionType.FIRST_SEEN_EVENT,
+  DataConditionType.ISSUE_RESOLVED_TRIGGER,
   DataConditionType.REGRESSION_EVENT,
   DataConditionType.REAPPEARED_EVENT,
 ]);

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -158,6 +158,7 @@ describe('AutomationNewSettings', () => {
               logicType: 'any-short',
               conditions: [
                 {type: 'first_seen_event', comparison: true, conditionResult: true},
+                {type: 'issue_resolved_trigger', comparison: true, conditionResult: true},
                 {type: 'reappeared_event', comparison: true, conditionResult: true},
                 {type: 'regression_event', comparison: true, conditionResult: true},
               ],


### PR DESCRIPTION
Adds a label for the issue resolved condition and adds it to the default set of conditions when creating a new alert.

<img width="748" height="610" alt="CleanShot 2026-01-09 at 16 37 23@2x" src="https://github.com/user-attachments/assets/28fc951d-16e0-4384-bb6f-85e540a665cc" />
