### PR TITLE
Container pointer events prop

### DIFF
--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -52,6 +52,8 @@ interface ContainerLayoutProps {
   overflowX?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowY?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
 
+  pointerEvents?: Responsive<React.CSSProperties['pointerEvents']>;
+
   radius?: Responsive<Shorthand<RadiusSize, 4>>;
 
   width?: Responsive<React.CSSProperties['width']>;
@@ -188,6 +190,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'overflow',
   'overflowX',
   'overflowY',
+  'pointerEvents',
   'padding',
   'paddingTop',
   'paddingBottom',
@@ -233,6 +236,8 @@ export const Container = styled(
   ${p => rc('overflow', p.overflow, p.theme)};
   ${p => rc('overflow-x', p.overflowX, p.theme)};
   ${p => rc('overflow-y', p.overflowY, p.theme)};
+
+  ${p => rc('pointer-events', p.pointerEvents, p.theme)};
 
   ${p => rc('padding', p.padding, p.theme, getSpacing)};
   ${p => rc('padding-top', p.paddingTop, p.theme, getSpacing)};


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds a `pointerEvents` prop to the `Container` component, allowing control over how the component responds to pointer events. This enables use cases where a container needs to ignore or capture mouse/touch interactions.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D090L9MST54/p1768319812347239?thread_ts=1768319812.347239&cid=D090L9MST54)

<a href="https://cursor.com/background-agent?bcId=bc-8b743efb-b5da-4a95-b3f2-107ac7a90b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b743efb-b5da-4a95-b3f2-107ac7a90b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

