### PR TITLE
fix(aci): fix `failure_rate` input suffix and placeholder

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -61,7 +61,10 @@ import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel
 import {PriorityDot} from 'sentry/views/detectors/components/priorityDot';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
-import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {
+  getMetricDetectorSuffix,
+  getStaticDetectorThresholdPlaceholder,
+} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 function MetricDetectorForm() {
   useAutoMetricDetectorName();
@@ -223,6 +226,7 @@ function PriorityRow({
     METRIC_DETECTOR_FORM_FIELDS.conditionType
   );
   const thresholdSuffix = getMetricDetectorSuffix(detectionType, aggregate);
+  const thresholdPlaceholder = getStaticDetectorThresholdPlaceholder(aggregate);
   const isHigh = priority === 'high';
   const isStatic = detectionType === 'static';
 
@@ -284,7 +288,7 @@ function PriorityRow({
               flexibleControlStateSize
               inline={false}
               hideLabel
-              placeholder="0"
+              placeholder={thresholdPlaceholder}
               name={thresholdFieldName}
               suffix={thresholdSuffix}
               required={isHigh}

--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -98,7 +98,8 @@ export function ResolveSection() {
   }
 
   const thresholdSuffix = getStaticDetectorThresholdSuffix(aggregate);
-  const thresholdPlaceholder = getStaticDetectorThresholdPlaceholder(aggregate);
+  const thresholdPlaceholder =
+    detectionType === 'percent' ? '0' : getStaticDetectorThresholdPlaceholder(aggregate);
 
   // Compute the automatic resolution threshold: medium if present, otherwise high
   const resolutionThreshold =

--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -9,7 +9,10 @@ import RadioField from 'sentry/components/forms/fields/radioField';
 import {t} from 'sentry/locale';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetectorResolutionDescription';
-import {getStaticDetectorThresholdSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {
+  getStaticDetectorThresholdPlaceholder,
+  getStaticDetectorThresholdSuffix,
+} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 import type {MetricDetectorFormData} from './metricFormData';
 import {METRIC_DETECTOR_FORM_FIELDS, useMetricDetectorFormField} from './metricFormData';
@@ -95,6 +98,7 @@ export function ResolveSection() {
   }
 
   const thresholdSuffix = getStaticDetectorThresholdSuffix(aggregate);
+  const thresholdPlaceholder = getStaticDetectorThresholdPlaceholder(aggregate);
 
   // Compute the automatic resolution threshold: medium if present, otherwise high
   const resolutionThreshold =
@@ -169,7 +173,7 @@ export function ResolveSection() {
             name={METRIC_DETECTOR_FORM_FIELDS.resolutionValue}
             inline={false}
             flexibleControlStateSize
-            placeholder="0"
+            placeholder={thresholdPlaceholder}
             suffix={detectionType === 'percent' ? '%' : thresholdSuffix}
             validate={validateResolutionThreshold}
             required

--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -16,7 +16,7 @@ import type {
   MetricDetectorConfig,
 } from 'sentry/types/workflowEngine/detectors';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
-import {SESSIONS_OPERATIONS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
+import {isSessionPercentageOperation} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 function createThresholdMarkLine(lineColor: string, threshold: number) {
   return MarkLine({
@@ -79,22 +79,6 @@ function createPercentThresholdSeries(
     seriesName,
     data: thresholdData,
   };
-}
-
-/**
- * Checks if an aggregate function is a SESSIONS_OPERATION with percentage output type.
- */
-function isSessionPercentageOperation(aggregate: string): boolean {
-  // Extract function name from aggregate (e.g., "crash_free_rate" from "crash_free_rate(session)")
-  const match = aggregate.match(/^([^(]+)/);
-  const functionName = match?.[1];
-
-  if (!functionName) {
-    return false;
-  }
-
-  const sessionOp = SESSIONS_OPERATIONS[functionName as keyof typeof SESSIONS_OPERATIONS];
-  return sessionOp?.outputType === 'percentage';
 }
 
 /**

--- a/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
@@ -1,5 +1,6 @@
 import {
   getMetricDetectorSuffix,
+  getStaticDetectorThresholdPlaceholder,
   getStaticDetectorThresholdSuffix,
 } from './metricDetectorSuffix';
 
@@ -16,8 +17,12 @@ describe('getStaticDetectorThresholdSuffix', () => {
     expect(getStaticDetectorThresholdSuffix('any(transaction)')).toBe('');
   });
 
-  it('returns % for percentage aggregate', () => {
-    expect(getStaticDetectorThresholdSuffix('failure_rate()')).toBe('%');
+  it('returns empty string for failure_rate (stores as decimal, not percentage)', () => {
+    expect(getStaticDetectorThresholdSuffix('failure_rate()')).toBe('');
+  });
+
+  it('returns % for session percentage aggregate', () => {
+    expect(getStaticDetectorThresholdSuffix('crash_free_rate(session)')).toBe('%');
   });
 
   it('returns ms for duration aggregate', () => {
@@ -43,5 +48,27 @@ describe('getMetricDetectorSuffix', () => {
 
   it('returns ms as default for dynamic detection type with duration aggregate', () => {
     expect(getMetricDetectorSuffix('dynamic', aggregate)).toBe('ms');
+  });
+});
+
+describe('getStaticDetectorThresholdPlaceholder', () => {
+  it('returns 0 for integer aggregate', () => {
+    expect(getStaticDetectorThresholdPlaceholder('count()')).toBe('0');
+  });
+
+  it('returns 0 for number aggregate', () => {
+    expect(getStaticDetectorThresholdPlaceholder('avg(stack.colno)')).toBe('0');
+  });
+
+  it('returns 0 for duration aggregate', () => {
+    expect(getStaticDetectorThresholdPlaceholder('p95(transaction.duration)')).toBe('0');
+  });
+
+  it('returns 0.05 for failure_rate (stores as decimal)', () => {
+    expect(getStaticDetectorThresholdPlaceholder('failure_rate()')).toBe('0.05');
+  });
+
+  it('returns 5 for session percentage aggregate (stores as percentage)', () => {
+    expect(getStaticDetectorThresholdPlaceholder('crash_free_rate(session)')).toBe('5');
   });
 });

--- a/static/app/views/detectors/utils/metricDetectorSuffix.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.tsx
@@ -1,6 +1,25 @@
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {unreachable} from 'sentry/utils/unreachable';
+import {SESSIONS_OPERATIONS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
+
+/**
+ * Checks if an aggregate function is a SESSIONS_OPERATION with percentage output type.
+ * Session operations like crash_free_rate store as percentage (5 for 5%)
+ * Other operations like failure_rate store as decimal (0.05 for 5%)
+ */
+export function isSessionPercentageOperation(aggregate: string): boolean {
+  // Extract function name from aggregate (e.g., "crash_free_rate" from "crash_free_rate(session)")
+  const match = aggregate.match(/^([^(]+)/);
+  const functionName = match?.[1];
+
+  if (!functionName) {
+    return false;
+  }
+
+  const sessionOp = SESSIONS_OPERATIONS[functionName as keyof typeof SESSIONS_OPERATIONS];
+  return sessionOp?.outputType === 'percentage';
+}
 
 export function getStaticDetectorThresholdSuffix(aggregate: string) {
   const type = aggregateOutputType(aggregate);
@@ -11,7 +30,10 @@ export function getStaticDetectorThresholdSuffix(aggregate: string) {
     case 'score':
       return '';
     case 'percentage':
-      return '%';
+      // Session operations like crash_free_rate store as percentage (5 for 5%)
+      // Other operations like failure_rate store as decimal (0.05 for 5%)
+      // Only show % suffix for session operations that store as percentage
+      return isSessionPercentageOperation(aggregate) ? '%' : '';
     case 'duration':
       return 'ms';
     case 'size':
@@ -39,4 +61,17 @@ export function getMetricDetectorSuffix(
     default:
       return '';
   }
+}
+
+/**
+ * Gets an appropriate placeholder value for threshold input fields.
+ * Session operations like crash_free_rate store as percentage (5 for 5%)
+ * Other operations like failure_rate store as decimal (0.05 for 5%)
+ */
+export function getStaticDetectorThresholdPlaceholder(aggregate: string): string {
+  const type = aggregateOutputType(aggregate);
+  if (type === 'percentage') {
+    return isSessionPercentageOperation(aggregate) ? '5' : '0.05';
+  }
+  return '0';
 }


### PR DESCRIPTION
fixes a bug found while fixing https://github.com/getsentry/sentry/pull/105962 where `failure_rate` takes 0.05 as 5%, but the UI does not reflect this

fix:
<img width="629" height="530" alt="Screenshot 2026-01-12 at 12 05 38 PM" src="https://github.com/user-attachments/assets/17913aa5-8d80-4ab6-8d3a-b51c62d9d007" />

note that `crash_free_rate` and other session operations take 5 for 5%:
<img width="748" height="505" alt="Screenshot 2026-01-12 at 12 05 22 PM" src="https://github.com/user-attachments/assets/4387e20b-c8f4-4efd-ba3c-1efb5c0359a1" />
