### PR TITLE
feat(usage overview): Move trial CTA back to table

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -85,7 +85,7 @@ function HeaderCards({organization, subscription}: HeaderCardsProps) {
           md: navIsCollapsed ? `repeat(${cards.length}, minmax(0, 1fr))` : undefined,
           lg: `repeat(${cards.length}, minmax(0, 1fr))`,
         }}
-        gap="xl"
+        gap="lg"
         data-test-id="subscription-header-cards"
       >
         {cards}

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/productTrialRibbon.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/productTrialRibbon.tsx
@@ -36,7 +36,7 @@ function ProductTrialRibbon({
     : t('Trial available');
 
   return (
-    <RibbonContainer>
+    <RibbonContainer isActiveProductTrial={!!activeProductTrial}>
       <RibbonBase ribbonColor={ribbonColor}>
         <Tooltip title={tooltipContent}>
           {activeProductTrial ? (
@@ -56,11 +56,11 @@ function ProductTrialRibbon({
 
 export default ProductTrialRibbon;
 
-const RibbonContainer = styled('td')`
+const RibbonContainer = styled('td')<{isActiveProductTrial: boolean}>`
   display: flex;
   position: absolute;
   left: -1px;
-  top: 14px;
+  top: ${p => (p.isActiveProductTrial ? '16px' : '20px')};
   z-index: 1000;
 `;
 

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/tableRow.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/tableRow.tsx
@@ -8,7 +8,7 @@ import {Container, Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import ProgressRing from 'sentry/components/progressRing';
 import {IconClock, IconLock, IconPlay, IconWarning} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import useMedia from 'sentry/utils/useMedia';
@@ -323,9 +323,11 @@ function UsageOverviewTableRow({
             <td>
               <Flex justify="end">
                 <Tag variant="promotion" icon={<IconClock />}>
-                  {tct('[daysLeft] days left', {
-                    daysLeft: -1 * getDaysSinceDate(activeProductTrial.endDate ?? ''),
-                  })}
+                  {tn(
+                    '%s day left',
+                    '%s days left',
+                    -1 * getDaysSinceDate(activeProductTrial.endDate ?? '')
+                  )}
                 </Tag>
               </Flex>
             </td>

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/tableRow.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/tableRow.tsx
@@ -389,7 +389,7 @@ function DisabledProductRow({
   return (
     <Fragment>
       <ProductRow
-        data-test-id={`product-row-${product}`}
+        data-test-id={`product-row-disabled-${product}`}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         isSelected={isSelected}
@@ -410,7 +410,12 @@ function DisabledProductRow({
           />
         )}
         <td>
-          <Flex paddingLeft={potentialProductTrial ? 'lg' : undefined} wrap="nowrap">
+          <Flex
+            paddingLeft={potentialProductTrial ? 'lg' : undefined}
+            wrap="nowrap"
+            align="center"
+            height="100%"
+          >
             <Text as="span" variant="muted" textWrap="balance">
               {displayName}{' '}
               <IconContainer>
@@ -419,6 +424,28 @@ function DisabledProductRow({
             </Text>
           </Flex>
         </td>
+        {potentialProductTrial && (
+          <Fragment>
+            <td />
+            <td>
+              <Flex justify="end">
+                <StartTrialButton
+                  organization={organization}
+                  source="usage-overview-table"
+                  requestData={{
+                    productTrial: {
+                      category: potentialProductTrial.category,
+                      reasonCode: potentialProductTrial.reasonCode,
+                    },
+                  }}
+                  size="xs"
+                  icon={<IconPlay />}
+                  priority="primary"
+                />
+              </Flex>
+            </td>
+          </Fragment>
+        )}
         {(isSelected || isHovered) && <SelectedPill isSelected={isSelected} />}
       </ProductRow>
       {showPanelInline && isSelected && (

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -99,7 +99,7 @@ function UsageOverview({subscription, organization, usageData}: UsageOverviewPro
 
   return (
     <Grid
-      columns={{xs: '1fr', [SIDE_PANEL_MIN_SCREEN_BREAKPOINT]: '50% 50%'}}
+      columns={{xs: '1fr', [SIDE_PANEL_MIN_SCREEN_BREAKPOINT]: 'repeat(2, 1fr)'}}
       gap="lg"
       align="start"
     >


### PR DESCRIPTION
If there is a potential product trial available, render the starter button in the respective table row as well.

### when product is locked for customer
<img width="1420" height="765" alt="Screenshot 2026-01-12 at 3 28 48 PM" src="https://github.com/user-attachments/assets/02e009fd-9efc-4b77-b8be-84311bf0c9b8" />

### when product is unlocked for customer
<img width="1422" height="772" alt="Screenshot 2026-01-12 at 3 29 16 PM" src="https://github.com/user-attachments/assets/37181067-cd36-4060-867c-e4854dd8fc73" />





Also snuck in an alignment fix (aligns center column gap for header cards with the column gap for table/panel):

<img width="1172" height="588" alt="Screenshot 2026-01-09 at 4 30 47 PM" src="https://github.com/user-attachments/assets/caf5ed38-9656-4a6e-97d0-1ec1e933306f" />
