### PR TITLE
fix(ui): Prevent infinite render loop in `PageAlertProvider`

### DIFF
--- a/static/app/utils/performance/contexts/pageAlert.spec.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.spec.tsx
@@ -33,4 +33,50 @@ describe('Performance > Contexts > pageError', () => {
 
     expect(await screen.findByTestId('errorAlert')).toHaveTextContent('Fresh new error');
   });
+
+  it('prevents unnecessary re-renders when setting the same message multiple times', async () => {
+    let renderCount = 0;
+
+    function RenderCountingComponent() {
+      const {setPageDanger} = usePageAlert();
+      renderCount++;
+
+      return (
+        <div>
+          <div data-test-id="render-count">{renderCount}</div>
+          <button
+            data-test-id="set-error"
+            onClick={() => setPageDanger('Same error message')}
+          />
+        </div>
+      );
+    }
+
+    render(
+      <PageAlertProvider>
+        <PageAlert />
+        <RenderCountingComponent />
+      </PageAlertProvider>
+    );
+
+    const button = screen.getByTestId('set-error');
+
+    // Initial render count
+    expect(screen.getByTestId('render-count')).toHaveTextContent('1');
+
+    // Click once - should trigger a re-render
+    await userEvent.click(button);
+    expect(screen.getByTestId('render-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('page-error-alert')).toHaveTextContent(
+      'Same error message'
+    );
+
+    // Click again with same message - should NOT trigger a re-render
+    await userEvent.click(button);
+    expect(screen.getByTestId('render-count')).toHaveTextContent('2');
+
+    // Click a third time - still should NOT trigger a re-render
+    await userEvent.click(button);
+    expect(screen.getByTestId('render-count')).toHaveTextContent('2');
+  });
 });

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -43,23 +43,68 @@ export function PageAlertProvider({children}: {children: React.ReactNode}) {
   const [pageAlert, setPageAlert] = useState<PageAlertOptions | undefined>();
 
   const setPageInfo: PageAlertSetter = useCallback((message, options) => {
-    setPageAlert({message, variant: 'info', ...options});
+    setPageAlert(prev => {
+      if (
+        prev?.message === message &&
+        prev?.variant === 'info' &&
+        prev?.dismissId === options?.dismissId
+      ) {
+        return prev;
+      }
+      return {message, variant: 'info', ...options};
+    });
   }, []);
 
   const setPageMuted: PageAlertSetter = useCallback((message, options) => {
-    setPageAlert({message, variant: 'muted', ...options});
+    setPageAlert(prev => {
+      if (
+        prev?.message === message &&
+        prev?.variant === 'muted' &&
+        prev?.dismissId === options?.dismissId
+      ) {
+        return prev;
+      }
+      return {message, variant: 'muted', ...options};
+    });
   }, []);
 
   const setPageSuccess: PageAlertSetter = useCallback((message, options) => {
-    setPageAlert({message, variant: 'success', ...options});
+    setPageAlert(prev => {
+      if (
+        prev?.message === message &&
+        prev?.variant === 'success' &&
+        prev?.dismissId === options?.dismissId
+      ) {
+        return prev;
+      }
+      return {message, variant: 'success', ...options};
+    });
   }, []);
 
   const setPageWarning: PageAlertSetter = useCallback((message, options) => {
-    setPageAlert({message, variant: 'warning', ...options});
+    setPageAlert(prev => {
+      if (
+        prev?.message === message &&
+        prev?.variant === 'warning' &&
+        prev?.dismissId === options?.dismissId
+      ) {
+        return prev;
+      }
+      return {message, variant: 'warning', ...options};
+    });
   }, []);
 
   const setPageDanger: PageAlertSetter = useCallback((message, options) => {
-    setPageAlert({message, variant: 'danger', ...options});
+    setPageAlert(prev => {
+      if (
+        prev?.message === message &&
+        prev?.variant === 'danger' &&
+        prev?.dismissId === options?.dismissId
+      ) {
+        return prev;
+      }
+      return {message, variant: 'danger', ...options};
+    });
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

Fixes infinite render loop in database span sample panel that was causing "Maximum update depth exceeded" errors.

Fixes https://sentry.sentry.io/issues/JAVASCRIPT-3693
Fixes DAIN-1152

## Problem

React was throwing "Maximum update depth exceeded" errors in the database module span sample panel (`/insights/backend/database/spans/span/:groupId/`). The issue occurred when:
1. Component renders with data fetching error
2. `setPageDanger()` called during render
3. Context state updates → component re-renders
4. Error still exists → `setPageDanger()` called again
5. Loop continues until React's 50-update limit

## Solution

Modified `PageAlertProvider` to add state comparison logic to all setter functions (`setPageDanger`, `setPageWarning`, `setPageInfo`, `setPageSuccess`, `setPageMuted`). Each setter now checks if the incoming message, variant, and dismissId match the current state. If they do, it returns the previous state object, preventing React from triggering a re-render.