### PR TITLE
ref(similarity): gate MinHash similarity if on SaaS

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -251,8 +251,10 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
     def delete_instance(self, instance: Group) -> None:
         from sentry import similarity
 
+        # Don't do MinHash work if we use embeddings-based similarity.
         if not self.skip_models or similarity not in self.skip_models:
-            similarity.delete(None, instance)
+            if not instance.project.get_option("sentry:similarity_backfill_completed"):
+                similarity.delete(None, instance)
 
         return super().delete_instance(instance)
 

--- a/src/sentry/issues/endpoints/group_similar_issues.py
+++ b/src/sentry/issues/endpoints/group_similar_issues.py
@@ -21,11 +21,20 @@ def _fix_label(label: tuple[str, ...] | str) -> str:
 
 @region_silo_endpoint
 class GroupSimilarIssuesEndpoint(GroupEndpoint):
+    """
+    This endpoint uses the legacy MinHash similarity system which has been replaced
+    by embeddings-based grouping for SaaS.
+    """
+
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, group: Group) -> Response:
+        # Any project using embeddings-based grouping will not work with this endpoint
+        if group.project.get_option("sentry:similarity_backfill_completed"):
+            return Response([])
+
         features = similarity.features
 
         limit_s = request.GET.get("limit", None)

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -112,7 +112,9 @@ def merge_groups(
             # work for this group.
             from_object_ids.remove(from_object_id)
 
-            similarity.merge(group.project, new_group, [group], allow_unsafe=True)
+            # Don't do MinHash work if we use embeddings-based similarity.
+            if not group.project.get_option("sentry:similarity_backfill_completed"):
+                similarity.merge(group.project, new_group, [group], allow_unsafe=True)
 
             environment_ids = list(
                 Environment.objects.filter(projects=group.project).values_list("id", flat=True)

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -276,6 +276,8 @@ def finish_reprocessing(project_id: int, group_id: int) -> None:
 
     eventstream.backend.exclude_groups(project_id, [group_id])
 
-    from sentry import similarity
+    # Don't do MinHash work if we use embeddings-based similarity.
+    if not group.project.get_option("sentry:similarity_backfill_completed"):
+        from sentry import similarity
 
-    similarity.delete(None, group)
+        similarity.delete(None, group)

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -272,7 +272,9 @@ def truncate_denormalizations(project: Project, group: Group) -> None:
         [str(group.id)],
     )
 
-    similarity.delete(project, group)
+    # Don't do MinHash work if we use embeddings-based similarity.
+    if not project.get_option("sentry:similarity_backfill_completed"):
+        similarity.delete(project, group)
 
 
 def collect_group_environment_data(
@@ -458,8 +460,7 @@ def repair_denormalizations(
     repair_group_release_data(caches, project, events)
     repair_tsdb_data(caches, project, events)
 
-    # Skip MinHash similarity indexing for projects that have been backfilled to Seer.
-    # Those projects use Seer's embeddings-based similarity instead.
+    # Don't do MinHash work if we use embeddings-based similarity.
     if not project.get_option("sentry:similarity_backfill_completed"):
         for event in events:
             similarity.record(project, [event])


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/105973. We should only do `MinHash` similarity work if we are not on embeddings-based grouping.