### PR TITLE
feat(scraps): renderToString util

### DIFF
--- a/static/app/components/core/renderToString.spec.tsx
+++ b/static/app/components/core/renderToString.spec.tsx
@@ -1,0 +1,38 @@
+import {ThemeProvider} from '@emotion/react';
+import {ThemeFixture} from 'sentry-fixture/theme';
+
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {Tag} from '@sentry/scraps/badge';
+
+import {useRenderToString} from './renderToString';
+
+const theme = ThemeFixture();
+
+describe('renderToString', () => {
+  it('should render a simple component to string', async () => {
+    function SimpleComponent() {
+      return <div>Hello, World!</div>;
+    }
+
+    const {result} = renderHook(() => useRenderToString());
+
+    const string = await act(() => result.current(<SimpleComponent />));
+
+    expect(string).toMatchInlineSnapshot("'<div>Hello, World!</div>'");
+  });
+  it('should render a scraps component to string', async () => {
+    function ScrapsComponent() {
+      return <Tag variant="success">SuccessTag</Tag>;
+    }
+
+    const {result} = renderHook(() => useRenderToString(), {
+      wrapper: ({children}) => <ThemeProvider theme={theme}>{children}</ThemeProvider>,
+    });
+
+    const string = await act(() => result.current(<ScrapsComponent />));
+
+    expect(string).toContain('data-test-id="tag-background"');
+    expect(string).toContain('SuccessTag');
+  });
+});

