### PR TITLE
feat(toolbar): Return the CSRF token into the toolbar auth flow for use

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -139,6 +139,9 @@ Required context variables:
             document.cookie = getCookieValue(cookie, regionUrl);
             log('Cleared the current cookie');
 
+            sessionStorage.removeItem('csrfToken');
+            log('Removed CSRF token from sessionStorage');
+
             const accessToken = localStorage.removeItem('accessToken')
             log('Removed accessToken from localStorage');
 

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -98,10 +98,14 @@ Required context variables:
         }
 
         const loginWindowMessageDispatch = {
-          'did-login': ({ cookie, token }) => {
+          'did-login': ({ cookie, csrfToken, token }) => {
             if (cookie) {
               document.cookie = getCookieValue(cookie, window.location.hostname);
               log('Saved a cookie', document.cookie.indexOf(cookie) >= 0);
+            }
+            if (csrfToken) {
+              sessionStorage.setItem('csrfToken', csrfToken);
+              log('Saved a CSRF token to sessionStorage');
             }
             if (token) {
               localStorage.setItem('accessToken', token);
@@ -150,6 +154,9 @@ Required context variables:
             const accessToken = localStorage.getItem('accessToken');
             const bearer = accessToken ? { 'Authorization': `Bearer ${accessToken}` } : {};
 
+            const csrfToken = sessionStorage.getItem('csrfToken');
+            const csrfHeader = csrfToken ? { 'X-CSRFToken': csrfToken } : {};
+
             // If either of these is invalid, or both are missing, we will
             // forward the resulting 401 to the application, which will request
             // tokens be destroyed and reload the iframe in an unauth state.
@@ -158,7 +165,7 @@ Required context variables:
             const url = new URL('/api/0' + path, organizationUrl);
             const initWithCreds = {
               ...init,
-              headers: { ...init.headers, ...bearer },
+              headers: { ...init.headers, ...bearer, ...csrfHeader },
               credentials: 'include',
             };
             const response = await fetch(url, initWithCreds);

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -25,7 +25,7 @@
       const delay = {{ delay_ms|escapejs }};
       const cookie = '{{ cookie|escapejs }}';
       const csrfCookieName = '{{ csrf_cookie_name|escapejs }}';
-      const csrfToken = document.cookie.split(';').find(c => c.trim().startsWith(csrfCookieName + '=')).split('=')[1];
+      const csrfToken = document.cookie.split(';').find(c => c.trim().startsWith(csrfCookieName + '='))?.split('=')[1] ?? '';
       const token = '{{ token|escapejs }}';
 
       if (window.location.origin === 'https://sentry.io') {

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -24,6 +24,7 @@
       const orgSlug = '{{ organization_slug|escape }}';
       const delay = {{ delay_ms|escapejs }};
       const cookie = '{{ cookie|escapejs }}';
+      const csrfToken = '{{ csrf_token|escapejs }}';
       const token = '{{ token|escapejs }}';
 
       if (window.location.origin === 'https://sentry.io') {
@@ -42,6 +43,7 @@
           source: 'sentry-toolbar',
           message: 'did-login',
           cookie,
+          csrfToken,
           token,
         }, window.location.origin);
 

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -24,7 +24,8 @@
       const orgSlug = '{{ organization_slug|escape }}';
       const delay = {{ delay_ms|escapejs }};
       const cookie = '{{ cookie|escapejs }}';
-      const csrfToken = '{{ csrf_token|escapejs }}';
+      const csrfCookieName = '{{ csrf_cookie_name|escapejs }}';
+      const csrfToken = document.cookie.split(';').find(c => c.trim().startsWith(csrfCookieName + '=')).split('=')[1];
       const token = '{{ token|escapejs }}';
 
       if (window.location.origin === 'https://sentry.io') {

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -21,7 +21,7 @@ class LoginSuccessView(OrganizationView):
                 "delay_sec": int(delay_ms / 1000),
                 "delay_ms": delay_ms,
                 "cookie": f"{session_cookie_name}={request.COOKIES.get(session_cookie_name)}",
-                "csrf_token": f"{csrf_cookie_name}={request.COOKIES.get(csrf_cookie_name)}",
+                "csrf_token": request.COOKIES.get(csrf_cookie_name),
                 "token": "",
             },
         )

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -21,7 +21,7 @@ class LoginSuccessView(OrganizationView):
                 "delay_sec": int(delay_ms / 1000),
                 "delay_ms": delay_ms,
                 "cookie": f"{session_cookie_name}={request.COOKIES.get(session_cookie_name)}",
-                "csrf_token": request.COOKIES.get(csrf_cookie_name),
+                "csrf_cookie_name": csrf_cookie_name,
                 "token": "",
             },
         )

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -6,8 +6,7 @@ from sentry.web.frontend.base import OrganizationView, region_silo_view
 TEMPLATE = "sentry/toolbar/login-success.html"
 
 session_cookie_name = settings.SESSION_COOKIE_NAME
-
-# touch 123
+csrf_cookie_name = settings.CSRF_COOKIE_NAME
 
 
 @region_silo_view
@@ -22,6 +21,7 @@ class LoginSuccessView(OrganizationView):
                 "delay_sec": int(delay_ms / 1000),
                 "delay_ms": delay_ms,
                 "cookie": f"{session_cookie_name}={request.COOKIES.get(session_cookie_name)}",
+                "csrf_token": f"{csrf_cookie_name}={request.COOKIES.get(csrf_cookie_name)}",
                 "token": "",
             },
         )


### PR DESCRIPTION
We need the csrf token so the toolbar can make POST/PUT requests and make the toolbar read/write.