### PR TITLE
fix(preprod): hide missing git metadata while uploading

### DIFF
--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -84,7 +84,7 @@ describe('BuildDetailsSidebarContent', () => {
     expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
   });
 
-  it('renders app info section when artifact state is PROCESSED', async () => {
+  it('renders app info, build metadata section when artifact state is PROCESSED', async () => {
     const buildDetailsData = {
       ...mockBuildDetailsData,
       state: BuildDetailsState.PROCESSED,
@@ -109,7 +109,7 @@ describe('BuildDetailsSidebarContent', () => {
     expect(screen.getByText('test-repo')).toBeInTheDocument(); // repo_name
   });
 
-  it('hides app info section when artifact state is UPLOADED', async () => {
+  it('hides app info, status check info and build metadata section when artifact state is UPLOADED', () => {
     const buildDetailsData = {
       ...mockBuildDetailsData,
       state: BuildDetailsState.UPLOADED,
@@ -119,22 +119,13 @@ describe('BuildDetailsSidebarContent', () => {
       organization,
     });
 
-    // Build Metadata should still show VCS data
-    await waitFor(() => {
-      expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-    });
-    expect(screen.getByText('abc123')).toBeInTheDocument(); // head_sha
-    expect(screen.getByText('def456')).toBeInTheDocument(); // base_sha
-    expect(screen.getByText('main')).toBeInTheDocument(); // head_ref
-    expect(screen.getByText('master')).toBeInTheDocument(); // base_ref
-    expect(screen.getByText('123')).toBeInTheDocument(); // pr_number
-    expect(screen.getByText('test-repo')).toBeInTheDocument(); // repo_name
-
-    // App info should be hidden
+    // App info, status check info and build metadata section should be hidden
     expect(screen.queryByText('Test App')).not.toBeInTheDocument();
+    expect(screen.queryByText('Status check info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Build Metadata')).not.toBeInTheDocument();
   });
 
-  it('hides app info section when artifact state is UPLOADING', async () => {
+  it('hides app info, status check info and build metadata section when artifact state is UPLOADING', () => {
     const buildDetailsData = {
       ...mockBuildDetailsData,
       state: BuildDetailsState.UPLOADING,
@@ -144,22 +135,13 @@ describe('BuildDetailsSidebarContent', () => {
       organization,
     });
 
-    // Build Metadata should still show VCS data
-    await waitFor(() => {
-      expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-    });
-    expect(screen.getByText('abc123')).toBeInTheDocument(); // head_sha
-    expect(screen.getByText('def456')).toBeInTheDocument(); // base_sha
-    expect(screen.getByText('main')).toBeInTheDocument(); // head_ref
-    expect(screen.getByText('master')).toBeInTheDocument(); // base_ref
-    expect(screen.getByText('123')).toBeInTheDocument(); // pr_number
-    expect(screen.getByText('test-repo')).toBeInTheDocument(); // repo_name
-
-    // App info should be hidden
+    // App info, status check info and build metadata section should be hidden
     expect(screen.queryByText('Test App')).not.toBeInTheDocument();
+    expect(screen.queryByText('Status check info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Build Metadata')).not.toBeInTheDocument();
   });
 
-  it('hides app info section when artifact state is FAILED', async () => {
+  it('hides app info, status check info and build metadata section when artifact state is FAILED', () => {
     const buildDetailsData = {
       ...mockBuildDetailsData,
       state: BuildDetailsState.FAILED,
@@ -169,19 +151,10 @@ describe('BuildDetailsSidebarContent', () => {
       organization,
     });
 
-    // Build Metadata should still show VCS data
-    await waitFor(() => {
-      expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-    });
-    expect(screen.getByText('abc123')).toBeInTheDocument(); // head_sha
-    expect(screen.getByText('def456')).toBeInTheDocument(); // base_sha
-    expect(screen.getByText('main')).toBeInTheDocument(); // head_ref
-    expect(screen.getByText('master')).toBeInTheDocument(); // base_ref
-    expect(screen.getByText('123')).toBeInTheDocument(); // pr_number
-    expect(screen.getByText('test-repo')).toBeInTheDocument(); // repo_name
-
-    // App info should be hidden
+    // App info, status check info and build metadata section should be hidden
     expect(screen.queryByText('Test App')).not.toBeInTheDocument();
+    expect(screen.queryByText('Status check info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Build Metadata')).not.toBeInTheDocument();
   });
 
   describe('Base Build row', () => {

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -24,16 +24,18 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
     return <SidebarLoadingSkeleton data-testid="sidebar-loading-skeleton" />;
   }
 
+  /* App info + status check info + VCS info - only show when artifact is processed */
+  if (buildDetailsData.state !== BuildDetailsState.PROCESSED) {
+    return null;
+  }
+
   return (
     <Flex direction="column" gap="2xl">
-      {/* App info - only show when artifact is processed */}
-      {buildDetailsData.state === BuildDetailsState.PROCESSED && (
-        <BuildDetailsSidebarAppInfo
-          appInfo={buildDetailsData.app_info}
-          projectId={projectId}
-          artifactId={artifactId}
-        />
-      )}
+      <BuildDetailsSidebarAppInfo
+        appInfo={buildDetailsData.app_info}
+        projectId={projectId}
+        artifactId={artifactId}
+      />
 
       {/* Status check info */}
       {buildDetailsData.posted_status_checks?.size && (
@@ -43,7 +45,6 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
         />
       )}
 
-      {/* VCS info */}
       <BuildVcsInfo buildDetailsData={buildDetailsData} projectId={projectId} />
     </Flex>
   );


### PR DESCRIPTION
Hide the “Missing Git metadata” build details while an artifact is still uploading/processing.

We currently hide the app info block, showing build metadata is missing while not showing the app info looks strange, this PR address that by hiding all sidebar blocks when app is being processed regardless to whether we have data to show individual blocks.

Refs EME-691