### PR TITLE
feat(top-issues): add experimental badge to Top Issues page

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -7,6 +7,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {bulkUpdate} from 'sentry/actionCreators/group';
 import {openConfirmModal} from 'sentry/components/confirm';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Checkbox} from 'sentry/components/core/checkbox';
@@ -715,8 +716,9 @@ function DynamicGrouping() {
           >
             <Flex align="center" gap="md">
               <ClickableHeading as="h1" onClick={() => setShowDevTools(prev => !prev)}>
-                {t('Top Issues (Experimental)')}
+                {t('Top Issues')}
               </ClickableHeading>
+              <FeatureBadge type="experimental" />
               {isUsingCustomData && (
                 <CustomDataBadge>
                   <Text size="xs" bold>


### PR DESCRIPTION
Add the experimental badge to the top issues page, in preparation for more internal testing
<img width="267" height="60" alt="Screenshot 2026-01-13 at 3 55 38 PM" src="https://github.com/user-attachments/assets/716cf436-a031-4603-98fe-bf596b8aead1" />
