### PR TITLE
feat(sentry-apps): Add region RPC service for sentry app operations

### DIFF
--- a/src/sentry/sentry_apps/services/region/__init__.py
+++ b/src/sentry/sentry_apps/services/region/__init__.py
@@ -1,0 +1,2 @@
+from .model import *  # noqa
+from .service import *  # noqa

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sentry import deletions
+from sentry import deletions, tsdb
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
@@ -20,6 +20,7 @@ from sentry.sentry_apps.services.region.model import (
 )
 from sentry.sentry_apps.services.region.service import SentryAppRegionService
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+from sentry.tsdb.base import TSDBModel
 from sentry.users.services.user import RpcUser
 
 
@@ -230,3 +231,42 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 for hp in hook_projects
             ]
         )
+
+    def record_interaction(
+        self,
+        *,
+        organization_id: int,
+        sentry_app_id: int,
+        sentry_app_slug: str,
+        tsdb_field: str,
+        component_type: str | None = None,
+    ) -> RpcDeleteResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/sentry_app_interaction.py @ POST
+        """
+        model = getattr(TSDBModel, tsdb_field, None)
+
+        if model == TSDBModel.sentry_app_component_interacted:
+            valid_component_types = ["stacktrace-link", "issue-link"]
+            if component_type is None or component_type not in valid_component_types:
+                return RpcDeleteResult(
+                    error=RpcSentryAppError(
+                        message=f"componentType is required and must be one of {valid_component_types}",
+                        webhook_context={},
+                        status_code=400,
+                    )
+                )
+            key = f"{sentry_app_slug}:{component_type}"
+        elif model == TSDBModel.sentry_app_viewed:
+            key = f"{sentry_app_id}"
+        else:
+            return RpcDeleteResult(
+                error=RpcSentryAppError(
+                    message="tsdbField must be one of: sentry_app_viewed, sentry_app_component_interacted",
+                    webhook_context={},
+                    status_code=400,
+                )
+            )
+
+        tsdb.backend.incr(model, key)
+        return RpcDeleteResult(success=True)

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -1,12 +1,15 @@
 from typing import Any
 
+from sentry import deletions
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
 from sentry.sentry_apps.services.region.model import (
+    RpcDeleteResult,
     RpcIssueLinkResult,
     RpcPlatformExternalIssue,
     RpcSelectRequesterResult,
@@ -168,3 +171,31 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 web_url=external_issue.web_url,
             )
         )
+
+    def delete_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        external_issue_id: int,
+    ) -> RpcDeleteResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py @ DELETE
+        """
+        try:
+            platform_external_issue = PlatformExternalIssue.objects.get(
+                id=external_issue_id,
+                project__organization_id=organization_id,
+                service_type=installation.sentry_app.slug,
+            )
+        except PlatformExternalIssue.DoesNotExist:
+            return RpcDeleteResult(
+                error=RpcSentryAppError(
+                    message="Could not find the corresponding external issue",
+                    webhook_context={},
+                    status_code=404,
+                )
+            )
+
+        deletions.exec_sync(platform_external_issue)
+        return RpcDeleteResult(success=True)

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -1,0 +1,49 @@
+from sentry.models.project import Project
+from sentry.sentry_apps.external_requests.select_requester import SelectRequester
+from sentry.sentry_apps.services.app import RpcSentryAppInstallation
+from sentry.sentry_apps.services.region.model import RpcSelectRequesterResult, RpcSentryAppError
+from sentry.sentry_apps.services.region.service import SentryAppRegionService
+from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+
+
+class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
+    def get_select_options(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        uri: str,
+        project_id: int | None = None,
+        query: str | None = None,
+        dependent_data: str | None = None,
+    ) -> RpcSelectRequesterResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_requests.py @ GET
+        """
+
+        project_slug: str | None = None
+        if project_id is not None:
+            project = Project.objects.filter(id=project_id, organization_id=organization_id).first()
+            if project:
+                project_slug = project.slug
+
+        try:
+            result = SelectRequester(
+                install=installation,
+                uri=uri,
+                query=query,
+                dependent_data=dependent_data,
+                project_slug=project_slug,
+            ).run()
+        except (SentryAppIntegratorError, SentryAppSentryError) as e:
+            error = RpcSentryAppError(
+                message=e.message,
+                webhook_context=e.webhook_context,
+                status_code=e.status_code,
+            )
+            return RpcSelectRequesterResult(error=error)
+
+        return RpcSelectRequesterResult(
+            choices=list(result.get("choices", [])),
+            default_value=result.get("defaultValue"),
+        )

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -7,6 +7,7 @@ from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIs
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
 from sentry.sentry_apps.services.region.model import (
     RpcDeleteResult,
@@ -14,6 +15,8 @@ from sentry.sentry_apps.services.region.model import (
     RpcPlatformExternalIssue,
     RpcSelectRequesterResult,
     RpcSentryAppError,
+    RpcServiceHookProject,
+    RpcServiceHookProjectsResult,
 )
 from sentry.sentry_apps.services.region.service import SentryAppRegionService
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
@@ -199,3 +202,31 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
 
         deletions.exec_sync(platform_external_issue)
         return RpcDeleteResult(success=True)
+
+    def get_service_hook_projects(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+    ) -> RpcServiceHookProjectsResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py @ GET
+        """
+        try:
+            hook = ServiceHook.objects.get(installation_id=installation.id)
+        except ServiceHook.DoesNotExist:
+            return RpcServiceHookProjectsResult(
+                error=RpcSentryAppError(
+                    message="Could not find service hook for installation",
+                    webhook_context={},
+                    status_code=404,
+                )
+            )
+
+        hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id)
+        return RpcServiceHookProjectsResult(
+            projects=[
+                RpcServiceHookProject(id=str(hp.id), project_id=str(hp.project_id))
+                for hp in hook_projects
+            ]
+        )

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
@@ -96,6 +97,60 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 user=user,
             ).run()
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
+            return RpcIssueLinkResult(
+                error=RpcSentryAppError(
+                    message=e.message,
+                    webhook_context=e.webhook_context,
+                    status_code=e.status_code,
+                )
+            )
+
+        return RpcIssueLinkResult(
+            external_issue=RpcPlatformExternalIssue(
+                id=str(external_issue.id),
+                issue_id=str(external_issue.group_id),
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            )
+        )
+
+    def create_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        issue_id: int,
+        web_url: str,
+        project: str,
+        identifier: str,
+    ) -> RpcIssueLinkResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issues.py @ POST
+        """
+        try:
+            group = Group.objects.get(
+                id=issue_id,
+                project_id__in=Project.objects.filter(organization_id=organization_id),
+            )
+        except Group.DoesNotExist:
+            return RpcIssueLinkResult(
+                error=RpcSentryAppError(
+                    message="Could not find the corresponding issue for the given issueId",
+                    webhook_context={},
+                    status_code=404,
+                )
+            )
+
+        try:
+            external_issue = ExternalIssueCreator(
+                install=installation,
+                group=group,
+                web_url=web_url,
+                project=project,
+                identifier=identifier,
+            ).run()
+        except SentryAppSentryError as e:
             return RpcIssueLinkResult(
                 error=RpcSentryAppError(
                     message=e.message,

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -38,3 +38,13 @@ class RpcIssueLinkResult(RpcModel):
 class RpcDeleteResult(RpcModel):
     success: bool = False
     error: RpcSentryAppError | None = None
+
+
+class RpcServiceHookProject(RpcModel):
+    id: str
+    project_id: str
+
+
+class RpcServiceHookProjectsResult(RpcModel):
+    projects: list[RpcServiceHookProject] = Field(default_factory=list)
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -20,3 +20,16 @@ class RpcSelectRequesterResult(RpcModel):
     choices: list[list[str]] = Field(default_factory=list)
     default_value: str | None = None
     error: RpcSentryAppError | None = None
+
+
+class RpcPlatformExternalIssue(RpcModel):
+    id: str
+    issue_id: str
+    service_type: str
+    display_name: str
+    web_url: str
+
+
+class RpcIssueLinkResult(RpcModel):
+    external_issue: RpcPlatformExternalIssue | None = None
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -1,0 +1,22 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from typing import Any
+
+from pydantic.fields import Field
+
+from sentry.hybridcloud.rpc import RpcModel
+
+
+class RpcSentryAppError(RpcModel):
+    message: str
+    webhook_context: dict[str, Any]
+    status_code: int | None = None
+
+
+class RpcSelectRequesterResult(RpcModel):
+    choices: list[list[str]] = Field(default_factory=list)
+    default_value: str | None = None
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -10,6 +10,8 @@ from pydantic.fields import Field
 from sentry.hybridcloud.rpc import RpcModel
 
 
+# XXX: Normally RPCs wouldn't return errors like this, but we need to surface these errors to Sentry
+# Apps and by moving operation into these services, we'd lose the helpful errors without this.
 class RpcSentryAppError(RpcModel):
     message: str
     webhook_context: dict[str, Any]
@@ -30,13 +32,8 @@ class RpcPlatformExternalIssue(RpcModel):
     web_url: str
 
 
-class RpcIssueLinkResult(RpcModel):
+class RpcPlatformExternalIssueResult(RpcModel):
     external_issue: RpcPlatformExternalIssue | None = None
-    error: RpcSentryAppError | None = None
-
-
-class RpcDeleteResult(RpcModel):
-    success: bool = False
     error: RpcSentryAppError | None = None
 
 
@@ -47,4 +44,9 @@ class RpcServiceHookProject(RpcModel):
 
 class RpcServiceHookProjectsResult(RpcModel):
     projects: list[RpcServiceHookProject] = Field(default_factory=list)
+    error: RpcSentryAppError | None = None
+
+
+class RpcEmptyResult(RpcModel):
+    success: bool = False
     error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -33,3 +33,8 @@ class RpcPlatformExternalIssue(RpcModel):
 class RpcIssueLinkResult(RpcModel):
     external_issue: RpcPlatformExternalIssue | None = None
     error: RpcSentryAppError | None = None
+
+
+class RpcDeleteResult(RpcModel):
+    success: bool = False
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -13,6 +13,7 @@ from sentry.sentry_apps.services.region.model import (
     RpcDeleteResult,
     RpcIssueLinkResult,
     RpcSelectRequesterResult,
+    RpcServiceHookProjectsResult,
 )
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
@@ -92,6 +93,17 @@ class SentryAppRegionService(RpcService):
         external_issue_id: int,
     ) -> RpcDeleteResult:
         """Deletes a PlatformExternalIssue by id."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def get_service_hook_projects(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+    ) -> RpcServiceHookProjectsResult:
