### PR TITLE
fix(ai-insights): set has_insights_agent_monitoring flag

### DIFF
--- a/src/sentry/insights/__init__.py
+++ b/src/sentry/insights/__init__.py
@@ -14,6 +14,7 @@ class FilterSpan(NamedTuple):
     category: str | None
     description: str | None
     transaction_op: str | None
+    gen_ai_op_name: str | None
 
     @classmethod
     def from_span_v1(cls, span: dict[str, Any]) -> "FilterSpan":
@@ -23,6 +24,7 @@ class FilterSpan(NamedTuple):
             category=span.get("sentry_tags", {}).get("category"),
             description=span.get("description"),
             transaction_op=span.get("sentry_tags", {}).get("transaction.op"),
+            gen_ai_op_name=None,
         )
 
     @classmethod
@@ -33,6 +35,7 @@ class FilterSpan(NamedTuple):
             category=(attributes.get("sentry.category") or {}).get("value"),
             description=(attributes.get("sentry.description") or {}).get("value"),
             transaction_op=(attributes.get("sentry.transaction_op") or {}).get("value"),
+            gen_ai_op_name=(attributes.get("gen_ai.operation.name") or {}).get("value"),
         )
 
 
@@ -69,7 +72,7 @@ def is_queue(span: FilterSpan) -> bool:
 
 
 def is_agents(span: FilterSpan) -> bool:
-    return span.op is not None and span.op.startswith("gen_ai.")
+    return span.gen_ai_op_name is not None or (span.op is not None and span.op.startswith("gen_ai"))
 
 
 def is_mcp(span: FilterSpan) -> bool:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2032,51 +2032,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         self.project.refresh_from_db()
         assert self.project.flags.has_insights_db
 
-    def test_first_insight_span_agents_via_gen_ai_op_name(self) -> None:
-        """Test that spans with gen_ai.operation.name sentry tag trigger agents insight."""
-        event_data = make_event(
-            transaction="test_transaction",
-            contexts={
-                "trace": {
-                    "parent_span_id": "bce14471e0e9654d",
-                    "op": "foobar",
-                    "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
-                    "span_id": "bf5be759039ede9a",
-                }
-            },
-            spans=[
-                {
-                    "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
-                    "parent_span_id": "bf5be759039ede9a",
-                    "span_id": "a" * 16,
-                    "start_timestamp": 0,
-                    "timestamp": 1,
-                    "same_process_as_parent": True,
-                    "op": "http.client",
-                    "description": "POST /api/chat",
-                    "sentry_tags": {
-                        "description": "POST /api/chat",
-                        "category": "http",
-                        "op": "http.client",
-                        "transaction": "/app/index",
-                        "gen_ai.operation.name": "chat",
-                    },
-                }
-            ],
-            timestamp="2019-06-14T14:01:40Z",
-            start_timestamp="2019-06-14T14:01:40Z",
-            type="transaction",
-        )
-
-        assert not self.project.flags.has_insights_agent_monitoring
-
-        manager = EventManager(event_data)
-        manager.normalize()
-        manager.save(self.project.id)
-
-        self.project.refresh_from_db()
-        assert self.project.flags.has_insights_agent_monitoring
-
     def test_sdk(self) -> None:
         manager = EventManager(make_event(**{"sdk": {"name": "sentry-unity", "version": "1.0"}}))
         manager.normalize()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2032,6 +2032,51 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         self.project.refresh_from_db()
         assert self.project.flags.has_insights_db
 
+    def test_first_insight_span_agents_via_gen_ai_op_name(self) -> None:
+        """Test that spans with gen_ai.operation.name sentry tag trigger agents insight."""
+        event_data = make_event(
+            transaction="test_transaction",
+            contexts={
+                "trace": {
+                    "parent_span_id": "bce14471e0e9654d",
+                    "op": "foobar",
+                    "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                    "span_id": "bf5be759039ede9a",
+                }
+            },
+            spans=[
+                {
+                    "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                    "parent_span_id": "bf5be759039ede9a",
+                    "span_id": "a" * 16,
+                    "start_timestamp": 0,
+                    "timestamp": 1,
+                    "same_process_as_parent": True,
+                    "op": "http.client",
+                    "description": "POST /api/chat",
+                    "sentry_tags": {
+                        "description": "POST /api/chat",
+                        "category": "http",
+                        "op": "http.client",
+                        "transaction": "/app/index",
+                        "gen_ai.operation.name": "chat",
+                    },
+                }
+            ],
+            timestamp="2019-06-14T14:01:40Z",
+            start_timestamp="2019-06-14T14:01:40Z",
+            type="transaction",
+        )
+
+        assert not self.project.flags.has_insights_agent_monitoring
+
+        manager = EventManager(event_data)
+        manager.normalize()
+        manager.save(self.project.id)
+
+        self.project.refresh_from_db()
+        assert self.project.flags.has_insights_agent_monitoring
+
     def test_sdk(self) -> None:
         manager = EventManager(make_event(**{"sdk": {"name": "sentry-unity", "version": "1.0"}}))
         manager.normalize()

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -241,6 +241,25 @@ class TestSpansTask(TestCase):
 
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_http"]
+        assert "has_insights_agent_monitoring" not in signals
+
+    @mock.patch("sentry.spans.consumers.process_segments.message.set_project_flag_and_signal")
+    def test_record_signals_agents_via_gen_ai_op_name(self, mock_track):
+        """Test that spans with gen_ai.operation.name attribute trigger agents insight."""
+        span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+            span_op="http.client",
+            attributes={
+                "sentry.op": {"value": "http.client"},
+                "gen_ai.operation.name": {"value": "chat"},
+            },
+        )
+        spans = process_segment([span])
+        assert len(spans) == 1
+
+        signals = [args[0][1] for args in mock_track.call_args_list]
+        assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
     def test_segment_name_propagation(self):
         child_span, segment_span = self.generate_basic_spans()


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/TET-1723/spans-with-gen-aioperationname-do-not-set-the-has-agents-insights-flag