### PR TITLE
fix(grouping): Parameterize hard-coded values in Python process spawning code

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -62,6 +62,8 @@ register_grouping_config(
         # Preserve a long-standing bug, wherein our "non-URL frame" test actually looks for frames
         # *with* URLs
         "handle_js_single_frame_url_origin_backwards": True,
+        # Don't parameterize `spawn_main(tracker_fd=12, pipe_handle=31)`-type context lines
+        "prevent_python_multiprocessing_context_line_parameterization": True,
     },
     enhancements_base="all-platforms:2023-01-11",
     fingerprinting_bases=["javascript@2024-02-02"],

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -75,6 +75,7 @@ register_grouping_config(
     initial_context={
         "use_legacy_exception_subcomponent_order": False,
         "handle_js_single_frame_url_origin_backwards": False,
+        "prevent_python_multiprocessing_context_line_parameterization": False,
     },
     enhancements_base="all-platforms:2025-11-21",
 )

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -22,7 +22,7 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "3571928a03eadf8e0e5c9b10b81a51de"
+    hash: "4f60cfec2087a65190b283cb848bea62"
     contributing component: exception
     hint: None
     root_component:
@@ -37,7 +37,7 @@ contributing variants:
               function*
                 "<module>"
               context_line*
-                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
             frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
@@ -102,7 +102,7 @@ contributing variants:
               context_line*
                 "run_post_process_job("
   system*
-    hash: "6791947bdfd6cf2ca7024f026df974ae"
+    hash: "e5ae333037d1ba0ea9379b6d9693aca4"
     contributing component: exception
     hint: None
     root_component:
@@ -117,7 +117,7 @@ contributing variants:
               function*
                 "<module>"
               context_line*
-                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
             frame*
               module*
                 "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -22,7 +22,7 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "5c93008bb8f6628bbcd13c401f2d16fa"
+    hash: "126f65e182d6fbc222480cf9f391a3e1"
     contributing component: exception
     hint: None
     root_component:
@@ -37,7 +37,7 @@ contributing variants:
               function*
                 "<module>"
               context_line*
-                "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
             frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
               module*
                 "multiprocessing.spawn"
@@ -102,7 +102,7 @@ contributing variants:
               context_line*
                 "run_post_process_job("
   system*
-    hash: "405c5ace25bef65fa6193d0c0a18b059"
+    hash: "bce0926d11f0ebe7d72ab74b56717aa6"
     contributing component: exception
     hint: None
     root_component:
@@ -117,7 +117,7 @@ contributing variants:
               function*
                 "<module>"
               context_line*
-                "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
             frame*
               module*
                 "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -80,7 +80,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -929,7 +929,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "exception stacktrace — in-app frames",
-      "hash": "3571928a03eadf8e0e5c9b10b81a51de",
+      "hash": "4f60cfec2087a65190b283cb848bea62",
       "hint": null,
       "key": "app_exception_stacktrace",
       "type": "component"
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "exception stacktrace — all frames",
-      "hash": "6791947bdfd6cf2ca7024f026df974ae",
+      "hash": "e5ae333037d1ba0ea9379b6d9693aca4",
       "hint": null,
       "key": "system_exception_stacktrace",
       "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -80,7 +80,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -929,7 +929,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "exception stacktrace — in-app frames",
-      "hash": "5c93008bb8f6628bbcd13c401f2d16fa",
+      "hash": "126f65e182d6fbc222480cf9f391a3e1",
       "hint": null,
       "key": "app_exception_stacktrace",
       "type": "component"
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "exception stacktrace — all frames",
-      "hash": "405c5ace25bef65fa6193d0c0a18b059",
+      "hash": "bce0926d11f0ebe7d72ab74b56717aa6",
       "hint": null,
       "key": "system_exception_stacktrace",
       "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -80,7 +80,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -80,7 +80,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+                          "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
                         ]
                       }
                     ]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_posix.pysnap
@@ -2,7 +2,7 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "3571928a03eadf8e0e5c9b10b81a51de"
+  hash: "4f60cfec2087a65190b283cb848bea62"
   contributing component: exception
   hint: None
   root_component:
@@ -21,7 +21,7 @@ app:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
           frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
@@ -204,7 +204,7 @@ default:
         "Failed to process pipeline step %s"
 --------------------------------------------------------------------------
 system:
-  hash: "6791947bdfd6cf2ca7024f026df974ae"
+  hash: "e5ae333037d1ba0ea9379b6d9693aca4"
   contributing component: exception
   hint: None
   root_component:
@@ -223,7 +223,7 @@ system:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
           frame*
             module*
               "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -2,7 +2,7 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "5c93008bb8f6628bbcd13c401f2d16fa"
+  hash: "126f65e182d6fbc222480cf9f391a3e1"
   contributing component: exception
   hint: None
   root_component:
@@ -21,7 +21,7 @@ app:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
           frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
             module*
               "multiprocessing.spawn"
