### PR TITLE
ref(scraps): background surface500/400/300 to background tokens

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -241,7 +241,7 @@ const InnerLabel = styled(TextOverflow)`
 
 const InputWrapper = styled('div')<{isEmpty: boolean}>`
   display: inline-block;
-  background: ${p => p.theme.colors.surface300};
+  background: ${p => p.theme.tokens.background.tertiary};
   border-radius: ${p => p.theme.radius.md};
   margin: -${space(0.5)} -${space(1)};
   padding: ${space(0.5)} ${space(1)};

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -403,7 +403,9 @@ const DefaultLine = styled('div')<{
   justify-content: space-between;
   align-items: center;
   background: ${p =>
-    p.isSubFrame ? `${p.theme.colors.surface200}` : `${p.theme.colors.surface300}`};
+    p.isSubFrame
+      ? `${p.theme.colors.surface200}`
+      : `${p.theme.tokens.background.tertiary}`};
   min-height: 40px;
   word-break: break-word;
   padding: ${space(0.75)} ${space(1.5)};

--- a/static/app/components/notificationActions/notificationActionItem.tsx
+++ b/static/app/components/notificationActions/notificationActionItem.tsx
@@ -361,7 +361,7 @@ const StyledCard = styled(Card)<{isEditing: boolean}>`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   background-color: ${props =>
-    props.isEditing ? props.theme.colors.surface300 : 'inherit'};
+    props.isEditing ? props.theme.tokens.background.tertiary : 'inherit'};
 `;
 
 const IconContainer = styled('div')`

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -526,7 +526,7 @@ const FrameBar = styled('div')<{withoutBorders?: boolean}>`
   overflow: auto;
   width: 100%;
   position: relative;
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   ${p => !p.withoutBorders && `border-top: 1px solid ${p.theme.tokens.border.primary};`}
   flex: 1 1 100%;
 `;

--- a/static/app/components/profiling/flamegraph/callTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/callTreeTable.tsx
@@ -66,7 +66,7 @@ export const CallTreeTable = styled('div')`
     }
 
     &[data-hovered='true']:not([tabindex='0']) {
-      background: ${p => p.theme.colors.surface300};
+      background: ${p => p.theme.tokens.background.tertiary};
     }
   }
 
@@ -231,7 +231,7 @@ export const CallTreeTableHeaderButton = styled('button')`
   justify-content: space-between;
   padding: 0 ${space(1)};
   border: none;
-  background-color: ${props => props.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   transition: background-color 100ms ease-in-out;
   line-height: 29px;
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
@@ -351,7 +351,7 @@ const ProfilingDetailsFrameTabs = styled('ul')`
   padding: 0 ${space(1)};
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.tokens.border.primary};
-  background-color: ${props => props.theme.colors.surface300};
+  background-color: ${props => props.theme.tokens.background.tertiary};
   user-select: none;
   grid-area: tabs;
 `;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -361,7 +361,7 @@ export const ProfilingDetailsFrameTabs = styled('ul')`
   padding: 0 ${space(1)};
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.tokens.border.primary};
-  background-color: ${props => props.theme.colors.surface300};
+  background-color: ${props => props.theme.tokens.background.tertiary};
   user-select: none;
   grid-area: tabs;
 `;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -391,7 +391,7 @@ const FrameBar = styled('div')`
   overflow: auto;
   width: 100%;
   position: relative;
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   border-top: 1px solid ${p => p.theme.tokens.border.primary};
   flex: 1 1 100%;
   grid-area: table;

--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -361,7 +361,7 @@ const StoryTypesTable = styled('table')`
   table-layout: fixed;
 
   th {
-    background-color: ${p => p.theme.colors.surface300};
+    background-color: ${p => p.theme.tokens.background.tertiary};
   }
 
   tr:not(:last-child) {
@@ -380,13 +380,13 @@ const StoryTypesTable = styled('table')`
 
 const StoryTypesTableHeader = styled('thead')`
   tr {
-    background-color: ${p => p.theme.colors.surface300};
+    background-color: ${p => p.theme.tokens.background.tertiary};
     border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
   }
 `;
 
 const StoryTypesTableHeaderCell = styled('th')`
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   padding: ${p => p.theme.space.md};
 `;
 
