### PR TITLE
ref(preprod): Move Preprod{Static,Delta}GroupType to /preprod

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -724,49 +724,6 @@ class WebVitalsGroup(GroupType):  # TODO: Rename to WebVitalsGroupType
     released = True
 
 
-@dataclass(frozen=True)
-class PreprodStaticGroupType(GroupType):
-    """
-    Issues detected in a single uploaded artifact. For example an
-    Android app not being 16kb page size ready.
-    Typically these end up grouped across multiple builds e.g. if CI
-    uploads a build of an app for each commit to main each of those
-    uploads could result in an occurrence of some issue like the 16kb
-    page size.
-    """
-
-    type_id = 11001
-    slug = "preprod_static"
-    description = "Static Analysis"
-    category = GroupCategory.PREPROD.value
-    category_v2 = GroupCategory.PREPROD.value
-    default_priority = PriorityLevel.LOW
-    released = False
-    enable_auto_resolve = True
-    enable_escalation_detection = False
-
-
-@dataclass(frozen=True)
-class PreprodDeltaGroupType(GroupType):
-    """
-    Issues detected examining the delta between two uploaded artifacts.
-    For example a binary size regression. These are typically *not*
-    grouped. A size regression between v1 and v2 likely does not have
-    the same root cause (and hence resolution) as another regression
-    between v2 and v3.
-    """
-
-    type_id = 11002
-    slug = "preprod_delta"
-    description = "Static Analysis Delta"
-    category = GroupCategory.PREPROD.value
-    category_v2 = GroupCategory.PREPROD.value
-    default_priority = PriorityLevel.LOW
-    released = False
-    enable_auto_resolve = True
-    enable_escalation_detection = False
-
-
 def should_create_group(
     grouptype: type[GroupType],
     client: RedisCluster | StrictRedis,

--- a/src/sentry/preprod/grouptype.py
+++ b/src/sentry/preprod/grouptype.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.types.group import PriorityLevel
+
+
+@dataclass(frozen=True)
+class PreprodStaticGroupType(GroupType):
+    """
+    Issues detected in a single uploaded artifact. For example an
+    Android app not being 16kb page size ready.
+    Typically these end up grouped across multiple builds e.g. if CI
+    uploads a build of an app for each commit to main each of those
+    uploads could result in an occurrence of some issue like the 16kb
+    page size.
+    """
+
+    type_id = 11001
+    slug = "preprod_static"
+    description = "Static Analysis"
+    category = GroupCategory.PREPROD.value
+    category_v2 = GroupCategory.PREPROD.value
+    default_priority = PriorityLevel.LOW
+    released = False
+    enable_auto_resolve = True
+    enable_escalation_detection = False
+
+
+@dataclass(frozen=True)
+class PreprodDeltaGroupType(GroupType):
+    """
+    Issues detected examining the delta between two uploaded artifacts.
+    For example a binary size regression. These are typically *not*
+    grouped. A size regression between v1 and v2 likely does not have
+    the same root cause (and hence resolution) as another regression
+    between v2 and v3.
+    """
+
+    type_id = 11002
+    slug = "preprod_delta"
+    description = "Static Analysis Delta"
+    category = GroupCategory.PREPROD.value
+    category_v2 = GroupCategory.PREPROD.value
+    default_priority = PriorityLevel.LOW
+    released = False
+    enable_auto_resolve = True
+    enable_escalation_detection = False

--- a/src/sentry/preprod/size_analysis/issues.py
+++ b/src/sentry/preprod/size_analysis/issues.py
@@ -2,11 +2,11 @@ from datetime import datetime, timezone
 from typing import Any, Literal
 from uuid import uuid4
 
-from sentry.issues.grouptype import PreprodDeltaGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     platform_from_artifact_type,
 )
+from sentry.preprod.grouptype import PreprodDeltaGroupType
 from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.preprod.size_analysis.models import SizeMetricDiffItem
 

--- a/tests/sentry/preprod/size_analysis/test_issues.py
+++ b/tests/sentry/preprod/size_analysis/test_issues.py
@@ -1,4 +1,4 @@
-from sentry.issues.grouptype import PreprodDeltaGroupType
+from sentry.preprod.grouptype import PreprodDeltaGroupType
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 from sentry.preprod.size_analysis.issues import artifact_to_tags, diff_to_occurrence
 from sentry.preprod.size_analysis.models import SizeMetricDiffItem


### PR DESCRIPTION
Should be a noop. This makes adding detectors for `Preprod{Static,Delta}GroupType` simpler. 