### PR TITLE
ref(theme): remove `backgroundSecondary` definition

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -552,8 +552,6 @@ const commonTheme = {
   ...formTheme,
 };
 
-type Aliases = typeof lightAliases;
-
 export interface SentryTheme
   extends Omit<typeof lightThemeDefinition, 'chart' | 'tokens'> {
   chart: {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -277,11 +277,7 @@ const generateButtonTheme = (colors: Colors, tokens: Tokens): ButtonColors => ({
   },
 });
 
-const generateAlertTheme = (
-  colors: Colors,
-  alias: Aliases,
-  tokens: Tokens
-): AlertColors => ({
+const generateAlertTheme = (colors: Colors, tokens: Tokens): AlertColors => ({
   info: {
     border: colors.blue200,
     background: colors.blue400,
@@ -298,7 +294,7 @@ const generateAlertTheme = (
   },
   muted: {
     background: colors.gray200,
-    backgroundLight: alias.backgroundSecondary,
+    backgroundLight: tokens.background.secondary,
     border: tokens.border.primary,
     borderHover: tokens.border.primary,
     color: 'inherit',
@@ -1109,11 +1105,6 @@ const darkShadows = {
 
 const generateAliases = (tokens: Tokens) => ({
   /**
-   * Secondary background color used as a slight contrast against primary background
-   */
-  backgroundSecondary: tokens.background.secondary,
-
-  /**
    * Tertiary background color used as a stronger contrast against primary background
    */
   backgroundTertiary: tokens.background.tertiary,
@@ -1264,7 +1255,7 @@ const lightThemeDefinition = {
 
   // @TODO: these colors need to be ported
   ...generateThemeUtils(baseLightTheme.tokens),
-  alert: generateAlertTheme(lightColors, lightAliases, baseLightTheme.tokens),
+  alert: generateAlertTheme(lightColors, baseLightTheme.tokens),
   button: generateButtonTheme(lightColors, baseLightTheme.tokens),
   tag: generateTagTheme(lightColors),
   level: generateLevelTheme(baseLightTheme.tokens, 'light'),
@@ -1304,7 +1295,7 @@ export const darkTheme: SentryTheme = {
 
   // @TODO: these colors need to be ported
   ...generateThemeUtils(baseDarkTheme.tokens),
-  alert: generateAlertTheme(darkColors, darkAliases, baseDarkTheme.tokens),
+  alert: generateAlertTheme(darkColors, baseDarkTheme.tokens),
   button: generateButtonTheme(darkColors, baseDarkTheme.tokens),
   tag: generateTagTheme(darkColors),
   level: generateLevelTheme(baseDarkTheme.tokens, 'dark'),


### PR DESCRIPTION
Removes `backgroundSecondary` from the theme as part of DE-333

We were also able to remove the last internal reference to aliases, just 4 values remaining!

Stacked PR on top of https://github.com/getsentry/sentry/pull/106037