### PR TITLE
chore(autofix): Explicit opt in to autofix-on-explorer

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -111,6 +111,7 @@ const IDLE_POLL_INTERVAL = 2500; // Slower polling when not actively processing
 
 const makeExplorerAutofixQueryKey = (orgSlug: string, groupId: string): ApiQueryKey => [
   `/organizations/${orgSlug}/issues/${groupId}/autofix/`,
+  {query: {mode: 'explorer'}},
 ];
 
 const makeInitialExplorerAutofixData = (): ExplorerAutofixResponse => ({
@@ -329,6 +330,7 @@ export function useExplorerAutofix(
           `/organizations/${orgSlug}/issues/${groupId}/autofix/`,
           {
             method: 'POST',
+            query: {mode: 'explorer'},
             data: {
               step,
               ...(runId !== undefined && {run_id: runId}),

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -416,6 +416,7 @@ export function useExplorerAutofix(
             `/organizations/${orgSlug}/issues/${groupId}/autofix/`,
             {
               method: 'POST',
+              query: {mode: 'explorer'},
               data: {
                 step: 'coding_agent_handoff',
                 run_id: runId,


### PR DESCRIPTION
This sends the `mode=explorer` in autofix when using explorer to make it easy to toggle between the 2 modes.