### PR TITLE
fix(oauth): Support public clients for device flow per RFC 8628 §5.6

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -17,11 +17,7 @@ from rest_framework.request import Request
 from sentry import options
 from sentry.locks import locks
 from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus
-from sentry.models.apidevicecode import (
-    DEFAULT_INTERVAL,
-    ApiDeviceCode,
-    DeviceCodeStatus,
-)
+from sentry.models.apidevicecode import DEFAULT_INTERVAL, ApiDeviceCode, DeviceCodeStatus
 from sentry.models.apigrant import ApiGrant, ExpiredGrantError, InvalidGrantError
 from sentry.models.apitoken import ApiToken
 from sentry.ratelimits import backend as ratelimiter

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -17,7 +17,11 @@ from rest_framework.request import Request
 from sentry import options
 from sentry.locks import locks
 from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus
-from sentry.models.apidevicecode import DEFAULT_INTERVAL, ApiDeviceCode, DeviceCodeStatus
+from sentry.models.apidevicecode import (
+    DEFAULT_INTERVAL,
+    ApiDeviceCode,
+    DeviceCodeStatus,
+)
 from sentry.models.apigrant import ApiGrant, ExpiredGrantError, InvalidGrantError
 from sentry.models.apitoken import ApiToken
 from sentry.ratelimits import backend as ratelimiter
@@ -104,6 +108,8 @@ class OAuthTokenView(View):
         Client authentication
         - Either Authorization header (Basic) or form fields `client_id`/`client_secret`
           (RFC 6749 §2.3.1). Only one method may be used per request.
+        - For device_code grant: supports public clients per RFC 8628 §5.6, which only
+          require `client_id`. If `client_secret` is provided, it will be validated.
 
         Request format
         - Requests are `application/x-www-form-urlencoded` as defined in RFC 6749 §3.2.
