### PR TITLE
test(location): Support state param in location config

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -341,6 +341,10 @@ function parseLocationConfig(location: LocationConfig | undefined): InitialEntry
     return LocationFixture().pathname;
   }
 
+  if (!location.query && !location.state) {
+    return location.pathname;
+  }
+
   const config: InitialEntry = {
     pathname: location.pathname,
   };

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -83,6 +83,7 @@ interface BaseRenderOptions<T extends boolean = boolean>
 type LocationConfig = {
   pathname: string;
   query?: Record<string, string | number | string[]>;
+  state?: any;
 };
 
 export type RouterConfig = {
@@ -340,14 +341,19 @@ function parseLocationConfig(location: LocationConfig | undefined): InitialEntry
     return LocationFixture().pathname;
   }
 
+  const config: InitialEntry = {
+    pathname: location.pathname,
+  };
+
   if (location.query) {
-    return {
-      pathname: location.pathname,
-      search: parseQueryString(location.query),
-    };
+    config.search = parseQueryString(location.query);
   }
 
-  return location.pathname;
+  if (location.state) {
+    config.state = location.state;
+  }
+
+  return config;
 }
 
 function parseQueryString(query: Record<string, string | number | string[]> | undefined) {
@@ -555,11 +561,11 @@ export * from '@testing-library/react';
 
 export {
   // eslint-disable-next-line import/export
+  fireEvent,
+  // eslint-disable-next-line import/export
   render,
   renderGlobalModal,
   renderHookWithProviders,
   userEvent,
-  // eslint-disable-next-line import/export
-  fireEvent,
   waitForDrawerToHide,
 };


### PR DESCRIPTION
Allows us to set location state on render in tests. Currently `location.state` is typed as `any` so I also used `any` for the typing here.

I'd like to test this property in a flow where a navigation also submits additional state that can be read in the resulting route.