### PR TITLE
fix(seer): Fix repository lookup to handle renamed repos

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -631,45 +631,75 @@ def rpc_get_profile_flamegraph(
     }
 
 
-def get_repository_definition(*, organization_id: int, repo_full_name: str) -> dict | None:
+def get_repository_definition(
+    *,
+    organization_id: int,
+    repo_full_name: str,
+    external_id: str | None = None,
+) -> dict | None:
     """
-    Look up a repository by full name (owner/repo-name) that the org has access to.
+    Look up a repository that the org has access to.
     Returns full RepoDefinition if found and accessible via code mappings, None otherwise.
+
+    Lookup priority:
+    1. external_id (GitHub's repo ID - stable across renames)
+    2. Current name (exact match)
 
     Args:
         organization_id: The ID of the organization
         repo_full_name: Full repository name in format "owner/repo-name" (e.g., "getsentry/seer")
+        external_id: Optional external repository ID (e.g., GitHub repo ID). Stable across renames.
+                     If provided, this is used for lookup instead of name.
 
     Returns:
-        dict with RepoDefinition fields if found, None otherwise
+        dict with RepoDefinition fields if found, None otherwise. Includes external_id
+        which should be stored for future lookups.
     """
-    parts = repo_full_name.split("/")
-    if len(parts) != 2:
-        logger.warning(
-            "seer.rpc.invalid_repo_name_format",
-            extra={"repo_full_name": repo_full_name},
-        )
-        return None
+    repo: Repository | None = None
 
-    owner, name = parts
+    if external_id:
+        repo = Repository.objects.filter(
+            organization_id=organization_id,
+            external_id=external_id,
+            status=ObjectStatus.ACTIVE,
+            provider__in=SEER_SUPPORTED_SCM_PROVIDERS,
+        ).first()
 
-    repo = Repository.objects.filter(
-        organization_id=organization_id,
-        name=repo_full_name,
-        status=ObjectStatus.ACTIVE,
-        provider__in=SEER_SUPPORTED_SCM_PROVIDERS,
-    ).first()
+    if not repo:
+        parts = repo_full_name.split("/")
+        if len(parts) < 2:
+            logger.warning(
+                "seer.rpc.invalid_repo_name_format",
+                extra={"repo_full_name": repo_full_name},
+            )
+            return None
+
+        repo = Repository.objects.filter(
+            organization_id=organization_id,
+            name=repo_full_name,
+            status=ObjectStatus.ACTIVE,
+            provider__in=SEER_SUPPORTED_SCM_PROVIDERS,
+        ).first()
 
     if not repo:
         logger.info(
             "seer.rpc.repository_not_found",
-            extra={"organization_id": organization_id, "repo_full_name": repo_full_name},
+            extra={
+                "organization_id": organization_id,
+                "repo_full_name": repo_full_name,
+                "external_id": external_id,
+            },
         )
         return None
 
+    # Use the actual repo name from the database, not the requested name.
+    repo_name_parts = repo.name.split("/")
+    owner = repo_name_parts[0]
+    name = "/".join(repo_name_parts[1:])
+
     return {
         "organization_id": organization_id,
-        "integration_id": str(repo.integration_id) if repo.integration_id else None,
+        "integration_id": str(repo.integration_id) if repo.integration_id is not None else None,
         "provider": repo.provider,
         "owner": owner,
         "name": name,


### PR DESCRIPTION
<!-- Describe your PR here. -->
Problem:
Current get_repository_ definition() is called by seer uses name lookup which fails when a repository has been renamed.

Solution:
Update the method to take in an optional external_id which stays stable across renaming. A follow up PR in the sentry repo will stash and use these ids for future repo lookups.

Tests:
Added unit tests here for basic functionality of methods. Integration testing will be done with seer before those changes are merged but this should be backwards compatible