### PR TITLE
feat(explore): Expose boolean attribute type

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -36,13 +36,15 @@ from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
 
 
-def as_tag_key(name: str, type: Literal["string", "number"]):
+def as_tag_key(name: str, type: Literal["string", "number", "boolean"]):
     key, _, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
 
     if key is not None:
         name = key
     elif type == "number":
         key = f"tags[{name},number]"
+    elif type == "boolean":
+        key = f"tags[{name},boolean]"
     else:
         key = name
 
@@ -61,8 +63,16 @@ class OrganizationSpansFieldsEndpointBase(OrganizationEventsEndpointBase):
     owner = ApiOwner.DATA_BROWSING
 
 
+ATTR_MAP = {
+    "number": AttributeKey.Type.TYPE_DOUBLE,
+    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
+}
+
+
 class OrganizationSpansFieldsEndpointSerializer(serializers.Serializer):
-    type = serializers.ChoiceField(["string", "number"], required=False, default="string")
+    type = serializers.ChoiceField(
+        ["string", "number", "boolean"], required=False, default="string"
+    )
 
 
 @region_silo_endpoint
@@ -107,15 +117,12 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
             )
             meta = resolver.resolve_meta(referrer=Referrer.API_SPANS_TAG_KEYS_RPC.value)
 
+            attr_type = ATTR_MAP.get(serialized["type"], AttributeKey.Type.TYPE_STRING)
             rpc_request = TraceItemAttributeNamesRequest(
                 meta=meta,
                 limit=max_span_tags,
                 offset=0,
-                type=(
-                    AttributeKey.Type.TYPE_DOUBLE
-                    if serialized["type"] == "number"
-                    else AttributeKey.Type.TYPE_STRING
-                ),
+                type=attr_type,
             )
 
             rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -220,6 +220,12 @@ def as_attribute_key(
     return attribute_key
 
 
+ATTR_MAP = {
+    "number": AttributeKey.Type.TYPE_DOUBLE,
+    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
+}
+
+
 @region_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
@@ -274,15 +280,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
 
-        attr_type = (
-            AttributeKey.Type.TYPE_DOUBLE
-            if attribute_type == "number"
-            else (
-                AttributeKey.Type.TYPE_BOOLEAN
-                if attribute_type == "boolean"
-                else AttributeKey.Type.TYPE_STRING
-            )
-        )
+        attr_type = ATTR_MAP.get(attribute_type, AttributeKey.Type.TYPE_STRING)
 
         include_internal = is_active_superuser(request) or is_active_staff(request)
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -194,6 +194,9 @@ def as_attribute_key(
     elif type == "number":
         public_key = f"tags[{name},number]"
         public_name = name
+    elif type == "boolean":
+        public_key = f"tags[{name},boolean]"
+        public_name = name
     else:
         public_key = name
         public_name = name

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -132,7 +132,7 @@ class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
         [e.value for e in SupportedTraceItemType], required=True, source="item_type"
     )
     attributeType = serializers.ChoiceField(
-        ["string", "number"], required=True, source="attribute_type"
+        ["string", "number", "boolean"], required=True, source="attribute_type"
     )
     substringMatch = serializers.CharField(required=False, source="substring_match")
     query = serializers.CharField(required=False)
@@ -182,7 +182,7 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 
 
 def as_attribute_key(
-    name: str, type: Literal["string", "number"], item_type: SupportedTraceItemType
+    name: str, type: Literal["string", "number", "boolean"], item_type: SupportedTraceItemType
 ) -> TraceItemAttributeKey:
     public_key, public_name, attribute_source = translate_internal_to_public_alias(
         name, type, item_type
@@ -277,7 +277,11 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         attr_type = (
             AttributeKey.Type.TYPE_DOUBLE
             if attribute_type == "number"
-            else AttributeKey.Type.TYPE_STRING
+            else (
+                AttributeKey.Type.TYPE_BOOLEAN
+                if attribute_type == "boolean"
+                else AttributeKey.Type.TYPE_STRING
+            )
         )
 
         include_internal = is_active_superuser(request) or is_active_staff(request)

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -122,10 +122,17 @@ LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[s
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
         if not definition.secondary_alias and definition.search_type != "string"
+        # TODO: Add boolean support once we have boolean attributes in the frontend
+        # and definition.search_type != "boolean"
     },
 }
 

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -112,7 +112,9 @@ OURLOG_VIRTUAL_CONTEXTS = {
     for key in constants.PROJECT_FIELDS
 }
 
-LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[str, str]] = {
+LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
+    Literal["string", "number", "boolean"], dict[str, str]
+] = {
     "string": {
         definition.internal_name: definition.public_alias
         for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()

--- a/src/sentry/search/eap/profile_functions/attributes.py
+++ b/src/sentry/search/eap/profile_functions/attributes.py
@@ -140,7 +140,7 @@ PROFILE_FUNCTIONS_VIRTUAL_CONTEXTS = {
 }
 
 PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    Literal["string", "number"], dict[str, str]
+    Literal["string", "number", "boolean"], dict[str, str]
 ] = {
     "string": {
         definition.internal_name: definition.public_alias

--- a/src/sentry/search/eap/profile_functions/attributes.py
+++ b/src/sentry/search/eap/profile_functions/attributes.py
@@ -151,10 +151,17 @@ PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS.values()
         if not definition.secondary_alias and definition.search_type != "string"
+        # TODO: Add boolean support once we have boolean attributes in the frontend
+        # and definition.search_type != "boolean"
     },
 }
 

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -591,7 +591,9 @@ def is_starred_segment_context_constructor(params: SnubaParams) -> VirtualColumn
     )
 
 
-SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[str, str]] = {
+SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
+    Literal["string", "number", "boolean"], dict[str, str]
+] = {
     "string": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -607,10 +607,17 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[
         "sentry.span_id": "id",
         "sentry.segment_name": "transaction",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
         if not definition.secondary_alias and definition.search_type != "string"
+        # TODO: Add boolean support once we have boolean attributes in the frontend
+        # and definition.search_type != "boolean"
     }
     | {
         "sentry.start_timestamp": PRECISE_START_TS,

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -94,10 +94,17 @@ TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in TRACE_METRICS_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in TRACE_METRICS_ATTRIBUTE_DEFINITIONS.values()
         if not definition.secondary_alias and definition.search_type != "string"
+        # TODO: Add boolean support once we have boolean attributes in the frontend
+        # and definition.search_type != "boolean"
     },
 }
 

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -83,7 +83,7 @@ TRACE_METRICS_VIRTUAL_CONTEXTS = {
 }
 
 TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    Literal["string", "number"], dict[str, str]
+    Literal["string", "number", "boolean"], dict[str, str]
 ] = {
     "string": {
         definition.internal_name: definition.public_alias

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -63,7 +63,7 @@ def add_start_end_conditions(
 
 
 INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    SupportedTraceItemType, dict[Literal["string", "number"], dict[str, str]]
+    SupportedTraceItemType, dict[Literal["string", "number", "boolean"], dict[str, str]]
 ] = {
     SupportedTraceItemType.SPANS: SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SupportedTraceItemType.LOGS: LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
@@ -125,7 +125,7 @@ TRACE_ITEM_TYPE_DEFINITIONS: dict[SupportedTraceItemType, ColumnDefinitions] = {
 
 def translate_internal_to_public_alias(
     internal_alias: str,
-    type: Literal["string", "number"],
+    type: Literal["string", "number", "boolean"],
     item_type: SupportedTraceItemType,
 ) -> tuple[str | None, str | None, AttributeSource]:
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(type, {})

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -143,6 +143,33 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, APITestCase):
                 {"key": "span.duration", "name": "span.duration"},
             ]
 
+    def test_tags_list_boolean(self) -> None:
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            organization_id=self.organization.id,
+            parent_span_id=None,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            transaction="foo",
+            duration=100,
+            exclusive_time=100,
+            is_eap=True,
+        )
+
+        for features in [
+            None,  # use the default features
+            ["organizations:performance-trace-explorer"],
+        ]:
+            response = self.do_request(
+                features=features,
+                query={"dataset": "spans", "type": "boolean", "process": 1},
+            )
+            assert response.status_code == 200, response.data
+            # is_transaction is a known boolean field on spans
+            assert {"key": "is_transaction", "name": "is_transaction"} in response.data
+
 
 class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
     view = "sentry-api-0-organization-spans-fields-values"

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -24,11 +24,19 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
         ),
         pytest.param(
             "!foo:true OR transaction.duration:11",
-            "(!foo:true OR span.duration:11) AND is_transaction:1",
+            "(!(tags[foo,boolean]:true OR tags[foo,number]:1 OR foo:true) OR span.duration:11) AND is_transaction:1",
         ),
         pytest.param(
             "foo:true OR transaction.duration:11",
-            "((tags[foo,number]:1 OR foo:true) OR span.duration:11) AND is_transaction:1",
+            "((tags[foo,boolean]:true OR tags[foo,number]:1 OR foo:true) OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
+            "foo:false OR transaction.duration:11",
+            "((tags[foo,boolean]:false OR tags[foo,number]:0 OR foo:false) OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
+            "tags[test_bool,boolean]:true",
+            "(tags[test_bool,boolean]:true) AND is_transaction:1",
         ),
         pytest.param(
             "has:transaction.duration OR has:measurements.lcp",

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -362,6 +362,37 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             "tags[timestamp,string]",
         }
 
