### PR TITLE
feat(ingest-metrics): Add option to count segment spans as transactions

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -174,20 +174,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
         )
 
     def has_is_segment_tag(self, generic_metric: GenericMetric) -> bool:
-        if (tag_value := generic_metric["tags"].get(self.span_is_segment_tag)) is None:
-            return False
-
-        return "true" == self._resolve(generic_metric["mapping_meta"], tag_value)
-
-    def _resolve(self, mapping_meta: Mapping[str, Any], indexed_value: int | str) -> str | None:
-        if isinstance(indexed_value, str):
-            return indexed_value
-
-        for _, inner_meta in mapping_meta.items():
-            if (string_value := inner_meta.get(str(indexed_value))) is not None:
-                return string_value
-
-        return None
+        return generic_metric["tags"].get(self.span_is_segment_tag) == "true"
 
     def join(self, timeout: float | None = None) -> None:
         self.__next_step.join(timeout)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1355,6 +1355,14 @@ register(
 # contents stored as separate release files.
 register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Option which rolls out counting transactions based on the span usage metric.
+register(
+    "ingest.billing_metrics_consumer.use_only_span_metric_orgs",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 


### PR DESCRIPTION
Introduces an option which allows switching the billing metric consumer to consume the span usage metric for transactions counts, relying on the `is_segment` tag.

The longterm path is to no longer rely on the transaction metric(s).

Also removed the database dependency of the tests.