### PR TITLE
fix(escalating-forecast): bump down step size for generating forecast again

### DIFF
--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -24,7 +24,7 @@ ParsedGroupsCount = dict[int, GroupCount]
 
 logger = logging.getLogger(__name__)
 
-ITERATOR_CHUNK = 1_000
+ITERATOR_CHUNK = 500
 
 
 @instrumented_task(


### PR DESCRIPTION
Refs SENTRY-4A8H


Follow up to https://github.com/getsentry/sentry/pull/105780 — we bumped it from 5000 -> 1000, and saw a big improvement in timeouts:
<img width="503" height="128" alt="Screenshot 2026-01-12 at 1 23 00 PM" src="https://github.com/user-attachments/assets/2cb4ff7f-06aa-45ab-90cf-d1ae6db59204" />
Tasks were also generated as expected ([datadog](https://app.datadoghq.com/notebook/13706772/weekly-forecast-task-issues)). 

We're still seeing a few timeouts with large queries, and it wouldn't hurt to decrease the step size one more time to fix a few more of these timeouts.