### PR TITLE
feat(usageStats): Add new `ignored` client discard reason

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -96,6 +96,10 @@ describe('getReasonGroupName', () => {
     expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'queue_overflow')).toBe(
       ClientDiscardReason.QUEUE_OVERFLOW
     );
+
+    expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'ignored')).toBe(
+      ClientDiscardReason.IGNORED
+    );
   });
 
   it('handles abuse limit reason types', () => {

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -83,6 +83,7 @@ export enum ClientDiscardReason {
   INTERNAL_SDK_ERROR = 'internal_sdk_error',
   INSUFFICIENT_DATA = 'insufficient_data',
   BACKPRESSURE = 'backpressure',
+  IGNORED = 'ignored',
 }
 
 enum RateLimitedReason {
@@ -236,6 +237,7 @@ function getClientDiscardReasonGroupName(reason: ClientDiscardReason): string {
     case ClientDiscardReason.INTERNAL_SDK_ERROR:
     case ClientDiscardReason.INSUFFICIENT_DATA:
     case ClientDiscardReason.BACKPRESSURE:
+    case ClientDiscardReason.IGNORED:
       return reason;
     default:
       return 'other';


### PR DESCRIPTION
This PR adds the newly added `ignored` client discard reason, which we'll use SDK-side for recording outcomes for telemetry dropped via ignore-list-like options. For now, this will be used for span-first spans ignored via the `ignoreSpans` option. 

<img width="587" height="513" alt="image" src="https://github.com/user-attachments/assets/0daf02b4-a82e-4e68-829d-793e78f25814" />


reviewers, please let me know if I need to change something else. This is all I could find and it seems like the new reason shows up correctly in the UI. I might have missed something though.

ref:
- Snuba: https://github.com/getsentry/snuba/pull/7635
- Develop docs https://github.com/getsentry/sentry-docs/pull/16010
- Linear: https://linear.app/getsentry/issue/FE-678/add-new-ignore-discard-reason-for-client-reports