### PR TITLE
chore(aci): option for defaulting to rule or workflow id in notifs

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -63,7 +63,10 @@ from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
     get_suspect_commit_users,
 )
-from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.notifications.utils.rules import (
+    get_rule_or_workflow_id,
+    get_rule_or_workflow_id_default,
+)
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
@@ -668,7 +671,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         rule_id = None
         rule_environment_id = None
-        key = "legacy_rule_id"
+        key = get_rule_or_workflow_id_default()
         if self.rules:
             key, value = get_rule_or_workflow_id(self.rules[0])
             rule_id = int(value)

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -40,7 +40,7 @@ def get_rule_or_workflow_id_default() -> str:
 
 
 def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
-    keys = ["legacy_rule_id", "workflow_id"]
+    keys: list[RuleIdType] = ["legacy_rule_id", "workflow_id"]
     if options.get("workflow_engine.default_workflow_links"):
         keys = ["workflow_id", "legacy_rule_id"]
 

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -49,4 +49,4 @@ def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
             return (key, get_key_from_rule_data(rule, key))
         except AssertionError:
             pass
-    return (get_rule_or_workflow_id_default(), str(rule.id))
+    return (keys[0], str(rule.id))  # default is first key

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
+from sentry import options
 from sentry.models.rule import Rule
 
 RuleIdType = Literal["workflow_id", "legacy_rule_id"]
@@ -32,13 +33,20 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
     return RulesAndWorkflows(rules=parsed_rules, workflow_rules=workflow_rules)
 
 
-def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
-    try:
-        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
-    except AssertionError:
-        pass
+def get_rule_or_workflow_id_default() -> str:
+    if options.get("workflow_engine.default_workflow_links"):
+        return "workflow_id"
+    return "legacy_rule_id"
 
-    try:
-        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
-    except AssertionError:
-        return ("legacy_rule_id", str(rule.id))
+
+def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
+    keys = ["legacy_rule_id", "workflow_id"]
+    if options.get("workflow_engine.default_workflow_links"):
+        keys = ["workflow_id", "legacy_rule_id"]
+
+    for key in keys:
+        try:
+            return (key, get_key_from_rule_data(rule, key))
+        except AssertionError:
+            pass
+    return (get_rule_or_workflow_id_default(), str(rule.id))

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3351,6 +3351,13 @@ register(
 )
 
 register(
+    "workflow_engine.default_workflow_links",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "grouping.grouphash_metadata.ingestion_writes_enabled",
     type=Bool,
     default=True,


### PR DESCRIPTION
When we are sure we won't roll back GA, we can start sending links solely to workflows, remove the redirection in the UI, and voila we're never showing people Rules again