### PR TITLE
ref(unmerge): bump unmerge timeout to 300s

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -493,7 +493,7 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 @instrumented_task(
     name="sentry.tasks.unmerge",
     namespace=issues_tasks,
-    processing_deadline_duration=60,
+    processing_deadline_duration=300,
     silo_mode=SiloMode.REGION,
 )
 def unmerge(*posargs: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
Refs SENTRY-4192

Unmerge is still timing out even after https://github.com/getsentry/sentry/pull/105973, which, based on the stacktrace, is leading to some stuck `GroupHashes`. Since the task volume is so low, and since the task does several computationally expensive things, we can bump the timeout to see if this fixes the issue.