### PR TITLE
feat(ACI): Document organization workflow index GET and DELETE endpoints

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -244,6 +244,108 @@ class WorkflowEngineExamples:
                     "enabled": True,
                     "lastTriggered": None,
                 },
+                {
+                    "id": "456",
+                    "name": "Notify team #example-team",
+                    "organizationId": "1",
+                    "createdBy": "34567",
+                    "dateCreated": "2026-01-15T23:46:39.594915Z",
+                    "dateUpdated": "2026-01-15T23:46:39.594903Z",
+                    "triggers": {
+                        "id": "12345",
+                        "organizationId": "1",
+                        "logicType": "any-short",
+                        "conditions": [],
+                        "actions": [],
+                    },
+                    "actionFilters": [
+                        {
+                            "id": "6789",
+                            "organizationId": "1",
+                            "logicType": "any-short",
+                            "conditions": [
+                                {
+                                    "id": "5678",
+                                    "type": "event_frequency_count",
+                                    "comparison": {"value": 100, "interval": "1h"},
+                                    "conditionResult": True,
+                                }
+                            ],
+                            "actions": [
+                                {
+                                    "id": "1234",
+                                    "type": "email",
+                                    "integrationId": None,
+                                    "data": {},
+                                    "config": {
+                                        "targetType": "team",
+                                        "targetDisplay": None,
+                                        "targetIdentifier": "1234567890",
+                                    },
+                                    "status": "active",
+                                }
+                            ],
+                        }
+                    ],
+                    "environment": None,
+                    "config": {"frequency": 1440},
+                    "detectorIds": [],
+                    "enabled": True,
+                    "lastTriggered": None,
+                },
+                {
+                    "id": "789",
+                    "name": "Notify Jane Doe",
+                    "organizationId": "1",
+                    "createdBy": "2345",
+                    "dateCreated": "2026-01-15T23:46:39.594915Z",
+                    "dateUpdated": "2026-01-15T23:49:57.697583Z",
+                    "triggers": {
+                        "id": "56789",
+                        "organizationId": "1",
+                        "logicType": "any-short",
+                        "conditions": [],
+                        "actions": [],
+                    },
+                    "actionFilters": [
+                        {
+                            "id": "56789",
+                            "organizationId": "1",
+                            "logicType": "any-short",
+                            "conditions": [
+                                {
+                                    "id": "234567",
+                                    "type": "event_unique_user_frequency_count",
+                                    "comparison": {
+                                        "value": 100,
+                                        "filters": [{"key": "foo", "match": "eq", "value": "bar"}],
+                                        "interval": "1h",
+                                    },
+                                    "conditionResult": True,
+                                }
+                            ],
+                            "actions": [
+                                {
+                                    "id": "456789",
+                                    "type": "email",
+                                    "integrationId": None,
+                                    "data": {},
+                                    "config": {
+                                        "targetType": "user",
+                                        "targetDisplay": None,
+                                        "targetIdentifier": "123456",
+                                    },
+                                    "status": "active",
+                                }
+                            ],
+                        }
+                    ],
+                    "environment": None,
+                    "config": {"frequency": 1440},
+                    "detectorIds": [],
+                    "enabled": True,
+                    "lastTriggered": None,
+                },
             ],
             status_codes=["201"],
             response_only=True,

--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -185,3 +185,67 @@ class WorkflowEngineExamples:
             response_only=True,
         )
     ]
+    LIST_WORKFLOWS = [
+        OpenApiExample(
+            "List all workflows in an organization",
+            value=[
+                {
+                    "id": "123",
+                    "name": "Send a notification for high priority issues",
+                    "organizationId": "1",
+                    "createdBy": None,
+                    "dateCreated": "2025-03-18T20:48:55.495059Z",
+                    "dateUpdated": "2025-03-18T20:48:55.579094Z",
+                    "triggers": {
+                        "id": "12345",
+                        "organizationId": "1",
+                        "logicType": "any-short",
+                        "conditions": [
+                            {
+                                "id": "2345",
+                                "type": "new_high_priority_issue",
+                                "comparison": True,
+                                "conditionResult": True,
+                            },
+                            {
+                                "id": "3456",
+                                "type": "existing_high_priority_issue",
+                                "comparison": True,
+                                "conditionResult": True,
+                            },
+                        ],
+                        "actions": [],
+                    },
+                    "actionFilters": [
+                        {
+                            "id": "5678",
+                            "organizationId": "1",
+                            "logicType": "all",
+                            "conditions": [],
+                            "actions": [
+                                {
+                                    "id": "234",
+                                    "type": "email",
+                                    "integrationId": None,
+                                    "data": {"fallthroughType": "ActiveMembers"},
+                                    "config": {
+                                        "targetType": "issue_owners",
+                                        "targetDisplay": None,
+                                        "targetIdentifier": None,
+                                    },
+                                    "status": "active",
+                                }
+                            ],
+                        }
+                    ],
+                    "environment": None,
+                    "config": {"frequency": 30},
+                    "detectorIds": [],
+                    "enabled": True,
+                    "lastTriggered": None,
+                },
+            ],
+            status_codes=["201"],
+            response_only=True,
+        )
+    ]

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -502,6 +502,7 @@ Available fields are:
 - `dateUpdated`
 - `connectedDetectors`
 - `actions`