+        """Gets service hook projects for an installation."""
         pass
 
 

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -63,5 +63,20 @@ class SentryAppRegionService(RpcService):
         """Invokes IssueLinkCreator to create an issue link."""
         pass
 
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def create_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        issue_id: int,
+        web_url: str,
+        project: str,
+        identifier: str,
+    ) -> RpcIssueLinkResult:
+        """Invokes ExternalIssueCreator to create an external issue."""
+        pass
+
 
 sentry_app_region_service = SentryAppRegionService.create_delegation()

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -4,12 +4,14 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
+from typing import Any
 
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
-from sentry.sentry_apps.services.region.model import RpcSelectRequesterResult
+from sentry.sentry_apps.services.region.model import RpcIssueLinkResult, RpcSelectRequesterResult
 from sentry.silo.base import SiloMode
+from sentry.users.services.user import RpcUser
 
 
 class SentryAppRegionService(RpcService):
@@ -43,6 +45,22 @@ class SentryAppRegionService(RpcService):
         dependent_data: str | None = None,
     ) -> RpcSelectRequesterResult:
         """Invokes SelectRequester to get select options."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def create_issue_link(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        group_id: int,
+        action: str,
+        fields: dict[str, Any],
+        uri: str,
+        user: RpcUser,
+    ) -> RpcIssueLinkResult:
+        """Invokes IssueLinkCreator to create an issue link."""
         pass
 
 

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -10,8 +10,8 @@ from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
 from sentry.sentry_apps.services.region.model import (
-    RpcDeleteResult,
-    RpcIssueLinkResult,
+    RpcEmptyResult,
+    RpcPlatformExternalIssueResult,
     RpcSelectRequesterResult,
     RpcServiceHookProjectsResult,
 )
@@ -64,7 +64,7 @@ class SentryAppRegionService(RpcService):
         fields: dict[str, Any],
         uri: str,
         user: RpcUser,
-    ) -> RpcIssueLinkResult:
+    ) -> RpcPlatformExternalIssueResult:
         """Invokes IssueLinkCreator to create an issue link."""
         pass
 
@@ -79,7 +79,7 @@ class SentryAppRegionService(RpcService):
         web_url: str,
         project: str,
         identifier: str,
-    ) -> RpcIssueLinkResult:
+    ) -> RpcPlatformExternalIssueResult:
         """Invokes ExternalIssueCreator to create an external issue."""
         pass
 
@@ -91,7 +91,7 @@ class SentryAppRegionService(RpcService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         external_issue_id: int,
-    ) -> RpcDeleteResult:
+    ) -> RpcEmptyResult:
         """Deletes a PlatformExternalIssue by id."""
         pass
 
@@ -116,7 +116,7 @@ class SentryAppRegionService(RpcService):
         sentry_app_slug: str,
         tsdb_field: str,
         component_type: str | None = None,
-    ) -> RpcDeleteResult:
+    ) -> RpcEmptyResult:
         """Records a sentry app interaction in TSDB."""
         pass
 

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -106,5 +106,19 @@ class SentryAppRegionService(RpcService):
         """Gets service hook projects for an installation."""
         pass
 
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def record_interaction(
+        self,
+        *,
+        organization_id: int,
+        sentry_app_id: int,
+        sentry_app_slug: str,
+        tsdb_field: str,
+        component_type: str | None = None,
+    ) -> RpcDeleteResult:
+        """Records a sentry app interaction in TSDB."""
+        pass
+
 
 sentry_app_region_service = SentryAppRegionService.create_delegation()

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -9,7 +9,11 @@ from typing import Any
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
-from sentry.sentry_apps.services.region.model import RpcIssueLinkResult, RpcSelectRequesterResult
+from sentry.sentry_apps.services.region.model import (
+    RpcDeleteResult,
+    RpcIssueLinkResult,
+    RpcSelectRequesterResult,
+)
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
 
@@ -76,6 +80,18 @@ class SentryAppRegionService(RpcService):
         identifier: str,
     ) -> RpcIssueLinkResult:
         """Invokes ExternalIssueCreator to create an external issue."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def delete_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        external_issue_id: int,
