### PR TITLE
fix(uptime): Use alert permissions for preview check endpoint

### DIFF
--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -8,7 +8,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
     RESPONSE_FORBIDDEN,
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
+    permission_classes = (OrganizationAlertRulePermission,)
 
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -1,5 +1,6 @@
 import responses
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.conf.types.uptime import UptimeRegionConfig
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
@@ -96,3 +97,45 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
                 body=None,
                 region="default",
             )
+
+    @responses.activate
+    def test_alerts_write_permission(self) -> None:
+        """Test that a user with only alerts:write permission can run a preview check"""
+        with self.feature(self.features):
+            api_key = self.create_api_key(
+                organization=self.organization, scope_list=["alerts:write"]
+            )
+
+            responses.add(
+                responses.POST,
+                "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/validate_check",
+                status=200,
+                json={"succeeded": True},
+            )
+            responses.add(
+                responses.POST,
+                "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/execute_config",
+                status=200,
+                json={"succeeded": True},
+            )
+
+            url = reverse(
+                "sentry-api-0-organization-uptime-alert-preview-check",
+                kwargs={"organization_id_or_slug": self.organization.slug},
+            )
+            response = self.client.post(
+                url,
+                data={
+                    "name": "test",
+                    "environment": "uptime-prod",
+                    "owner": f"user:{self.user.id}",
+                    "url": "http://sentry.io",
+                    "timeoutMs": 1500,
+                    "body": None,
+                    "region": "default",
+                },
+                format="json",
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+            )
+
+            assert response.status_code == 200, response.content


### PR DESCRIPTION
Changed the uptime alert preview check endpoint to use alert-specific
permissions (alerts:read, alerts:write) instead of requiring org:write.
This aligns with other uptime endpoints and allows users with only
alert permissions to test their uptime monitors.

- Created OrganizationUptimeAlertPreviewPermission with project and
  alert scopes
- Added test to verify alerts:write permission works