### PR TITLE
feat(autofix): Support query param to switch autofix mode

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -107,7 +107,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
     def _should_use_explorer(self, request: Request, organization: Organization) -> bool:
         """Check if explorer mode should be used based on query params and feature flags."""
-        if request.GET.get("mode") != "explorer":
+        if request.GET.get("mode") == "legacy":
             return False
 
         if not features.has("organizations:seer-explorer", organization, actor=request.user):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -861,8 +861,11 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
     """Tests for feature flag routing to Explorer-based autofix."""
 
-    def _get_url(self, group_id: int) -> str:
-        return f"/api/0/issues/{group_id}/autofix/"
+    def _get_url(self, group_id: int, mode: str | None = None) -> str:
+        url = f"/api/0/issues/{group_id}/autofix/"
+        if mode:
+            url = f"{url}?mode={mode}"
+        return url
 
     def setUp(self) -> None:
         super().setUp()
@@ -871,44 +874,44 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         self.organization.save()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_explorer_state")
-    def test_get_routes_to_explorer_with_mode_param(
+    def test_get_routes_to_explorer_with_both_flags(
         self, mock_get_explorer_state, mock_get_seer_org_acknowledgement
     ):
-        """GET routes to explorer when mode=explorer is in query params and both flags are enabled."""
+        """GET routes to explorer when both seer-explorer and autofix-on-explorer flags are enabled."""
         group = self.create_group()
         mock_get_explorer_state.return_value = None
-
-        self.login_as(user=self.user)
-        response = self.client.get(f"{self._get_url(group.id)}?mode=explorer", format="json")
-
-        assert response.status_code == 200, response.data
-        mock_get_explorer_state.assert_called_once_with(group.organization, group.id)
-
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_state")
-    def test_get_routes_to_legacy_without_mode_param(
-        self, mock_get_autofix_state, mock_get_seer_org_acknowledgement
-    ):
-        """GET routes to legacy when mode=explorer is NOT in query params even with both flags enabled."""
-        group = self.create_group()
-        mock_get_autofix_state.return_value = None
 
         self.login_as(user=self.user)
         response = self.client.get(self._get_url(group.id), format="json")
 
         assert response.status_code == 200, response.data
+        mock_get_explorer_state.assert_called_once_with(group.organization, group.id)
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_state")
+    def test_get_routes_to_legacy_with_mode_param(
+        self, mock_get_autofix_state, mock_get_seer_org_acknowledgement
+    ):
+        """GET routes to legacy when mode=legacy is in query params even with both flags enabled."""
+        group = self.create_group()
+        mock_get_autofix_state.return_value = None
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id, mode="legacy"), format="json")
+
+        assert response.status_code == 200, response.data
         mock_get_autofix_state.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_explorer")
-    def test_post_routes_to_explorer_with_mode_param(
+    def test_post_routes_to_explorer_with_both_flags(
         self, mock_trigger_explorer, mock_get_seer_org_acknowledgement
     ):
-        """POST routes to explorer when mode=explorer is in query params and both flags are enabled."""
+        """POST routes to explorer when both seer-explorer and autofix-on-explorer flags are enabled."""
         group = self.create_group()
         mock_trigger_explorer.return_value = 123
 
         self.login_as(user=self.user)
         response = self.client.post(
-            f"{self._get_url(group.id)}?mode=explorer",
+            self._get_url(group.id),
             data={"step": "root_cause"},
             format="json",
         )
@@ -920,14 +923,14 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
-    def test_post_routes_to_legacy_without_mode_param(
+    def test_post_routes_to_legacy_with_mode_param(
         self,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call_autofix,
         mock_get_seer_org_acknowledgement,
     ):
-        """POST routes to legacy when mode=explorer is NOT in query params even with both flags enabled."""
+        """POST routes to legacy when mode=legacy is in query params even with both flags enabled."""
         release = self.create_release(project=self.project, version="1.0.0")
 
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -947,7 +950,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         response = self.client.post(
-            self._get_url(group.id),
+            self._get_url(group.id, mode="legacy"),
             data={"instruction": "test"},
             format="json",
         )


### PR DESCRIPTION
To allow using both autofix modes in the interim, use a query param to switch when the feature flags are enabled.