### PR TITLE
chore(explorer): add error toast when failing to launch cursor agent

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -409,14 +409,26 @@ export function useExplorerAutofix(
       setWaitingForResponse(true);
 
       try {
-        await api.requestPromise(`/organizations/${orgSlug}/issues/${groupId}/autofix/`, {
-          method: 'POST',
-          data: {
-            step: 'coding_agent_handoff',
-            run_id: runId,
-            integration_id: integrationId,
-          },
-        });
+        const response: {failures: Array<{error_message: string}>; successes: unknown[]} =
+          await api.requestPromise(
+            `/organizations/${orgSlug}/issues/${groupId}/autofix/`,
+            {
+              method: 'POST',
+              data: {
+                step: 'coding_agent_handoff',
+                run_id: runId,
+                integration_id: integrationId,
+              },
+            }
+          );
+
+        // Check for failures in the response
+        if (response.failures && response.failures.length > 0) {
+          const errorMessage =
+            response.failures[0]?.error_message ?? 'Failed to launch coding agent';
+          addErrorMessage(errorMessage);
+          return;
+        }
 
         // Invalidate to fetch fresh data
         queryClient.invalidateQueries({

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -427,7 +427,6 @@ export function useExplorerAutofix(
           const errorMessage =
             response.failures[0]?.error_message ?? 'Failed to launch coding agent';
           addErrorMessage(errorMessage);
-          return;
         }
 
         // Invalidate to fetch fresh data
@@ -435,9 +434,10 @@ export function useExplorerAutofix(
           queryKey: makeExplorerAutofixQueryKey(orgSlug, groupId),
         });
       } catch (e: any) {
-        setWaitingForResponse(false);
         addErrorMessage(e?.responseJSON?.detail ?? 'Failed to launch coding agent');
         throw e;
+      } finally {
+        setWaitingForResponse(false);
       }
     },
     [api, orgSlug, groupId, queryClient]


### PR DESCRIPTION
For transparency to the user so they know why it fails, rather than just nothing happening