### PR TITLE
feat(options) Use a dedicated cache profile for options

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -495,11 +495,13 @@ def bind_cache_to_option_store() -> None:
     # settings and/or configuration values. Those options should have been
     # loaded at this point, so we can plug in the cache backend before
     # continuing to initialize the remainder of the application.
-    from django.core.cache import cache as default_cache
+    from django.core.cache import caches
 
     from sentry.options import default_store
 
-    default_store.set_cache_impl(default_cache)
+    # Prefer the 'options' cache profile if defined, otherwise use default
+    cache = caches["options"] if "options" in caches else caches["default"]
+    default_store.set_cache_impl(cache)
 
 
 def apply_legacy_settings(settings: Any) -> None:

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -272,7 +272,7 @@ def test_bind_cache_to_option_store_with_options_cache() -> None:
         bind_cache_to_option_store()
 
         # Should use 'options' cache, not 'default'
-        default_store.cache = caches["options"]
+        assert default_store.cache == caches["options"]
 
 
 def test_bind_cache_to_option_store_without_options_cache() -> None:
@@ -285,4 +285,4 @@ def test_bind_cache_to_option_store_without_options_cache() -> None:
         bind_cache_to_option_store()
 
         # Should use 'default' cache when 'options' doesn't exist
-        default_store.cache = caches["default"]
+        assert default_store.cache == caches["default"]

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -1,8 +1,14 @@
 import types
+from unittest.mock import Mock, patch
 
 import pytest
 
-from sentry.runner.initializer import ConfigurationError, apply_legacy_settings, bootstrap_options
+from sentry.runner.initializer import (
+    ConfigurationError,
+    apply_legacy_settings,
+    bind_cache_to_option_store,
+    bootstrap_options,
+)
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 
@@ -250,3 +256,36 @@ def test_require_secret_key(settings) -> None:
     assert "system.secret-key" not in settings.SENTRY_OPTIONS
     with pytest.raises(ConfigurationError):
         apply_legacy_settings(settings)
+
+
+def test_bind_cache_to_option_store_with_options_cache() -> None:
+    """Test that bind_cache_to_option_store prefers 'options' cache when available"""
+    mock_options_cache = Mock()
+    mock_default_cache = Mock()
+    mock_caches = {"options": mock_options_cache, "default": mock_default_cache}
+    mock_store = Mock()
+
+    with (
+        patch("django.core.cache.caches", mock_caches),
+        patch("sentry.options.default_store", mock_store),
+    ):
+        bind_cache_to_option_store()
+
+        # Should use 'options' cache, not 'default'
+        mock_store.set_cache_impl.assert_called_once_with(mock_options_cache)
+
+
+def test_bind_cache_to_option_store_without_options_cache() -> None:
+    """Test that bind_cache_to_option_store falls back to 'default' cache"""
+    mock_default_cache = Mock()
+    mock_caches = {"default": mock_default_cache}
+    mock_store = Mock()
+
+    with (
+        patch("django.core.cache.caches", mock_caches),
+        patch("sentry.options.default_store", mock_store),
+    ):
+        bind_cache_to_option_store()
+
+        # Should use 'default' cache when 'options' doesn't exist
+        mock_store.set_cache_impl.assert_called_once_with(mock_default_cache)


### PR DESCRIPTION
During inc-1562 an option change didn't take effect in all deployments immediately because those pods were configured to use a separate memcache pool. When options-automator runs it only updates the default memcache cluster.

Instead of using the default memcache cluster (which varies by deployment) we can have options always use a cache profile that is connected to the same cluster as options automator.