### PR TITLE
feat(api): add endpoint for AI conversation details

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,0 +1,83 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.snuba.referrer import Referrer
+from sentry.snuba.spans_rpc import Spans
+
+# Base span fields always returned
+BASE_SPAN_COLUMNS = [
+    "span_id",
+    "trace",
+    "parent_span",
+    "precise.start_ts",
+    "precise.finish_ts",
+    "span.op",
+    "span.status",
+    "span.description",
+    "gen_ai.conversation.id",
+]
+
+
+@region_silo_endpoint
+class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.DATA_BROWSING
+
+    def get(self, request: Request, organization: Organization, conversation_id: str) -> Response:
+        if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
+            return Response(status=404)
+
+        try:
+            snuba_params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response(status=404)
+
+        additional_attributes = request.GET.getlist("additional_attributes", [])
+        selected_columns = BASE_SPAN_COLUMNS + additional_attributes
+
+        def data_fn(offset: int, limit: int):
+            return self._fetch_conversation_spans(
+                snuba_params=snuba_params,
+                conversation_id=conversation_id,
+                selected_columns=selected_columns,
+                offset=offset,
+                limit=limit,
+            )
+
+        with handle_query_errors():
+            return self.paginate(
+                request=request,
+                paginator=GenericOffsetPaginator(data_fn=data_fn),
+                default_per_page=100,
+                max_per_page=1000,
+            )
+
+    def _fetch_conversation_spans(
+        self,
+        snuba_params,
+        conversation_id: str,
+        selected_columns: list[str],
+        offset: int,
+        limit: int,
+    ):
+        result = Spans.run_table_query(
+            params=snuba_params,
+            query_string=f"gen_ai.conversation.id:{conversation_id}",
+            selected_columns=selected_columns,
+            orderby=["precise.start_ts"],
+            offset=offset,
+            limit=limit,
+            referrer=Referrer.API_AI_CONVERSATION_DETAILS.value,
+            config=SearchResolverConfig(auto_fields=True),
+            sampling_mode="HIGHEST_ACCURACY",
+        )
+        return result.get("data", [])

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
+from sentry.api.endpoints.organization_ai_conversation_details import (
+    OrganizationAIConversationDetailsEndpoint,
+)
 from sentry.api.endpoints.organization_ai_conversations import OrganizationAIConversationsEndpoint
 from sentry.api.endpoints.organization_auth_token_details import (
     OrganizationAuthTokenDetailsEndpoint,
@@ -1727,6 +1730,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/$",
         OrganizationAIConversationsEndpoint.as_view(),
         name="sentry-api-0-organization-ai-conversations",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/(?P<conversation_id>[^/]+)/$",
+        OrganizationAIConversationDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-ai-conversation-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1732,7 +1732,7 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-ai-conversations",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/(?P<conversation_id>[^/]+)/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/(?P<conversation_id>(?:\d+|[A-Za-z0-9-_]+))/$",
         OrganizationAIConversationDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-ai-conversation-details",
     ),

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -489,6 +489,7 @@ class Referrer(StrEnum):
     API_AI_CONVERSATIONS_COMPLETE = "api.ai-conversations.complete"
     API_AI_CONVERSATIONS_ENRICHMENT = "api.ai-conversations.enrichment"
     API_AI_CONVERSATIONS_FIRST_LAST_IO = "api.ai-conversations.first-last-io"
+    API_AI_CONVERSATION_DETAILS = "api.ai-conversation-details"
     API_AI_PIPELINES_VIEW = "api.ai-pipelines.view"
     API_AI_PIPELINES_DETAILS_VIEW = "api.ai-pipelines.details.view"
     API_PROFILING_ONBOARDING = "profiling-onboarding"

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -188,6 +188,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/access-requests/'
   | '/organizations/$organizationIdOrSlug/access-requests/$requestId/'
   | '/organizations/$organizationIdOrSlug/ai-conversations/'
