### PR TITLE
Fix(preprod): Fix list-builds project param for slug or id (EME-730)

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -87,7 +87,11 @@ export function SizeCompareSelectionContent({
     build_configuration: headBuildDetails.app_info?.build_configuration,
     ...(cursor && {cursor}),
     ...(searchQuery && {query: searchQuery}),
-    ...(projectId && {project: projectId}),
+    ...(projectId
+      ? /^\d+$/.test(projectId)
+        ? {project: projectId}
+        : {projectSlug: projectId}
+      : {}),
   };
 
   const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =

--- a/static/app/views/preprod/buildList/buildList.tsx
+++ b/static/app/views/preprod/buildList/buildList.tsx
@@ -37,7 +37,11 @@ export default function BuildList() {
   }
 
   if (projectId) {
-    queryParams.project = projectId;
+    if (/^\d+$/.test(projectId)) {
+      queryParams.project = projectId;
+    } else {
+      queryParams.projectSlug = projectId;
+    }
   }
 
   const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =


### PR DESCRIPTION
endpoint works with either, but we're always parsing as the project ID, even though the compare build button takes you to `{project-slug}` route