### PR TITLE
Fix validators using ActorField, replace with ActorOwnerField

### DIFF
--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -17,3 +17,51 @@ class ActorField(serializers.Field):
 
     def to_internal_value(self, data) -> Actor | None:
         return parse_and_validate_actor(data, self.context["organization"].id)
+
+
+@extend_schema_field(field=OpenApiTypes.STR)
+class OwnerActorField(ActorField):
+    """
+    ActorField variant for owner assignment that validates team membership.
+
+    When assigning a team as owner, validates that the requesting user either:
+    - Has team:admin scope, OR
+    - Is a member of the team being assigned
+
+    This prevents IDOR vulnerabilities where users could assign teams they
+    don't belong to as owners when Open Team Membership is disabled.
+    """
+
+    def to_internal_value(self, data) -> Actor | None:
+        actor = super().to_internal_value(data)
+
+        if actor is None:
+            return actor
+
+        if actor.is_team:
+            self._validate_team_assignment(actor)
+
+        return actor
+
+    def _validate_team_assignment(self, actor: Actor) -> None:
+        from sentry.models.organizationmemberteam import OrganizationMemberTeam
+
+        request = self.context.get("request")
+
+        # Users with team:admin scope can assign any team
+        if request and request.access.has_scope("team:admin"):
+            return
+
+        # Fail closed if we can't verify the user
+        if not request or not getattr(request, "user", None):
+            raise serializers.ValidationError("You do not have permission to assign this owner")
+
+        # Check if user is a member of the team
+        user_is_team_member = OrganizationMemberTeam.objects.filter(
+            team_id=actor.id,
+            organizationmember__user_id=request.user.id,
+            is_active=True,
+        ).exists()
+
+        if not user_is_team_member:
+            raise serializers.ValidationError("You do not have permission to assign this owner")

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -47,9 +47,10 @@ class OwnerActorField(ActorField):
         from sentry.models.organizationmemberteam import OrganizationMemberTeam
 
         request = self.context.get("request")
+        access = getattr(request, "access", None)
 
         # Users with team:admin scope can assign any team
-        if request and request.access.has_scope("team:admin"):
+        if access and access.has_scope("team:admin"):
             return
 
         # Fail closed if we can't verify the user

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -60,7 +60,7 @@ class OwnerActorField(ActorField):
 
         # Fail closed
         if not user:
