### PR TITLE
feat(aci): Add warning message when action is not compatible with metric detectors

### DIFF
--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -19,6 +19,8 @@ import {
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 import {useAvailableActionsQuery} from 'sentry/views/automations/hooks';
+import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
+import {getIncompatibleActionWarning} from 'sentry/views/automations/utils/getIncompatibleActionWarning';
 
 interface ActionNodeListProps {
   actions: Action[];
@@ -68,6 +70,7 @@ export default function ActionNodeList({
 }: ActionNodeListProps) {
   const {data: availableActions = []} = useAvailableActionsQuery();
   const {errors, removeError} = useAutomationBuilderErrorContext();
+  const connectedDetectors = useConnectedDetectors();
 
   const options = useMemo(() => {
     const notificationActions: Option[] = [];
@@ -118,6 +121,9 @@ export default function ActionNodeList({
           return null;
         }
         const error = errors?.[action.id];
+        const warningMessage = getIncompatibleActionWarning(action, {
+          connectedDetectors,
+        });
         return (
           <AutomationBuilderRow
             key={`actionFilters.${conditionGroupId}.action.${action.id}`}
@@ -126,6 +132,7 @@ export default function ActionNodeList({
             }}
             hasError={!!error}
             errorMessage={error}
+            warningMessage={warningMessage}
           >
             <ActionNodeContext.Provider
               value={{

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -13,6 +13,7 @@ interface RowProps {
   onDelete: () => void;
   errorMessage?: string;
   hasError?: boolean;
+  warningMessage?: React.ReactNode;
 }
 
 export default function AutomationBuilderRow({
@@ -20,6 +21,7 @@ export default function AutomationBuilderRow({
   children,
   hasError,
   errorMessage,
+  warningMessage,
 }: RowProps) {
   return (
     <Flex direction="column" gap="xs">
@@ -35,6 +37,7 @@ export default function AutomationBuilderRow({
         />
       </RowContainer>
       {hasError && errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
+      {warningMessage && <Alert variant="warning">{warningMessage}</Alert>}
     </Flex>
   );
 }

--- a/static/app/views/automations/hooks/useConnectedDetectors.tsx
+++ b/static/app/views/automations/hooks/useConnectedDetectors.tsx
@@ -1,0 +1,11 @@
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
+
+export function useConnectedDetectors() {
+  const detectorIds = useFormField<string[]>('detectorIds') ?? [];
+  const {data: detectors = []} = useDetectorsQuery(
+    {ids: detectorIds, includeIssueStreamDetectors: true},
+    {enabled: detectorIds.length > 0}
+  );
+  return detectors;
+}

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import type {ActionType} from 'sentry/types/workflowEngine/actions';
+import {ActionType} from 'sentry/types/workflowEngine/actions';
 import type {Automation, StatusWarning} from 'sentry/types/workflowEngine/automations';
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
 import {

--- a/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
+++ b/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
@@ -1,0 +1,32 @@
+import {t} from 'sentry/locale';
+import {ActionType, type Action} from 'sentry/types/workflowEngine/actions';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+
+const METRIC_DETECTOR_SUPPORTED_ACTIONS = new Set<ActionType>([
+  ActionType.EMAIL,
+  ActionType.SLACK,
+  ActionType.MSTEAMS,
+  ActionType.PAGERDUTY,
+  ActionType.OPSGENIE,
+  ActionType.DISCORD,
+  ActionType.SENTRY_APP,
+]);
+
+/**
+ * Metric detectors only support a subset of actions, so we need
+ * to display a warning if the action is not supported.
+ */
+export function getIncompatibleActionWarning(
+  action: Action,
+  {connectedDetectors}: {connectedDetectors: Detector[]}
+): string | null {
+  if (METRIC_DETECTOR_SUPPORTED_ACTIONS.has(action.type)) {
+    return null;
+  }
+
+  if (!connectedDetectors.some(detector => detector.type === 'metric_issue')) {
+    return null;
+  }
+
+  return t('This action will not fire for metric issues.');
+}


### PR DESCRIPTION
Fixes ISWF-837

Defines a list of actions which are compatible with metric detectors, and if an action is not in that list displays this warning:

<img width="1374" height="674" alt="CleanShot 2026-01-13 at 17 20 26@2x" src="https://github.com/user-attachments/assets/bd8826a2-86f0-43d7-9129-dae984a3177d" />
