### PR TITLE
chore(tsc): Fix type error with old theme colors

### DIFF
--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -904,7 +904,7 @@ const CodingAgentStatusTag = styled('span')<{
   color: ${p => {
     switch (p.$status) {
       case 'completed':
-        return p.theme.alert.success.color;
+        return p.theme.tokens.content.success;
       case 'failed':
         return p.theme.alert.danger.color;
       default:

--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -904,9 +904,9 @@ const CodingAgentStatusTag = styled('span')<{
   color: ${p => {
     switch (p.$status) {
       case 'completed':
-        return p.theme.successText;
+        return p.theme.alert.success.color;
       case 'failed':
-        return p.theme.errorText;
+        return p.theme.alert.danger.color;
       default:
         return p.theme.blue400;
     }

--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -906,7 +906,7 @@ const CodingAgentStatusTag = styled('span')<{
       case 'completed':
         return p.theme.tokens.content.success;
       case 'failed':
-        return p.theme.alert.danger.color;
+        return p.theme.tokens.content.danger;
       default:
         return p.theme.blue400;
     }


### PR DESCRIPTION
Builds are failing due to the old theme colors being used 