-            raise serializers.ValidationError("You do not have permission to assign this owner")
+            raise serializers.ValidationError("User not found.")
 
         user_is_team_member = OrganizationMemberTeam.objects.filter(
             team_id=actor.id,

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -60,7 +60,7 @@ class OwnerActorField(ActorField):
 
         # Fail closed
         if not user:
-            raise serializers.ValidationError("User not found.")
+            raise serializers.ValidationError("You do not have permission to assign this owner")
 
         user_is_team_member = OrganizationMemberTeam.objects.filter(
             team_id=actor.id,

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -10,7 +10,7 @@ from rest_framework import serializers
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry.api.exceptions import BadRequest, RequestTimeout
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
@@ -76,7 +76,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
     aggregate = serializers.CharField(required=True, min_length=1)
 
     # This will be set to required=True once the frontend starts sending it.
-    owner = ActorField(required=False, allow_null=True)
+    owner = OwnerActorField(required=False, allow_null=True)
 
     description = serializers.CharField(required=False, allow_blank=True)
     sensitivity = serializers.CharField(required=False, allow_null=True)

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -13,7 +13,7 @@ from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework import serializers
 
 from sentry import audit_log, quotas
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
@@ -297,7 +297,7 @@ class MonitorValidator(CamelSnakeSerializer):
         default="active",
         help_text="Status of the monitor. Disabled monitors will not accept events and will not count towards the monitor quota.",
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False,
         allow_null=True,
         help_text="The ID of the team or user that owns the monitor. (eg. user:51 or team:6)",

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -8,12 +8,11 @@ from rest_framework import serializers
 from rest_framework.fields import URLField
 
 from sentry import audit_log, quotas
-from sentry.api.fields import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.environment import Environment
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.uptime.models import (
     UptimeSubscription,
     UptimeSubscriptionDataSourceHandler,
@@ -150,7 +149,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
         default="active",
         help_text="Status of the uptime monitor. Disabled uptime monitors will not perform checks and do not count against the uptime monitor quota.",
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False,
         allow_null=True,
         help_text="The ID of the team or user that owns the uptime monitor. (eg. user:51 or team:6)",
@@ -248,35 +247,6 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
 
     def validate_mode(self, mode):
         return _validate_mode(mode, self.context["request"])
-
-    def validate_owner(self, owner):
-        """
-        Validate that the user has permission to assign the specified team as owner.
-        When Open Team Membership is disabled, users can only assign teams they belong to.
-        """
-        if owner is None:
-            return owner
-
-        if owner.is_team:
-            request = self.context.get("request")
-
-            # Users with team:admin scope can assign any team as owner
-            if request and request.access.has_scope("team:admin"):
-                return owner
-
-            if not request or not getattr(request, "user", None):
-                raise serializers.ValidationError("You do not have permission to assign this owner")
-
-            # Check if the user is a member of the team
-            user_is_team_member = OrganizationMemberTeam.objects.filter(
-                team_id=owner.id,
-                organizationmember__user_id=request.user.id,
-                is_active=True,
-            ).exists()
-            if not user_is_team_member:
-                raise serializers.ValidationError("You do not have permission to assign this owner")
-
-        return owner
 
     def create(self, validated_data):
         if validated_data.get("environment") is not None:

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -7,7 +7,7 @@ from jsonschema import ValidationError as JSONSchemaValidationError
 from rest_framework import serializers
 
 from sentry import audit_log
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
@@ -54,7 +54,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
     )
     type = serializers.CharField()
     config = serializers.JSONField(default=dict)
-    owner = ActorField(required=False, allow_null=True)
+    owner = OwnerActorField(required=False, allow_null=True)
     description = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     enabled = serializers.BooleanField(required=False)
     condition_group = BaseDataConditionGroupValidator(required=False)

--- a/tests/sentry/api/fields/test_actor.py
+++ b/tests/sentry/api/fields/test_actor.py
@@ -1,0 +1,178 @@
+from rest_framework import serializers
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.api.fields.actor import ActorField, OwnerActorField
+from sentry.testutils.cases import TestCase
+
+
+class DummySerializer(serializers.Serializer):
+    """Test serializer using ActorField."""
+
+    owner = ActorField(required=False, allow_null=True)
+
+
+class DummyOwnerSerializer(serializers.Serializer):
+    """Test serializer using OwnerActorField."""
+
+    owner = OwnerActorField(required=False, allow_null=True)
+
+
+class ActorFieldTest(TestCase):
+    """Tests for the base ActorField."""
+
+    def test_accepts_valid_team(self):
+        serializer = DummySerializer(
+            data={"owner": f"team:{self.team.id}"},
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.team.id
+        assert serializer.validated_data["owner"].is_team
+
+    def test_accepts_valid_user(self):
+        serializer = DummySerializer(
+            data={"owner": f"user:{self.user.id}"},
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.user.id
+        assert serializer.validated_data["owner"].is_user
+
+    def test_accepts_null(self):
+        serializer = DummySerializer(
+            data={"owner": None},
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"] is None
+
+
+class OwnerActorFieldTest(TestCase):
+    """
+    Tests for OwnerActorField which validates team membership.
+
+    These tests verify that users can only assign teams they belong to as owners,
+    unless they have team:admin scope. This prevents IDOR vulnerabilities.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Create a second team that self.user is NOT a member of
+        self.other_team = self.create_team(organization=self.organization, name="other-team")
+
+    def _get_mock_request(self, user, access):
+        """Create a mock request object with the given user and access."""
+
+        class MockRequest:
+            pass
+
+        request = MockRequest()
+        request.user = user
+        request.access = access
+        return request
+
+    def test_accepts_user_owner_without_restriction(self):
+        """User ownership doesn't require membership check."""
+        request = self._get_mock_request(self.user, self.create_request().access)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"user:{self.user.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.user.id
+        assert serializer.validated_data["owner"].is_user
+
+    def test_accepts_null_owner(self):
+        """Null owner is always allowed."""
+        request = self._get_mock_request(self.user, self.create_request().access)
+        serializer = DummyOwnerSerializer(
+            data={"owner": None},
+            context={"organization": self.organization, "request": request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"] is None
+
+    def test_member_can_assign_own_team(self):
+        """Members can assign teams they belong to."""
+        # self.user is a member of self.team via create_member in setUp
+        request = self._get_mock_request(self.user, self.create_request().access)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.team.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.team.id
+        assert serializer.validated_data["owner"].is_team
+
+    def test_member_cannot_assign_other_team(self):
+        """Members cannot assign teams they don't belong to."""
+        request = self._get_mock_request(self.user, self.create_request().access)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.other_team.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "owner": [
+                ErrorDetail(
+                    string="You do not have permission to assign this owner",
+                    code="invalid",
+                )
+            ]
+        }
+
+    def test_admin_can_assign_any_team(self):
+        """Users with team:admin scope can assign any team."""
+        admin_user = self.create_user()
+        self.create_member(
+            user=admin_user,
+            organization=self.organization,
+            role="admin",
+            teams=[self.team],
+        )
+        self.login_as(admin_user)
+        request = self.make_request(user=admin_user)
+
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.other_team.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.other_team.id
+
+    def test_no_request_context_denied(self):
+        """Fails closed when no request context is available."""
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.team.id}"},
+            context={"organization": self.organization},
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "owner": [
+                ErrorDetail(
+                    string="You do not have permission to assign this owner",
+                    code="invalid",
+                )
+            ]
+        }
+
+    def test_no_user_on_request_denied(self):
+        """Fails closed when request has no user."""
+
+        class MockRequest:
+            user = None
+            access = None
+
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.team.id}"},
+            context={"organization": self.organization, "request": MockRequest()},
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "owner": [
+                ErrorDetail(
+                    string="You do not have permission to assign this owner",
+                    code="invalid",
+                )
+            ]
+        }

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -717,6 +717,89 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         resp = self.get_response(self.organization.slug, **data_member)
         assert resp.status_code == 403
 
+    def test_owner_team_not_member_denied(self) -> None:
+        """
+        Test that members cannot assign a team they are not a member of as owner.
+        This is a regression test for an IDOR vulnerability.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+            "owner": f"team:{other_team.id}",
+        }
+        response = self.get_error_response(self.organization.slug, **data, status_code=400)
+        assert response.data == {
+            "owner": [
+                ErrorDetail(
+                    string="You do not have permission to assign this owner",
+                    code="invalid",
+                )
+            ]
+        }
+
+    def test_owner_team_member_allowed(self) -> None:
+        """
+        Test that members CAN assign a team they are a member of as owner.
+        """
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+            "owner": f"team:{self.team.id}",
+        }
+        response = self.get_success_response(self.organization.slug, **data)
+        monitor = Monitor.objects.get(slug=response.data["slug"])
+        assert monitor.owner_team_id == self.team.id
+
+    def test_owner_team_admin_can_assign_any_team(self) -> None:
+        """
+        Test that users with team:admin scope CAN assign any team as owner.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=admin_user,
+            organization=self.organization,
+            role="admin",
+            teams=[self.team],
+        )
+        self.login_as(admin_user)
+
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+            "owner": f"team:{other_team.id}",
+        }
+        response = self.get_success_response(self.organization.slug, **data)
+        monitor = Monitor.objects.get(slug=response.data["slug"])
+        assert monitor.owner_team_id == other_team.id
+
 
 class BulkEditOrganizationMonitorTest(MonitorTestCase):
     endpoint = "sentry-api-0-organization-monitor-index"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1217,8 +1217,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         self.login_as(user_with_team)
 