@@ -398,7 +398,7 @@ const StoryTypesTableCell = styled('td')`
 const StoryTypesTableDefinitionCell = styled('td')`
   padding: ${p => p.theme.space.md};
   padding-left: 0;
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
 
   button {
     margin-left: ${p => p.theme.space['2xs']};

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -359,7 +359,7 @@ export const makeDarkFlamegraphTheme = (theme: Theme): FlamegraphTheme => {
 
       // Layout colors
       GRID_LINE_COLOR: theme.colors.surface200,
-      GRID_FRAME_BACKGROUND_COLOR: theme.colors.surface400,
+      GRID_FRAME_BACKGROUND_COLOR: theme.tokens.background.secondary,
       MINIMAP_POSITION_OVERLAY_BORDER_COLOR: theme.colors.gray300,
       MINIMAP_POSITION_OVERLAY_COLOR: theme.colors.gray200,
 

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -418,7 +418,7 @@ const TriggerActions = styled('div')`
 
 const TriggerText = styled('span')`
   display: block;
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   padding: ${space(0.25)} ${space(0.75)};
   border-radius: ${p => p.theme.radius.md};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -804,7 +804,7 @@ function LoadingScreen({
 const LoadingPlaceholder = styled(({className}: PlaceholderProps) => (
   <Placeholder height="200px" className={className} />
 ))`
-  background-color: ${p => p.theme.colors.surface400};
+  background-color: ${p => p.theme.tokens.background.secondary};
 `;
 
 const BigNumberResizeWrapper = styled('div')<{noPadding?: boolean}>`

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -118,7 +118,8 @@ const ToolbarPanel = styled('div')`
   justify-content: flex-end;
   align-items: flex-start;
 
-  background-color: ${p => color(p.theme.colors.surface400).alpha(0.7).string()};
+  background-color: ${p =>
+    color(p.theme.tokens.background.secondary).alpha(0.7).string()};
   border-radius: calc(${p => p.theme.radius.md} - 1px);
 `;
 

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -165,7 +165,7 @@ const OptionLabel = styled('label')<{disabled?: boolean}>`
   grid-template-columns: 1fr;
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.theme.colors.surface500};
+  background-color: ${p => p.theme.background.primary};
   font-weight: ${p => p.theme.fontWeight.normal};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   overflow: hidden;

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -165,7 +165,7 @@ const OptionLabel = styled('label')<{disabled?: boolean}>`
   grid-template-columns: 1fr;
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.theme.background.primary};
+  background-color: ${p => p.theme.tokens.background.primary};
   font-weight: ${p => p.theme.fontWeight.normal};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   overflow: hidden;

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -89,7 +89,7 @@ const FrameContainer = styled('div')`
 
   border-top: 1px solid ${p => p.theme.tokens.border.primary};
 
-  background: ${p => p.theme.colors.surface300};
+  background: ${p => p.theme.tokens.background.tertiary};
 `;
 
 const ProjectAvatarContainer = styled('div')`

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -188,7 +188,7 @@ const EventItemRoot = styled(Link)`
   font-size: ${p => p.theme.fontSize.sm};
 
   &:hover {
-    background-color: ${p => p.theme.colors.surface300};
+    background-color: ${p => p.theme.tokens.background.tertiary};
     color: ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/views/nav/mobileTopbar.tsx
+++ b/static/app/views/nav/mobileTopbar.tsx
@@ -132,7 +132,7 @@ const Topbar = styled('header')<{showSuperuserWarning: boolean}>`
   padding-left: ${space(1.5)};
   padding-right: ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.colors.gray200};
-  background: ${p => p.theme.colors.surface400};
+  background: ${p => p.theme.tokens.background.secondary};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/static/app/views/nav/mobileTopbar.tsx
+++ b/static/app/views/nav/mobileTopbar.tsx
@@ -156,7 +156,7 @@ const NavigationOverlay = styled('nav')`
   left: 0;
   display: flex;
   flex-direction: column;
-  background: ${p => p.theme.colors.surface300};
+  background: ${p => p.theme.tokens.background.tertiary};
   z-index: ${p => p.theme.zIndex.modal};
   --color: ${p => p.theme.tokens.content.primary};
   --color-hover: ${p => p.theme.tokens.interactive.link.accent.rest};

--- a/static/app/views/nav/secondary/secondaryMobile.tsx
+++ b/static/app/views/nav/secondary/secondaryMobile.tsx
@@ -52,7 +52,7 @@ const GroupHeader = styled('h2')`
   position: sticky;
   top: 0;
   z-index: 1;
-  background: ${p => p.theme.colors.surface300};
+  background: ${p => p.theme.tokens.background.tertiary};
   display: flex;
   align-items: center;
   padding: ${space(2)} ${space(1)};

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -73,7 +73,11 @@ export function IssueViewQueryCount({view, isActive}: IssueViewQueryCountProps) 
     <QueryCountBubble
       animate={{
         backgroundColor: isFetching
-          ? [theme.colors.surface500, theme.colors.surface200, theme.colors.surface500]
+          ? [
+              theme.tokens.background.primary,
+              theme.colors.surface200,
+              theme.colors.surface500,
+            ]
           : `#00000000`,
       }}
       transition={{

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -76,7 +76,7 @@ export function IssueViewQueryCount({view, isActive}: IssueViewQueryCountProps) 
           ? [
               theme.tokens.background.primary,
               theme.colors.surface200,
-              theme.colors.surface500,
+              theme.tokens.background.primary,
             ]
           : `#00000000`,
       }}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -786,7 +786,7 @@ const TableValueRow = styled('div')`
   gap: ${space(1)};
 
   border-radius: 4px;
-  background-color: ${p => p.theme.colors.surface300};
+  background-color: ${p => p.theme.tokens.background.tertiary};
   margin: 2px;
 `;
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -351,7 +351,7 @@ const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
   ${p =>
     p.isSelected &&
     `
-      background-color: ${p.theme.colors.surface300};
+      background-color: ${p.theme.tokens.background.tertiary};
     `}
 `;
 

--- a/static/app/views/relocation/components/wrapper.tsx
+++ b/static/app/views/relocation/components/wrapper.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.colors.surface500};
+  background-color: ${p => p.theme.tokens.background.primary};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -147,7 +147,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.colors.surface500};
+  background-color: ${p => p.theme.tokens.background.primary};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -187,7 +187,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.colors.surface500};
+  background-color: ${p => p.theme.tokens.background.primary};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;

--- a/static/app/views/replays/detail/network/details/tabs.tsx
+++ b/static/app/views/replays/detail/network/details/tabs.tsx
@@ -48,7 +48,7 @@ const StyledNetworkDetailsTabs = styled(NetworkDetailsTabs)`
   & > li {
     margin-right: 0;
     padding-right: ${space(3)};
-    background: ${p => p.theme.colors.surface500};
+    background: ${p => p.theme.tokens.background.primary};
     z-index: ${p => p.theme.zIndex.initial};
   }
   & > li:first-child {


### PR DESCRIPTION
to increase semantic token usage and get closer to the goal of not using `theme.color`, this PR moves `background` and `background-color` usages of `theme.colors.surfaceNNN` to the equivalent semantic `theme.tokens.background` token:

`theme.colors.surface500` -> `theme.tokens.background.primary`
`theme.colors.surface400` -> `theme.tokens.background.secondary`
`theme.colors.surface300` -> `theme.tokens.background.tertiary`

note: there are some instance of these colors that are unrelated to `background`. I’ve kept them as-is, as we need to look at those individually. There are also `surface200` usages for `background-color`, but this would translate to `border.muted` and would thus be semantically incorrect. Not sure what they should become eventually. @Jesse-Box FYI