--- a/static/app/components/core/renderToString.spec.tsx
+++ b/static/app/components/core/renderToString.spec.tsx
@@ -19,7 +19,7 @@ describe('renderToString', () => {
 
     const string = await act(() => result.current(<SimpleComponent />));
 
-    expect(string).toMatchInlineSnapshot("'<div>Hello, World!</div>'");
+    expect(string).toMatchInlineSnapshot('"<div>Hello, World!</div>"');
   });
   it('should render a scraps component to string', async () => {
     function ScrapsComponent() {

--- a/static/app/components/core/renderToString.tsx
+++ b/static/app/components/core/renderToString.tsx
@@ -1,0 +1,26 @@
+import type {ReactNode} from 'react';
+import {flushSync} from 'react-dom';
+import {createRoot} from 'react-dom/client';
+import {ThemeProvider, useTheme} from '@emotion/react';
+
+const renderToString = (tree: ReactNode) => {
+  const div = document.createElement('div');
+  const root = createRoot(div);
+
+  flushSync(() => {
+    root.render(tree);
+  });
+
+  const html = div.innerHTML;
+
+  root.unmount();
+
+  return html;
+};
+
+export const useRenderToString = () => {
+  const theme = useTheme();
+
+  return (tree: ReactNode) =>
+    renderToString(<ThemeProvider theme={theme}>{tree}</ThemeProvider>);
+};

--- a/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
@@ -2,21 +2,18 @@ import {useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import type {ECharts, TreemapSeriesOption} from 'echarts';
 
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {useRenderToString} from '@sentry/scraps/renderToString';
 import {Separator} from '@sentry/scraps/separator/separator';
-import {Heading} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
 import {IconContract} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Theme} from 'sentry/utils/theme';
 import {getAppSizeDiffCategoryInfo} from 'sentry/views/preprod/components/visualizations/appSizeTreemapTheme';
 import {TreemapControlButtons} from 'sentry/views/preprod/components/visualizations/treemapControlButtons';
-import type {
-  DiffItem,
-  DiffType,
-  TreemapDiffElement,
-} from 'sentry/views/preprod/types/appSizeTypes';
+import type {DiffItem, TreemapDiffElement} from 'sentry/views/preprod/types/appSizeTypes';
 import {formattedSizeDiff} from 'sentry/views/preprod/utils/labelUtils';
 import {buildTreemapDiff} from 'sentry/views/preprod/utils/treemapDiffUtils';
 
@@ -28,6 +25,7 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
   const theme = useTheme();
   const [isZoomed, setIsZoomed] = useState(false);
   const chartRef = useRef<ECharts | null>(null);
+  const renderToString = useRenderToString();
 
   const treemapDiff = useMemo(() => {
     return buildTreemapDiff(diffItems);
@@ -200,28 +198,30 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
       fontFamily: 'Rubik',
     },
     formatter: function (params: any) {
-      const pathElement = params.data?.path
-        ? `<p style="font-size: 12px; margin-bottom: -4px;">${params.data.path}</p>`
-        : null;
-
       const sizeDiff = params.data?.size_diff || 0;
       const diffType = params.data?.diff_type || 'unchanged';
       const diffCategoryInfo = getAppSizeDiffCategoryInfo(theme)[diffType];
       if (!diffCategoryInfo) {
         throw new Error(`Diff type ${diffType} not found`);
       }
-      const diffTag = DiffTag(theme, sizeDiff, diffType, diffCategoryInfo.displayName);
-      return `
-        <div style="font-family: Rubik;">
-          <div style="display: flex; flex-direction: column; line-height: 1; gap: ${theme.space.sm}">
-            <div style="display: flex; align-items: center; gap: 6px;">
-              <span style="font-size: 14px; font-weight: bold;">${params.name}</span>
-            </div>
-            ${pathElement || ''}
-            <div style="display: flex; width: 100%;"><span style="display: inline-flex;">${diffTag}</span></div>
-          </div>
-        </div>
-      `.trim();
+
+      const diffString = formattedSizeDiff(sizeDiff);
+      let tagType: TagType = 'muted';
+      if (diffType === 'increased' || diffType === 'added') {
+        tagType = 'danger';
+      } else if (diffType === 'decreased' || diffType === 'removed') {
+        tagType = 'success';
+      }
+
+      return renderToString(
+        <Stack gap="sm">
+          <Flex gap="sm">
+            <Text bold>{params.name}</Text>
+          </Flex>
+          {params.data?.path ? <Text size="sm">{params.data.path}</Text> : null}
+          <Tag variant={tagType}>{`${diffString} (${diffCategoryInfo.displayName})`}</Tag>
+        </Stack>
+      );
     },
   };
 
@@ -267,54 +267,3 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
 }
 
 type TagType = 'success' | 'danger' | 'muted';
-const tagColors = (
-  theme: Theme
-): Record<TagType, {backgroundColor: string; color: string}> => ({
-  success: {backgroundColor: theme.colors.green100, color: theme.colors.green500},
-  danger: {backgroundColor: theme.colors.red100, color: theme.colors.red500},
-  muted: {backgroundColor: theme.colors.surface500, color: theme.colors.gray500},
-});
-
-function DiffTag(
-  theme: Theme,
-  sizeDiff: number,
-  diffType: DiffType,
-  label: string
-): string {
-  const diffString = formattedSizeDiff(sizeDiff);
-  let tagType: TagType = 'muted';
-  if (diffType === 'increased' || diffType === 'added') {
-    tagType = 'danger';
-  } else if (diffType === 'decreased' || diffType === 'removed') {
-    tagType = 'success';
-  }
-
-  // Intentionally a string as Echarts cannot render React components
-  return `<div style="
-    font-size: ${theme.font.size.sm};
-    background-color: ${tagColors(theme)[tagType].backgroundColor};
-    display: inline-flex;
-    align-items: center;
-    height: 20px;
-    border-radius: 4px;
-    padding: 0 ${theme.space.md};
-    gap: ${theme.space.md};
-    color: ${tagColors(theme)[tagType].color};
-  ">
-    <span style="
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      display: inline-block;
-      font-weight: bold;
-    ">
-      ${diffString}
-    </span>
-    <span style="
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      display: inline-block;
-    ">(${label})</span>
-  </div>`;
-}


### PR DESCRIPTION
Scraps exports a new `useRenderToString` util that allows rendering a component into a string; This is useful for situations where we have to pass raw html strings to third parties like ECharts.

Advantages of this approach are:

- no more manual styling necessary - just render scraps components as usual
- proper input escaping, since the stringification is taken care of by react

The implementation is done with the suggested approach of the react docs, [`createRoot` and `flushSync`](https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code).

As a first proof of concept, the treeMap tooltips were re-written.

before:
<img width="454" height="328" alt="Screenshot 2026-01-14 at 13 43 02" src="https://github.com/user-attachments/assets/2d153194-22f0-48b4-a7fa-c20dd4d07639" />

after:
<img width="511" height="355" alt="Screenshot 2026-01-14 at 13 42 57" src="https://github.com/user-attachments/assets/c4b53137-1b00-45c4-9395-c3ffcc11a5ab" />

there’s a slight visual difference - the text in the `Tag` is no longer bold, but that is now consistent with how all our Tags look like.