### PR TITLE
fix(uptime): Fix skip backfill logic to only run after the interval has been changed

### DIFF
--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -683,6 +683,7 @@ class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
     def update_data_source(self, instance: Detector, data_source: dict[str, Any]):
         subscription = get_uptime_subscription(instance)
         update_uptime_subscription(
+            detector=instance,
             subscription=subscription,
             url=data_source.get("url", NOT_SET),
             interval_seconds=data_source.get("interval_seconds", NOT_SET),

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from datetime import datetime, timezone
 
 from django.db import router, transaction
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
@@ -39,7 +40,12 @@ from sentry.uptime.types import (
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
     UptimeMonitorMode,
 )
-from sentry.uptime.utils import build_fingerprint, build_last_update_key, get_cluster
+from sentry.uptime.utils import (
+    build_fingerprint,
+    build_last_interval_change_timestamp_key,
+    build_last_update_key,
+    get_cluster,
+)
 from sentry.utils.db import atomic_transaction
 from sentry.utils.not_set import NOT_SET, NotSet, default_if_not_set
 from sentry.utils.outcomes import Outcome
@@ -158,6 +164,7 @@ def create_uptime_subscription(
 
 
 def update_uptime_subscription(
+    detector: Detector,
     subscription: UptimeSubscription,
     url: str | NotSet = NOT_SET,
     interval_seconds: int | NotSet = NOT_SET,
@@ -179,12 +186,15 @@ def update_uptime_subscription(
     if headers is None:
         headers = []
 
+    new_interval_seconds = default_if_not_set(subscription.interval_seconds, interval_seconds)
+    interval_updated = new_interval_seconds != subscription.interval_seconds
+
     subscription.update(
         status=UptimeSubscription.Status.UPDATING.value,
         url=url,
         url_domain=result.domain,
         url_domain_suffix=result.suffix,
-        interval_seconds=default_if_not_set(subscription.interval_seconds, interval_seconds),
+        interval_seconds=new_interval_seconds,
         timeout_ms=default_if_not_set(subscription.timeout_ms, timeout_ms),
         method=default_if_not_set(subscription.method, method),
         headers=headers,
@@ -198,6 +208,11 @@ def update_uptime_subscription(
     def commit_tasks():
         update_remote_uptime_subscription.delay(subscription.id)
         fetch_subscription_rdap_info.delay(subscription.id)
+        if interval_updated:
+            last_interval_change_key = build_last_interval_change_timestamp_key(detector)
+            cluster = get_cluster()
+            change_timestamp_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+            cluster.set(last_interval_change_key, change_timestamp_ms, ex=60 * 60 * 24)
 
     transaction.on_commit(commit_tasks, using=router.db_for_write(UptimeSubscription))
 
@@ -366,6 +381,7 @@ def update_uptime_detector(
     ):
         uptime_subscription = get_uptime_subscription(detector)
         update_uptime_subscription(
+            detector,
             uptime_subscription,
             url=url,
             interval_seconds=interval_seconds,

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -10,8 +10,8 @@ def build_last_update_key(detector: Detector) -> str:
     return f"project-sub-last-update:detector:{detector.id}"
 
 
-def build_last_seen_interval_key(detector: Detector) -> str:
-    return f"project-sub-last-seen-interval:detector:{detector.id}"
+def build_last_interval_change_timestamp_key(detector: Detector) -> str:
+    return f"project-sub-last-interval-change-timestamp:detector:{detector.id}"
 
 
 def build_detector_fingerprint_component(detector: Detector) -> str:

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -40,6 +41,7 @@ from sentry.uptime.types import (
     DEFAULT_RECOVERY_THRESHOLD,
     UptimeMonitorMode,
 )
+from sentry.uptime.utils import build_last_interval_change_timestamp_key, get_cluster
 from sentry.utils.outcomes import Outcome
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -173,6 +175,55 @@ class UpdateUptimeSubscriptionTest(UptimeTestCase):
         assert uptime_sub.headers == [["something", "some_val"]]
         assert uptime_sub.body == body
         assert uptime_sub.trace_sampling == trace_sampling
+
+    def test_interval_change_sets_redis_timestamp(self) -> None:
+        """Verify that updating the interval sets the interval change timestamp in Redis."""
+        with self.tasks():
+            uptime_sub = create_uptime_subscription("https://sentry.io", 300, 500)
+        uptime_sub.refresh_from_db()
+
+        detector = self.create_uptime_detector(uptime_subscription=uptime_sub)
+        cluster = get_cluster()
+        interval_change_key = build_last_interval_change_timestamp_key(detector)
+
+        assert cluster.get(interval_change_key) is None
+
+        with self.tasks():
+            update_uptime_subscription(
+                detector=detector,
+                subscription=uptime_sub,
+                interval_seconds=600,
+            )
+
+        timestamp_ms = cluster.get(interval_change_key)
+        assert timestamp_ms is not None
+        assert int(timestamp_ms) > 0
+
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        assert abs(now_ms - int(timestamp_ms)) < 60000  # Within 60 seconds
+
+    def test_no_interval_change_no_redis_timestamp(self) -> None:
+        """Verify that updating without changing interval does not set Redis timestamp."""
+        with self.tasks():
+            uptime_sub = create_uptime_subscription("https://sentry.io", 300, 500)
+        uptime_sub.refresh_from_db()
+
+        # Create a detector for this subscription
+        detector = self.create_uptime_detector(uptime_subscription=uptime_sub)
+        cluster = get_cluster()
+        interval_change_key = build_last_interval_change_timestamp_key(detector)
+
+        # Update with the same interval (no change)
+        with self.tasks():
+            update_uptime_subscription(
+                detector=detector,
+                subscription=uptime_sub,
+                url="https://santry.io",  # Change something else
+                interval_seconds=300,  # Same as original
+            )
+
+        # Verify no timestamp was set
+        assert cluster.get(interval_change_key) is None
 
 
 class DeleteUptimeSubscriptionTest(UptimeTestCase):

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -145,6 +145,9 @@ class UpdateUptimeSubscriptionTest(UptimeTestCase):
         uptime_sub.refresh_from_db()
         prev_subscription_id = uptime_sub.subscription_id
 
+        # Create a detector for this subscription
+        detector = self.create_uptime_detector(uptime_subscription=uptime_sub)
+
         url = "https://santry.io"
         interval_seconds = 600
         timeout_ms = 1000
@@ -153,12 +156,13 @@ class UpdateUptimeSubscriptionTest(UptimeTestCase):
         trace_sampling = True
         with self.tasks():
             update_uptime_subscription(
-                uptime_sub,
-                url,
-                interval_seconds,
-                timeout_ms,
-                method,
-                [("something", "some_val")],
+                detector=detector,
+                subscription=uptime_sub,
+                url=url,
+                interval_seconds=interval_seconds,
+                timeout_ms=timeout_ms,
+                method=method,
+                headers=[("something", "some_val")],
                 body=body,
                 trace_sampling=trace_sampling,
             )


### PR DESCRIPTION
Currently, the skip backfill logic is causing us to not write misses a lot of the time. I'm updating this logic so that we:
 - Store a timestamp after we update the interval
 - If the last_update_ms timestamp occurred before the update, then skip the backfill, since we can assume that any misses there are caused by the change in interval.
