### PR TITLE
fix(tags): Handle status tag

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -470,7 +470,8 @@ class OrganizationTagsTest(APITestCase, OccurrenceTestMixin, SnubaTestCase):
         data.sort(key=lambda val: val["name"])
         assert data == [
             {"name": "Level", "key": "level", "totalValues": 1},
-            {"name": "Status", "key": "status", "totalValues": 1},
+            {"key": "project", "name": "Project", "totalValues": 1},
+            {"name": "Tags[Status]", "key": "tags[status]", "totalValues": 1},
         ]
 
 


### PR DESCRIPTION
- The status field has unique handling in the Errors querybuilder where it becomes the group.status instead. But this means if a user sends an event with status as a tag the two get confused. This updates the tag endpoint so if we see `status` we assume the user doesn't want the group status but rather whatever status they sent us instead
- https://github.com/getsentry/sentry/blob/master/src/sentry/search/events/builder/errors.py#L110-L112