### PR TITLE
fix(preprod): Fix breadcrumb links on build pages (EME-720)

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.spec.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.spec.tsx
@@ -1,0 +1,105 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricsArtifactType} from 'sentry/views/preprod/types/appSizeTypes';
+import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import {BuildCompareHeaderContent} from './buildCompareHeaderContent';
+
+describe('BuildCompareHeaderContent', () => {
+  const organization = OrganizationFixture({slug: 'test-org'});
+
+  it('renders breadcrumbs with correct links using projectId', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(
+      {
+        state: BuildDetailsSizeAnalysisState.COMPLETED,
+        size_metrics: [
+          {
+            metrics_artifact_type: MetricsArtifactType.MAIN_ARTIFACT,
+            install_size_bytes: 1024000,
+            download_size_bytes: 512000,
+          },
+        ],
+        base_size_metrics: [],
+      },
+      {
+        app_info: {
+          version: '3.10',
+          build_number: '100',
+          name: 'Test App',
+          app_id: 'com.test.app',
+          artifact_type: null,
+          build_configuration: null,
+          date_added: undefined,
+          date_built: null,
+          is_installable: undefined,
+          platform: 'ios',
+        },
+      }
+    );
+
+    render(<BuildCompareHeaderContent buildDetails={buildDetails} projectId="123456" />, {
+      organization,
+    });
+
+    const releasesLink = screen.getByRole('link', {name: 'Releases'});
+    expect(releasesLink).toHaveAttribute(
+      'href',
+      '/organizations/test-org/explore/releases/?project=123456&tab=mobile-builds'
+    );
+
+    const versionLink = screen.getByRole('link', {name: '3.10'});
+    expect(versionLink).toHaveAttribute(
+      'href',
+      '/organizations/test-org/explore/releases/?project=123456&tab=mobile-builds&query=3.10'
+    );
+
+    expect(screen.queryByRole('link', {name: 'Compare'})).not.toBeInTheDocument();
+    expect(screen.getByText('Compare')).toBeInTheDocument();
+  });
+
+  it('renders breadcrumbs without version when version is not present', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(
+      {
+        state: BuildDetailsSizeAnalysisState.COMPLETED,
+        size_metrics: [
+          {
+            metrics_artifact_type: MetricsArtifactType.MAIN_ARTIFACT,
+            install_size_bytes: 1024000,
+            download_size_bytes: 512000,
+          },
+        ],
+        base_size_metrics: [],
+      },
+      {
+        app_info: {
+          version: '',
+          build_number: '100',
+          name: 'Test App',
+          app_id: 'com.test.app',
+          artifact_type: null,
+          build_configuration: null,
+          date_added: undefined,
+          date_built: null,
+          is_installable: undefined,
+          platform: 'ios',
+        },
+      }
+    );
+
+    render(<BuildCompareHeaderContent buildDetails={buildDetails} projectId="123456" />, {
+      organization,
+    });
+
+    const releasesLink = screen.getByRole('link', {name: 'Releases'});
+    expect(releasesLink).toHaveAttribute(
+      'href',
+      '/organizations/test-org/explore/releases/?project=123456&tab=mobile-builds'
+    );
+
+    expect(screen.queryByRole('link', {name: /^\d+\.\d+/})).not.toBeInTheDocument();
+    expect(screen.getByText('Compare')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -12,7 +12,7 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {IconCode, IconDownload, IconJson, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import ProjectsStore from 'sentry/stores/projectsStore';
+import useOrganization from 'sentry/utils/useOrganization';
 import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import {
   isSizeInfoCompleted,
@@ -34,19 +34,19 @@ interface BuildCompareHeaderContentProps {
 
 export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps) {
   const {buildDetails, projectId} = props;
+  const organization = useOrganization();
   const theme = useTheme();
-  const project = ProjectsStore.getBySlug(projectId);
   const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(project?.id, {tab: 'mobile-builds'}),
+      to: makeReleasesUrl(organization.slug, projectId, {tab: 'mobile-builds'}),
       label: t('Releases'),
     },
   ];
 
   if (buildDetails.app_info.version) {
     breadcrumbs.push({
-      to: makeReleasesUrl(project?.id, {
+      to: makeReleasesUrl(organization.slug, projectId, {
         query: buildDetails.app_info.version,
         tab: 'mobile-builds',
       }),

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -85,11 +85,11 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     );
   }
 
-  const project = ProjectsStore.getBySlug(projectId);
+  const project = ProjectsStore.getById(projectId);
 
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(project?.id, {tab: 'mobile-builds'}),
+      to: makeReleasesUrl(organization.slug, projectId, {tab: 'mobile-builds'}),
       label: 'Releases',
     },
   ];
@@ -99,7 +99,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   if (version) {
     breadcrumbs.push({
-      to: makeReleasesUrl(project?.id, {
+      to: makeReleasesUrl(organization.slug, projectId, {
         query: version,
         tab: 'mobile-builds',
       }),

--- a/static/app/views/preprod/utils/releasesUrl.ts
+++ b/static/app/views/preprod/utils/releasesUrl.ts
@@ -4,6 +4,7 @@ type ReleasesUrlParams = {
 };
 
 export function makeReleasesUrl(
+  organizationSlug: string,
   projectId: string | undefined,
   {query, tab = 'mobile-builds'}: ReleasesUrlParams = {}
 ): string {
@@ -25,5 +26,5 @@ export function makeReleasesUrl(
     params.set('query', queries.join(' '));
   }
 
-  return `/explore/releases/?${params}`;
+  return `/organizations/${organizationSlug}/explore/releases/?${params}`;
 }


### PR DESCRIPTION
Fixes breadcrumb navigation links on preprod build details and comparison pages that were non-functional.

The issue had two root causes:
1. `ProjectsStore.getBySlug()` was being called with a numeric project ID instead of a slug, causing failed lookups
2. Generated URLs were missing the organization slug (e.g., `/explore/releases/` instead of `/organizations/{orgSlug}/explore/releases/`)

This caused breadcrumbs to either link to `#` or produce "Organization not found" errors.

Breadcrumb links now correctly navigate to the releases explore page with proper project filtering.

Fixes EME-720