### PR TITLE
chore(aci): default to using issue stream detector

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3336,13 +3336,6 @@ register(
 )
 
 register(
-    "workflow_engine.exclude_issue_stream_detector",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "grouping.grouphash_metadata.ingestion_writes_enabled",
     type=Bool,
     default=True,

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -275,22 +275,20 @@ def get_detectors_for_event_data(
     We expect a detector to be passed in for Activity updates.
     """
     issue_stream_detector: Detector | None = None
-    exclude_issue_stream = options.get("workflow_engine.exclude_issue_stream_detector")
 
-    if not exclude_issue_stream:
-        try:
-            issue_stream_detector = Detector.get_issue_stream_detector_for_project(
-                event_data.group.project_id
-            )
-        except Detector.DoesNotExist:
-            metrics.incr("workflow_engine.detectors.error")
-            logger.exception(
-                "Issue stream detector not found for event",
-                extra={
-                    "project_id": event_data.group.project_id,
-                    "group_id": event_data.group.id,
-                },
-            )
+    try:
+        issue_stream_detector = Detector.get_issue_stream_detector_for_project(
+            event_data.group.project_id
+        )
+    except Detector.DoesNotExist:
+        metrics.incr("workflow_engine.detectors.error")
+        logger.exception(
+            "Issue stream detector not found for event",
+            extra={
+                "project_id": event_data.group.project_id,
+                "group_id": event_data.group.id,
+            },
+        )
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         try:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -445,7 +445,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert WorkflowFireHistory.objects.count() == 3
         assert mock_trigger_action.call_count == 3
 
-    @override_options({"workflow_engine.exclude_issue_stream_detector": False})
     def test_uses_issue_stream_workflows(self) -> None:
         issue_occurrence = self.build_occurrence()
         self.group_event.occurrence = issue_occurrence
@@ -466,7 +465,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert result.data.triggered_actions is not None
         assert len(result.data.triggered_actions) == 0
 
-    @override_options({"workflow_engine.exclude_issue_stream_detector": False})
     def test_multiple_detectors__preferred(self) -> None:
         _, issue_stream_detector, _, _ = self.create_detector_and_workflow(
             name_prefix="issue_stream",

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -572,7 +572,6 @@ class TestWorkflowEngineIntegrationPostProcessRollout(BaseWorkflowIntegrationTes
     @override_options(
         {
             "workflow_engine.issue_alert.group.type_id.ga": [1],
-            "workflow_engine.exclude_issue_stream_detector": True,
         }
     )
     def test_errors_only_rollout(self) -> None:
@@ -585,20 +584,6 @@ class TestWorkflowEngineIntegrationPostProcessRollout(BaseWorkflowIntegrationTes
     @override_options(
         {
             "workflow_engine.issue_alert.group.type_id.ga": [1],
-            "workflow_engine.exclude_issue_stream_detector": False,
-        }
-    )
-    def test_issue_stream_errors_only(self) -> None:
-        with mock.patch(
-            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
-        ) as mock_process_workflow:
-            self.call_post_process_group(self.feedback_group.id)
-            assert not mock_process_workflow.called  # still not called because not in rollout FF
-
-    @override_options(
-        {
-            "workflow_engine.issue_alert.group.type_id.ga": [1],
-            "workflow_engine.exclude_issue_stream_detector": False,
             "workflow_engine.issue_alert.group.type_id.rollout": [6001],
         }
     )


### PR DESCRIPTION
This options call is being made for every single event and we're using the issue stream detector now, so we can remove it.