@@ -120,6 +126,16 @@ class OAuthTokenView(View):
         """
         grant_type = request.POST.get("grant_type")
 
+        # Validate grant_type first (needed to determine auth requirements)
+        if not grant_type:
+            return self.error(request=request, name="invalid_request", reason="missing grant_type")
+        if grant_type not in [
+            GrantTypes.AUTHORIZATION,
+            GrantTypes.REFRESH,
+            GrantTypes.DEVICE_CODE,
+        ]:
+            return self.error(request=request, name="unsupported_grant_type")
+
         # Determine client credentials from header or body (mutually exclusive).
         (client_id, client_secret), cred_error = self._extract_basic_auth_credentials(request)
         if cred_error is not None:
@@ -131,42 +147,76 @@ class OAuthTokenView(View):
             tags={
                 "client_id_exists": bool(client_id),
                 "client_secret_exists": bool(client_secret),
+                "grant_type": grant_type,
             },
         )
 
-        if not client_id or not client_secret:
-            return self.error(
-                request=request,
-                name="invalid_client",
-                reason="missing client credentials",
-                status=401,
-            )
+        # Device flow supports public clients per RFC 8628 §5.6.
+        # Public clients only provide client_id to identify themselves.
+        # If client_secret is provided, we still validate it for confidential clients.
+        if grant_type == GrantTypes.DEVICE_CODE:
+            if not client_id:
+                return self.error(
+                    request=request,
+                    name="invalid_client",
+                    reason="missing client_id",
+                    status=401,
+                )
 
-        if not grant_type:
-            return self.error(request=request, name="invalid_request", reason="missing grant_type")
-        if grant_type not in [GrantTypes.AUTHORIZATION, GrantTypes.REFRESH, GrantTypes.DEVICE_CODE]:
-            return self.error(request=request, name="unsupported_grant_type")
+            # Build query - validate secret only if provided (confidential client)
+            query = {"client_id": client_id}
+            if client_secret:
+                query["client_secret"] = client_secret
 
-        try:
-            # Note: We don't filter by status here to distinguish between invalid
-            # credentials (unknown client) and inactive applications. This allows
-            # proper grant cleanup per RFC 6749 §10.5 and clearer metrics.
-            application = ApiApplication.objects.get(
-                client_id=client_id,
-                client_secret=client_secret,
-            )
-        except ApiApplication.DoesNotExist:
-            metrics.incr(
-                "oauth_token.post.invalid",
-                sample_rate=1.0,
-            )
-            logger.warning("Invalid client_id / secret pair", extra={"client_id": client_id})
-            return self.error(
-                request=request,
-                name="invalid_client",
-                reason="invalid client_id or client_secret",
-                status=401,
-            )
+            try:
+                application = ApiApplication.objects.get(**query)
+            except ApiApplication.DoesNotExist:
+                metrics.incr("oauth_token.post.invalid", sample_rate=1.0)
+                if client_secret:
+                    logger.warning(
+                        "Invalid client_id / secret pair",
+                        extra={"client_id": client_id},
+                    )
+                    reason = "invalid client_id or client_secret"
+                else:
+                    logger.warning("Invalid client_id", extra={"client_id": client_id})
+                    reason = "invalid client_id"
+                return self.error(
+                    request=request,
+                    name="invalid_client",
+                    reason=reason,
+                    status=401,
+                )
+        else:
+            # Other grant types require confidential client authentication
+            if not client_id or not client_secret:
+                return self.error(
+                    request=request,
+                    name="invalid_client",
+                    reason="missing client credentials",
+                    status=401,
+                )
+
+            try:
+                # Note: We don't filter by status here to distinguish between invalid
+                # credentials (unknown client) and inactive applications. This allows
+                # proper grant cleanup per RFC 6749 §10.5 and clearer metrics.
+                application = ApiApplication.objects.get(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+            except ApiApplication.DoesNotExist:
+                metrics.incr(
+                    "oauth_token.post.invalid",
+                    sample_rate=1.0,
+                )
+                logger.warning("Invalid client_id / secret pair", extra={"client_id": client_id})
+                return self.error(
+                    request=request,
+                    name="invalid_client",
+                    reason="invalid client_id or client_secret",
+                    status=401,
+                )
 
         # Check application status separately from credential validation.
         # This preserves metric clarity and provides consistent error handling.
@@ -340,9 +390,15 @@ class OAuthTokenView(View):
                 code_verifier=request.POST.get("code_verifier"),
             )
         except InvalidGrantError as e:
-            return {"error": "invalid_grant", "reason": str(e) if str(e) else "invalid grant"}
+            return {
+                "error": "invalid_grant",
+                "reason": str(e) if str(e) else "invalid grant",
+            }
         except ExpiredGrantError as e:
-            return {"error": "invalid_grant", "reason": str(e) if str(e) else "grant expired"}
+            return {
+                "error": "invalid_grant",
+                "reason": str(e) if str(e) else "grant expired",
+            }
 
         token_data = {"token": api_token}
 


### PR DESCRIPTION
## Summary

Fixes the OAuth 2.0 Device Authorization Grant implementation to properly support **public clients** as required by [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628).

## Problem

The current token endpoint requires `client_secret` for ALL grant types, including `device_code`. This breaks the fundamental design of the device flow, which is explicitly designed for public clients (CLIs, native apps, IoT devices) that **cannot securely store secrets**.

### What the RFC Says

**[RFC 8628 §5.6 - Non-Confidential Clients](https://datatracker.ietf.org/doc/html/rfc8628#section-5.6):**
> Device clients are generally incapable of maintaining the confidentiality of their credentials, as users in possession of the device can reverse-engineer it and extract the credentials. **Therefore, unless additional measures are taken, they should be treated as public clients** (as defined by Section 2.1 of [RFC6749]).

**[RFC 8628 §3.4 - Device Access Token Request](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4):**
> `client_id` - REQUIRED if the client is **not authenticating** with the authorization server as described in Section 3.2.1. of [RFC6749].

**[RFC 6749 §2.1 - Client Types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1):**
> **public** - Clients incapable of maintaining the confidentiality of their credentials (e.g., clients executing on the device used by the resource owner, such as an installed native application or a web browser-based application)

## Solution

- Move `grant_type` validation **before** credential check (needed to determine auth requirements)
- For `device_code` grant: only require `client_id` (public client mode per RFC 8628 §5.6)
- If `client_secret` is provided: still validate it (supports confidential clients that choose to authenticate)
- Other grant types (`authorization_code`, `refresh_token`): unchanged, still require `client_id` + `client_secret`

## Changes

| File | Change |
|------|--------|
| `src/sentry/web/frontend/oauth_token.py` | Allow public client auth for device_code grant |
| `tests/sentry/web/frontend/test_oauth_token.py` | Added 5 new tests for public client support |

## New Tests

1. `test_public_client_success` - Public client can exchange approved device code
2. `test_public_client_invalid_client_id` - Invalid client_id rejected with 401
3. `test_public_client_missing_client_id` - Missing client_id rejected with 401
4. `test_public_client_authorization_pending` - Polling works for public clients
5. `test_confidential_client_wrong_secret_rejected` - Wrong secret still rejected when provided

## Security Considerations

This change is **RFC-compliant** and does not reduce security:

1. **Device code binding**: The `device_code` is bound to the `application` at creation time, so a public client can only poll for tokens for its own application
2. **User authorization**: The user must still explicitly approve the request via the browser
3. **Confidential clients still supported**: If a client provides `client_secret`, we validate it
4. **Rate limiting**: Existing rate limiting on device code polling remains in place

## Related

- Original device flow implementation: #105675
- RFC 8628: https://datatracker.ietf.org/doc/html/rfc8628