### PR TITLE
feat(issues): Add details to current event marker tooltip

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -246,6 +246,7 @@ export function EventGraph({
     eventSeries,
     isFiltered: isUnfilteredStatsEnabled,
     unfilteredEventSeries,
+    seriesType: visibleSeries,
   });
 
   const [legendSelected, setLegendSelected] = useLocalStorageState(

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -244,6 +244,8 @@ export function EventGraph({
     event,
     group,
     eventSeries,
+    isFiltered: isUnfilteredStatsEnabled,
+    unfilteredEventSeries,
   });
 
   const [legendSelected, setLegendSelected] = useLocalStorageState(


### PR DESCRIPTION
On the line that indicates the current event, add all the tooltips from the regular tooltip so that the tooltip doesn't feel in the way. Also fix a color issue

before

<img width="285" height="236" alt="image" src="https://github.com/user-attachments/assets/f71265ef-7c6b-4c8c-847e-c0440009252b" />


after

<img width="377" height="256" alt="Screenshot 2026-01-13 at 10 05 31 AM" src="https://github.com/user-attachments/assets/aebf80ac-4fd3-404f-8cb7-28d00fa137c0" />