+    ) -> RpcDeleteResult:
+        """Deletes a PlatformExternalIssue by id."""
         pass
 
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -4,6 +4,7 @@ from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.region import sentry_app_region_service
 from sentry.testutils.cases import TestCase
@@ -211,3 +212,26 @@ class TestSentryAppRegionService(TestCase):
         assert result.success is False
         assert "Could not find the corresponding external issue" in result.error.message
         assert result.error.status_code == 404
+
+    def test_get_service_hook_projects(self) -> None:
+        with assume_test_silo_mode_of(ServiceHook):
+            hook = ServiceHook.objects.get(installation_id=self.install.id)
+            ServiceHookProject.objects.create(service_hook_id=hook.id, project_id=self.project.id)
+
+        result = sentry_app_region_service.get_service_hook_projects(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+        )
+
+        assert result.error is None
+        assert len(result.projects) == 1
+        assert result.projects[0].project_id == str(self.project.id)
+
+    def test_get_service_hook_projects_empty(self) -> None:
+        result = sentry_app_region_service.get_service_hook_projects(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+        )
+
+        assert result.error is None
+        assert len(result.projects) == 0

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -3,10 +3,12 @@ import responses
 from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.region import sentry_app_region_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import all_silo_test
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
+from sentry.users.services.user.serial import serialize_rpc_user
 
 
 @all_silo_test
