### PR TITLE
chore(ui): Limit files typechecked by fork-ts-plugin

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -464,6 +464,7 @@ const appConfig: Configuration = {
                   'tests/**/*',
                   '**/*.spec.*',
                   'static/eslint/**/*',
+                  'scripts/**/*',
                 ],
               },
             },

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -454,6 +454,18 @@ const appConfig: Configuration = {
           new TsCheckerRspackPlugin({
             typescript: {
               configFile: path.resolve(import.meta.dirname, './tsconfig.json'),
+              configOverwrite: {
+                compilerOptions: {
+                  allowJs: false,
+                  checkJs: false,
+                },
+                exclude: [
+                  'node_modules/**/*',
+                  'tests/**/*',
+                  '**/*.spec.*',
+                  'static/eslint/**/*',
+                ],
+              },
             },
             devServer: false,
           }),


### PR DESCRIPTION
Saves about 1gb of memory when actively typechecking. After consolidating tsconfigs in #106034 we were typechecking more files. This reverts the fork-ts-typechecker plugin to the original behavior.

reminder that you can always turn this off and save a bunch of cpu/memory with `NO_TS_FORK=1`