### PR TITLE
fix(groupsnooze):  Add cooldown cache to prevent Snuba rate limits 

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -199,16 +199,16 @@ class GroupSnooze(Model):
 
     def test_user_counts(self, group: Group) -> bool:
         cache_key = f"groupsnooze:v1:{self.id}:test_user_counts:events_seen_counter"
-        cooldown_key = f"groupsnooze:v1:{self.id}:test_user_counts:snuba_cooldown"
+        CACHE_TTL = 3600  # Redis TTL in seconds
+
+        debounce_key = f"groupsnooze:v1:{self.id}:test_user_counts:snuba_cooldown"
+        snuba_debounce_ttl = options.get("snuba.groupsnooze.user-counts-debounce-seconds")
         if self.state is None:
             users_seen = 0
         else:
             users_seen = self.state.get("users_seen", 0)
 
         threshold = self.user_count + users_seen
-
-        CACHE_TTL = 3600  # Redis TTL in seconds
-        snuba_cooldown = options.get("snuba.groupsnooze.user-counts-cooldown-seconds")
 
         cached_event_count: int | float = float("inf")  # using +inf as a sentinel value
         try:
@@ -222,21 +222,21 @@ class GroupSnooze(Model):
             metrics.incr("groupsnooze.test_user_counts", tags={"cached": "true", "hit": "true"})
             return True
 
-        if snuba_cooldown > 0:
-            cooldown_result = cache.get(cooldown_key)
-            if cooldown_result is not None:
+        if snuba_debounce_ttl > 0:
+            debounce_result = cache.get(debounce_key)
+            if debounce_result is not None:
                 metrics.incr(
-                    "groupsnooze.test_user_counts", tags={"cached": "true", "hit": "cooldown"}
+                    "groupsnooze.test_user_counts", tags={"cached": "true", "hit": "debounce"}
                 )
-                return cooldown_result < threshold
+                return True
 
         metrics.incr("groupsnooze.test_user_counts", tags={"cached": "true", "hit": "false"})
         metrics.incr("groupsnooze.test_user_counts.snuba_call")
         real_count = group.count_users_seen(
             referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE.value
         )
-        if snuba_cooldown > 0 and real_count < threshold * 0.95:
-            cache.set(cooldown_key, real_count, snuba_cooldown)
+        if snuba_debounce_ttl > 0 and real_count < threshold * 0.95:
+            cache.set(debounce_key, real_count, snuba_debounce_ttl)
         cache.set(cache_key, real_count, CACHE_TTL)
         return real_count < threshold
 

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -222,7 +222,6 @@ class GroupSnooze(Model):
             metrics.incr("groupsnooze.test_user_counts", tags={"cached": "true", "hit": "true"})
             return True
 
-        # Check if we're in cooldown period from a recent Snuba query
         if snuba_cooldown > 0:
             cooldown_result = cache.get(cooldown_key)
             if cooldown_result is not None:
@@ -236,9 +235,6 @@ class GroupSnooze(Model):
         real_count = group.count_users_seen(
             referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE.value
         )
-        # Store the Snuba result in cooldown cache to prevent query storms.
-        # Only cache when user count is below 95% of threshold to ensure
-        # timely snooze lifting when close to the threshold.
         if snuba_cooldown > 0 and real_count < threshold * 0.95:
             cache.set(cooldown_key, real_count, snuba_cooldown)
         cache.set(cache_key, real_count, CACHE_TTL)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -882,11 +882,12 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Cooldown period (in seconds) between Snuba queries for groupsnooze user count validation.
+# Cooldown period (in seconds) between Snuba queries for groupsnooze user count validation. Value of 0 disables the debounce check.
 register(
-    "snuba.groupsnooze.user-counts-cooldown-seconds",
+    "snuba.groupsnooze.user-counts-debounce-seconds",
     default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
+    type=Int,
 )
 
 # Kafka Publisher

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -883,11 +883,9 @@ register(
 )
 
 # Cooldown period (in seconds) between Snuba queries for groupsnooze user count validation.
-# Prevents query storms for high-volume issues where user count is close to threshold.
-# Set to 0 to disable the cooldown (not recommended for production).
 register(
     "snuba.groupsnooze.user-counts-cooldown-seconds",
-    default=60,
+    default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -882,6 +882,15 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Cooldown period (in seconds) between Snuba queries for groupsnooze user count validation.
+# Prevents query storms for high-volume issues where user count is close to threshold.
+# Set to 0 to disable the cooldown (not recommended for production).
+register(
+    "snuba.groupsnooze.user-counts-cooldown-seconds",
+    default=60,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Kafka Publisher
 register(
     "kafka-publisher.raw-event-sample-rate",


### PR DESCRIPTION
if a issue is snoozed but has a user threshold for unsnoozing and a high number of errors (while staying below the threshold) we might hit a snuba rate limit because we are making too many requests. this pr adds in a cache so we can avoid making the additional snuba requests while we stay below threshold. right now it'll only cache results if we are below 95% of the threshold, allowing us to make sure that if we hit the threshold, we will react appropriately. the cache ttl is controlled by an option so we can determine what is a "good" value, i think starting at 1 minute seems fair

helps with [SENTRY-49ZR](https://sentry.sentry.io/issues/?project=1&query=SENTRY-49ZR) 