### PR TITLE
fix(objectstore): Only drop Content-Length for wsgiref

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -85,10 +85,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         target_url = get_target_url(path)
 
         headers = dict(request.headers)
-
         headers.pop("Host", None)
-        headers.pop("Content-Length", None)
-        transfer_encoding = headers.pop("Transfer-Encoding", "")
 
         stream: Generator[bytes] | ChunkedEncodingDecoder | None = None
         wsgi_input = request.META.get("wsgi.input")
@@ -101,7 +98,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
                 "request_id": request.META.get("HTTP_X_REQUEST_ID"),
                 "content_type": request.META.get("CONTENT_TYPE"),
                 "content_length": request.META.get("CONTENT_LENGTH"),
-                "transfer_encoding": transfer_encoding,
+                "transfer_encoding": request.META.get("HTTP_TRANSFER_ENCODING"),
                 "server_software": request.META.get("SERVER_SOFTWARE"),
                 "has_wsgi_input": wsgi_input is not None,
                 "x_forwarded_for": request.META.get("HTTP_X_FORWARDED_FOR"),
@@ -116,7 +113,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         # For now, support bodies only on PUT and POST requests.
         elif request.method in ("PUT", "POST"):
             if uwsgi:
-                if transfer_encoding.lower() == "chunked":
+                if headers.pop("Transfer-Encoding", "").lower() == "chunked":
 
                     def stream_generator():
                         while True:
@@ -133,6 +130,10 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
                 # This code path assumes wsgiref, used in dev/test mode.
                 # Note that we don't handle non-chunked transfer encoding here as our client (which we use for tests) always uses chunked encoding.
                 stream = ChunkedEncodingDecoder(wsgi_input._read)  # type: ignore[union-attr]
+
+        # This is also for wsgiref only
+        if "WSGIServer" in request.META.get("SERVER_SOFTWARE", ""):
+            headers.pop("Content-Length", None)
 
         response = requests.request(
             request.method,

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable, Generator
 from typing import Any
 from urllib.parse import urlparse
@@ -22,6 +23,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
@@ -89,6 +92,23 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
 
         stream: Generator[bytes] | ChunkedEncodingDecoder | None = None
         wsgi_input = request.META.get("wsgi.input")
+
+        logger.info(
+            "objectstore proxy request",
+            extra={
+                "method": request.method,
+                "path": path,
+                "request_id": request.META.get("HTTP_X_REQUEST_ID"),
+                "content_type": request.META.get("CONTENT_TYPE"),
+                "content_length": request.META.get("CONTENT_LENGTH"),
+                "transfer_encoding": transfer_encoding,
+                "server_software": request.META.get("SERVER_SOFTWARE"),
+                "has_wsgi_input": wsgi_input is not None,
+                "x_forwarded_for": request.META.get("HTTP_X_FORWARDED_FOR"),
+                "x_forwarded_proto": request.META.get("HTTP_X_FORWARDED_PROTO"),
+                "x_forwarded_host": request.META.get("HTTP_X_FORWARDED_HOST"),
+            },
+        )
 
         if "granian" in request.META.get("SERVER_SOFTWARE", "").lower():
             stream = wsgi_input

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -86,6 +86,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
 
         headers = dict(request.headers)
         headers.pop("Host", None)
+        transfer_encoding = headers.pop("Transfer-Encoding", "")
 
         stream: Generator[bytes] | ChunkedEncodingDecoder | None = None
         wsgi_input = request.META.get("wsgi.input")
@@ -113,7 +114,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         # For now, support bodies only on PUT and POST requests.
         elif request.method in ("PUT", "POST"):
             if uwsgi:
-                if headers.pop("Transfer-Encoding", "").lower() == "chunked":
+                if transfer_encoding.lower() == "chunked":
 
                     def stream_generator():
                         while True:


### PR DESCRIPTION
In an effort to solve the problem with vanishing PUT/POST bodies, isolates the removal of the `Content-Length` to the path that strictly needs it to function. 
Tested locally with all three server.
