### PR TITLE
feat(ownership): Migrate issue owners cache invalidation to use timestamp versioning on ownership

### DIFF
--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -224,7 +224,7 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
             if not ownership:
                 ownership = ProjectOwnership(project_id=group.project.id)
             GroupOwner.invalidate_assignee_exists_cache(group.project.id, group.id)
-            GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(group.project.id, group.id)
+            GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(group.id)
 
             metrics.incr("group.assignee.change", instance="deassigned", skip_internal=True)
             # sync Sentry assignee to external issues

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -151,18 +151,14 @@ def modify_date_updated(instance, **kwargs):
 
 def process_resource_change(instance, change, **kwargs):
     from sentry.models.groupowner import GroupOwner
-    from sentry.models.projectownership import ProjectOwnership
 
     cache.set(
         ProjectCodeOwners.get_cache_key(instance.project_id),
         None,
         READ_CACHE_DURATION,
     )
-    ownership = ProjectOwnership.get_ownership_cached(instance.project_id)
-    if not ownership:
-        ownership = ProjectOwnership(project_id=instance.project_id)
 
-    GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
+    GroupOwner.set_project_ownership_version(instance.project_id)
 
 
 pre_save.connect(

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -423,7 +423,7 @@ def process_resource_change(instance, change, **kwargs):
         READ_CACHE_DURATION,
     )
     GroupOwner.invalidate_assignee_exists_cache(instance.project.id)
-    GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
+    GroupOwner.set_project_ownership_version(instance.project_id)
 
 
 # Signals update the cached reads used in post_processing

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -229,6 +229,7 @@ def handle_owner_assignment(job):
         ASSIGNEE_EXISTS_KEY,
         ISSUE_OWNERS_DEBOUNCE_DURATION,
         ISSUE_OWNERS_DEBOUNCE_KEY,
+        GroupOwner,
     )
     from sentry.models.projectownership import ProjectOwnership
 
@@ -250,11 +251,25 @@ def handle_owner_assignment(job):
         return
 
     issue_owners_key = ISSUE_OWNERS_DEBOUNCE_KEY(group.id)
-    debounce_issue_owners = cache.get(issue_owners_key)
+    issue_owners_debounce_time = cache.get(issue_owners_key)
 
-    if debounce_issue_owners:
-        metrics.incr("sentry.tasks.post_process.handle_owner_assignment.debounce")
-        return
+    # Debounce check with timestamp-based invalidation:
+    # - issue_owners_debounce_time is None: no debounce, process ownership
+    # - issue_owners_debounce_time is True: legacy format, debounce (backwards compatibility)
+    # - issue_owners_debounce_time is float: compare timestamps
+    #   - If ownership_changed_at is None or ownership_changed_at < issue_owners_debounce_time: debounce
+    #   - If ownership_changed_at >= issue_owners_debounce_time: ownership rules changed, re-evaluate
+    if issue_owners_debounce_time is not None:
+        # TODO(shashank): once rolled out for 24hrs, remove this legacy cache format check and the comment line above. prob will need to remove some tests in test_post_process.py as well.
+        if issue_owners_debounce_time is True:
+            # Backwards compatibility: old cache format, debounce
+            metrics.incr("sentry.tasks.post_process.handle_owner_assignment.debounce")
+            return
+
+        ownership_changed_at = GroupOwner.get_project_ownership_version(project.id)
+        if ownership_changed_at is None or ownership_changed_at < issue_owners_debounce_time:
+            metrics.incr("sentry.tasks.post_process.handle_owner_assignment.debounce")
+            return
 
     if should_issue_owners_ratelimit(
         project_id=project.id,
@@ -286,7 +301,7 @@ def handle_owner_assignment(job):
         issue_owners = ProjectOwnership.get_issue_owners(project.id, event.data)
         cache.set(
             issue_owners_key,
-            True,
+            timezone.now().timestamp(),
             ISSUE_OWNERS_DEBOUNCE_DURATION,
         )
 


### PR DESCRIPTION
We've been seeing [some timeouts](https://sentry.sentry.io/issues/6731345393/?project=1&referrer=Linear) in the `code_owners_auto_sync` task since it performs expensive O(n) cache invalidation. When CODEOWNERS or ownership rules changed, we would previously:
1. Query all groups in the project with recent events
2. Delete the issue owners debounce cache entry for each group individually (via batched `cache.delete_many`)

The solution implemented in this PR is to replace this expensive fan-out cache invalidation with an O(1) timestamp-based versioning system on ownership schemas.

**Before**:
- Issue owners debounce cache simply stored `True` for each group
- On ownership change: delete cache entries for ALL active groups in the project

**After**:
- Issue owners debounce cache stores the timestamp of when owners were last evaluated for the group
- On ownership change: set a cache value with a project-wide `ownership_changed_at` timestamp
- On debounce check:
    - If `issue_owners_debounce_time` is None --> no debounce, evaluate ownership
    - If `issue_owners_debounce_time` is True --> legacy cache value, debounce (will disappear from cache 24hrs after this PR is rolled out, and then this logic can be removed)
    - If `issue_owners_debounce_time` is a timestamp --> compare timestamps
        - If `ownership_changed_at` is None or `ownership_changed_at` < `issue_owners_debounce_time` --> debounce
        - If `ownership_changed_at` >= `issue_owners_debounce_time` --> ownership rules changed in the interim, evaluate ownership

### Follow-up

Left TODOs for the first two in the code:
- Remove backwards compatibility logic for `True` cache values 24 hrs after this PR is rolled out
- Investigate applying same O(1) cache invalidation pattern to `invalidate_assignee_exists_cache`
- Can maybe reduce the processing deadline duration for the `code_owners_auto_sync` task