-        data = self.valid_detector
-        data["owner"] = f"team:{other_team.id}"
+        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
         response = self.get_error_response(
             self.organization.slug,
             projectId=self.project.id,
@@ -1240,8 +1239,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         self.login_as(user_with_team)
 
-        data = self.valid_detector
-        data["owner"] = f"team:{self.team.id}"
+        data = {**self.valid_data, "owner": f"team:{self.team.id}"}
         response = self.get_success_response(
             self.organization.slug,
             projectId=self.project.id,
@@ -1266,8 +1264,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         self.login_as(admin_user)
 
-        data = self.valid_detector
-        data["owner"] = f"team:{other_team.id}"
+        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
         response = self.get_success_response(
             self.organization.slug,
             projectId=self.project.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1220,7 +1220,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         data = {**self.valid_data, "owner": f"team:{other_team.id}"}
         response = self.get_error_response(
             self.organization.slug,
-            projectId=self.project.id,
             **data,
             status_code=400,
         )
@@ -1242,7 +1241,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         data = {**self.valid_data, "owner": f"team:{self.team.id}"}
         response = self.get_success_response(
             self.organization.slug,
-            projectId=self.project.id,
             **data,
             status_code=201,
         )
@@ -1267,7 +1265,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         data = {**self.valid_data, "owner": f"team:{other_team.id}"}
         response = self.get_success_response(
             self.organization.slug,
-            projectId=self.project.id,
             **data,
             status_code=201,
         )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1201,6 +1201,82 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.type == UptimeDomainCheckFailure.slug
 
+    def test_owner_team_not_member_denied(self) -> None:
+        """
+        Test that members cannot assign a team they are not a member of as owner.
+        This is a regression test for an IDOR vulnerability.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = self.valid_detector
+        data["owner"] = f"team:{other_team.id}"
+        response = self.get_error_response(
+            self.organization.slug,
+            projectId=self.project.id,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"owner": ["You do not have permission to assign this owner"]}
+
+    def test_owner_team_member_allowed(self) -> None:
+        """
+        Test that members CAN assign a team they are a member of as owner.
+        """
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = self.valid_detector
+        data["owner"] = f"team:{self.team.id}"
+        response = self.get_success_response(
+            self.organization.slug,
+            projectId=self.project.id,
+            **data,
+            status_code=201,
+        )
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.owner_team_id == self.team.id
+
+    def test_owner_team_admin_can_assign_any_team(self) -> None:
+        """
+        Test that users with team:admin scope CAN assign any team as owner.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=admin_user,
+            organization=self.organization,
+            role="admin",
+            teams=[self.team],
+        )
+        self.login_as(admin_user)
+
+        data = self.valid_detector
+        data["owner"] = f"team:{other_team.id}"
+        response = self.get_success_response(
+            self.organization.slug,
+            projectId=self.project.id,
+            **data,
+            status_code=201,
+        )
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.owner_team_id == other_team.id
+
 
 @region_silo_test
 @with_feature("organizations:incidents")


### PR DESCRIPTION
ActorField didn't always require ownership validation, created OwnerActorField that extends ActorField with team membership validation - users can only assign teams they belong to (or have team:admin scope). ActorField can still be about identity and OwnerActorField extends it for authorization. 

Replace ActorField with OwnerActorField in:
- UptimeMonitorValidator
- MonitorValidator 
- AlertRuleSerializer
- BaseDetectorTypeValidator 

Prevents several IDORs where org members could create alerts targeting unauthorized teams when Open Team Membership is disabled.