### PR TITLE
fix(code-review): Use "prevent" deployment for code review

### DIFF
--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -95,14 +95,12 @@ def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
     # Import here to avoid circular import
     from sentry.seer.code_review.webhooks.config import get_direct_to_seer_gh_orgs
 
+    repo_owner = payload.get("data", {}).get("repo", {}).get("owner")
+    direct_to_seer_orgs = get_direct_to_seer_gh_orgs()
+
     seer_url = (
         settings.SEER_PREVENT_AI_URL
-        if (
-            get_direct_to_seer_gh_orgs()
-            and "organization" in payload
-            and isinstance(payload["organization"], dict)
-            and payload["organization"].get("login") in get_direct_to_seer_gh_orgs()
-        )
+        if (direct_to_seer_orgs and repo_owner and repo_owner in direct_to_seer_orgs)
         else settings.SEER_AUTOFIX_URL
     )
     response = make_signed_seer_api_request(

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -93,7 +93,7 @@ def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
         The response data from the Seer API
     """
     response = make_signed_seer_api_request(
-        connection_pool=connection_from_url(settings.SEER_AUTOFIX_URL),
+        connection_pool=connection_from_url(settings.SEER_PREVENT_AI_URL),
         path=path,
         body=orjson.dumps(payload),
     )

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -92,8 +92,21 @@ def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
     Returns:
         The response data from the Seer API
     """
+    # Import here to avoid circular import
+    from sentry.seer.code_review.webhooks.config import get_direct_to_seer_gh_orgs
+
+    seer_url = (
+        settings.SEER_PREVENT_AI_URL
+        if (
+            get_direct_to_seer_gh_orgs()
+            and "organization" in payload
+            and isinstance(payload["organization"], dict)
+            and payload["organization"].get("login") in get_direct_to_seer_gh_orgs()
+        )
+        else settings.SEER_AUTOFIX_URL
+    )
     response = make_signed_seer_api_request(
-        connection_pool=connection_from_url(settings.SEER_PREVENT_AI_URL),
+        connection_pool=connection_from_url(seer_url),
         path=path,
         body=orjson.dumps(payload),
     )

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
 
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.models.organization import Organization
@@ -10,6 +11,7 @@ from sentry.seer.code_review.utils import (
     SeerCodeReviewTrigger,
     _get_target_commit_sha,
     _get_trigger_metadata,
+    make_seer_request,
     transform_webhook_to_codegen_request,
 )
 from sentry.testutils.cases import TestCase
@@ -282,3 +284,47 @@ class TestTransformWebhookToCodegenRequest:
                 "sha123",
                 SeerCodeReviewTrigger.ON_READY_FOR_REVIEW,
             )
+
+
+class TestMakeSeerRequestUrlSwitch(TestCase):
+    """Test that make_seer_request uses the correct Seer URL based on organization in payload."""
+
+    @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
+    @patch("sentry.seer.code_review.utils.connection_from_url")
+    def test_uses_autofix_url_when_org_not_in_direct_to_seer_list(
+        self, mock_connection: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """When organization is not in the direct-to-seer list, use SEER_AUTOFIX_URL."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.data = b'{"success": true}'
+        mock_request.return_value = mock_response
+
+        with override_settings(
+            SEER_AUTOFIX_URL="https://autofix.seer.example.com",
+            SEER_PREVENT_AI_URL="https://preventai.seer.example.com",
+        ):
+            with self.options({"seer.code-review.direct-to-seer-enabled-gh-orgs": ["other-org"]}):
+                make_seer_request("/test/path", {"organization": {"login": "some-org"}})
+
+            mock_connection.assert_called_once_with("https://autofix.seer.example.com")
+
+    @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
+    @patch("sentry.seer.code_review.utils.connection_from_url")
+    def test_uses_prevent_ai_url_when_org_in_direct_to_seer_list(
+        self, mock_connection: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """When organization login is in the direct-to-seer list, use SEER_PREVENT_AI_URL."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.data = b'{"success": true}'
+        mock_request.return_value = mock_response
+
+        with override_settings(
+            SEER_AUTOFIX_URL="https://autofix.seer.example.com",
+            SEER_PREVENT_AI_URL="https://preventai.seer.example.com",
+        ):
+            with self.options({"seer.code-review.direct-to-seer-enabled-gh-orgs": ["test-org"]}):
+                make_seer_request("/test/path", {"organization": {"login": "test-org"}})
+
+            mock_connection.assert_called_once_with("https://preventai.seer.example.com")

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -287,25 +287,26 @@ class TestTransformWebhookToCodegenRequest:
 
 
 class TestMakeSeerRequestUrlSwitch(TestCase):
-    """Test that make_seer_request uses the correct Seer URL based on organization in payload."""
+    """Test that make_seer_request uses the correct Seer URL based on repo owner in payload."""
 
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.utils.connection_from_url")
     def test_uses_autofix_url_when_org_not_in_direct_to_seer_list(
         self, mock_connection: MagicMock, mock_request: MagicMock
     ) -> None:
-        """When organization is not in the direct-to-seer list, use SEER_AUTOFIX_URL."""
+        """When repo owner is not in the direct-to-seer list, use SEER_AUTOFIX_URL."""
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.data = b'{"success": true}'
         mock_request.return_value = mock_response
+        payload = {"data": {"repo": {"owner": "some-org"}}}
 
         with override_settings(
             SEER_AUTOFIX_URL="https://autofix.seer.example.com",
             SEER_PREVENT_AI_URL="https://preventai.seer.example.com",
         ):
             with self.options({"seer.code-review.direct-to-seer-enabled-gh-orgs": ["other-org"]}):
-                make_seer_request("/test/path", {"organization": {"login": "some-org"}})
+                make_seer_request("/test/path", payload)
 
             mock_connection.assert_called_once_with("https://autofix.seer.example.com")
 
@@ -314,17 +315,18 @@ class TestMakeSeerRequestUrlSwitch(TestCase):
     def test_uses_prevent_ai_url_when_org_in_direct_to_seer_list(
         self, mock_connection: MagicMock, mock_request: MagicMock
     ) -> None:
-        """When organization login is in the direct-to-seer list, use SEER_PREVENT_AI_URL."""
+        """When repo owner is in the direct-to-seer list, use SEER_PREVENT_AI_URL."""
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.data = b'{"success": true}'
         mock_request.return_value = mock_response
+        payload = {"data": {"repo": {"owner": "test-org"}}}
 
         with override_settings(
             SEER_AUTOFIX_URL="https://autofix.seer.example.com",
             SEER_PREVENT_AI_URL="https://preventai.seer.example.com",
         ):
             with self.options({"seer.code-review.direct-to-seer-enabled-gh-orgs": ["test-org"]}):
-                make_seer_request("/test/path", {"organization": {"login": "test-org"}})
+                make_seer_request("/test/path", payload)
 
             mock_connection.assert_called_once_with("https://preventai.seer.example.com")


### PR DESCRIPTION
Use this "prevent" seer deployment for code review. These pods are separate than that for "autofix" feature to allow for separate scaling needed to support the code review feature.

https://github.com/getsentry/sentry/pull/101160
https://github.com/getsentry/getsentry/pull/18575

Closes https://linear.app/getsentry/issue/CW-293/background-on-seer-prevent-deployment-and-rollout
