### PR TITLE
ref: Add convert_args to ProjectArtifactBundleFileDetailsEndpoint

### DIFF
--- a/src/sentry/api/bases/artifact_bundle.py
+++ b/src/sentry/api/bases/artifact_bundle.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.models.artifactbundle import ArtifactBundle
+from sentry.models.project import Project
+
+
+class ProjectArtifactBundleEndpoint(ProjectEndpoint):
+    """
+    Base class for endpoints that operate on artifact bundles within a project.
+
+    This class provides common functionality for resolving artifact bundles
+    that are bound to a specific project.
+    """
+
+    def convert_args(
+        self,
+        request: Request,
+        bundle_id: str,
+        *args,
+        **kwargs,
+    ):
+        # Call parent to get project
+        args, kwargs = super().convert_args(request, *args, **kwargs)
+        project: Project = kwargs["project"]
+
+        # Fetch artifact bundle bound to this project
+        try:
+            artifact_bundle = ArtifactBundle.objects.filter(
+                organization_id=project.organization.id,
+                bundle_id=bundle_id,
+                projectartifactbundle__project_id=project.id,
+            )[0]
+        except IndexError:
+            raise ParseError(
+                f"The artifact bundle with {bundle_id} is not bound to this project or doesn't exist"
+            )
+
+        kwargs["artifact_bundle"] = artifact_bundle
+        return args, kwargs

--- a/src/sentry/api/bases/artifact_bundle.py
+++ b/src/sentry/api/bases/artifact_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 
@@ -20,9 +22,9 @@ class ProjectArtifactBundleEndpoint(ProjectEndpoint):
         self,
         request: Request,
         bundle_id: str,
-        *args,
-        **kwargs,
-    ):
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         # Call parent to get project
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project: Project = kwargs["project"]

--- a/src/sentry/api/bases/artifact_bundle.py
+++ b/src/sentry/api/bases/artifact_bundle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from rest_framework import status
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, ErrorDetail
 from rest_framework.request import Request
 
 from sentry.api.bases.project import ProjectEndpoint
@@ -24,7 +24,7 @@ class ArtifactBundleError(APIException):
     def __init__(self, message: str):
         # Set detail directly to produce {"error": "..."} format
         # instead of DRF's default {"detail": "..."} format
-        self.detail = {"error": message}
+        self.detail = {"error": ErrorDetail(message)}
 
 
 class ProjectArtifactBundleEndpoint(ProjectEndpoint):


### PR DESCRIPTION
## Summary

Implement `convert_args` method in `ProjectArtifactBundleFileDetailsEndpoint` to eliminate duplicate artifact bundle fetching.

**Changes:**
- Added `convert_args` method to resolve artifact bundle once during URL resolution
- Moved artifact bundle lookup from `get()` method to `convert_args`
- Added type annotations for `project`, `artifact_bundle`, and `file_id` parameters
- Used `ParseError` to preserve 400 status code for bundles not bound to project
- Kept file_id validation in `get()` to maintain existing error handling

**Benefits:**
- Reduces redundant database queries
- Improves code maintainability
- Follows established pattern used in other endpoints

**Error Handling Preserved:**
- 400 status for bundles not bound to the project (using `ParseError`)
- 400 status for invalid file_id encoding (handled in `get()`)
- 403 status for permission denials (handled in `get()`)
- 404 status for files not found in bundle (handled in mixin)

## Test Plan

- [x] All existing tests pass (2/2)
- [x] No behavioral changes
- [x] All error codes preserved (400, 403, 404)
- [x] Pre-commit hooks pass