+- `priorityDetector`
 
 Prefix with `-` to sort in descending order.
     """,

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -40,13 +40,18 @@ from sentry.apidocs.constants import (
     RESPONSE_SUCCESS,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, WorkflowParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import ensure_aware
-from sentry.workflow_engine.endpoints.serializers.workflow_serializer import WorkflowSerializer
+from sentry.workflow_engine.endpoints.serializers.workflow_serializer import (
+    WorkflowSerializer,
+    WorkflowSerializerResponse,
+)
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
 from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
@@ -106,6 +111,7 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
 
 
 @region_silo_endpoint
+@extend_schema(tags=["Workflows"])
 class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
@@ -175,7 +181,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         return queryset
 
     @extend_schema(
-        operation_id="Fetch Workflows",
+        operation_id="Fetch Alerts",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             WorkflowParams.SORT_BY,
@@ -184,16 +190,19 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
             OrganizationParams.PROJECT,
         ],
         responses={
-            201: WorkflowSerializer,
+            201: inline_sentry_response_serializer(
+                "ListWorkflowSerializer", list[WorkflowSerializerResponse]
+            ),
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=WorkflowEngineExamples.LIST_WORKFLOWS,
     )
     def get(self, request, organization):
         """
-        Returns a list of workflows for a given org
+        Returns a list of alerts for a given organization
         """
         sort_by = SortByParam.parse(request.GET.get("sortBy", "id"), SORT_COL_MAP)
 

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -374,9 +374,12 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Delete an Organization's Workflows",
+        operation_id="Delete an Organization's Alerts",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
+            WorkflowParams.QUERY,
+            WorkflowParams.ID,
+            OrganizationParams.PROJECT,
         ],
         responses={
             200: RESPONSE_SUCCESS,
@@ -389,7 +392,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request, organization):
         """
-        Deletes workflows for a given org
+        Bulk delete alerts for a given organization
         """
         if not (
             request.GET.getlist("id")

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import datetime
 from typing import Any, TypedDict
-
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any
+from typing import Any, TypedDict
+
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
@@ -11,6 +12,46 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
+
+
+class ActionSerializerResponse(TypedDict):
+    id: str
+    type: str
+    integrationId: str | None
+    data: dict[str, str]
+    config: dict[str, Any]
+    status: str
+
+
+class ConditionSerializerResponse(TypedDict):
+    id: str
+    type: str
+    comparison: bool
+    conditionResult: bool
+
+
+class TriggerSerializerResponse(TypedDict):
+    id: str
+    organizationId: str
+    logicType: str
+    conditions: list[ConditionSerializerResponse] | None
+    actions: list[ActionSerializerResponse] | None
+
+
+class WorkflowSerializerResponse(TypedDict):
+    id: str
+    name: str
+    organizationId: str
+    createdBy: str | None
+    dateCreated: datetime
+    dateUpdated: datetime
+    triggers: TriggerSerializerResponse | None
+    actionFilters: list[TriggerSerializerResponse]
+    environment: str | None
+    config: dict[str, Any]
+    detectorIds: list[str] | None
+    enabled: bool
+    lastTriggered: datetime | None
 
 
 @register(Workflow)
@@ -30,7 +71,6 @@ class WorkflowSerializer(Serializer):
                 trigger_conditions, serialize(trigger_conditions, user=user)
             )
         }
-
         last_triggered_map = get_last_fired_dates([w.id for w in item_list])
 
         wdcg_list = list(WorkflowDataConditionGroup.objects.filter(workflow__in=item_list))


### PR DESCRIPTION
Add documentation for `OrganizationWorkflowIndexEndpoint`'s GET and DELETE endpoints. This will not be actually published yet, but to prepare all of the new workflow engine endpoints we're keeping them marked as experimental and not adding the new sidebar item just yet.

<img width="984" height="718" alt="Screenshot 2026-01-13 at 11 41 29 AM" src="https://github.com/user-attachments/assets/6dd2eb16-4b97-4012-a20b-329db8bde7a7" />
<img width="994" height="683" alt="Screenshot 2026-01-13 at 12 07 45 PM" src="https://github.com/user-attachments/assets/9325f530-848d-4567-b39e-134ee9edd842" />