### PR TITLE
ref: Generic HMAC service authentication class

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -655,6 +655,7 @@ def compare_service_signature(
     shared_secret_setting: list[str],
     service_name: str,
     signature_prefix: str = "rpc0:",
+    include_url_in_signature: bool = False,
 ) -> bool:
     """
     Generic function to compare request data + signature signed by one of the shared secrets.
@@ -669,6 +670,7 @@ def compare_service_signature(
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for logging (e.g., "Seer", "Launchpad")
         signature_prefix: Expected prefix for the signature (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
+        include_url_in_signature: If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
     """
 
     if not shared_secret_setting:
@@ -694,7 +696,13 @@ def compare_service_signature(
         # We aren't using the version bits currently.
         _, signature_data = signature.split(":", 2)
 
-        signature_input = body
+        if include_url_in_signature:
+            signature_input = b"%s:%s" % (
+                url.encode("utf8"),
+                body,
+            )
+        else:
+            signature_input = body
 
         for key in shared_secret_setting:
             computed = hmac.new(key.encode(), signature_input, hashlib.sha256).hexdigest()
@@ -720,6 +728,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
     - service_name: str - name of the service for logging (e.g., "Seer", "Launchpad")
     - sdk_tag_name: str - name for the SDK tag (e.g., "seer_rpc_auth", "launchpad_rpc_auth")
     - signature_prefix: str - prefix for the signature format (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
+    - include_url_in_signature: bool - If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
     """
 
     token_name = b"rpcsignature"
@@ -727,6 +736,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
     service_name: str
     sdk_tag_name: str
     signature_prefix: str = "rpc0:"
+    include_url_in_signature: bool = False
 
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not auth or len(auth) < 2:
@@ -748,6 +758,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
             shared_secret_setting,
             self.service_name,
             self.signature_prefix,
+            self.include_url_in_signature,
         ):
             raise AuthenticationFailed("Invalid signature")
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -654,7 +654,7 @@ def compare_service_signature(
     signature: str,
     shared_secret_setting: list[str],
     service_name: str,
-    signature_prefix: str = "rpc0:",
+    signature_prefix: str = "rpc0",
     include_url_in_signature: bool = False,
 ) -> bool:
     """
@@ -669,7 +669,7 @@ def compare_service_signature(
         signature: The signature to validate
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for logging (e.g., "Seer", "Launchpad")
-        signature_prefix: Expected prefix for the signature (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
+        signature_prefix: Expected prefix for the signature (e.g., "rpc0", "service0"). The colon will be added automatically. Defaults to "rpc0" for backward compatibility.
         include_url_in_signature: If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
     """
 
@@ -684,7 +684,7 @@ def compare_service_signature(
             f"Cannot validate {service_name} request signatures with empty shared secret"
         )
 
-    if not signature.startswith(signature_prefix):
+    if not signature.startswith(f"{signature_prefix}:"):
         logger.error(
             "%s signature validation failed: invalid signature prefix (expected %s)",
             service_name,
@@ -727,7 +727,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
     - shared_secret_setting_name: str - name of the settings attribute (e.g., "SEER_RPC_SHARED_SECRET")
     - service_name: str - name of the service for logging (e.g., "Seer", "Launchpad")
     - sdk_tag_name: str - name for the SDK tag (e.g., "seer_rpc_auth", "launchpad_rpc_auth")
-    - signature_prefix: str - prefix for the signature format (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
+    - signature_prefix: str - prefix for the signature format (e.g., "rpc0", "service0"). The colon will be added automatically. Defaults to "rpc0" for backward compatibility.
     - include_url_in_signature: bool - If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
     """
 
@@ -735,7 +735,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
     shared_secret_setting_name: str
     service_name: str
     sdk_tag_name: str
-    signature_prefix: str = "rpc0:"
+    signature_prefix: str = "rpc0"
     include_url_in_signature: bool = False
 
     def accepts_auth(self, auth: list[bytes]) -> bool:

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -654,6 +654,7 @@ def compare_service_signature(
     signature: str,
     shared_secret_setting: list[str],
     service_name: str,
+    signature_prefix: str = "rpc0:",
 ) -> bool:
     """
     Generic function to compare request data + signature signed by one of the shared secrets.
@@ -667,21 +668,26 @@ def compare_service_signature(
         signature: The signature to validate
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for logging (e.g., "Seer", "Launchpad")
+        signature_prefix: Expected prefix for the signature (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
     """
 
     if not shared_secret_setting:
         raise RpcAuthenticationSetupException(
-            f"Cannot validate {service_name} RPC request signatures without shared secret"
+            f"Cannot validate {service_name} request signatures without shared secret"
         )
 
     # Ensure no empty secrets
     if any(not secret.strip() for secret in shared_secret_setting):
         raise RpcAuthenticationSetupException(
-            f"Cannot validate {service_name} RPC request signatures with empty shared secret"
+            f"Cannot validate {service_name} request signatures with empty shared secret"
         )
 
-    if not signature.startswith("rpc0:"):
-        logger.error("%s RPC signature validation failed: invalid signature prefix", service_name)
+    if not signature.startswith(signature_prefix):
+        logger.error(
+            "%s signature validation failed: invalid signature prefix (expected %s)",
+            service_name,
+            signature_prefix,
+        )
         return False
 
     try:
@@ -696,29 +702,31 @@ def compare_service_signature(
             if is_valid:
                 return True
     except Exception:
-        logger.exception("%s RPC signature validation failed", service_name)
+        logger.exception("%s signature validation failed", service_name)
         return False
 
-    logger.error("%s RPC signature validation failed", service_name)
+    logger.error("%s signature validation failed", service_name)
 
     return False
 
 
-class ServiceRpcSignatureAuthentication(StandardAuthentication):
+class HmacSignatureAuthentication(StandardAuthentication):
     """
-    Generic authentication for service RPC requests.
+    HMAC authentication for service-to-service requests.
     Requests are sent with an HMAC signed by a shared private key.
 
     Subclasses should define:
     - shared_secret_setting_name: str - name of the settings attribute (e.g., "SEER_RPC_SHARED_SECRET")
     - service_name: str - name of the service for logging (e.g., "Seer", "Launchpad")
     - sdk_tag_name: str - name for the SDK tag (e.g., "seer_rpc_auth", "launchpad_rpc_auth")
+    - signature_prefix: str - prefix for the signature format (e.g., "rpc0:", "service0:"). Defaults to "rpc0:" for backward compatibility.
     """
 
     token_name = b"rpcsignature"
     shared_secret_setting_name: str
     service_name: str
     sdk_tag_name: str
+    signature_prefix: str = "rpc0:"
 
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not auth or len(auth) < 2:
@@ -730,11 +738,16 @@ class ServiceRpcSignatureAuthentication(StandardAuthentication):
 
         if shared_secret_setting is None:
             raise RpcAuthenticationSetupException(
-                f"Cannot validate {self.service_name} RPC request signatures without shared secret"
+                f"Cannot validate {self.service_name} request signatures without shared secret"
             )
 
         if not compare_service_signature(
-            request.path_info, request.body, token, shared_secret_setting, self.service_name
+            request.path_info,
+            request.body,
+            token,
+            shared_secret_setting,
+            self.service_name,
+            self.signature_prefix,
         ):
             raise AuthenticationFailed("Invalid signature")
 

--- a/src/sentry/preprod/authentication.py
+++ b/src/sentry/preprod/authentication.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 
-from sentry.api.authentication import AuthenticationSiloLimit, ServiceRpcSignatureAuthentication
+from sentry.api.authentication import AuthenticationSiloLimit, HmacSignatureAuthentication
 from sentry.silo.base import SiloMode
 
 LAUNCHPAD_RPC_SHARED_SECRET_SETTING = "LAUNCHPAD_RPC_SHARED_SECRET"
 
 
 @AuthenticationSiloLimit(SiloMode.REGION)
-class LaunchpadRpcSignatureAuthentication(ServiceRpcSignatureAuthentication):
+class LaunchpadRpcSignatureAuthentication(HmacSignatureAuthentication):
     """
     Authentication for Launchpad RPC requests.
     Requests are sent with an HMAC signed by a shared private key.

--- a/src/sentry/testutils/auth.py
+++ b/src/sentry/testutils/auth.py
@@ -10,17 +10,20 @@ def generate_service_request_signature(
     shared_secret_setting: list[str] | None,
     service_name: str,
     signature_prefix: str = "rpc0:",
+    include_url_in_signature: bool = False,
 ) -> str:
     """
-    Generate a signature for the request body with the first shared secret.
+    Generate a signature for the request with the first shared secret.
     If there are other shared secrets in the list they are only to be used
     for verification during key rotation.
 
     Args:
-        url_path: The request URL path (unused but kept for compatibility)
+        url_path: The request URL path
         body: The request body to sign
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for error messages
+        signature_prefix: Prefix for the signature format (e.g., "rpc0:", "service0:")
+        include_url_in_signature: If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
 
     NOTE: This function is used only for testing and has been moved from
     production code since no actual services are using it in production yet.
@@ -31,7 +34,14 @@ def generate_service_request_signature(
             f"Cannot sign {service_name} RPC requests without shared secret"
         )
 
-    signature_input = body
+    if include_url_in_signature:
+        signature_input = b"%s:%s" % (
+            url_path.encode("utf8"),
+            body,
+        )
+    else:
+        signature_input = body
+
     secret = shared_secret_setting[0]
     signature = hmac.new(secret.encode("utf-8"), signature_input, hashlib.sha256).hexdigest()
     return f"{signature_prefix}{signature}"

--- a/src/sentry/testutils/auth.py
+++ b/src/sentry/testutils/auth.py
@@ -5,7 +5,11 @@ from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException
 
 
 def generate_service_request_signature(
-    url_path: str, body: bytes, shared_secret_setting: list[str] | None, service_name: str
+    url_path: str,
+    body: bytes,
+    shared_secret_setting: list[str] | None,
+    service_name: str,
+    signature_prefix: str = "rpc0:",
 ) -> str:
     """
     Generate a signature for the request body with the first shared secret.
@@ -30,4 +34,4 @@ def generate_service_request_signature(
     signature_input = body
     secret = shared_secret_setting[0]
     signature = hmac.new(secret.encode("utf-8"), signature_input, hashlib.sha256).hexdigest()
-    return f"rpc0:{signature}"
+    return f"{signature_prefix}{signature}"

--- a/src/sentry/testutils/auth.py
+++ b/src/sentry/testutils/auth.py
@@ -19,7 +19,7 @@ def generate_service_request_signature(
 
     Args:
         url_path: The request URL path
-        body: The request body to sign
+        body: The request body to sign. For GET requests (which have no body), use an empty bytes string (b"").
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for error messages
         signature_prefix: Prefix for the signature format (e.g., "rpc0:", "service0:")

--- a/src/sentry/testutils/auth.py
+++ b/src/sentry/testutils/auth.py
@@ -9,7 +9,7 @@ def generate_service_request_signature(
     body: bytes,
     shared_secret_setting: list[str] | None,
     service_name: str,
-    signature_prefix: str = "rpc0:",
+    signature_prefix: str = "rpc0",
     include_url_in_signature: bool = False,
 ) -> str:
     """
@@ -22,7 +22,7 @@ def generate_service_request_signature(
         body: The request body to sign. For GET requests (which have no body), use an empty bytes string (b"").
         shared_secret_setting: List of shared secrets from settings
         service_name: Name of the service for error messages
-        signature_prefix: Prefix for the signature format (e.g., "rpc0:", "service0:")
+        signature_prefix: Prefix for the signature format (e.g., "rpc0", "service0"). The colon will be added automatically.
         include_url_in_signature: If True, signs "url:body". If False, signs only "body". Defaults to False for backward compatibility.
 
     NOTE: This function is used only for testing and has been moved from
@@ -44,4 +44,4 @@ def generate_service_request_signature(
 
     secret = shared_secret_setting[0]
     signature = hmac.new(secret.encode("utf-8"), signature_input, hashlib.sha256).hexdigest()
-    return f"{signature_prefix}{signature}"
+    return f"{signature_prefix}:{signature}"

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -603,7 +603,7 @@ class TestHmacSignatureAuthentication(TestCase):
             shared_secret_setting_name = "TEST_SERVICE_RPC_SHARED_SECRET"
             service_name = "TestService"
             sdk_tag_name = "test_service_rpc_auth"
-            signature_prefix = "service0:"
+            signature_prefix = "service0"
 
         auth = CustomPrefixAuth()
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -11,11 +11,11 @@ from sentry_relay.auth import generate_key_pair
 from sentry.api.authentication import (
     ClientIdSecretAuthentication,
     DSNAuthentication,
+    HmacSignatureAuthentication,
     JWTClientSecretAuthentication,
     OrgAuthTokenAuthentication,
     RelayAuthentication,
     RpcSignatureAuthentication,
-    ServiceRpcSignatureAuthentication,
     UserAuthTokenAuthentication,
     compare_service_signature,
 )
@@ -552,12 +552,12 @@ class TestRpcSignatureAuthentication(TestCase):
                 self.auth.authenticate(request)
 
 
-class TestServiceRpcSignatureAuthentication(TestCase):
+class TestHmacSignatureAuthentication(TestCase):
     def setUp(self) -> None:
         super().setUp()
 
         # Create a concrete implementation for testing
-        class TestServiceAuth(ServiceRpcSignatureAuthentication):
+        class TestServiceAuth(HmacSignatureAuthentication):
             shared_secret_setting_name = "TEST_SERVICE_RPC_SHARED_SECRET"
             service_name = "TestService"
             sdk_tag_name = "test_service_rpc_auth"
@@ -596,6 +596,36 @@ class TestServiceRpcSignatureAuthentication(TestCase):
         user, token = self.auth.authenticate(request)
         assert user.is_anonymous
         assert token == signature
+
+    def test_authenticate_with_custom_prefix(self) -> None:
+        # Create a service auth with custom prefix
+        class CustomPrefixAuth(HmacSignatureAuthentication):
+            shared_secret_setting_name = "TEST_SERVICE_RPC_SHARED_SECRET"
+            service_name = "TestService"
+            sdk_tag_name = "test_service_rpc_auth"
+            signature_prefix = "service0:"
+
+        auth = CustomPrefixAuth()
+
+        data = b'{"test": "data"}'
+        request = drf_request_from_request(
+            RequestFactory().post("/test", data=data, content_type="application/json")
+        )
+
+        # Generate signature with rpc0: prefix (from test utility)
+        rpc_signature = generate_service_request_signature(
+            request.path_info, request.body, ["test-secret-key"], "TestService"
+        )
+        # Extract signature data and use custom prefix
+        signature_data = rpc_signature.split(":", 1)[1]
+        custom_signature = f"service0:{signature_data}"
+
+        request.META["HTTP_AUTHORIZATION"] = f"rpcsignature {custom_signature}"
+
+        with override_settings(TEST_SERVICE_RPC_SHARED_SECRET=["test-secret-key"]):
+            user, token = auth.authenticate(request)
+            assert user.is_anonymous
+            assert token == custom_signature
 
     def test_authenticate_without_signature(self) -> None:
         request = drf_request_from_request(


### PR DESCRIPTION
This PR replaces the ServiceRpcSignatureAuthentication with a more generic HmacSignatureAuthentication class which attempts to provide a class to do hmac authentication which is not RPC specific in any way.

The motivation for this change to enable new service (Synapse), which does not use RPC to be able to utilize this implementation.

The are two main changes here:
- make the service prefix (which was previously hardcoded to `rpc0:`) configurable. Since this class never did any parsing of request bodies and just did cryptographic validation on body bytes this should be a fairly easy/safe change to make
- make it possible to sign both the URL as well as body. Currently the implementation only signs the body which is not great for GET requests which have none.

Default args are set for backward compatibility.

Note: the querystring is not included in the url that is signed. I didn't add this here to avoid more changes / encoding complexities.
