### PR TITLE
feat(dashboards): update jobs chart to be a line chart

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -115,7 +115,7 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       id: 'jobs-chart',
       title: 'Jobs',
       description: '',
-      displayType: DisplayType.BAR,
+      displayType: DisplayType.LINE,
       thresholds: null,
       interval: '1h',
       queries: [


### PR DESCRIPTION
Bar chart was hard to read, updates the chart to be a line chart. We might end up changing the entire visualization to be a stacked bar chart, but this is a quick fix for now.
Before
<img width="456" height="306" alt="image" src="https://github.com/user-attachments/assets/45318d92-708f-4554-b9d1-a4b212564ed8" />

After
<img width="479" height="289" alt="image" src="https://github.com/user-attachments/assets/351fe0fb-098a-40ca-91ec-2dade135b745" />
