### PR TITLE
fix(dynamic-grouping): Remove cluster id when selecting project

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -735,7 +735,7 @@ function DynamicGrouping() {
           </Flex>
 
           <Flex gap="sm" align="center" style={{marginBottom: space(2)}}>
-            <ProjectPageFilter />
+            <ProjectPageFilter resetParamsOnChange={['cluster']} />
             {showDevTools && (
               <Button
                 size="sm"


### PR DESCRIPTION
removes the cluster query parameter if the project selection is changed