+    def test_boolean_attributes(self) -> None:
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "is_active": {"bool_value": True},
+                    "is_deleted": {"bool_value": False},
+                    "feature_enabled": True,  # Direct boolean value
+                },
+            ),
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "is_active": {"bool_value": False},
+                    "another_flag": False,  # Direct boolean value
+                },
+            ),
+        ]
+        self.store_ourlogs(logs)
+
+        response = self.do_request(query={"attributeType": "boolean"})
+
+        assert response.status_code == 200, response.content
+        keys = {item["key"] for item in response.data}
+        assert "is_active" in keys
+        assert "is_deleted" in keys
+        assert "feature_enabled" in keys
+        assert "another_flag" in keys
+
 
 class OrganizationTraceItemAttributesEndpointSpansTest(
     OrganizationTraceItemAttributesEndpointTestBase, BaseSpansTestCase, SpanTestCase
@@ -789,6 +820,27 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert "__sentry_internal_span_buffer_outcome" in attribute_names
         assert "__sentry_internal_test" in attribute_names
 
+    def test_boolean_attributes(self) -> None:
+        span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
+        span1["data"] = {
+            "is_feature_enabled": True,
+            "is_debug": False,
+        }
+        span2 = self.create_span(start_ts=before_now(days=0, minutes=10))
+        span2["data"] = {
+            "is_feature_enabled": False,
+            "is_production": True,
+        }
+        self.store_spans([span1, span2], is_eap=True)
+
+        response = self.do_request(query={"attributeType": "boolean"})
+        assert response.status_code == 200, response.content
+
+        keys = {item["key"] for item in response.data}
+        assert "is_feature_enabled" in keys
+        assert "is_debug" in keys
+        assert "is_production" in keys
+
 
 class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
     OrganizationTraceItemAttributesEndpointTestBase, TraceMetricsTestCase
@@ -920,6 +972,45 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
         # Verify number attributes are returned
         # Note: The exact keys depend on how the backend processes numeric attributes
         assert len(data) >= 0  # May be 0 if number attributes are handled differently
+
+    def test_trace_metrics_boolean_attributes(self) -> None:
+        """Test that we can retrieve boolean attributes from trace metrics"""
+        metrics = [
+            self.create_trace_metric(
+                metric_name="custom.metric",
+                metric_value=100.0,
+                metric_type="distribution",
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "is_enabled": True,
+                    "is_debug": False,
+                },
+            ),
+            self.create_trace_metric(
+                metric_name="another.metric",
+                metric_value=200.0,
+                metric_type="distribution",
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "is_enabled": False,
+                    "is_production": True,
+                },
+            ),
+        ]
+        self.store_trace_metrics(metrics)
+
+        response = self.do_request(query={"attributeType": "boolean"})
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        # Verify boolean attributes are returned
+        attribute_keys = {item["key"] for item in data}
+        assert "is_enabled" in attribute_keys
+        assert "is_debug" in attribute_keys
+        assert "is_production" in attribute_keys
 
 
 class OrganizationTraceItemAttributeValuesEndpointBaseTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -388,10 +388,10 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
-        assert "is_active" in keys
-        assert "is_deleted" in keys
-        assert "feature_enabled" in keys
-        assert "another_flag" in keys
+        assert "tags[is_active,boolean]" in keys
+        assert "tags[is_deleted,boolean]" in keys
+        assert "tags[feature_enabled,boolean]" in keys
+        assert "tags[another_flag,boolean]" in keys
 
 
 class OrganizationTraceItemAttributesEndpointSpansTest(
@@ -837,9 +837,9 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         keys = {item["key"] for item in response.data}
-        assert "is_feature_enabled" in keys
-        assert "is_debug" in keys
-        assert "is_production" in keys
+        assert "tags[is_feature_enabled,boolean]" in keys
+        assert "tags[is_debug,boolean]" in keys
+        assert "tags[is_production,boolean]" in keys
 
 
 class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
@@ -1006,11 +1006,11 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
         assert response.status_code == 200, response.content
         data = response.data
 
-        # Verify boolean attributes are returned
+        # Verify boolean attributes are returned with tags[name,boolean] format
         attribute_keys = {item["key"] for item in data}
-        assert "is_enabled" in attribute_keys
-        assert "is_debug" in attribute_keys
-        assert "is_production" in attribute_keys
+        assert "tags[is_enabled,boolean]" in attribute_keys
+        assert "tags[is_debug,boolean]" in attribute_keys
+        assert "tags[is_production,boolean]" in attribute_keys
 
 
 class OrganizationTraceItemAttributeValuesEndpointBaseTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
This PR updates the `/trace-items/attributes` endpoint to accept `boolean` on the `attributeType` query param.

Ticket: EXP-688