### PR TITLE
feat(tracemetrics): Add "All Metrics" option to Add to Dashboard

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -419,7 +419,9 @@ describe('add to dashboard modal', () => {
         '/organizations/org-slug/dashboards/1/',
         expect.objectContaining({
           data: expect.objectContaining({
-            widgets: [{...widget, widgetType: WidgetType.ERRORS}],
+            widgets: [
+              {...widget, widgetType: WidgetType.ERRORS, layout: expect.any(Object)},
+            ],
           }),
         })
       );
@@ -496,6 +498,7 @@ describe('add to dashboard modal', () => {
                   },
                 ],
                 title: 'Test title',
+                layout: expect.any(Object),
               },
             ],
           }),
@@ -576,6 +579,7 @@ describe('add to dashboard modal', () => {
                   },
                 ],
                 title: 'Test title',
+                layout: expect.any(Object),
               },
             ],
           }),
@@ -1035,7 +1039,7 @@ describe('add to dashboard modal', () => {
           '/organizations/org-slug/dashboards/1/',
           expect.objectContaining({
             data: expect.objectContaining({
-              widgets: expect.arrayContaining([
+              widgets: [
                 expect.objectContaining({
                   title: 'Widget 1',
                   description: 'First widget',
@@ -1046,7 +1050,7 @@ describe('add to dashboard modal', () => {
                   description: 'Second widget',
                   displayType: DisplayType.AREA,
                 }),
-              ]),
+              ],
             }),
           })
         );

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -519,7 +519,7 @@ describe('add to dashboard modal', () => {
     });
     widget = {
       ...widget,
-      displayType: DisplayType.TOP_N,
+      displayType: DisplayType.AREA,
       queries: [
         {
           conditions: '',
@@ -564,7 +564,7 @@ describe('add to dashboard modal', () => {
             widgets: [
               {
                 description: 'Test description',
-                displayType: 'top_n',
+                displayType: 'area',
                 interval: '5m',
                 limit: 5,
                 queries: [

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -845,4 +845,277 @@ describe('add to dashboard modal', () => {
       statsPeriod: '1h',
     });
   });
+
+  describe('multiple widgets', () => {
+    let multipleWidgets: [Widget, Widget];
+
+    beforeEach(() => {
+      multipleWidgets = [
+        {
+          title: 'Widget 1',
+          description: 'First widget',
+          displayType: DisplayType.LINE,
+          interval: '5m',
+          queries: [
+            {
+              conditions: '',
+              fields: ['count()'],
+              aggregates: ['count()'],
+              fieldAliases: [],
+              columns: [] as string[],
+              orderby: '',
+              name: '',
+            },
+          ],
+        },
+        {
+          title: 'Widget 2',
+          description: 'Second widget',
+          displayType: DisplayType.AREA,
+          interval: '5m',
+          queries: [
+            {
+              conditions: '',
+              fields: ['p95(transaction.duration)'],
+              aggregates: ['p95(transaction.duration)'],
+              fieldAliases: [],
+              columns: [] as string[],
+              orderby: '',
+              name: '',
+            },
+          ],
+        },
+      ];
+    });
+
+    it('hides widget name input when multiple widgets are provided', async () => {
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+
+      // Widget name input should not be present
+      expect(screen.queryByLabelText('Widget Name')).not.toBeInTheDocument();
+    });
+
+    it('hides widget preview when multiple widgets are provided', async () => {
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+
+      // Widget preview message should not be present
+      expect(
+        screen.queryByText(
+          /This is a preview of how the widget will appear in your dashboard./
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows message about adding multiple widgets', async () => {
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+
+      // Should show message about adding multiple widgets with full text
+      expect(
+        screen.getByText(
+          /Adding 2 widgets to the selected dashboard\. Any conflicting filters from these queries will be overridden by Dashboard filters\./
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Add + Open Dashboard" button for multiple widgets', async () => {
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          actions={['add-and-stay-on-current-page', 'add-and-open-dashboard']}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+
+      // Should show "Add + Open Dashboard" button
+      expect(
+        screen.getByRole('button', {name: 'Add + Open Dashboard'})
+      ).toBeInTheDocument();
+      // Should not show "Open in Widget Builder" for multiple widgets
+      expect(
+        screen.queryByRole('button', {name: 'Open in Widget Builder'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('adds multiple widgets to existing dashboard', async () => {
+      const dashboardDetailGetMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: {id: '1', widgets: []},
+      });
+      const dashboardDetailPutMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        method: 'PUT',
+        body: {},
+      });
+
+      const {router} = render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          actions={['add-and-stay-on-current-page', 'add-and-open-dashboard']}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+      await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
+
+      await userEvent.click(screen.getByText('Add + Open Dashboard'));
+      expect(dashboardDetailGetMock).toHaveBeenCalled();
+
+      // Assert both widgets are sent as an update to the dashboard
+      await waitFor(() => {
+        expect(dashboardDetailPutMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/dashboards/1/',
+          expect.objectContaining({
+            data: expect.objectContaining({
+              widgets: expect.arrayContaining([
+                expect.objectContaining({
+                  title: 'Widget 1',
+                  description: 'First widget',
+                  displayType: DisplayType.LINE,
+                }),
+                expect.objectContaining({
+                  title: 'Widget 2',
+                  description: 'Second widget',
+                  displayType: DisplayType.AREA,
+                }),
+              ]),
+            }),
+          })
+        );
+      });
+
+      // Should navigate to the dashboard after adding
+      expect(router.location.pathname).toBe('/organizations/org-slug/dashboard/1/');
+    });
+
+    it('navigates to new dashboard with multiple widgets in location state', async () => {
+      const {router} = render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={multipleWidgets}
+          selection={defaultSelection}
+          actions={['add-and-stay-on-current-page', 'add-and-open-dashboard']}
+          source={DashboardWidgetSource.TRACEMETRICS}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+      await selectEvent.select(
+        screen.getByText('Select Dashboard'),
+        '+ Create New Dashboard'
+      );
+
+      await userEvent.click(screen.getByText('Add + Open Dashboard'));
+
+      // Should navigate to dashboard create page
+      expect(router.location.pathname).toBe('/organizations/org-slug/dashboards/new/');
+
+      // Should pass widgets via location state
+      expect(router.location.state?.widgets).toHaveLength(2);
+
+      // Check first widget has required properties
+      expect(router.location.state?.widgets[0]).toMatchObject({
+        title: 'Widget 1',
+        displayType: DisplayType.LINE,
+      });
+      expect(router.location.state?.widgets[0]?.tempId).toBeDefined();
+      expect(router.location.state?.widgets[0]?.layout).toMatchObject({
+        x: expect.any(Number),
+        y: expect.any(Number),
+        w: expect.any(Number),
+        h: expect.any(Number),
+        minH: expect.any(Number),
+      });
+
+      // Check second widget has required properties
+      expect(router.location.state?.widgets[1]).toMatchObject({
+        title: 'Widget 2',
+        displayType: DisplayType.AREA,
+      });
+      expect(router.location.state?.widgets[1]?.tempId).toBeDefined();
+      expect(router.location.state?.widgets[1]?.layout).toMatchObject({
+        x: expect.any(Number),
+        y: expect.any(Number),
+        w: expect.any(Number),
+        h: expect.any(Number),
+        minH: expect.any(Number),
+      });
+    });
+  });
 });

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -912,7 +912,7 @@ describe('add to dashboard modal', () => {
       });
 
       // Widget name input should not be present
-      expect(screen.queryByLabelText('Widget Name')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Optional Widget Name')).not.toBeInTheDocument();
     });
 
     it('hides widget preview when multiple widgets are provided', async () => {

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -225,7 +225,12 @@ function AddToDashboardModal({
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
-      if (!(w.displayType === DisplayType.AREA && w.queries[0]!.columns.length)) {
+      if (
+        !(
+          [DisplayType.AREA, DisplayType.TOP_N].includes(w.displayType) &&
+          w.queries[0]!.columns.length
+        )
+      ) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
       }
       const queries = w.queries.map(query => ({
@@ -265,7 +270,7 @@ function AddToDashboardModal({
         getInitialColumnDepths()
       );
 
-      goToDashboard('preview', widgetsWithLayouts);
+      goToDashboard('preview', normalizeWidgets(widgetsWithLayouts));
       closeModal();
       return;
     }

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -266,6 +266,7 @@ function AddToDashboardModal({
     if (!hasMultipleWidgets) {
       await handleAddWidget();
       goToDashboard('preview');
+      closeModal();
       return;
     }
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -193,7 +193,7 @@ function AddToDashboardModal({
     };
   }, [api, organization.slug, selectedDashboardId]);
 
-  function goToDashboard(page: 'builder' | 'preview', state?: any) {
+  function goToDashboard(page: 'builder' | 'preview', widgetsState?: Widget[]) {
     const dashboardsPath =
       selectedDashboardId === NEW_DASHBOARD_ID
         ? `/organizations/${organization.slug}/dashboards/new/`
@@ -218,7 +218,7 @@ function AddToDashboardModal({
             : pageFiltersToQueryParams(selection)),
         },
       }),
-      {state}
+      {state: {widgets: widgetsState ?? []}}
     );
     closeModal();
   }
@@ -279,9 +279,7 @@ function AddToDashboardModal({
         getInitialColumnDepths()
       );
 
-      goToDashboard('preview', {
-        widgets: widgetsWithLayouts,
-      });
+      goToDashboard('preview', widgetsWithLayouts);
       closeModal();
       return;
     }

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -225,7 +225,7 @@ function AddToDashboardModal({
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
-      if (!(DisplayType.AREA && w.queries[0]!.columns.length)) {
+      if (!(widget.displayType === DisplayType.AREA && w.queries[0]!.columns.length)) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
       }
       const queries = w.queries.map(query => ({

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -225,7 +225,7 @@ function AddToDashboardModal({
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
-      if (!(widget.displayType === DisplayType.AREA && w.queries[0]!.columns.length)) {
+      if (!(w.displayType === DisplayType.AREA && w.queries[0]!.columns.length)) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
       }
       const queries = w.queries.map(query => ({

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -340,9 +340,9 @@ function AddToDashboardModal({
           .map(({title, id, widgetDisplay}) => ({
             label: title,
             value: id,
-            disabled: widgetDisplay.length >= MAX_WIDGETS,
+            disabled: widgetDisplay.length + widgets.length >= MAX_WIDGETS,
             tooltip:
-              widgetDisplay.length >= MAX_WIDGETS &&
+              widgetDisplay.length + widgets.length >= MAX_WIDGETS &&
               tct('Max widgets ([maxWidgets]) per dashboard reached.', {
                 maxWidgets: MAX_WIDGETS,
               }),
@@ -350,7 +350,7 @@ function AddToDashboardModal({
           })),
       ].filter(Boolean) as Array<SelectValue<string>>;
     },
-    [currentDashboardId, dashboards]
+    [currentDashboardId, dashboards, widgets.length]
   );
 
   const widgetLegendState = new WidgetLegendSelectionState({

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -9,7 +9,11 @@ import {
   fetchDashboards,
   updateDashboard,
 } from 'sentry/actionCreators/dashboards';
-import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
@@ -30,6 +34,13 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 import {DashboardCreateLimitWrapper} from 'sentry/views/dashboards/createLimitWrapper';
 import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEventsSelectionAlert';
+import {
+  assignDefaultLayout,
+  assignTempId,
+  calculateColumnDepths,
+  getDashboardLayout,
+  getInitialColumnDepths,
+} from 'sentry/views/dashboards/layoutUtils';
 import type {
   DashboardDetails,
   DashboardListItem,
@@ -58,7 +69,7 @@ import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSele
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
-type AddToDashboardModalActions =
+export type AddToDashboardModalActions =
   | 'add-and-open-dashboard'
   | 'add-and-stay-on-current-page'
   | 'open-in-widget-builder';
@@ -120,6 +131,9 @@ function AddToDashboardModal({
 
   const {dashboardId: currentDashboardId} = useParams<{dashboardId: string}>();
 
+  // Check if we have multiple widgets to adjust UI accordingly
+  const hasMultipleWidgets = widgets.length > 1;
+
   const handleWidgetTableSort = (sort: Sort) => {
     const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
     setOrderBy(newOrderBy);
@@ -179,7 +193,7 @@ function AddToDashboardModal({
     };
   }, [api, organization.slug, selectedDashboardId]);
 
-  function goToDashboard(page: 'builder' | 'preview') {
+  function goToDashboard(page: 'builder' | 'preview', state?: any) {
     const dashboardsPath =
       selectedDashboardId === NEW_DASHBOARD_ID
         ? `/organizations/${organization.slug}/dashboards/new/`
@@ -203,7 +217,8 @@ function AddToDashboardModal({
             ? getSavedPageFilters(selectedDashboard)
             : pageFiltersToQueryParams(selection)),
         },
-      })
+      }),
+      {state}
     );
     closeModal();
   }
@@ -244,9 +259,67 @@ function AddToDashboardModal({
   }
 
   async function handleAddAndOpenDashboard() {
-    await handleAddWidget();
+    if (!canSubmit) {
+      return;
+    }
 
-    goToDashboard('preview');
+    if (!hasMultipleWidgets) {
+      await handleAddWidget();
+      goToDashboard('preview');
+      return;
+    }
+
+    // For new dashboards, use location state since there's no dashboard to update yet
+    if (selectedDashboardId === NEW_DASHBOARD_ID) {
+      // Assign tempIds and default layouts to widgets before passing via location state
+      const widgetsWithTempIds = widgets.map(w => assignTempId(w));
+      const widgetsWithLayouts = assignDefaultLayout(
+        widgetsWithTempIds,
+        getInitialColumnDepths()
+      );
+
+      goToDashboard('preview', {
+        widgets: widgetsWithLayouts,
+        source: 'trace-metrics',
+      });
+      closeModal();
+      return;
+    }
+
+    // For existing dashboards, add widgets via API first, then navigate
+    try {
+      addLoadingMessage(t('Adding widgets to dashboard...'));
+      await handleAddMultipleWidgetsToExistingDashboard();
+      addSuccessMessage(t('Successfully added widgets to dashboard'));
+
+      // Navigate to dashboard (widgets already saved, no location state needed)
+      goToDashboard('preview');
+      closeModal();
+    } catch (error) {
+      addErrorMessage(t('Failed to add widgets to dashboard'));
+    }
+  }
+
+  async function handleAddMultipleWidgetsToExistingDashboard() {
+    if (selectedDashboard === null) {
+      return;
+    }
+
+    // Calculate column depths from existing widgets
+    const existingLayout = getDashboardLayout(selectedDashboard.widgets);
+    const columnDepths = calculateColumnDepths(existingLayout);
+
+    // Assign tempIds and default layouts to new widgets
+    const widgetsWithTempIds = widgets.map(w => assignTempId(w));
+    const widgetsWithLayouts = assignDefaultLayout(widgetsWithTempIds, columnDepths);
+
+    // Add all widgets to the dashboard
+    const newDashboard = {
+      ...selectedDashboard,
+      widgets: [...selectedDashboard.widgets, ...widgetsWithLayouts],
+    };
+
+    await updateDashboard(api, organization.slug, newDashboard);
   }
 
   const canSubmit = selectedDashboardId !== null;
@@ -339,73 +412,87 @@ function AddToDashboardModal({
             )}
           </DashboardCreateLimitWrapper>
         </Wrapper>
+        {!hasMultipleWidgets && (
+          <Wrapper>
+            <SectionHeader title={t('Widget Name')} optional />
+            <Input
+              type="text"
+              aria-label={t('Optional Widget Name')}
+              placeholder={t('Name')}
+              onChange={e => updateWidgetTitle(e.target.value)}
+            />
+          </Wrapper>
+        )}
         <Wrapper>
-          <SectionHeader title={t('Widget Name')} optional />
-          <Input
-            type="text"
-            aria-label={t('Optional Widget Name')}
-            placeholder={t('Name')}
-            onChange={e => updateWidgetTitle(e.target.value)}
-          />
+          {hasMultipleWidgets
+            ? tct(
+                'Adding [count] widgets to the selected dashboard. Any conflicting filters from these queries will be overridden by Dashboard filters.',
+                {count: widgets.length}
+              )
+            : t(
+                'Any conflicting filters from this query will be overridden by Dashboard filters. This is a preview of how the widget will appear in your dashboard.'
+              )}
         </Wrapper>
-        <Wrapper>
-          {t(
-            'Any conflicting filters from this query will be overridden by Dashboard filters. This is a preview of how the widget will appear in your dashboard.'
-          )}
-        </Wrapper>
-        <MetricsCardinalityProvider organization={organization} location={location}>
-          <MetricsDataSwitcher
-            organization={organization}
-            eventView={eventViewFromWidget(newWidgetTitle, widget.queries[0]!, selection)}
-            location={location}
-            hideLoadingIndicator
-          >
-            {metricsDataSide => (
-              <DashboardsMEPProvider>
-                <MEPSettingProvider
-                  location={location}
-                  forceTransactions={metricsDataSide.forceTransactionsOnly}
-                >
-                  <WidgetCardWrapper>
-                    <WidgetCard
-                      organization={organization}
-                      isEditingDashboard={false}
-                      showContextMenu={false}
-                      widgetLimitReached={false}
-                      selection={
-                        selectedDashboard
-                          ? getSavedFiltersAsPageFilters(selectedDashboard)
-                          : selection
-                      }
-                      dashboardFilters={
-                        getDashboardFiltersFromURL(location) ?? selectedDashboard?.filters
-                      }
-                      widget={{
-                        ...widget,
-                        title: newWidgetTitle,
-                        tableWidths,
-                        queries: getUpdatedWidgetQueries(),
-                      }}
-                      shouldResize
-                      widgetLegendState={widgetLegendState}
-                      onLegendSelectChanged={() => {}}
-                      legendOptions={
-                        widgetLegendState.widgetRequiresLegendUnselection(widget)
-                          ? {selected: unselectedReleasesForCharts}
-                          : undefined
-                      }
-                      disableFullscreen
-                      onWidgetTableResizeColumn={handleWidgetTableColumnResize}
-                      onWidgetTableSort={handleWidgetTableSort}
-                      disableTableActions
-                    />
-                  </WidgetCardWrapper>
-                  <IndexedEventsSelectionAlert widget={widget} />
-                </MEPSettingProvider>
-              </DashboardsMEPProvider>
-            )}
-          </MetricsDataSwitcher>
-        </MetricsCardinalityProvider>
+        {!hasMultipleWidgets && (
+          <MetricsCardinalityProvider organization={organization} location={location}>
+            <MetricsDataSwitcher
+              organization={organization}
+              eventView={eventViewFromWidget(
+                newWidgetTitle,
+                widget.queries[0]!,
+                selection
+              )}
+              location={location}
+              hideLoadingIndicator
+            >
+              {metricsDataSide => (
+                <DashboardsMEPProvider>
+                  <MEPSettingProvider
+                    location={location}
+                    forceTransactions={metricsDataSide.forceTransactionsOnly}
+                  >
+                    <WidgetCardWrapper>
+                      <WidgetCard
+                        organization={organization}
+                        isEditingDashboard={false}
+                        showContextMenu={false}
+                        widgetLimitReached={false}
+                        selection={
+                          selectedDashboard
+                            ? getSavedFiltersAsPageFilters(selectedDashboard)
+                            : selection
+                        }
+                        dashboardFilters={
+                          getDashboardFiltersFromURL(location) ??
+                          selectedDashboard?.filters
+                        }
+                        widget={{
+                          ...widget,
+                          title: newWidgetTitle,
+                          tableWidths,
+                          queries: getUpdatedWidgetQueries(),
+                        }}
+                        shouldResize
+                        widgetLegendState={widgetLegendState}
+                        onLegendSelectChanged={() => {}}
+                        legendOptions={
+                          widgetLegendState.widgetRequiresLegendUnselection(widget)
+                            ? {selected: unselectedReleasesForCharts}
+                            : undefined
+                        }
+                        disableFullscreen
+                        onWidgetTableResizeColumn={handleWidgetTableColumnResize}
+                        onWidgetTableSort={handleWidgetTableSort}
+                        disableTableActions
+                      />
+                    </WidgetCardWrapper>
+                    <IndexedEventsSelectionAlert widget={widget} />
+                  </MEPSettingProvider>
+                </DashboardsMEPProvider>
+              )}
+            </MetricsDataSwitcher>
+          </MetricsCardinalityProvider>
+        )}
       </Body>
 
       <Footer>
@@ -421,6 +508,7 @@ function AddToDashboardModal({
           )}
           {actions.includes('add-and-open-dashboard') && (
             <Button
+              priority={hasMultipleWidgets ? 'primary' : 'default'}
               onClick={handleAddAndOpenDashboard}
               disabled={!canSubmit}
               title={canSubmit ? undefined : SELECT_DASHBOARD_MESSAGE}
@@ -428,7 +516,7 @@ function AddToDashboardModal({
               {t('Add + Open Dashboard')}
             </Button>
           )}
-          {actions.includes('open-in-widget-builder') && (
+          {actions.includes('open-in-widget-builder') && !hasMultipleWidgets && (
             <Button
               priority="primary"
               onClick={() => goToDashboard('builder')}

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -280,7 +280,6 @@ function AddToDashboardModal({
 
       goToDashboard('preview', {
         widgets: widgetsWithLayouts,
-        source: 'trace-metrics',
       });
       closeModal();
       return;

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -20,7 +20,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import {Select} from 'sentry/components/core/select';
 import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -249,10 +249,22 @@ function AddToDashboardModal({
   async function handleAddAndStayOnCurrentPage() {
     try {
       await handleAddWidgetsToExistingDashboard();
-      addSuccessMessage(t('Successfully added widget to dashboard'));
+      addSuccessMessage(
+        tn(
+          'Successfully added widget to dashboard',
+          'Successfully added widgets to dashboard',
+          widgets.length
+        )
+      );
       closeModal();
     } catch (error) {
-      addErrorMessage(t('Failed to add widget to dashboard'));
+      addErrorMessage(
+        tn(
+          'Failed to add widget to dashboard',
+          'Failed to add widgets to dashboard',
+          widgets.length
+        )
+      );
     }
   }
 
@@ -276,14 +288,32 @@ function AddToDashboardModal({
 
     // For existing dashboards, add widgets via API first, then navigate
     try {
-      addLoadingMessage(t('Adding widgets to dashboard...'));
+      addLoadingMessage(
+        tn(
+          'Adding widget to dashboard...',
+          'Adding widgets to dashboard...',
+          widgets.length
+        )
+      );
       await handleAddWidgetsToExistingDashboard();
-      addSuccessMessage(t('Successfully added widgets to dashboard'));
+      addSuccessMessage(
+        tn(
+          'Successfully added widget to dashboard',
+          'Successfully added widgets to dashboard',
+          widgets.length
+        )
+      );
 
       // Navigate to dashboard (widgets already saved, no location state needed)
       goToDashboard('preview');
     } catch (error) {
-      addErrorMessage(t('Failed to add widgets to dashboard'));
+      addErrorMessage(
+        tn(
+          'Failed to add widget to dashboard',
+          'Failed to add widgets to dashboard',
+          widgets.length
+        )
+      );
     }
   }
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -271,7 +271,6 @@ function AddToDashboardModal({
       );
 
       goToDashboard('preview', normalizeWidgets(widgetsWithLayouts));
-      closeModal();
       return;
     }
 
@@ -283,7 +282,6 @@ function AddToDashboardModal({
 
       // Navigate to dashboard (widgets already saved, no location state needed)
       goToDashboard('preview');
-      closeModal();
     } catch (error) {
       addErrorMessage(t('Failed to add widgets to dashboard'));
     }

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -242,9 +242,8 @@ function AddToDashboardModal({
   }
 
   async function handleAddAndStayOnCurrentPage() {
-    await handleAddWidgetsToExistingDashboard();
-
     try {
+      await handleAddWidgetsToExistingDashboard();
       addSuccessMessage(t('Successfully added widget to dashboard'));
       closeModal();
     } catch (error) {

--- a/static/app/views/dashboards/create.spec.tsx
+++ b/static/app/views/dashboards/create.spec.tsx
@@ -1,0 +1,255 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import CreateDashboard from 'sentry/views/dashboards/create';
+import {DisplayType} from 'sentry/views/dashboards/types';
+
+describe('Dashboards > CreateDashboard', () => {
+  const organization = OrganizationFixture({
+    features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
+  });
+
+  let mockPOST: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    ProjectsStore.loadInitialData([ProjectFixture()]);
+    PageFiltersStore.reset();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/measurements-meta/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+
+    mockPOST = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      method: 'POST',
+      body: [],
+    });
+  });
+
+  it('renders create dashboard without widgets', async () => {
+    render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+        },
+      },
+    });
+
+    // Should render the dashboard in create mode
+    expect(screen.getByText('Create Dashboard')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Save and Finish'})
+    ).toBeInTheDocument();
+  });
+
+  it('auto-adds widgets from location.state.widgets to dashboard', async () => {
+    const widget1 = WidgetFixture({
+      id: '1',
+      title: 'Test Widget 1',
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          orderby: '',
+        },
+      ],
+    });
+
+    const widget2 = WidgetFixture({
+      id: '2',
+      title: 'Test Widget 2',
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: '',
+          conditions: 'event.type:error',
+          fields: ['title', 'count()'],
+          aggregates: ['count()'],
+          columns: ['title'],
+          orderby: '-count()',
+        },
+      ],
+    });
+
+    const {router} = render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+          state: {widgets: [widget1, widget2]},
+        },
+      },
+    });
+
+    // Wait for widgets to be rendered
+    expect(await screen.findAllByTestId('sortable-widget')).toHaveLength(2);
+
+    // Verify location state is cleared after consuming widgets
+    await waitFor(() => {
+      expect(router.location.state).toEqual({});
+    });
+    expect(router.location.pathname).toBe('/organizations/org-slug/dashboards/new/');
+
+    // Click save to check that the widgets are passed to the API
+    await userEvent.click(await screen.findByRole('button', {name: 'Save and Finish'}));
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          widgets: [expect.objectContaining(widget1), expect.objectContaining(widget2)],
+        }),
+      })
+    );
+  });
+
+  it('handles single widget from location.state', async () => {
+    const widget = WidgetFixture({
+      title: 'Error Count Widget',
+      displayType: DisplayType.BIG_NUMBER,
+      queries: [
+        {
+          name: '',
+          conditions: 'event.type:error',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          orderby: '',
+        },
+      ],
+    });
+
+    render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+          state: {widgets: [widget]},
+        },
+      },
+    });
+
+    // Widget should be rendered in the dashboard
+    expect(await screen.findByTestId('sortable-widget')).toBeInTheDocument();
+
+    // Click save to check that the widgets are passed to the API
+    await userEvent.click(await screen.findByRole('button', {name: 'Save and Finish'}));
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          widgets: [expect.objectContaining(widget)],
+        }),
+      })
+    );
+  });
+
+  it('handles empty widgets array in location.state', async () => {
+    render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+          state: {widgets: []},
+        },
+      },
+    });
+
+    // Should render like a normal create dashboard without widgets
+    expect(await screen.findByText('Create Dashboard')).toBeInTheDocument();
+    expect(screen.queryByTestId('sortable-widget')).not.toBeInTheDocument();
+  });
+
+  it('preserves widget properties when auto-adding from location.state', async () => {
+    const complexWidget = WidgetFixture({
+      title: 'Complex Widget',
+      displayType: DisplayType.AREA,
+      interval: '5m',
+      queries: [
+        {
+          name: 'Query 1',
+          conditions: 'transaction.duration:>100',
+          fields: ['transaction', 'p95(transaction.duration)', 'count()'],
+          aggregates: ['p95(transaction.duration)', 'count()'],
+          columns: ['transaction'],
+          orderby: '-p95(transaction.duration)',
+        },
+        {
+          name: 'Query 2',
+          conditions: 'transaction.duration:<50',
+          fields: ['transaction', 'p50(transaction.duration)'],
+          aggregates: ['p50(transaction.duration)'],
+          columns: ['transaction'],
+          orderby: '-p50(transaction.duration)',
+        },
+      ],
+    });
+
+    render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+          state: {widgets: [complexWidget]},
+        },
+      },
+    });
+
+    // Widget with all its properties should be rendered
+    expect(await screen.findByTestId('sortable-widget')).toBeInTheDocument();
+
+    // Click save to check that the widgets are passed to the API
+    await userEvent.click(await screen.findByRole('button', {name: 'Save and Finish'}));
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          widgets: [expect.objectContaining(complexWidget)],
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -32,7 +32,7 @@ export default function CreateDashboard() {
     ? cloneDashboard(template)
     : cloneDashboard(EMPTY_DASHBOARD);
 
-  const hasWidgetsToAdd = Object.keys(location.state?.widgets ?? {}).length > 0;
+  const hasWidgetsToAdd = !!location.state?.widgets && location.state.widgets.length > 0;
 
   const [dashboard] = useState<DashboardDetails>(() => {
     if (hasWidgetsToAdd) {

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -1,19 +1,56 @@
+import {useEffect, useState} from 'react';
+
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 
 import {EMPTY_DASHBOARD, getDashboardTemplates} from './data';
 import DashboardDetail from './detail';
+import type {DashboardDetails, Widget} from './types';
 import {DashboardState} from './types';
 import {cloneDashboard} from './utils';
 
 export default function CreateDashboard() {
   const organization = useOrganization();
   const {templateId} = useParams<{templateId: string}>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const template = templateId
+    ? getDashboardTemplates(organization).find(
+        dashboardTemplate => dashboardTemplate.id === templateId
+      )
+    : undefined;
+
+  const baseDashboard = template
+    ? cloneDashboard(template)
+    : cloneDashboard(EMPTY_DASHBOARD);
+
+  const hasWidgetsToAdd = Object.keys(location.state?.widgets ?? {}).length > 0;
+
+  const [dashboard] = useState<DashboardDetails>(() => {
+    if (hasWidgetsToAdd) {
+      // Pre-populate dashboard with widgets from location state
+      return {
+        ...baseDashboard,
+        widgets: location.state.widgets as Widget[],
+      };
+    }
+    return baseDashboard;
+  });
+
+  // Clear location state after consuming it
+  useEffect(() => {
+    if (hasWidgetsToAdd) {
+      navigate(location.pathname, {replace: true, state: {}});
+    }
+  }, [hasWidgetsToAdd, navigate, location.pathname]);
 
   function renderDisabled() {
     return (
@@ -27,14 +64,6 @@ export default function CreateDashboard() {
     );
   }
 
-  const template = templateId
-    ? getDashboardTemplates(organization).find(
-        dashboardTemplate => dashboardTemplate.id === templateId
-      )
-    : undefined;
-  const dashboard = template ? cloneDashboard(template) : cloneDashboard(EMPTY_DASHBOARD);
-  const initialState = template ? DashboardState.PREVIEW : DashboardState.CREATE;
-
   return (
     <Feature
       features="dashboards-edit"
@@ -43,7 +72,7 @@ export default function CreateDashboard() {
     >
       <ErrorBoundary>
         <DashboardDetail
-          initialState={initialState}
+          initialState={template ? DashboardState.PREVIEW : DashboardState.CREATE}
           dashboard={dashboard}
           dashboards={[]}
         />

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -151,7 +151,12 @@ function SortableWidget(props: Props) {
   };
 
   return (
-    <GridWidgetWrapper ref={widgetRef} onClick={onWidgetClick} isClickable={hasSlideout}>
+    <GridWidgetWrapper
+      ref={widgetRef}
+      onClick={onWidgetClick}
+      isClickable={hasSlideout}
+      data-test-id="sortable-widget"
+    >
       <DashboardsMEPProvider>
         <LazyRender containerHeight={200} withoutContainer>
           <WidgetCard {...widgetProps} />

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -232,6 +232,12 @@ export enum DashboardState {
   EMBEDDED = 'embedded',
 }
 
+// Location state for passing widgets between pages (e.g., from trace metrics to dashboard)
+export type DashboardLocationState = {
+  source?: string;
+  widgets?: Widget[];
+};
+
 // where we launch the dashboard widget from
 export enum DashboardWidgetSource {
   DISCOVERV2 = 'discoverv2',

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -232,12 +232,6 @@ export enum DashboardState {
   EMBEDDED = 'embedded',
 }
 
-// Location state for passing widgets between pages (e.g., from trace metrics to dashboard)
-export type DashboardLocationState = {
-  source?: string;
-  widgets?: Widget[];
-};
-
 // where we launch the dashboard widget from
 export enum DashboardWidgetSource {
   DISCOVERV2 = 'discoverv2',

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -12,7 +12,10 @@ import {
   DEFAULT_WIDGET_NAME,
   WidgetType,
 } from 'sentry/views/dashboards/types';
-import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {
+  handleAddMultipleQueriesToDashboard,
+  handleAddQueryToDashboard,
+} from 'sentry/views/discover/utils';
 import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
@@ -58,17 +61,33 @@ export function useAddMetricToDashboard() {
   );
 
   const addToDashboard = useCallback(
-    (metricQuery: BaseMetricQuery) => {
-      const eventView = getEventView(metricQuery);
+    (metricQuery: BaseMetricQuery | BaseMetricQuery[]) => {
+      const queries = Array.isArray(metricQuery) ? metricQuery : [metricQuery];
+      const eventViews = queries.map(q => getEventView(q));
 
-      handleAddQueryToDashboard({
-        organization,
-        location,
-        eventView,
-        yAxis: eventView.yAxis,
-        widgetType: WidgetType.TRACEMETRICS,
-        source: DashboardWidgetSource.TRACEMETRICS,
-      });
+      if (eventViews.length === 0) {
+        return;
+      }
+
+      // For multiple queries, we need to call a different modal opener
+      if (queries.length > 1) {
+        handleAddMultipleQueriesToDashboard({
+          organization,
+          location,
+          eventViews,
+          widgetType: WidgetType.TRACEMETRICS,
+          source: DashboardWidgetSource.TRACEMETRICS,
+        });
+      } else {
+        handleAddQueryToDashboard({
+          organization,
+          location,
+          eventView: eventViews[0]!,
+          yAxis: eventViews[0]!.yAxis,
+          widgetType: WidgetType.TRACEMETRICS,
+          source: DashboardWidgetSource.TRACEMETRICS,
+        });
+      }
     },
     [organization, location, getEventView]
   );

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -77,6 +77,7 @@ export function useAddMetricToDashboard() {
           eventViews,
           widgetType: WidgetType.TRACEMETRICS,
           source: DashboardWidgetSource.TRACEMETRICS,
+          selection,
         });
       } else {
         handleAddQueryToDashboard({
@@ -89,7 +90,7 @@ export function useAddMetricToDashboard() {
         });
       }
     },
-    [organization, location, getEventView]
+    [organization, location, getEventView, selection]
   );
 
   return {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -104,19 +104,33 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
         label: <span>{t('A Dashboard widget')}</span>,
         textValue: t('A Dashboard widget'),
         isSubmenu: true,
-        children: metricQueries.map((metricQuery, index) => {
-          return {
-            key: `add-to-dashboard-${index}`,
-            label: `${getVisualizeLabel(index)}: ${
-              formatTraceMetricsFunction(
-                metricQuery.queryParams.aggregateFields.find(isVisualize)?.yAxis ?? ''
-              ) as string
-            }`,
-            onAction: () => {
-              addToDashboard(metricQuery);
-            },
-          };
-        }),
+        children: [
+          ...(metricQueries.length > 1
+            ? [
+                {
+                  key: 'add-to-dashboard-all',
+                  label: <span>{t('All Metrics')}</span>,
+                  textValue: t('All Metrics'),
+                  onAction: () => {
+                    addToDashboard(metricQueries);
+                  },
+                },
+              ]
+            : []),
+          ...metricQueries.map((metricQuery, index) => {
+            return {
+              key: `add-to-dashboard-${index}`,
+              label: `${getVisualizeLabel(index)}: ${
+                formatTraceMetricsFunction(
+                  metricQuery.queryParams.aggregateFields.find(isVisualize)?.yAxis ?? ''
+                ) as string
+              }`,
+              onAction: () => {
+                addToDashboard(metricQuery);
+              },
+            };
+          }),
+        ],
       });
     }
 

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -101,7 +101,7 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
     if (hasTraceMetricsDashboards) {
       items.push({
         key: 'add-to-dashboard',
-        label: <span>{t('A Dashboard widget')}</span>,
+        label: t('A Dashboard widget'),
         textValue: t('A Dashboard widget'),
         isSubmenu: true,
         children: [
@@ -109,7 +109,7 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
             ? [
                 {
                   key: 'add-to-dashboard-all',
-                  label: <span>{t('All Metrics')}</span>,
+                  label: t('All Metrics'),
                   textValue: t('All Metrics'),
                   onAction: () => {
                     addToDashboard(metricQueries);


### PR DESCRIPTION
<img width="627" height="314" alt="Screenshot 2026-01-13 at 12 05 08 PM" src="https://github.com/user-attachments/assets/9075b67c-1b48-4fd6-afc6-8475b99e1111" />

Adds an option to the metrics "Save As" list to allow a user to take all of their current visualizations and move them to a dashboard. We have to handle both cases of existing and new dashboards. The modal has to change slightly to avoid showing the preview and I've updated its messaging. We may need to tweak the copy but that can occur later.

For existing dashboards:
- Just add the widgets to the dashboard, make the update request, then navigate to the dashboard
- We justify adding immediately because we want to remove Edit mode one day

For new dashboards:
- The widgets are sent in `location.state.widgets` when the navigation has occurred for new dashboards
- The `create.tsx` dashboard consumes the `location.state.widgets` data on mount to set its initial state