### PR TITLE
ref(grouping): Flag unknown fingerprint variables

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -388,6 +388,14 @@ def get_grouping_variants_for_event(
                 "hashed_checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
             }
 
+    # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we can
+    # remove this
+    use_legacy_unknown_variable_handling = (
+        True
+        if config is None
+        else config.initial_context.get("use_legacy_unknown_variable_handling", True)
+    )
+
     # Otherwise we go to the various forms of grouping based on fingerprints and/or event data
     # (stacktrace, message, etc.)
     raw_fingerprint = event.data.get("fingerprint") or ["{{ default }}"]
@@ -396,11 +404,19 @@ def get_grouping_variants_for_event(
     resolved_fingerprint = (
         raw_fingerprint
         if fingerprint_type == "default"
-        else resolve_fingerprint_values(raw_fingerprint, event.data)
+        else resolve_fingerprint_values(
+            raw_fingerprint,
+            event.data,
+            use_legacy_unknown_variable_handling=use_legacy_unknown_variable_handling,
+        )
     )
 
     # Check if the fingerprint includes a custom title, and if so, set the event's title accordingly.
-    _apply_custom_title_if_needed(fingerprint_info, event)
+    _apply_custom_title_if_needed(
+        fingerprint_info,
+        event,
+        use_legacy_unknown_variable_handling=use_legacy_unknown_variable_handling,
+    )
 
     # Run all of the event-data-based grouping strategies. Any which apply will create grouping
     # components, which will then be grouped into variants by variant type (system, app, default).
@@ -455,7 +471,9 @@ def get_grouping_variants_for_event(
     return final_variants
 
 
-def _apply_custom_title_if_needed(fingerprint_info: FingerprintInfo, event: Event) -> None:
+def _apply_custom_title_if_needed(
+    fingerprint_info: FingerprintInfo, event: Event, use_legacy_unknown_variable_handling: bool
+) -> None:
     """
     If the given event has a custom fingerprint which includes a title template, apply the custom
     title to the event.
@@ -463,7 +481,9 @@ def _apply_custom_title_if_needed(fingerprint_info: FingerprintInfo, event: Even
     custom_title_template = get_path(fingerprint_info, "matched_rule", "attributes", "title")
 
     if custom_title_template:
-        resolved_title = expand_title_template(custom_title_template, event.data)
+        resolved_title = expand_title_template(
+            custom_title_template, event.data, use_legacy_unknown_variable_handling
+        )
         event.data["title"] = resolved_title
 
 

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -78,6 +78,7 @@ register_grouping_config(
         "use_legacy_exception_subcomponent_order": False,
         "handle_js_single_frame_url_origin_backwards": False,
         "prevent_python_multiprocessing_context_line_parameterization": False,
+        "use_legacy_unknown_variable_handling": False,
     },
     enhancements_base="all-platforms:2025-11-21",
 )

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -64,6 +64,8 @@ register_grouping_config(
         "handle_js_single_frame_url_origin_backwards": True,
         # Don't parameterize `spawn_main(tracker_fd=12, pipe_handle=31)`-type context lines
         "prevent_python_multiprocessing_context_line_parameterization": True,
+        # Ignore rather than flagging unknown fingerprint variables
+        "use_legacy_unknown_variable_handling": True,
     },
     enhancements_base="all-platforms:2023-01-11",
     fingerprinting_bases=["javascript@2024-02-02"],


### PR DESCRIPTION
Currently, if we encounter a fingerprint variable we don't recognize, we leave it as is. This means that if someone typos their fingerprint rule (setting the fingerprint to `{{ massage }}` rather than `{{ message }}`, for example) or messes up the syntax (using `{{ dog_name }}` rather than `{{ tags.dog_name }}`, for example), we'll use `["{{ massage }}"]` or `["{{ dog_name }}"]` as the fingerprint, without telling them why. If the user doesn't notice the typo or has misunderstood the syntax, it'd be easy for them to attribute that behavior to a bug rather than to user error.

This PR therefore changes the behavior to highlight the problem, similar to the way we do if a fingerprint variable is recognized but doesn't have a corresponding value. In that case, we replace the variable (`{{ function }}` or `{{ tags.dog_name }}`, say) with a string indicating the missing value (`<no-function>` or `<no-value-for-tag-dog_name>`). After this change, unrecognized variables will now be replaced with the string `<unrecognized-variable-x>` (so in our examples, `<unrecognized-variable-massage>` and `<unrecognized-variable-dog_name>`). The same change is applied to fingerprint variables used to set an event's title.

Because this will have an effect on grouping, the new logic is only applied if the new `use_legacy_unknown_variable_handling` grouping config option (which defaults to `True`) is set to `False` (as it is in the new, as-yet-unreleased config).