### PR TITLE
ref(theme) always invoke CSS resolver

### DIFF
--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -251,7 +251,10 @@ export const Container = styled(
   ${p => rc('margin-left', p.marginLeft, p.theme, getMargin)};
   ${p => rc('margin-right', p.marginRight, p.theme, getMargin)};
 
-  ${p => rc('background', p.background, p.theme, v => p.theme.tokens.background[v])};
+  ${p =>
+    rc('background', p.background, p.theme, v =>
+      v ? p.theme.tokens.background[v] : undefined
+    )};
 
   ${p => rc('border-radius', p.radius, p.theme, getRadius)};
 

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -34,7 +34,7 @@ export const Heading = styled(
     rc('font-size', p.size ?? getDefaultHeadingFontSize(p.as), p.theme, v => {
       return getFontSize(v, p.theme);
     })};
-  ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v))};
+  ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v, p.theme))};
   ${p => rc('text-align', p.align, p.theme)};
 
   font-style: ${p => (p.italic ? 'italic' : undefined)};

--- a/static/app/components/core/text/styles.tsx
+++ b/static/app/components/core/text/styles.tsx
@@ -24,14 +24,17 @@ export function getLineHeight(
   density: 'compressed' | 'comfortable' | undefined,
   theme: Theme
 ): string | undefined {
+  if (density === undefined) {
+    return undefined;
+  }
+
   switch (density) {
     case 'compressed':
       return theme.font.lineHeight.compressed.toString();
     case 'comfortable':
       return theme.font.lineHeight.comfortable.toString();
-    case undefined:
     default:
-      return theme.font.lineHeight.default.toString();
+      return undefined;
   }
 }
 

--- a/static/app/components/core/text/styles.tsx
+++ b/static/app/components/core/text/styles.tsx
@@ -1,6 +1,5 @@
 import type {Theme} from '@emotion/react';
 
-import type {Responsive} from 'sentry/components/core/layout/styles';
 import type {FontSize} from 'sentry/utils/theme';
 
 import type {HeadingProps} from './heading';
@@ -21,21 +20,28 @@ export function getTextDecoration(p: TextProps<any> | HeadingProps) {
   return decorations.join(' ');
 }
 
-export function getLineHeight(density: ResponsiveValue<TextProps<any>['density']>) {
+export function getLineHeight(
+  density: 'compressed' | 'comfortable' | undefined,
+  theme: Theme
+): string | undefined {
   switch (density) {
     case 'compressed':
-      return '1';
+      return theme.font.lineHeight.compressed.toString();
     case 'comfortable':
-      return '1.4';
-    // @TODO: Fixed density is 16, how does that work with larger sizes?
+      return theme.font.lineHeight.comfortable.toString();
     case undefined:
     default:
-      return '1.2';
+      return theme.font.lineHeight.default.toString();
   }
 }
 
-export function getFontSize(size: FontSize, theme: Theme) {
+export function getFontSize(
+  size: FontSize | undefined,
+  theme: Theme
+): string | undefined {
+  if (size === undefined) {
+    return undefined;
+  }
+
   return theme.font.size[size];
 }
-
-type ResponsiveValue<T> = T extends Responsive<infer U> ? U : T;

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -122,7 +122,7 @@ export const Text = styled(
     shouldForwardProp: p => isPropValid(p),
   }
 )`
-  ${p => rc('font-size', p.size, p.theme, v => getFontSize(v ?? 'md', p.theme))};
+  ${p => rc('font-size', p.size, p.theme, v => getFontSize(v, p.theme))};
   ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v))};
   ${p => rc('text-align', p.align, p.theme)};
 

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -123,7 +123,7 @@ export const Text = styled(
   }
 )`
   ${p => rc('font-size', p.size, p.theme, v => getFontSize(v, p.theme))};
-  ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v))};
+  ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v, p.theme))};
   ${p => rc('text-align', p.align, p.theme)};
 
   font-style: ${p => (p.italic ? 'italic' : undefined)};


### PR DESCRIPTION
Modify the rc resolver to always be invoked, and allow for bailout via undefined value return