### PR TITLE
chore(preprod): Add artifact download panel to admin page

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_download.py
@@ -77,7 +77,7 @@ class ProjectPreprodArtifactDownloadEndpoint(PreprodArtifactEndpoint):
         file_size = file_obj.size
 
         if file_size is None or file_size < 0:
-            return Response({"error": "File size unavailable"}, status=500)
+            return Response({"detail": "File size unavailable"}, status=500)
 
         response = HttpResponse()
         response["Content-Length"] = file_size
@@ -114,7 +114,7 @@ class ProjectPreprodArtifactDownloadEndpoint(PreprodArtifactEndpoint):
         file_size = file_obj.size
 
         if file_size is None or file_size < 0:
-            return Response({"error": "File size unavailable"}, status=500)
+            return Response({"detail": "File size unavailable"}, status=500)
 
         range_header = request.META.get("HTTP_RANGE")
         if range_header:

--- a/static/app/utils/downloadPreprodArtifact.tsx
+++ b/static/app/utils/downloadPreprodArtifact.tsx
@@ -1,0 +1,75 @@
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+
+type ErrorDetail = {
+  code?: string;
+  message?: string;
+} | null;
+
+interface DownloadPreprodArtifactOptions {
+  artifactId: string | number;
+  organizationSlug: string;
+  projectSlug: string;
+  onStaffPermissionError?: (detail: ErrorDetail) => void;
+  regionUrl?: string;
+}
+
+export async function downloadPreprodArtifact({
+  organizationSlug,
+  projectSlug,
+  artifactId,
+  regionUrl,
+  onStaffPermissionError,
+}: DownloadPreprodArtifactOptions): Promise<void> {
+  const baseUrl = regionUrl || '';
+  const downloadUrl = `${baseUrl}/api/0/internal/${organizationSlug}/${projectSlug}/files/preprodartifacts/${artifactId}/`;
+
+  try {
+    const response = await fetch(downloadUrl, {
+      method: 'HEAD',
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      if (response.status === 403) {
+        let detail: ErrorDetail = null;
+        try {
+          const errorResponse = await fetch(downloadUrl, {
+            method: 'GET',
+            credentials: 'include',
+          });
+          const errorText = await errorResponse.text();
+          const errorJson = JSON.parse(errorText);
+          detail = errorJson.detail;
+        } catch {
+          detail = null;
+        }
+
+        if (onStaffPermissionError) {
+          onStaffPermissionError(detail);
+        } else {
+          addErrorMessage(t('Permission denied. Staff access may be required.'));
+        }
+      } else if (response.status === 404) {
+        addErrorMessage(t('Build file not found.'));
+      } else if (response.status === 401) {
+        addErrorMessage(t('Unauthorized.'));
+      } else {
+        addErrorMessage(t('Download failed (status: %s)', response.status));
+      }
+      return;
+    }
+
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = `preprod_artifact_${artifactId}.zip`;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    addSuccessMessage(t('Build download started'));
+  } catch (error) {
+    addErrorMessage(t('Download failed: %s', String(error)));
+  }
+}

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -133,8 +133,8 @@ export default function BuildDetails() {
           <BuildError
             title="Build details unavailable"
             message={
-              typeof buildDetailsQuery.error?.responseJSON?.detail === 'string'
-                ? buildDetailsQuery.error?.responseJSON.detail
+              typeof buildDetailsQuery.error?.responseJSON?.error === 'string'
+                ? buildDetailsQuery.error?.responseJSON.error
                 : t('Unable to load build details for this artifact')
             }
           >

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -133,8 +133,8 @@ export default function BuildDetails() {
           <BuildError
             title="Build details unavailable"
             message={
-              typeof buildDetailsQuery.error?.responseJSON?.error === 'string'
-                ? buildDetailsQuery.error?.responseJSON.error
+              typeof buildDetailsQuery.error?.responseJSON?.detail === 'string'
+                ? buildDetailsQuery.error?.responseJSON.detail
                 : t('Unable to load build details for this artifact')
             }
           >

--- a/static/gsAdmin/views/launchpadAdminPage.tsx
+++ b/static/gsAdmin/views/launchpadAdminPage.tsx
@@ -11,6 +11,7 @@ import {Link} from 'sentry/components/core/link';
 import {Heading, Text} from 'sentry/components/core/text';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Region} from 'sentry/types/system';
+import {downloadPreprodArtifact} from 'sentry/utils/downloadPreprodArtifact';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
@@ -158,35 +159,13 @@ function LaunchpadAdminPage() {
         return;
       }
 
-      const downloadUrl = `${region.url}/api/0/internal/${orgSlug}/${projectSlug}/files/preprodartifacts/${artifactId}/`;
-
-      const response = await fetch(downloadUrl, {
-        method: 'HEAD',
-        credentials: 'include',
+      await downloadPreprodArtifact({
+        organizationSlug: orgSlug,
+        projectSlug,
+        artifactId,
+        regionUrl: region.url,
       });
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          addErrorMessage('Permission denied. Staff access may be required.');
-        } else if (response.status === 404) {
-          addErrorMessage('Build file not found.');
-        } else if (response.status === 401) {
-          addErrorMessage('Unauthorized.');
-        } else {
-          addErrorMessage(`Download failed (status: ${response.status})`);
-        }
-        return;
-      }
-
-      const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = `preprod_artifact_${artifactId}.zip`;
-      link.style.display = 'none';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-      addSuccessMessage(`Build download started for artifact: ${downloadArtifactId}`);
       setDownloadArtifactId('');
     } catch (error) {
       addErrorMessage(`Failed to download artifact: ${downloadArtifactId}`);


### PR DESCRIPTION
Add the ability to download customers' builds if needed from the _admin preprod page

It's hard to test _admin page changes locally so I may iterate and do a follow up PR if anything is slightly off