@@ -204,7 +204,7 @@ default:
         "Failed to process pipeline step %s"
 --------------------------------------------------------------------------
 system:
-  hash: "405c5ace25bef65fa6193d0c0a18b059"
+  hash: "bce0926d11f0ebe7d72ab74b56717aa6"
   contributing component: exception
   hint: None
   root_component:
@@ -223,7 +223,7 @@ system:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
           frame*
             module*
               "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_posix.pysnap
@@ -21,7 +21,7 @@ app:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
           frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
@@ -223,7 +223,7 @@ system:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
           frame*
             module*
               "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -21,7 +21,7 @@ app:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
           frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
@@ -223,7 +223,7 @@ system:
             function*
               "<module>"
             context_line*
-              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
+              "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
           frame*
             module*
               "multiprocessing.spawn"

--- a/tests/sentry/stacktraces/test_context_line.py
+++ b/tests/sentry/stacktraces/test_context_line.py
@@ -1,0 +1,96 @@
+from typing import Any
+from unittest import TestCase
+
+from sentry.conf.server import WINTER_2023_GROUPING_CONFIG
+from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
+from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
+
+
+def _get_context_lines(event_data: dict[str, Any]) -> list[str]:
+    frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
+    return [frame["context_line"] for frame in frames]
+
+
+class PythonMultiprocessingContextLineTest(TestCase):
+    POSIX_MULTIPROCESSING_CONTEXT_LINE = (
+        "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=21)"
+    )
+    WINDOWS_MULTIPROCESSING_CONTEXT_LINE = (
+        "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=12, pipe_handle=31)"
+    )
+
+    def _make_event_data(self, context_lines: list[str], platform: str) -> dict[str, Any]:
+        return {
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "module": "__main__",
+                                    "filename": "<string>",
+                                    "function": "<module>",
+                                    "context_line": context_line,
+                                }
+                                for context_line in context_lines
+                            ],
+                        },
+                    }
+                ]
+            },
+            "platform": platform,
+        }
+
+    def test_no_parameterization_for_non_python_events(self) -> None:
+        context_lines = [self.POSIX_MULTIPROCESSING_CONTEXT_LINE]
+        event_data = self._make_event_data(context_lines, "javascript")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_context_lines(event_data) == context_lines
+
+    def test_no_parameterization_for_other_numbers_in_python_context_lines(self) -> None:
+        context_lines = [
+            "number_1_dog = 'maisey'",
+            "charlie_is_co_number_1_dog = True",
+            "maisey_dog_ranking = 1",
+            "charlie_dog_ranking = 1",
+        ]
+        event_data = self._make_event_data(context_lines, "python")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_context_lines(event_data) == context_lines
+
+    # TODO: This can go away once we're fully transitioned off of the `newstyle:2023-01-11` grouping
+    # config
+    def test_no_parameterization_under_2023_grouping_config(self) -> None:
+        context_lines = [self.POSIX_MULTIPROCESSING_CONTEXT_LINE]
+        event_data = self._make_event_data(context_lines, "javascript")
+
+        normalize_stacktraces_for_grouping(
+            event_data,
+            load_grouping_config(get_default_grouping_config_dict(WINTER_2023_GROUPING_CONFIG)),
+        )
+
+        assert _get_context_lines(event_data) == context_lines
+
+    def test_parameterizes_python_multiprocess_spawn_calls_posix(self) -> None:
+        context_lines = [self.POSIX_MULTIPROCESSING_CONTEXT_LINE]
+        event_data = self._make_event_data(context_lines, "python")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_context_lines(event_data) == [
+            "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=<int>, pipe_handle=<int>)"
+        ]
+
+    def test_parameterizes_python_multiprocess_spawn_calls_windows(self) -> None:
+        context_lines = [self.WINDOWS_MULTIPROCESSING_CONTEXT_LINE]
+        event_data = self._make_event_data(context_lines, "python")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_context_lines(event_data) == [
+            "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
+        ]


### PR DESCRIPTION
In Cpython, the way that process spawning is implemented is by [creating the spawn command for each process on the fly](https://github.com/python/cpython/blob/d5882c5b7057b1b0a9dfd7b797a44d27e12d7ad3/Lib/multiprocessing/spawn.py#L91-L92), and running it in the interpreter. This means that when such a process crashes, the command ends up as part of the stacktrace. And because the command includes specific values (for `tracker_fd`, `pipe_handle`, and/or `parent_pid`, depending on the operating system), each stacktrace ends up looking different to our grouping algorithm, because it doesn't expect event-specific values to show up in code lines. (See https://github.com/getsentry/sentry-python/issues/4744 for what this looks like in practice.) As a result, we end up under-grouping events.

To fix this problem, this PR adds parameterization to context lines which appear to originate from Cpython's process spawning. Because this will change grouping, it also adds a grouping config option, `prevent_python_multiprocessing_context_line_parameterization` (defaulting to `True`) so that the change won't take effect until the new grouping config is activated.