### PR TITLE
ref(theme): replace `backgroundSecondary` gradients

### DIFF
--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
@@ -122,9 +122,9 @@ const BannerWrapper = styled('div')`
   margin: ${space(1)} 0;
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
 `;
 

--- a/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
+++ b/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
@@ -97,9 +97,9 @@ export const BannerWrapper = styled('div')`
   border-radius: ${p => p.theme.radius.md};
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
   display: flex;
   flex-direction: row;

--- a/static/app/components/issues/suspect/suspectTable.tsx
+++ b/static/app/components/issues/suspect/suspectTable.tsx
@@ -47,9 +47,9 @@ const GradientBox = styled('div')`
   background: ${p => p.theme.tokens.background.primary};
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
   border-radius: ${p => p.theme.radius.md};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/styles.tsx
@@ -97,9 +97,9 @@ const BannerWrapper = styled('div')`
   padding: ${space(2)} ${space(3)};
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
   container-type: inline-size;
 `;

--- a/static/gsApp/components/dataConsentBanner.tsx
+++ b/static/gsApp/components/dataConsentBanner.tsx
@@ -111,9 +111,9 @@ const DataConsentBannerWrapper = styled('div')`
   grid-column: 1 / -1;
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
 `;
 

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
@@ -188,9 +188,9 @@ const BusinessTrialBannerWrapper = styled('div')`
   padding: ${space(2)};
   background: linear-gradient(
     90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
   );
   margin-bottom: 0;
 `;


### PR DESCRIPTION
Updates `backgroundSecondary` gradient usage as part of DE-333

Transparent colors now use `color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent)` instead of `${p => p.theme.backgroundSecondary}00` (please don't do that)

Stacked PR on top of #106037