### PR TITLE
fix(aci): fix empty targetIdentifier for slack action

### DIFF
--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -490,7 +490,7 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     actionHandler.sentryApp?.id ??
     actionHandler.integrations?.[0]?.services?.[0]?.id ??
     actionHandler.services?.[0]?.slug ??
-    null;
+    '';
   const targetDisplay =
     actionHandler.sentryApp?.name ??
     actionHandler.integrations?.[0]?.services?.[0]?.name ??

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -7,6 +7,7 @@ import type {
   ActionHandler,
 } from 'sentry/types/workflowEngine/actions';
 import {
+  ActionGroup,
   ActionTarget,
   ActionType,
   SentryAppIdentifier,
@@ -486,11 +487,18 @@ function getActionTargetType(actionType: ActionType): ActionTarget | null {
 
 function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
   const targetType = getActionTargetType(actionHandler.type);
-  const targetIdentifier =
+  const defaultTargetIdentifier =
     actionHandler.sentryApp?.id ??
     actionHandler.integrations?.[0]?.services?.[0]?.id ??
-    actionHandler.services?.[0]?.slug ??
-    '';
+    actionHandler.services?.[0]?.slug;
+
+  // Ticket creation actions require null (per backend schema)
+  // All other actions use empty string
+  const fallbackTargetIdentifier =
+    actionHandler.handlerGroup === ActionGroup.TICKET_CREATION ? null : '';
+
+  const targetIdentifier = defaultTargetIdentifier ?? fallbackTargetIdentifier;
+
   const targetDisplay =
     actionHandler.sentryApp?.name ??
     actionHandler.integrations?.[0]?.services?.[0]?.name ??

--- a/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
+++ b/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
@@ -18,7 +18,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: ActionTarget.ISSUE_OWNERS,
           targetDisplay: null,
-          targetIdentifier: null,
+          targetIdentifier: '',
         },
       });
 

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -180,7 +180,7 @@ describe('AutomationNewSettings', () => {
                     type: 'slack',
                     config: {
                       targetType: 'specific',
-                      targetIdentifier: null,
+                      targetIdentifier: '',
                       targetDisplay: '#alerts',
                     },
                     integrationId: '1',


### PR DESCRIPTION
Slack actions require targetIdentifier passed as a string instead of null

fixes https://linear.app/getsentry/issue/ISWF-834/attempting-to-create-a-new-alert-for-a-metric-monitor-and-send-a-test
fixes https://linear.app/getsentry/issue/ISWF-843/slack-alert-is-user-id-actually-optional