### PR TITLE
docs(chunk): Document CHUNK_UPLOAD_ACCEPT backwards compatibility

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -28,6 +28,11 @@ MAX_CONCURRENCY = settings.DEBUG and 1 or 8
 HASH_ALGORITHM = "sha1"
 SENTRYCLI_SEMVER_RE = re.compile(r"^sentry-cli\/(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
 API_PREFIX = "/api/0"
+# IMPORTANT: All values in CHUNK_UPLOAD_ACCEPT must be maintained for backwards compatibility
+# with Sentry CLI 2.x and older. Sentry CLI 3.x completely ignores the CHUNK_UPLOAD_ACCEPT
+# field (starting with 3.1.0), but older CLI versions still depend on these values being
+# present in the server's response. Removing any of these values would break functionality
+# for CLI 2.x and older.
 CHUNK_UPLOAD_ACCEPT = (
     "debug_files",  # DIF assemble
     "release_files",  # Release files assemble


### PR DESCRIPTION
## Summary

Adds documentation to `CHUNK_UPLOAD_ACCEPT` explaining that all values must be maintained for backwards compatibility with Sentry CLI 2.x and older. While Sentry CLI 3.1.0+ ignores this field, older CLI versions still depend on these values being present in the server's response.

Closes #103358
Closes [CLI-231](https://linear.app/getsentry/issue/CLI-231/add-comments-to-sentry-codebase-to-explain-chunk-upload-accept)