### PR TITLE
chore(attr breakdowns): Clean up calling the RRF function

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
@@ -160,9 +160,8 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
         assert "rankedAttributes" in response.data
 
     @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.compare_distributions")
-    @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.keyed_rrf_score")
     def test_baseline_distribution_includes_baseline_only_buckets(
-        self, mock_keyed_rrf_score, mock_compare_distributions
+        self, mock_compare_distributions
     ) -> None:
         """Test that buckets existing only in baseline (not in suspect) are included in scoring.
 
@@ -170,19 +169,14 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
         in all spans but NOT in the suspect cohort were missing from the baseline
         distribution passed to scoring algorithms.
         """
-        # Capture what's passed to the scoring functions
+        # Capture what's passed to compare_distributions
         captured_baseline = None
 
-        def capture_baseline(*args, **kwargs):
+        def capture_compare(*args, **kwargs):
             nonlocal captured_baseline
             captured_baseline = kwargs.get("baseline")
-            # Return results matching the actual internal attribute names
-            return [("sentry.browser", 1.0), ("sentry.device", 0.8)]
-
-        def capture_compare(*args, **kwargs):
             return {"results": [("sentry.browser", 0.9), ("sentry.device", 0.7)]}
 
-        mock_keyed_rrf_score.side_effect = capture_baseline
         mock_compare_distributions.side_effect = capture_compare
 
         tags = [
@@ -292,12 +286,11 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
             ), f"Attribute '{attr_name}' should be filtered (meta attribute)"
 
     @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.compare_distributions")
-    @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.keyed_rrf_score")
     @patch(
         "sentry.api.endpoints.organization_trace_item_attributes_ranked.translate_internal_to_public_alias"
     )
     def test_includes_user_defined_attributes_when_translate_returns_none(
-        self, mock_translate, mock_keyed_rrf_score, mock_compare_distributions
+        self, mock_translate, mock_compare_distributions
     ) -> None:
         """Test that user-defined attributes are included when translate_internal_to_public_alias returns None.
 
@@ -316,14 +309,7 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
 
         mock_translate.side_effect = mock_translate_func
 
-        # Mock primary scoring (keyed_rrf_score) to include our test attributes
-        mock_keyed_rrf_score.return_value = [
-            ("custom_user_attr", 0.9),
-            ("tags[filtered_tag]", 0.8),
-            ("regular_attr", 0.7),
-        ]
-
-        # Mock secondary scoring for RRR ordering
+        # Mock compare_distributions to return our test attributes (now the primary scoring)
         mock_compare_distributions.return_value = {
             "results": [
                 ("custom_user_attr", 0.9),


### PR DESCRIPTION
- Stop calling the RRF scorer
- Requires followup with the frontend and then a backend PR to make sure RRR changes are still being used properly without breaking anything else in the cleanup