@@ -78,4 +80,63 @@ class TestSentryAppRegionService(TestCase):
             "Something went wrong while getting options for Select FormField"
         )
         assert result.error.webhook_context["error_type"] == "select_options.requested.bad_response"
+        assert result.error.status_code == 500
+
+    @responses.activate
+    def test_create_issue_link(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={
+                "project": "Projectname",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists() is False
+        result = sentry_app_region_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=self.group.id,
+            action="create",
+            fields={"title": "An Issue"},
+            uri="/link-issue",
+            user=serialize_rpc_user(self.user),
+        )
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
+        assert result.error is None
+        assert result.external_issue is not None
+        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.web_url == "https://example.com/project/issue-id"
+        assert result.external_issue.display_name == "Projectname#issue-1"
+
+    @responses.activate
+    def test_create_issue_link_error(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={"error": "something went wrong"},
+            status=500,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=self.group.id,
+            action="create",
+            fields={},
+            uri="/link-issue",
+            user=serialize_rpc_user(self.user),
+        )
+
+        assert result.error is not None
+        assert result.external_issue is None
+        assert result.error.webhook_context["error_type"] == "external_issue.linked.bad_response"
         assert result.error.status_code == 500

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -140,3 +140,40 @@ class TestSentryAppRegionService(TestCase):
         assert result.external_issue is None
         assert result.error.webhook_context["error_type"] == "external_issue.linked.bad_response"
         assert result.error.status_code == 500
+
+    def test_create_external_issue(self) -> None:
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists() is False
+
+        result = sentry_app_region_service.create_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            issue_id=self.group.id,
+            web_url="https://example.com/project/issue-id",
+            project="Projectname",
+            identifier="issue-1",
+        )
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
+        assert result.error is None
+        assert result.external_issue is not None
+        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.web_url == "https://example.com/project/issue-id"
+        assert result.external_issue.display_name == "Projectname#issue-1"
+
+    def test_create_external_issue_error(self) -> None:
+        result = sentry_app_region_service.create_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            issue_id=999999,
+            web_url="https://example.com/project/issue-id",
+            project="Projectname",
+            identifier="issue-1",
+        )
+
+        assert result.error is not None
+        assert result.external_issue is None
+        assert "Could not find the corresponding issue" in result.error.message
+        assert result.error.status_code == 404

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -1,0 +1,81 @@
+import orjson
+import responses
+from django.utils.http import urlencode
+from responses.matchers import query_string_matcher
+
+from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.region import sentry_app_region_service
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test
+
+
+@all_silo_test
+class TestSentryAppRegionService(TestCase):
+    def setUp(self) -> None:
+        self.user = self.create_user(email="boop@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.group = self.create_group(project=self.project)
+
+        self.sentry_app = self.create_sentry_app(
+            name="Testin", organization=self.org, webhook_url="https://example.com"
+        )
+
+        self.install = self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app.slug, user=self.user
+        )
+        self.rpc_installation = app_service.get_many(filter=dict(uuids=[self.install.uuid]))[0]
+
+    @responses.activate
+    def test_get_select_options(self) -> None:
+        options = [{"label": "Project Name", "value": "1234"}]
+        dependent_data = orjson.dumps({"org_id": "A"}).decode()
+        qs = urlencode(
+            {
+                "projectSlug": self.project.slug,
+                "installationId": self.install.uuid,
+                "query": "proj",
+                "dependentData": dependent_data,
+            }
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://example.com/get-projects",
+            match=[query_string_matcher(qs)],
+            json=options,
+            status=200,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.get_select_options(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            uri="/get-projects",
+            project_id=self.project.id,
+            query="proj",
+            dependent_data=dependent_data,
+        )
+
+        assert result.error is None
+        assert result.choices == [["1234", "Project Name"]]
+
+    @responses.activate
+    def test_get_select_options_error(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://example.com/get-projects?installationId={self.install.uuid}",
+            status=500,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.get_select_options(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            uri="/get-projects",
+        )
+        assert result.error is not None
+        assert result.error.message.startswith(
+            "Something went wrong while getting options for Select FormField"
+        )
+        assert result.error.webhook_context["error_type"] == "select_options.requested.bad_response"
+        assert result.error.status_code == 500

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -235,3 +235,27 @@ class TestSentryAppRegionService(TestCase):
 
         assert result.error is None
         assert len(result.projects) == 0
+
+    def test_record_interaction(self) -> None:
+        result = sentry_app_region_service.record_interaction(
+            organization_id=self.org.id,
+            sentry_app_id=self.sentry_app.id,
+            sentry_app_slug=self.sentry_app.slug,
+            tsdb_field="sentry_app_viewed",
+        )
+
+        assert result.error is None
+        assert result.success is True
+
+    def test_record_interaction_error(self) -> None:
+        result = sentry_app_region_service.record_interaction(
+            organization_id=self.org.id,
+            sentry_app_id=self.sentry_app.id,
+            sentry_app_slug=self.sentry_app.slug,
+            tsdb_field="invalid_field",
+        )
+
+        assert result.error is not None
+        assert result.success is False
+        assert "tsdbField must be one of" in result.error.message
+        assert result.error.status_code == 400


### PR DESCRIPTION
add a new rpc service `sentry_app_region` to handle sentry app operations that require access to region-specific data.

this is the first step in migrating sentry app installation endpoints from the region silo to the control silo. the service needs to be deployed before the endpoints can be updated to use it via rpc calls.

methods:
- `get_select_options` - [installation_external_requests.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py)
- `create_issue_link` - [installation_external_issue_actions.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py)
- `create_external_issue` - [installation_external_issues.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py)
- `delete_external_issue` - [installation_external_issue_details.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py)
- `get_service_hook_projects` - [installation_service_hook_projects.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py)
- `record_interaction` - [sentry_app_interaction.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/api/endpoints/sentry_app_interaction.py)

Refs SENTRY-4BJ