### PR TITLE
ref(dashboards): convert generic widget queries to functional component

### DIFF
--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -13,7 +13,7 @@ type FetchDataFn = () => Promise<void>;
 
 type QueueItem = {
   fetchData: FetchDataFn;
-  widgetId: string | undefined;
+  widgetId: string;
 };
 
 export type WidgetQueryQueue = ReactAsyncQueuer<QueueItem>;
@@ -84,11 +84,7 @@ export function WidgetQueryQueueProvider({children}: {children: React.ReactNode}
     const addItem = (item: QueueItem) => {
       // Never add the same widget to the queue twice
       // even if the date selection has change `fetchData()` in `fetchWidgetItem` will still be called with the latest state.
-      if (
-        queue
-          .peekPendingItems()
-          .some(i => i.widgetId === item.widgetId || i.fetchData === item.fetchData)
-      ) {
+      if (queue.peekPendingItems().some(i => i.widgetId === item.widgetId)) {
         return true;
       }
       const queueIsEmpty = queue.peekAllItems().length === 0;

--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -82,8 +82,8 @@ export function WidgetQueryQueueProvider({children}: {children: React.ReactNode}
 
   const context = useMemo(() => {
     const addItem = (item: QueueItem) => {
-      // Never add the same widget to the queue twice
-      // even if the date selection has change `fetchData()` in `fetchWidgetItem` will still be called with the latest state.
+      // Never add the same widget to the queue twice based on widgetId
+      // When fetchData executes from the queue, it reads from refs to get the latest state (widget, selection, etc.)
       if (queue.peekPendingItems().some(i => i.widgetId === item.widgetId)) {
         return true;
       }

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -423,7 +423,8 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
   }, [widget, onDataFetchStart, fetchSeriesData, fetchTableData]);
 
   const fetchDataWithQueueIfAvailable = useCallback(() => {
-    if (queue) {
+    // We use the widget id to deduplicate requests for the same widget, if it's missing we don't use the queue.
+    if (queue && widget.id) {
       queryFetchIDRef.current = undefined;
       setLoading(true);
       setTableResults(undefined);

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -454,6 +454,7 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
 
   const fetchDataWithQueueIfAvailable = useCallback(() => {
     if (queue) {
+      queryFetchIDRef.current = undefined;
       // Pass the ref to the queue instead of the function
       // When the queue executes, it will call fetchDataRef.current which always points to the latest fetchData
       // Deduplication is based on fetchDataRef identity (per-component-instance)

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -429,11 +429,11 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
       setTableResults(undefined);
       setTimeseriesResults(undefined);
       setErrorMessage(undefined);
-      queue.addItem({widgetQuery: {fetchData}});
+      queue.addItem({fetchData, widgetId: widget.id});
       return;
     }
     fetchData();
-  }, [queue, fetchData]);
+  }, [queue, fetchData, widget.id]);
 
   useEffect(() => {
     isMountedRef.current = true;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -440,7 +440,6 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
     return () => {
       isMountedRef.current = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
@@ -372,6 +372,11 @@ function ReleaseWidgetQueries({
     [allProjects.projects, limit, releases, widget.displayType, widget.queries]
   );
 
+  const transformedWidget = useMemo(
+    () => transformWidget(widget),
+    [transformWidget, widget]
+  );
+
   return (
     <GenericWidgetQueries<SessionApiResponse, SessionApiResponse>
       queue={queue}
@@ -379,7 +384,7 @@ function ReleaseWidgetQueries({
       api={api}
       organization={organization}
       selection={selection}
-      widget={transformWidget(widget)}
+      widget={transformedWidget}
       dashboardFilters={dashboardFilters}
       cursor={cursor}
       limit={getLimit(widget.displayType, limit)}


### PR DESCRIPTION
This brings us closer to supporting `useQuery` in dashboards. I tried to do everything with as minimum changes as possible to avoid any regressions. 