### PR TITLE
fix(aci): allow action interval of 0 mins

### DIFF
--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -93,7 +93,7 @@ export function getAutomationFormData(
   return {
     detectorIds: automation.detectorIds,
     environment: automation.environment,
-    frequency: automation.config.frequency || null,
+    frequency: automation.config.frequency ?? 0,
     name: automation.name,
     enabled: automation.enabled,
     projectIds: [],

--- a/static/app/views/automations/components/forms/actionIntervalSelectField.tsx
+++ b/static/app/views/automations/components/forms/actionIntervalSelectField.tsx
@@ -6,6 +6,7 @@ import SelectField, {
 import {t} from 'sentry/locale';
 
 const FREQUENCY_OPTIONS = [
+  {value: 0, label: t('0 minutes')},
   {value: 5, label: t('5 minutes')},
   {value: 10, label: t('10 minutes')},
   {value: 30, label: t('30 minutes')},


### PR DESCRIPTION
we previously required an action interval of at least 5 mins, but metric alerts were migrated to not have an action interval (`frequency`) so we need to add this as an option in the UI

<img width="402" height="158" alt="Screenshot 2026-01-12 at 3 41 59 PM" src="https://github.com/user-attachments/assets/bd1ef0e1-987b-4882-98c7-88f71aa69327" />

closes https://linear.app/getsentry/issue/ISWF-835/zero-minute-action-interval