+  | '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/'
   | '/organizations/$organizationIdOrSlug/alert-rule-detector/'
   | '/organizations/$organizationIdOrSlug/alert-rule-workflow/'
   | '/organizations/$organizationIdOrSlug/alert-rules/'

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 from uuid import uuid4
 
 from django.urls import reverse
@@ -230,7 +231,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
                 trace_id=trace_id,
             )
 
-        query = {
+        query: dict[str, Any] = {
             "project": [self.project.id],
             "per_page": "2",
             "start": (now - timedelta(hours=1)).isoformat(),

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -172,8 +172,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         trace_ids = {span["trace"] for span in response.data}
         assert trace_ids == {trace_id_1, trace_id_2}
 
-    def test_additional_attributes(self) -> None:
-        """Test additional_attributes parameter includes extra fields"""
+    def test_returns_conversation_attributes(self) -> None:
+        """Test that the endpoint returns all AI conversation attributes"""
         now = before_now(days=40).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -183,23 +183,17 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             timestamp=now,
             op="gen_ai.chat",
             operation_type="ai_client",
-            tokens=150,
-            cost=0.002,
             trace_id=trace_id,
             messages=[{"role": "user", "content": "Hello"}],
             response_text="Hi there!",
+            user_id="user-123",
+            user_email="test@example.com",
         )
 
         query = {
             "project": [self.project.id],
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
-            "additional_attributes": [
-                "gen_ai.operation.type",
-                "gen_ai.usage.total_tokens",
-                "gen_ai.request.messages",
-                "gen_ai.response.text",
-            ],
         }
 
         response = self.do_request(conversation_id, query)
@@ -207,10 +201,19 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert len(response.data) == 1
 
         span = response.data[0]
-        assert span["gen_ai.operation.type"] == "ai_client"
-        assert span["gen_ai.usage.total_tokens"] == 150
+        # Verify core span fields
+        assert "span_id" in span
+        assert span["trace"] == trace_id
+        assert "precise.start_ts" in span
+        assert "precise.finish_ts" in span
+        assert span["span.op"] == "gen_ai.chat"
+        assert span["gen_ai.conversation.id"] == conversation_id
+        # Verify AI conversation attributes are included
         assert span["gen_ai.request.messages"] is not None
         assert span["gen_ai.response.text"] == "Hi there!"
+        # Verify user attributes are included
+        assert span["user.id"] == "user-123"
+        assert span["user.email"] == "test@example.com"
 
     def test_pagination(self) -> None:
         """Test pagination works correctly"""

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,0 +1,344 @@
+from datetime import timedelta
+from uuid import uuid4
+
+from django.urls import reverse
+
+from sentry.testutils.helpers import parse_link_header
+from sentry.testutils.helpers.datetime import before_now
+
+from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
+
+
+class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase):
+    view = "sentry-api-0-organization-ai-conversation-details"
+
+    def do_request(self, conversation_id, query=None, features=None, **kwargs):
+        if features is None:
+            features = ["organizations:gen-ai-conversations"]
+
+        query = query or {}
+
+        with self.feature(features):
+            return self.client.get(
+                reverse(
+                    self.view,
+                    kwargs={
+                        "organization_id_or_slug": self.organization.slug,
+                        "conversation_id": conversation_id,
+                    },
+                ),
+                query,
+                format="json",
+                **kwargs,
+            )
+
+    def test_no_feature(self) -> None:
+        conversation_id = uuid4().hex
+        response = self.do_request(conversation_id, features=[])
+        assert response.status_code == 404
+
+    def test_no_project(self) -> None:
+        conversation_id = uuid4().hex
+        response = self.do_request(conversation_id)
+        assert response.status_code == 404
+
+    def test_conversation_not_found(self) -> None:
+        """Test endpoint returns empty list when no spans match conversation ID"""
+        now = before_now(days=10).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        other_conversation_id = uuid4().hex
+
+        # Store a span with a different conversation ID
+        self.store_ai_span(
+            conversation_id=other_conversation_id,
+            timestamp=now,
+            op="gen_ai.chat",
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 0
+
+    def test_single_trace_conversation(self) -> None:
+        """Test returns all spans for a conversation in a single trace"""
+        now = before_now(days=20).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        # Store multiple spans in the same conversation and trace
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=3),
+            op="gen_ai.invoke_agent",
+            operation_type="invoke_agent",
+            agent_name="Test Agent",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            tokens=100,
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            trace_id=trace_id,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 3
+
+        # Verify all spans belong to the same conversation
+        for span in response.data:
+            assert span["gen_ai.conversation.id"] == conversation_id
+
+        # Verify all spans have the same trace ID
+        trace_ids = {span["trace"] for span in response.data}
+        assert len(trace_ids) == 1
+        assert trace_id in trace_ids
+
+    def test_multi_trace_conversation(self) -> None:
+        """Test returns all spans for a conversation across multiple traces"""
+        now = before_now(days=30).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id_1 = uuid4().hex
+        trace_id_2 = uuid4().hex
+
+        # Spans in first trace
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=4),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id_1,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=3),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            trace_id=trace_id_1,
+        )
+
+        # Spans in second trace
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id_2,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            trace_id=trace_id_2,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 4
+
+        # Verify spans come from both traces
+        trace_ids = {span["trace"] for span in response.data}
+        assert trace_ids == {trace_id_1, trace_id_2}
+
+    def test_additional_attributes(self) -> None:
+        """Test additional_attributes parameter includes extra fields"""
+        now = before_now(days=40).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            tokens=150,
+            cost=0.002,
+            trace_id=trace_id,
+            messages=[{"role": "user", "content": "Hello"}],
+            response_text="Hi there!",
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+            "additional_attributes": [
+                "gen_ai.operation.type",
+                "gen_ai.usage.total_tokens",
+                "gen_ai.request.messages",
+                "gen_ai.response.text",
+            ],
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+
+        span = response.data[0]
+        assert span["gen_ai.operation.type"] == "ai_client"
+        assert span["gen_ai.usage.total_tokens"] == 150
+        assert span["gen_ai.request.messages"] is not None
+        assert span["gen_ai.response.text"] == "Hi there!"
+
+    def test_pagination(self) -> None:
+        """Test pagination works correctly"""
+        now = before_now(days=50).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        # Create 5 spans
+        for i in range(5):
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=i),
+                op="gen_ai.chat",
+                trace_id=trace_id,
+            )
+
+        query = {
+            "project": [self.project.id],
+            "per_page": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        # First page
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 2
+
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        assert next_link["results"] == "true"
+        assert next_link["cursor"]
+
+        # Second page
+        query["cursor"] = next_link["cursor"]
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 2
+
+        # Third page (last)
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        query["cursor"] = next_link["cursor"]
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+
+    def test_span_ordering(self) -> None:
+        """Test spans are ordered by timestamp ascending"""
+        now = before_now(days=60).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        # Store spans in reverse chronological order
+        timestamps = [
+            now - timedelta(seconds=1),  # newest
+            now - timedelta(seconds=3),  # middle
+            now - timedelta(seconds=5),  # oldest
+        ]
+
+        for ts in timestamps:
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=ts,
+                op="gen_ai.chat",
+                trace_id=trace_id,
+            )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 3
+
+        # Verify spans are ordered by timestamp ascending (oldest first)
+        span_timestamps = [span["precise.start_ts"] for span in response.data]
+        assert span_timestamps == sorted(span_timestamps)
+
+    def test_only_returns_matching_conversation(self) -> None:
+        """Test that only spans from the requested conversation are returned"""
+        now = before_now(days=70).replace(microsecond=0)
+        conversation_id_1 = uuid4().hex
+        conversation_id_2 = uuid4().hex
+        trace_id = uuid4().hex
+
+        # Spans in conversation 1
+        self.store_ai_span(
+            conversation_id=conversation_id_1,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id_1,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        # Spans in conversation 2
+        self.store_ai_span(
+            conversation_id=conversation_id_2,
+            timestamp=now,
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        # Request conversation 1
+        response = self.do_request(conversation_id_1, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 2
+
+        for span in response.data:
+            assert span["gen_ai.conversation.id"] == conversation_id_1
+
+        # Request conversation 2
+        response = self.do_request(conversation_id_2, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["gen_ai.conversation.id"] == conversation_id_2

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -1,0 +1,97 @@
+from sentry.testutils.cases import APITestCase, BaseSpansTestCase, SpanTestCase
+from sentry.utils import json
+
+LLM_TOKENS = 100
+LLM_COST = 0.001
+
+
+class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
+    """Base test class for AI conversations-related endpoint tests.
+
+    Provides common utilities for creating AI span test data.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def store_ai_span(
+        self,
+        conversation_id,
+        timestamp,
+        op="gen_ai.chat",
+        description=None,
+        status="ok",
+        operation_type=None,
+        tokens=None,
+        cost=None,
+        trace_id=None,
+        agent_name=None,
+        messages=None,
+        response_text=None,
+        user_id=None,
+        user_email=None,
+        user_username=None,
+        user_ip=None,
+    ):
+        """Create and store an AI span with the given attributes.
+
+        Args:
+            conversation_id: The gen_ai.conversation.id attribute
+            timestamp: The span start timestamp
+            op: The span operation (default: "gen_ai.chat")
+            description: Span description
+            status: Span status (default: "ok")
+            operation_type: The gen_ai.operation.type attribute
+            tokens: Token count (gen_ai.usage.total_tokens)
+            cost: Cost (gen_ai.cost.total_tokens)
+            trace_id: The trace ID for the span
+            agent_name: The gen_ai.agent.name attribute
+            messages: The gen_ai.request.messages (will be JSON serialized)
+            response_text: The gen_ai.response.text attribute
+            user_id: User ID (sentry.user.id)
+            user_email: User email (sentry.user.email)
+            user_username: User username (sentry.user.username)
+            user_ip: User IP address (sentry.user.ip)
+
+        Returns:
+            The created span object
+        """
+        span_data = {"gen_ai.conversation.id": conversation_id}
+        if operation_type:
+            span_data["gen_ai.operation.type"] = operation_type
+        if tokens is not None:
+            span_data["gen_ai.usage.total_tokens"] = tokens
+        if cost is not None:
+            span_data["gen_ai.cost.total_tokens"] = cost
+        if agent_name is not None:
+            span_data["gen_ai.agent.name"] = agent_name
+        if messages is not None:
+            # Serialize as JSON string since test infrastructure doesn't support list attributes
+            span_data["gen_ai.request.messages"] = json.dumps(messages)
+        if response_text is not None:
+            span_data["gen_ai.response.text"] = response_text
+        # Store user data with sentry. prefix for EAP indexing
+        if user_id is not None:
+            span_data["sentry.user.id"] = user_id
+        if user_email is not None:
+            span_data["sentry.user.email"] = user_email
+        if user_username is not None:
+            span_data["sentry.user.username"] = user_username
+        if user_ip is not None:
+            span_data["sentry.user.ip"] = user_ip
+
+        extra_data = {
+            "description": description or "default",
+            "sentry_tags": {"status": status, "op": op},
+            "data": span_data,
+        }
+        if trace_id:
+            extra_data["trace_id"] = trace_id
+
+        span = self.create_span(
+            extra_data,
+            start_ts=timestamp,
+        )
+        self.store_spans([span], is_eap=True)
+        return span


### PR DESCRIPTION
- Introduced a new URL pattern for accessing details of specific AI conversations.
- Added a corresponding constant in the Referrer class for the new endpoint.
- Refactored tests to extend from a base test case for better organization and maintainability.


Closes https://linear.app/getsentry/issue/TET-1703/conversation-details-endpoint