### PR TITLE
fix(metric alerts): Separate SubscriptionProcessor fetch phase from evaluation

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -55,23 +55,75 @@ class MetricIssueDetectorConfig(TypedDict):
 
 class SubscriptionProcessor:
     """
-    Class for processing subscription updates for workflow engine. Accepts a subscription
-    and then can process one or more updates via `process_update`.
+    Class for processing subscription updates for workflow engine.
+    Use the `process` classmethod as the entry point.
     """
 
-    def __init__(self, subscription: QuerySubscription) -> None:
+    def __init__(
+        self,
+        subscription: QuerySubscription,
+        subscription_update: QuerySubscriptionUpdate,
+        detector: Detector,
+    ) -> None:
+        """
+        Initialize with pre-validated subscription, update, and detector.
+        Use the `process` classmethod rather than calling this directly.
+        """
         self.subscription = subscription
-        self.detector: Detector | None = None
-        self.last_update = to_datetime(0)
+        self.subscription_update = subscription_update
+        self.detector = detector
+        self.last_update = get_detector_last_update(detector, subscription.project_id)
 
+    @classmethod
+    def process(
+        cls,
+        subscription: QuerySubscription,
+        subscription_update: QuerySubscriptionUpdate,
+    ) -> bool:
+        """
+        Entry point for processing a subscription update.
+        Returns False if required objects don't exist or are invalid.
+        """
+        # Look up detector
         try:
