### PR TITLE
fix(search-query-builder): remove underline from Alpha badge

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -54,18 +54,19 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
     <AskSeerListItem ref={ref} onClick={handleClick} {...optionProps}>
       <InteractionStateLayer isHovered={isFocused} isPressed={isPressed} />
       <IconSeer />
-      <AiPrivacyTooltip
-        linkProps={{
-          onMouseOver: () => setOptionDisableOverride(true),
-          onMouseOut: () => setOptionDisableOverride(false),
-        }}
-        showUnderline={hasAskSeerConsentFlowChanges}
-        disabled={!hasAskSeerConsentFlowChanges}
-      >
-        <AskSeerLabel {...labelProps}>
-          {t('Ask AI to build your query')} <FeatureBadge type={aiSearchBadgeType} />
-        </AskSeerLabel>
-      </AiPrivacyTooltip>
+      <AskSeerLabel {...labelProps}>
+        <AiPrivacyTooltip
+          linkProps={{
+            onMouseOver: () => setOptionDisableOverride(true),
+            onMouseOut: () => setOptionDisableOverride(false),
+          }}
+          showUnderline={hasAskSeerConsentFlowChanges}
+          disabled={!hasAskSeerConsentFlowChanges}
+        >
+          {t('Ask AI to build your query')}
+        </AiPrivacyTooltip>
+        <FeatureBadge type={aiSearchBadgeType} />
+      </AskSeerLabel>
     </AskSeerListItem>
   );
 }


### PR DESCRIPTION
The 'Alpha' badge has an underline in the search query builder:
<img width="269" height="36" alt="Screenshot 2026-01-12 at 5 28 13 PM" src="https://github.com/user-attachments/assets/809f02c8-560a-4255-9c55-5af85e33a79c" />

Slightly edited version, to be consistent with the beta badge and other places in the app:
<img width="308" height="52" alt="Screenshot 2026-01-12 at 5 28 27 PM" src="https://github.com/user-attachments/assets/e968f784-c291-4683-841d-414c8bef5d0d" />
