### PR TITLE
fix(api): Update GroupSearchViewSerializerResponse TypedDict for nullable createdBy

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -12,7 +12,7 @@ from sentry.users.services.user.service import user_service
 
 class GroupSearchViewSerializerResponse(TypedDict):
     id: str
-    createdBy: UserSerializerResponse
+    createdBy: UserSerializerResponse | None
     name: str
     query: str
     querySort: SORT_LITERALS


### PR DESCRIPTION
Follow-up to 00555f94558 which fixed the runtime behavior to return None
for deleted users, but didn't update the TypedDict annotation.

The serializer has been returning `createdBy: None` since that commit, but
the TypedDict still claimed it was always non-null, causing type errors.

Ref: https://linear.app/getsentry/issue/ISWF-719