### PR TITLE
revert(code_review): Remove white listing of orgs

### DIFF
--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -17,7 +17,6 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.overwatch_webhooks.types import OrganizationSummary, WebhookDetails
 from sentry.overwatch_webhooks.webhook_publisher import OverwatchWebhookPublisher
 from sentry.seer.code_review.utils import get_webhook_option_key
-from sentry.seer.code_review.webhooks.config import get_direct_to_seer_gh_orgs
 from sentry.types.region import get_region_by_name
 from sentry.utils import metrics
 
@@ -144,22 +143,6 @@ class OverwatchGithubWebhookForwarder:
             enabled_regions = options.get("overwatch.enabled-regions")
             if not enabled_regions:
                 # feature isn't enabled, no work to do
-                return
-
-            repository = event.get("repository", {})
-            github_org = None
-            if isinstance(repository, dict):
-                github_org = repository.get("owner", {}).get("login")
-
-            direct_to_seer_orgs = get_direct_to_seer_gh_orgs()
-            if github_org and github_org in direct_to_seer_orgs:
-                verbose_log(
-                    "overwatch.debug.github_org_not_whitelisted",
-                    extra={
-                        "github_org": github_org,
-                        "direct_to_seer_orgs": direct_to_seer_orgs,
-                    },
-                )
                 return
 
             orgs_by_region = self._get_org_summaries_by_region_for_integration(

--- a/src/sentry/seer/code_review/metrics.py
+++ b/src/sentry/seer/code_review/metrics.py
@@ -18,6 +18,7 @@ class WebhookFilteredReason(StrEnum):
     )
     INVALID_PAYLOAD = "invalid_payload"  # Validation failed
     TRANSFORM_FAILED = "transform_failed"  # Couldn't build Seer payload
+    OVERWATCH_ENABLED = "overwatch_enabled"  # Option set to route to Overwatch not Seer
 
 
 CodeReviewFilteredReason = WebhookFilteredReason | PreflightDenialReason

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -62,7 +62,7 @@ def get_seer_endpoint_for_event(github_event: GithubWebhookType) -> SeerEndpoint
     return SeerEndpoint.OVERWATCH_REQUEST
 
 
-def get_webhook_option_key(webhook_type: GithubWebhookType) -> str | None:
+def get_webhook_option_key(webhook_type: GithubWebhookType) -> str:
     """
     Get the option key for a given GitHub webhook type.
 
@@ -74,7 +74,7 @@ def get_webhook_option_key(webhook_type: GithubWebhookType) -> str | None:
     """
     from .webhooks.config import WEBHOOK_TYPE_TO_OPTION_KEY
 
-    return WEBHOOK_TYPE_TO_OPTION_KEY.get(webhook_type)
+    return WEBHOOK_TYPE_TO_OPTION_KEY.get(webhook_type) or ""
 
 
 def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -1,4 +1,3 @@
-from sentry import options
 from sentry.integrations.github.webhook_types import GithubWebhookType
 
 # Mapping of webhook types to their corresponding option keys
@@ -6,10 +5,3 @@ WEBHOOK_TYPE_TO_OPTION_KEY = {
     GithubWebhookType.ISSUE_COMMENT: "github.webhook.issue-comment",
     GithubWebhookType.PULL_REQUEST: "github.webhook.pr",
 }
-
-
-def get_direct_to_seer_gh_orgs() -> list[str]:
-    """
-    Returns the list of GitHub org names that should always send directly to Seer.
-    """
-    return options.get("seer.code-review.direct-to-seer-enabled-gh-orgs") or []

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -76,23 +76,10 @@ def handle_webhook_event(
             )
         return
 
-    repository = event.get("repository", {})
-    if repository:
-        logger.info("repository: %s", repository)
-    github_org = event.get("repository", {}).get("owner", {}).get("login")
-    if github_org:
-        logger.info("github_org: %s", github_org)
-    else:
-        logger.info("github_org not found")
-    from .config import get_direct_to_seer_gh_orgs
-
-    gh_orgs_to_only_send_to_seer = get_direct_to_seer_gh_orgs()
-    logger.info("gh_orgs_to_only_send_to_seer: %s", gh_orgs_to_only_send_to_seer)
     handler(
         github_event=github_event,
         event=event,
         organization=organization,
-        github_org=github_org,
         repo=repo,
         integration=integration,
     )

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -24,7 +24,6 @@ from sentry.utils import metrics
 
 from ..metrics import WebhookFilteredReason, record_webhook_filtered
 from ..utils import SeerCodeReviewTrigger, get_seer_endpoint_for_event, make_seer_request
-from .config import get_direct_to_seer_gh_orgs
 
 logger = logging.getLogger(__name__)
 