-            self.detector = Detector.objects.get(
-                data_sources__source_id=str(self.subscription.id),
+            detector = Detector.objects.get(
+                data_sources__source_id=str(subscription.id),
                 data_sources__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
             )
-            self.last_update = get_detector_last_update(self.detector, self.subscription.project_id)
         except Detector.DoesNotExist:
-            logger.info("Detector not found", extra={"subscription_id": self.subscription.id})
+            logger.info("Detector not found", extra={"subscription_id": subscription.id})
+            metrics.incr(
+                "incidents.subscription_processor.detector_lookup",
+                amount=1,
+                tags={"found": "False"},
+            )
+            return False
+
+        metrics.incr(
+            "incidents.subscription_processor.detector_lookup",
+            amount=1,
+            tags={"found": "True"},
+        )
+
+        # Fetch and cache Project
+        try:
+            project = Project.objects.get_from_cache(id=subscription.project_id)
+            subscription.set_cached_field_value("project", project)
+        except Project.DoesNotExist:
+            metrics.incr("incidents.alert_rules.ignore_deleted_project")
+            return False
+
+        if project.status != ObjectStatus.ACTIVE:
+            metrics.incr("incidents.alert_rules.ignore_deleted_project")
+            return False
+
+        # Fetch and cache Organization
+        organization = Organization.objects.get_from_cache(id=project.organization_id)
+        project.set_cached_field_value("organization", organization)
+
+        # Create processor and run
+        processor = cls(subscription, subscription_update, detector)
+        return processor.process_update()
 
     def get_crash_rate_alert_metrics_aggregation_value(
         self, subscription_update: QuerySubscriptionUpdate
@@ -194,56 +246,25 @@ class SubscriptionProcessor:
 
         return False
 
-    def process_update(self, subscription_update: QuerySubscriptionUpdate) -> bool:
+    def process_update(self) -> bool:
         """
-        This is the core processing method utilized when Query Subscription Consumer fetches updates from kafka
+        Core processing method. Assumes subscription has cached project/organization
+        and detector exists (enforced by the `process` classmethod).
         """
-        detector = self.detector
-        metrics.incr(
-            "incidents.subscription_processor.detector_lookup",
-            amount=1,
-            tags={"found": str(detector is not None)},
-        )
-        if detector is None:
-            # Absent detector means it was deleted or reassociated.
-            # We quietly exit without processing the update.
-            logger.info(
-                "Detector not found for subscription, skipping subscription processing",
-                extra={"subscription_id": self.subscription.id},
-            )
-            return False
         dataset = self.subscription.snuba_query.dataset
-        try:
-            # Check that the project exists
-            self.subscription.set_cached_field_value(
-                "project",
-                Project.objects.get_from_cache(id=self.subscription.project_id),
-            )
-        except Project.DoesNotExist:
-            metrics.incr("incidents.alert_rules.ignore_deleted_project")
-            return False
-        if self.subscription.project.status != ObjectStatus.ACTIVE:
-            metrics.incr("incidents.alert_rules.ignore_deleted_project")
-            return False
-
-        self.subscription.project.set_cached_field_value(
-            "organization",
-            Organization.objects.get_from_cache(id=self.subscription.project.organization_id),
-        )
-
         organization = self.subscription.project.organization
 
         if self.has_downgraded(dataset, organization):
             return False
 
-        if subscription_update["timestamp"] <= self.last_update:
+        if self.subscription_update["timestamp"] <= self.last_update:
             metrics.incr("incidents.alert_rules.skipping_already_processed_update")
             return False
 
-        self.last_update = subscription_update["timestamp"]
+        self.last_update = self.subscription_update["timestamp"]
 
         if (
-            len(subscription_update["values"]["data"]) > 1
+            len(self.subscription_update["values"]["data"]) > 1
             and self.subscription.snuba_query.dataset != Dataset.Metrics.value
         ):
             logger.warning(
@@ -252,29 +273,36 @@ class SubscriptionProcessor:
                     "subscription_id": self.subscription.id,
                     "dataset": self.subscription.snuba_query.dataset,
                     "snuba_subscription_id": self.subscription.subscription_id,
-                    "result": subscription_update,
+                    "result": self.subscription_update,
                 },
             )
 
-        comparison_delta = None
         with (
             metrics.timer("incidents.alert_rules.process_update"),
             track_memory_usage("incidents.alert_rules.process_update_memory"),
         ):
             metrics.incr("incidents.alert_rules.process_update.start")
-            comparison_delta = self.get_comparison_delta(detector)
-            aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
+            comparison_delta = self.get_comparison_delta(self.detector)
+            aggregation_value = self.get_aggregation_value(
+                self.subscription_update, comparison_delta
+            )
 
             if aggregation_value is None or math.isnan(aggregation_value):
                 metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
                 # We have an invalid aggregate, but we _did_ process the update, so we store
                 # last_update to reflect that and avoid reprocessing.
-                store_detector_last_update(detector, self.subscription.project.id, self.last_update)
+                store_detector_last_update(
+                    self.detector, self.subscription.project.id, self.last_update
+                )
                 return False
 
-            self.process_results_workflow_engine(detector, subscription_update, aggregation_value)
+            self.process_results_workflow_engine(
+                self.detector, self.subscription_update, aggregation_value
+            )
             # Ensure that we have last_update stored for all Detector evaluations.
-            store_detector_last_update(detector, self.subscription.project.id, self.last_update)
+            store_detector_last_update(
+                self.detector, self.subscription.project.id, self.last_update
+            )
             return True
 
 

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -37,7 +37,7 @@ def handle_snuba_query_update(
 
     # noinspection SpellCheckingInspection
     with metrics.timer("incidents.subscription_procesor.process_update"):
-        SubscriptionProcessor(subscription).process_update(subscription_update)
+        SubscriptionProcessor.process(subscription, subscription_update)
 
 
 @instrumented_task(

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -65,13 +65,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_has_downgraded_incidents(self, mock_metrics: MagicMock) -> None:
-        processor = SubscriptionProcessor(self.sub)
         message = self.build_subscription_update(
             self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
         )
 
         with self.capture_on_commit_callbacks(execute=True):
-            assert processor.process_update(message) is False
+            assert SubscriptionProcessor.process(self.sub, message) is False
             mock_metrics.incr.assert_has_calls(
                 [call("incidents.alert_rules.ignore_update_missing_incidents")]
             )
@@ -82,13 +81,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         snuba_query.update(time_window=15 * 60, dataset=Dataset.Transactions.value)
         snuba_query.save()
 
-        processor = SubscriptionProcessor(self.sub)
         message = self.build_subscription_update(
             self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
         )
 
         with self.capture_on_commit_callbacks(execute=True):
-            assert processor.process_update(message) is False
+            assert SubscriptionProcessor.process(self.sub, message) is False
             mock_metrics.incr.assert_has_calls(
                 [call("incidents.alert_rules.ignore_update_missing_incidents_performance")]
             )
@@ -109,13 +107,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         snuba_query.update(time_window=15 * 60, dataset=Dataset.PerformanceMetrics.value)
         snuba_query.save()
 
-        processor = SubscriptionProcessor(self.sub)
         message = self.build_subscription_update(
             self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
         )
 
         with self.capture_on_commit_callbacks(execute=True):
-            assert processor.process_update(message) is False
+            assert SubscriptionProcessor.process(self.sub, message) is False
             mock_metrics.incr.assert_has_calls(
                 [call("incidents.alert_rules.ignore_update_missing_on_demand")]
             )
@@ -503,7 +500,6 @@ class ProcessUpdateUpsampledCountTest(ProcessUpdateBaseClass):
         if time_delta is None:
             time_delta = timedelta()
 
-        processor = SubscriptionProcessor(self.sub)
         message = self.build_upsampled_subscription_update(
             self.sub, upsampled_count=upsampled_count, time_delta=time_delta
         )
@@ -511,7 +507,7 @@ class ProcessUpdateUpsampledCountTest(ProcessUpdateBaseClass):
             self.feature("organizations:incidents"),
             self.feature("organizations:performance-view"),
         ):
-            processor.process_update(message)
+            SubscriptionProcessor.process(self.sub, message)
 
     def test_upsampled_count_no_detector_below_threshold(self) -> None:
         """Test that the detector is not triggered when upsampled count is below threshold"""
@@ -581,7 +577,6 @@ class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetr
     def send_crash_rate_detector_update(self, value, subscription, time_delta=None, count=EMPTY):
         if time_delta is None:
             time_delta = timedelta()
-        processor = SubscriptionProcessor(subscription)
 
         if time_delta is not None:
             timestamp = timezone.now() + time_delta
@@ -601,7 +596,8 @@ class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetr
                 else:
                     denominator = count
                     numerator = int(value * denominator)
-            processor.process_update(
+            SubscriptionProcessor.process(
+                subscription,
                 {
                     "entity": "entity",
                     "subscription_id": (
@@ -617,9 +613,8 @@ class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetr
                         ]
                     },
                     "timestamp": timestamp,
-                }
+                },
             )
-        return processor
 
     def test_crash_rate_detector_for_sessions_with_auto_resolve_critical(self) -> None:
         """
@@ -953,24 +948,27 @@ class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetr
     def test_ensure_case_when_no_metrics_index_not_found_is_handled_gracefully(
         self, helper_metrics
     ):
-        processor = SubscriptionProcessor(self.sub)
-        processor.process_update(
-            {
-                "entity": "entity",
-                "subscription_id": self.sub.subscription_id,
-                "values": {
-                    # 1001 is a random int that doesn't map to anything in the indexer
-                    "data": [
-                        {
-                            resolve_tag_key(
-                                UseCaseKey.RELEASE_HEALTH, self.organization.id, "session.status"
-                            ): 1001
-                        }
-                    ]
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            SubscriptionProcessor.process(
+                self.sub,
+                {
+                    "entity": "entity",
+                    "subscription_id": self.sub.subscription_id,
+                    "values": {
+                        # 1001 is a random int that doesn't map to anything in the indexer
+                        "data": [
+                            {
+                                resolve_tag_key(
+                                    UseCaseKey.RELEASE_HEALTH,
+                                    self.organization.id,
+                                    "session.status",
+                                ): 1001
+                            }
+                        ]
+                    },
+                    "timestamp": timezone.now(),
                 },
-                "timestamp": timezone.now(),
-            }
-        )
+            )
         assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
         helper_metrics.incr.assert_has_calls(
             [

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -58,13 +58,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.sub.project.save()
 
         assert self.send_update(self.critical_threshold + 1) is False
-        mock_metrics.incr.assert_has_calls([call(metrics_call)])
-
-        mock_metrics.reset_mock()
+        mock_metrics.incr.assert_any_call(metrics_call)
 
         self.sub.project.delete()
         assert self.send_update(self.critical_threshold + 1) is False
-        mock_metrics.incr.assert_has_calls([call(metrics_call)])
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_has_downgraded_incidents(self, mock_metrics: MagicMock) -> None:
@@ -129,16 +126,14 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         mock_metrics.incr.reset_mock()
         assert self.send_update(value=self.critical_threshold + 1) is False
 
-        mock_metrics.incr.assert_called_once_with(
-            "incidents.alert_rules.skipping_already_processed_update"
-        )
+        mock_metrics.incr.assert_any_call("incidents.alert_rules.skipping_already_processed_update")
         mock_metrics.incr.reset_mock()
         assert (
             self.send_update(value=self.critical_threshold + 1, time_delta=timedelta(hours=1))
             is True
         )
 
-        mock_metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
+        mock_metrics.incr.assert_any_call("incidents.alert_rules.process_update.start")
 
     def test_resolve(self) -> None:
         self.send_update(self.critical_threshold + 1, timedelta(minutes=-2))

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
@@ -49,7 +49,7 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
         subscription_id = int(self.metric_detector.data_sources.first().source_id)
         return QuerySubscription.objects.get(id=subscription_id)
 
-    def create_detector_data_source_and_data_conditions(self):
+    def create_detector_data_source_and_data_conditions(self) -> Detector:
         detector = self.create_detector(
             project=self.project,
             workflow_condition_group=self.create_data_condition_group(),
@@ -126,7 +126,7 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
         )
 
     @cached_property
-    def metric_detector(self):
+    def metric_detector(self) -> Detector:
         return self.create_detector_data_source_and_data_conditions()
 
     @cached_property


### PR DESCRIPTION
Part of the complexity of the SubscriptionProcessor historically has been dealing with the potential absence of required model objects between construction and actual processing. 
This simplifies the matter by making the fetch a prerequisite that a static helper manages, allowing the execution to 
assumee everything exists.

As part of this, we move to making the lack of matching Detecter a non-error that we track by metric, as missing Detectors are expected as we delete or reassociate.
This should resolve SENTRY-5BRV as a side effect.