### PR TITLE
fix(gsApp): Remove deprecated route props from route hook

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -46,11 +46,7 @@ import SettingsWrapper from 'sentry/views/settings/components/settingsWrapper';
 import {type SentryRouteObject} from './types';
 
 const routeHook = (name: HookName): SentryRouteObject => {
-  const route = HookStore.get(name)?.[0]?.() ?? {};
-  return {
-    ...route,
-    deprecatedRouteProps: true,
-  };
+  return HookStore.get(name)?.[0]?.() ?? {};
 };
 
 function buildRoutes(): RouteObject[] {

--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -1,3 +1,4 @@
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
@@ -11,15 +12,10 @@ import type {RouteWithName} from 'sentry/views/settings/components/settingsBread
 import SettingsHeader from 'sentry/views/settings/components/settingsHeader';
 import SettingsSearch from 'sentry/views/settings/components/settingsSearch';
 
-type Props = {
-  children: React.ReactNode;
-};
-
-export default function SubscriptionSettingsLayout(props: Props) {
+export default function SubscriptionSettingsLayout() {
   const location = useLocation();
   const params = useParams();
   const routes = useRoutes();
-  const {children} = props;
   let feedbackSource = location.pathname;
   for (let i = routes.length - 1; i >= 0; i--) {
     const route = routes[i] as RouteWithName;
@@ -53,7 +49,7 @@ export default function SubscriptionSettingsLayout(props: Props) {
         </Flex>
       </StyledSettingsHeader>
       <Flex minWidth={0} flex="1" direction="column">
-        {children}
+        <Outlet />
       </Flex>
     </SettingsColumn>
   );


### PR DESCRIPTION
Remove the last place it was required. Spot checked the rest and they look like they don't use it.