@@ -98,19 +97,9 @@ def process_github_webhook_event(
 
     # Skip this check for CHECK_RUN events (always go to Seer)
     if github_event != GithubWebhookType.CHECK_RUN:
-        # Check if repo owner is in the whitelist (always send to Seer for these orgs)
-        # Otherwise, check option key to see if Overwatch should handle this
-        repo_owner = event_payload.get("data", {}).get("repo", {}).get("owner")
-        logger.info("payload: %s", event_payload)
-        if repo_owner:
-            logger.info("repo_owner: %s", repo_owner)
-        else:
-            logger.info("repo_owner not found")
-        logger.info("get_direct_to_seer_gh_orgs: %s", get_direct_to_seer_gh_orgs())
-        if repo_owner not in get_direct_to_seer_gh_orgs():
-            # If option is True, Overwatch handles this - skip Seer processing
-            if option_key and options.get(option_key):
-                return
+        # If option is True, Overwatch handles this - skip Seer processing
+        if option_key and options.get(option_key):
+            return
 
     try:
         path = get_seer_endpoint_for_event(github_event).value

--- a/tests/sentry/seer/code_review/webhooks/test_check_run.py
+++ b/tests/sentry/seer/code_review/webhooks/test_check_run.py
@@ -150,25 +150,3 @@ class CheckRunEventWebhookTest(GitHubWebhookCodeReviewTestCase):
                 CHECK_RUN_REREQUESTED_ACTION_EVENT_EXAMPLE,
             )
             mock_make_seer_request.assert_not_called()
-
-    @patch("sentry.seer.code_review.webhooks.task.get_direct_to_seer_gh_orgs")
-    @patch("sentry.seer.code_review.webhooks.task.make_seer_request")
-    def test_check_run_bypasses_org_whitelist_check(
-        self, mock_make_seer_request: MagicMock, mock_get_orgs: MagicMock
-    ) -> None:
-        """Test that CHECK_RUN events go to Seer even when org is not whitelisted.
-
-        This verifies the bug fix: CHECK_RUN events should bypass the org whitelist
-        check because they are user-initiated reruns from GitHub UI.
-        """
-        mock_get_orgs.return_value = []
-
-        with self.code_review_setup(), self.tasks():
-            self._send_webhook_event(
-                GithubWebhookType.CHECK_RUN,
-                CHECK_RUN_REREQUESTED_ACTION_EVENT_EXAMPLE,
-            )
-
-            mock_make_seer_request.assert_called_once()
-            call_kwargs = mock_make_seer_request.call_args[1]
-            assert call_kwargs["path"] == "/v1/automation/codegen/pr-review/rerun"

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -16,7 +16,6 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
 
     OPTIONS_TO_SET = {
         "github.webhook.issue-comment": False,
-        "seer.code-review.direct-to-seer-enabled-gh-orgs": ["sentry-ecosystem"],
     }
 
     @pytest.fixture(autouse=True)
@@ -169,27 +168,3 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "test-user"
             assert payload["data"]["config"]["trigger_comment_id"] == 123456789
             assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
-
-    def test_processes_whitelisted_github_org(self) -> None:
-        """Test that whitelisted GitHub organizations are processed."""
-        with self.code_review_setup(), self.tasks():
-            event = self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-
-            response = self._send_issue_comment_event(event)
-            assert response.status_code == 204
-
-            self.mock_reaction.assert_called_once()
-            self.mock_seer.assert_called_once()
-
-    def test_skips_non_whitelisted_github_org(self) -> None:
-        """Test that non-whitelisted GitHub organizations are skipped."""
-        with self.code_review_setup(), self.tasks():
-            event = self._build_issue_comment_event(
-                f"Please {SENTRY_REVIEW_COMMAND} this PR", github_org="random-org"
-            )
-
-            response = self._send_issue_comment_event(event)
-            assert response.status_code == 204
-
-            self.mock_reaction.assert_not_called()
-            self.mock_seer.assert_not_called()

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -15,7 +15,6 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
 
     OPTIONS_TO_SET = {
         "github.webhook.pr": False,
-        "seer.code-review.direct-to-seer-enabled-gh-orgs": ["sentry-ecosystem"],
     }
 
     @pytest.fixture(autouse=True)
@@ -218,31 +217,4 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             )
 
             assert response.status_code == 204
-            self.mock_seer.assert_not_called()
-
-    def test_pull_request_processes_whitelisted_github_org(self) -> None:
-        """Test that whitelisted GitHub organizations are processed."""
-        with self.code_review_setup(), self.tasks():
-            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-            event["repository"]["owner"]["login"] = "sentry-ecosystem"
-
-            self._send_webhook_event(
-                GithubWebhookType.PULL_REQUEST,
-                orjson.dumps(event),
-            )
-
-            self.mock_seer.assert_called_once()
-
-    def test_pull_request_skips_non_whitelisted_github_org(self) -> None:
-        """Test that non-whitelisted GitHub organizations are skipped."""
-        with self.code_review_setup(), self.tasks():
-            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-            # "baxterthehacker" is the default in the fixture and is not whitelisted
-            assert event["repository"]["owner"]["login"] == "baxterthehacker"
-
-            self._send_webhook_event(
-                GithubWebhookType.PULL_REQUEST,
-                orjson.dumps(event),
-            )
-
             self.mock_seer.assert_not_called()


### PR DESCRIPTION
In #105844, we started using GitHub whitelisting to help us debug issues in `s4s` and `s4s2`.

We're at the point we don't need this.