### PR TITLE
feat(dashboards): always link to transaction summary from transaction field

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1125,7 +1125,13 @@ function ViewerTableV2({
             organization
           )!;
 
-          if (field === 'transaction' && dataRow.transaction) {
+          // For SPANS widgets, the customRenderer already returns a link, so we shouldn't wrap it
+          // to avoid nested anchor tags
+          if (
+            field === 'transaction' &&
+            dataRow.transaction &&
+            widget.widgetType !== WidgetType.SPANS
+          ) {
             return function (cellData, baggage) {
               return (
                 <TransactionLink


### PR DESCRIPTION
Updates the transaction field so it always links to the transaction summary in the spans dataset, additionally the project, span op and request method fields are added as filters when available in the table.
 This is to support the backend overview transactions table.
<img width="765" height="201" alt="image" src="https://github.com/user-attachments/assets/d38f4efa-d34a-4b9c-966b-e158709b2920" />

<img width="843" height="271" alt="image" src="https://github.com/user-attachments/assets/b776e0ec-b763-490c-a0b6-f60477c57ffd" />
