### PR TITLE
ref(scraps): move theme.tooltipUnderline to useHoverOverlay

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -184,7 +184,11 @@ const styles = (theme: Theme, darkTheme: Theme) => css`
   `}
 
   abbr {
-    ${theme.tooltipUnderline()};
+    text-decoration: 'underline';
+    text-decoration-thickness: '0.75px';
+    text-underline-offset: '1.25px';
+    text-decoration-color: ${theme.tokens.content.secondary};
+    text-decoration-style: 'dotted';
   }
 
   a {

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -184,11 +184,11 @@ const styles = (theme: Theme, darkTheme: Theme) => css`
   `}
 
   abbr {
-    text-decoration: 'underline';
-    text-decoration-thickness: '0.75px';
-    text-underline-offset: '1.25px';
+    text-decoration: underline;
+    text-decoration-thickness: 0.75px;
+    text-underline-offset: 1.25px;
     text-decoration-color: ${theme.tokens.content.secondary};
-    text-decoration-style: 'dotted';
+    text-decoration-style: dotted;
   }
 
   a {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -168,25 +168,7 @@ type AlertColors = Record<
   }
 >;
 
-const generateThemeUtils = (tokens: Tokens) => ({
-  tooltipUnderline: (
-    underlineColor: 'warning' | 'danger' | 'success' | 'muted' = 'muted'
-  ) => ({
-    textDecoration: 'underline' as const,
-    textDecorationThickness: '0.75px',
-    textUnderlineOffset: '1.25px',
-    textDecorationColor:
-      underlineColor === 'warning'
-        ? tokens.content.warning
-        : underlineColor === 'danger'
-          ? tokens.content.danger
-          : underlineColor === 'success'
-            ? tokens.content.success
-            : underlineColor === 'muted'
-              ? tokens.content.secondary
-              : undefined,
-    textDecorationStyle: 'dotted' as const,
-  }),
+const generateThemeUtils = () => ({
   // https://css-tricks.com/inclusively-hidden/
   visuallyHidden: css`
     clip: rect(0 0 0 0);
@@ -1157,7 +1139,7 @@ const lightThemeDefinition = {
   }),
 
   // @TODO: these colors need to be ported
-  ...generateThemeUtils(baseLightTheme.tokens),
+  ...generateThemeUtils(),
   alert: generateAlertTheme(lightColors, baseLightTheme.tokens),
   button: generateButtonTheme(lightColors, baseLightTheme.tokens),
   level: generateLevelTheme(baseLightTheme.tokens, 'light'),
@@ -1195,7 +1177,7 @@ export const darkTheme: SentryTheme = {
   }),
 
   // @TODO: these colors need to be ported
-  ...generateThemeUtils(baseDarkTheme.tokens),
+  ...generateThemeUtils(),
   alert: generateAlertTheme(darkColors, baseDarkTheme.tokens),
   button: generateButtonTheme(darkColors, baseDarkTheme.tokens),
   level: generateLevelTheme(baseDarkTheme.tokens, 'dark'),

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -13,6 +13,8 @@ import {usePopper} from 'react-popper';
 import {useTheme} from '@emotion/react';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
 
+import type {Theme} from 'sentry/utils/theme';
+
 function makeDefaultPopperModifiers(arrowElement: HTMLElement | null, offset: number) {
   return [
     {
@@ -158,6 +160,27 @@ function maybeClearRefTimeout(ref: React.MutableRefObject<number | undefined>) {
   }
 }
 
+const tooltipUnderline = (
+  theme: Theme,
+  underlineColor: 'warning' | 'danger' | 'success' | 'muted' = 'muted'
+) =>
+  ({
+    textDecoration: 'underline',
+    textDecorationThickness: '0.75px',
+    textUnderlineOffset: '1.25px',
+    textDecorationColor:
+      underlineColor === 'warning'
+        ? theme.tokens.content.warning
+        : underlineColor === 'danger'
+          ? theme.tokens.content.danger
+          : underlineColor === 'success'
+            ? theme.tokens.content.success
+            : underlineColor === 'muted'
+              ? theme.tokens.content.secondary
+              : undefined,
+    textDecorationStyle: 'dotted',
+  }) as const;
+
 /**
  * A hook used to trigger a positioned overlay on hover.
  */
@@ -284,7 +307,7 @@ function useHoverOverlay({
         if (showUnderline) {
           const triggerStyle = {
             ...(triggerChildren.props as any).style,
-            ...theme.tooltipUnderline(underlineColor),
+            ...tooltipUnderline(theme, underlineColor),
           };
 
           return cloneElement<any>(
@@ -308,7 +331,7 @@ function useHoverOverlay({
 
       const containerProps = Object.assign(providedProps, {
         style: {
-          ...(showUnderline ? theme.tooltipUnderline(underlineColor) : {}),
+          ...(showUnderline ? tooltipUnderline(theme, underlineColor) : {}),
           ...(containerDisplayMode ? {display: containerDisplayMode} : {}),
           maxWidth: '100%',
           ...style,

--- a/static/app/views/automations/components/automationActionSummary.tsx
+++ b/static/app/views/automations/components/automationActionSummary.tsx
@@ -61,7 +61,6 @@ const ActionContainer = styled(Flex)`
 `;
 
 const ActionsList = styled('span')`
-  ${p => p.theme.tooltipUnderline()};
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -143,6 +143,7 @@ export function PagePerformanceTable() {
         <AlignCenter>
           <StyledTooltip
             isHoverable
+            showUnderline
             title={
               <span>
                 {t('The overall performance rating of this page.')}
@@ -154,7 +155,7 @@ export function PagePerformanceTable() {
             }
           >
             <SortLink
-              title={<TooltipHeader>{t('Perf Score')}</TooltipHeader>}
+              title={t('Perf Score')}
               direction={sort?.field === col.key ? sort.kind : undefined}
               canSort={canSort}
               generateSortLink={generateSortLink}
@@ -169,6 +170,7 @@ export function PagePerformanceTable() {
         <AlignRight>
           <StyledTooltip
             isHoverable
+            showUnderline
             title={
               <span>
                 {t(
@@ -183,7 +185,7 @@ export function PagePerformanceTable() {
           >
             <SortLink
               align="right"
-              title={<TooltipHeader>{col.name}</TooltipHeader>}
+              title={col.name}
               direction={sort?.field === col.key ? sort.kind : undefined}
               canSort={canSort}
               generateSortLink={generateSortLink}
@@ -372,10 +374,6 @@ const SearchBarContainer = styled('div')`
 
 const GridContainer = styled('div')`
   margin-bottom: ${space(1)};
-`;
-
-const TooltipHeader = styled('span')`
-  ${p => p.theme.tooltipUnderline()};
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -295,6 +295,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
             <AlignCenter>
               <StyledTooltip
                 isHoverable
+                showUnderline
                 title={
                   <span>
                     {tct('The [webVital] performance rating of this sample.', {
@@ -307,11 +308,9 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
                   </span>
                 }
               >
-                <TooltipHeader>
-                  {tct('[webVital] Score', {
-                    webVital: datatype.toUpperCase(),
-                  })}
-                </TooltipHeader>
+                {tct('[webVital] Score', {
+                  webVital: datatype.toUpperCase(),
+                })}
               </StyledTooltip>
             </AlignCenter>
           }
@@ -679,10 +678,6 @@ const Wrapper = styled('div')`
   align-items: center;
   justify-content: flex-end;
   margin: 0;
-`;
-
-const TooltipHeader = styled('span')`
-  ${p => p.theme.tooltipUnderline()};
 `;
 
 const StyledTooltip = styled(Tooltip)`

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -131,6 +131,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
       return (
         <Tooltip
           isHoverable
+          showUnderline
           title={
             <span>
               {tct(
@@ -144,7 +145,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
             </span>
           }
         >
-          <OpportunityHeader>{col.name}</OpportunityHeader>
+          {col.name}
         </Tooltip>
       );
     }
@@ -297,10 +298,6 @@ const ChartContainer = styled('div')`
 const AlignCenter = styled('span')`
   text-align: center;
   width: 100%;
-`;
-
-const OpportunityHeader = styled('span')`
-  ${p => p.theme.tooltipUnderline()};
 `;
 
 const TableContainer = styled('div')`

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -120,7 +120,7 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
       align={alignment}
       canSort={Boolean(location && sort && SORTABLE_FIELDS.has(key))}
       direction={sort?.field === column.key ? sort.kind : undefined}
-      title={hasTooltip ? <TooltipHeader>{name}</TooltipHeader> : name}
+      title={name}
       generateSortLink={() => {
         return {
           ...location,
@@ -138,7 +138,7 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
 
     return (
       <AlignmentContainer>
-        <StyledTooltip isHoverable title={column.tooltip}>
+        <StyledTooltip isHoverable showUnderline title={column.tooltip}>
           {sortLink}
         </StyledTooltip>
       </AlignmentContainer>
@@ -181,8 +181,4 @@ const AlignRight = styled('span')`
 const StyledTooltip = styled(Tooltip)`
   top: 1px;
   position: relative;
-`;
-
-const TooltipHeader = styled('span')`
-  ${p => p.theme.tooltipUnderline()};
 `;


### PR DESCRIPTION
Most places in the product that were using `theme.tooltipUnderline()` were unnecessary because they were applied to texts inside a `Tooltip`, which has a `showUnderline` prop to do exactly that.

After removing them, that left two places:

- `useHoverOverlay`, which is used by `Tooltip`: this is the only place that should have these styles, so they are inlined there.
- `global.tsx` for `abbr` tags: Not sure where we use these but I’ve duplicated the styles for this one situation to avoid exposing them for further usage.