### PR TITLE
fix(aci): fix empty WHEN condition text on details page

### DIFF
--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -32,22 +32,26 @@ function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps) {
     <Panel>
       <ConditionGroupWrapper>
         <ConditionGroupHeader>
-          {tct(
-            '[when:When] an issue event is captured and [logicType] of the following occur',
-            {
-              when: <ConditionBadge />,
-              logicType:
-                TRIGGER_MATCH_OPTIONS.find(choice => choice.value === triggers?.logicType)
-                  ?.label || t('any'),
-            }
-          )}
+          {triggers?.conditions && triggers.conditions.length > 0
+            ? tct(
+                '[when:When] an issue event is captured and [logicType] of the following occur',
+                {
+                  when: <ConditionBadge />,
+                  logicType:
+                    TRIGGER_MATCH_OPTIONS.find(
+                      choice => choice.value === triggers?.logicType
+                    )?.label || t('any'),
+                }
+              )
+            : tct('[when:When] an issue event is captured', {
+                when: <ConditionBadge />,
+              })}
         </ConditionGroupHeader>
         {triggers?.conditions?.map((trigger, index) => (
           <div key={index}>
             <DataConditionDetails condition={trigger} />
           </div>
         ))}
-        {(!triggers || triggers.conditions.length === 0) && t('An event is captured')}
       </ConditionGroupWrapper>
       {actionFilters.map((actionFilter, index) => (
         <div key={index}>


### PR DESCRIPTION
fixes confusing wording on details page when there are no WHEN conditions

before
<img width="371" height="234" alt="image" src="https://github.com/user-attachments/assets/9a283f01-00ab-4b94-b782-3c06f1d0fe42" />

after
<img width="345" height="106" alt="Screenshot 2026-01-12 at 1 42 49 PM" src="https://github.com/user-attachments/assets/df313aea-89a8-4455-8b5f-b7f0db69400c" />
