### PR TITLE
feat(search): Support explicit boolean tags

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -35,14 +35,21 @@ from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
 
+ATTR_MAP = {
+    "number": AttributeKey.Type.TYPE_DOUBLE,
+    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
+}
 
-def as_tag_key(name: str, type: Literal["string", "number"]):
+
+def as_tag_key(name: str, type: Literal["string", "number", "boolean"]):
     key, _, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
 
     if key is not None:
         name = key
     elif type == "number":
         key = f"tags[{name},number]"
+    elif type == "boolean":
+        key = f"tags[{name},boolean]"
     else:
         key = name
 
@@ -62,7 +69,9 @@ class OrganizationSpansFieldsEndpointBase(OrganizationEventsEndpointBase):
 
 
 class OrganizationSpansFieldsEndpointSerializer(serializers.Serializer):
-    type = serializers.ChoiceField(["string", "number"], required=False, default="string")
+    type = serializers.ChoiceField(
+        ["string", "number", "boolean"], required=False, default="string"
+    )
 
 
 @region_silo_endpoint
@@ -107,15 +116,12 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
             )
             meta = resolver.resolve_meta(referrer=Referrer.API_SPANS_TAG_KEYS_RPC.value)
 
+            attr_type = ATTR_MAP.get(serialized["type"], AttributeKey.Type.TYPE_STRING)
             rpc_request = TraceItemAttributeNamesRequest(
                 meta=meta,
                 limit=max_span_tags,
                 offset=0,
-                type=(
-                    AttributeKey.Type.TYPE_DOUBLE
-                    if serialized["type"] == "number"
-                    else AttributeKey.Type.TYPE_STRING
-                ),
+                type=attr_type,
             )
 
             rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)

--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -35,11 +35,6 @@ from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
 
-ATTR_MAP = {
-    "number": AttributeKey.Type.TYPE_DOUBLE,
-    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
-}
-
 
 def as_tag_key(name: str, type: Literal["string", "number", "boolean"]):
     key, _, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
@@ -116,7 +111,9 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
             )
             meta = resolver.resolve_meta(referrer=Referrer.API_SPANS_TAG_KEYS_RPC.value)
 
-            attr_type = ATTR_MAP.get(serialized["type"], AttributeKey.Type.TYPE_STRING)
+            attr_type = constants.ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP.get(
+                serialized["type"], AttributeKey.Type.TYPE_STRING
+            )
             rpc_request = TraceItemAttributeNamesRequest(
                 meta=meta,
                 limit=max_span_tags,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -132,7 +132,7 @@ class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
         [e.value for e in SupportedTraceItemType], required=True, source="item_type"
     )
     attributeType = serializers.ChoiceField(
-        ["string", "number"], required=True, source="attribute_type"
+        ["string", "number", "boolean"], required=True, source="attribute_type"
     )
     substringMatch = serializers.CharField(required=False, source="substring_match")
     query = serializers.CharField(required=False)
@@ -182,7 +182,7 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 
 
 def as_attribute_key(
-    name: str, type: Literal["string", "number"], item_type: SupportedTraceItemType
+    name: str, type: Literal["string", "number", "boolean"], item_type: SupportedTraceItemType
 ) -> TraceItemAttributeKey:
     public_key, public_name, attribute_source = translate_internal_to_public_alias(
         name, type, item_type
@@ -193,6 +193,9 @@ def as_attribute_key(
         pass
     elif type == "number":
         public_key = f"tags[{name},number]"
+        public_name = name
+    elif type == "boolean":
+        public_key = f"tags[{name},boolean]"
         public_name = name
     else:
         public_key = name
@@ -218,6 +221,12 @@ def as_attribute_key(
         attribute_key["secondaryAliases"] = sorted(secondary_aliases)
 
     return attribute_key
+
+
+ATTR_TYPE_MAP = {
+    "number": AttributeKey.Type.TYPE_DOUBLE,
+    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
+}
 
 
 @region_silo_endpoint
@@ -274,12 +283,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
 
-        attr_type = (
-            AttributeKey.Type.TYPE_DOUBLE
-            if attribute_type == "number"
-            else AttributeKey.Type.TYPE_STRING
-        )
-
+        attr_type = ATTR_TYPE_MAP.get(attribute_type, AttributeKey.Type.TYPE_STRING)
         include_internal = is_active_superuser(request) or is_active_staff(request)
 
         def data_fn(offset: int, limit: int):

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -223,12 +223,6 @@ def as_attribute_key(
     return attribute_key
 
 
-ATTR_TYPE_MAP = {
-    "number": AttributeKey.Type.TYPE_DOUBLE,
-    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
-}
-
-
 @region_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
@@ -283,7 +277,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
 
-        attr_type = ATTR_TYPE_MAP.get(attribute_type, AttributeKey.Type.TYPE_STRING)
+        attr_type = constants.ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP.get(
+            attribute_type, AttributeKey.Type.TYPE_STRING
+        )
         include_internal = is_active_superuser(request) or is_active_staff(request)
 
         def data_fn(offset: int, limit: int):

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -211,3 +211,9 @@ SENTRY_INTERNAL_PREFIXES = ["__sentry_internal", "sentry._internal."]
 TIMESTAMP_PRECISE_ALIAS = "timestamp_precise"
 TIMESTAMP_ALIAS = "timestamp"
 TRACE_ALIAS = "trace"
+
+ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP = {
+    "number": AttributeKey.Type.TYPE_DOUBLE,
+    "boolean": AttributeKey.Type.TYPE_BOOLEAN,
+    "string": AttributeKey.Type.TYPE_STRING,
+}

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -112,7 +112,9 @@ OURLOG_VIRTUAL_CONTEXTS = {
     for key in constants.PROJECT_FIELDS
 }
 
-LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[str, str]] = {
+LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
+    Literal["string", "number", "boolean"], dict[str, str]
+] = {
     "string": {
         definition.internal_name: definition.public_alias
         for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
@@ -122,9 +124,15 @@ LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[s
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
+        # Include boolean attributes because they're stored as numbers (0 or 1)
         if not definition.secondary_alias and definition.search_type != "string"
     },
 }

--- a/src/sentry/search/eap/profile_functions/attributes.py
+++ b/src/sentry/search/eap/profile_functions/attributes.py
@@ -140,7 +140,7 @@ PROFILE_FUNCTIONS_VIRTUAL_CONTEXTS = {
 }
 
 PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    Literal["string", "number"], dict[str, str]
+    Literal["string", "number", "boolean"], dict[str, str]
 ] = {
     "string": {
         definition.internal_name: definition.public_alias
@@ -151,9 +151,15 @@ PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS.values()
+        # Include boolean attributes because they're stored as numbers (0 or 1)
         if not definition.secondary_alias and definition.search_type != "string"
     },
 }

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -591,7 +591,9 @@ def is_starred_segment_context_constructor(params: SnubaParams) -> VirtualColumn
     )
 
 
-SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[str, str]] = {
+SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
+    Literal["string", "number", "boolean"], dict[str, str]
+] = {
     "string": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
@@ -607,9 +609,15 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[
         "sentry.span_id": "id",
         "sentry.segment_name": "transaction",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+        # Include boolean attributes because they're stored as numbers (0 or 1)
         if not definition.secondary_alias and definition.search_type != "string"
     }
     | {

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -83,7 +83,7 @@ TRACE_METRICS_VIRTUAL_CONTEXTS = {
 }
 
 TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    Literal["string", "number"], dict[str, str]
+    Literal["string", "number", "boolean"], dict[str, str]
 ] = {
     "string": {
         definition.internal_name: definition.public_alias
@@ -94,9 +94,15 @@ TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
     },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in TRACE_METRICS_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
     "number": {
         definition.internal_name: definition.public_alias
         for definition in TRACE_METRICS_ATTRIBUTE_DEFINITIONS.values()
+        # Include boolean attributes because they're stored as numbers (0 or 1)
         if not definition.secondary_alias and definition.search_type != "string"
     },
 }

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -75,8 +75,8 @@ class AttributeSource(TypedDict):
 
 class TraceItemAttribute(TypedDict):
     name: str
-    type: Literal["string", "number"]
-    value: str | int | float
+    type: Literal["string", "number", "boolean"]
+    value: str | int | float | bool
 
 
 class EAPResponse(EventsResponse):

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -63,7 +63,7 @@ def add_start_end_conditions(
 
 
 INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
-    SupportedTraceItemType, dict[Literal["string", "number"], dict[str, str]]
+    SupportedTraceItemType, dict[Literal["string", "number", "boolean"], dict[str, str]]
 ] = {
     SupportedTraceItemType.SPANS: SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SupportedTraceItemType.LOGS: LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
@@ -125,7 +125,7 @@ TRACE_ITEM_TYPE_DEFINITIONS: dict[SupportedTraceItemType, ColumnDefinitions] = {
 
 def translate_internal_to_public_alias(
     internal_alias: str,
-    type: Literal["string", "number"],
+    type: Literal["string", "number", "boolean"],
     item_type: SupportedTraceItemType,
 ) -> tuple[str | None, str | None, AttributeSource]:
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(type, {})

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -75,7 +75,7 @@ class ProjectTraceItemDetailsEndpointTest(
 
         timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data["attributes"] == [
-            {"name": "bool_attr", "type": "bool", "value": True},
+            {"name": "tags[bool_attr,boolean]", "type": "bool", "value": True},
             {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
             {
                 "name": "observed_timestamp",
@@ -131,7 +131,7 @@ class ProjectTraceItemDetailsEndpointTest(
         timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data == {
             "attributes": [
-                {"name": "bool_attr", "type": "bool", "value": True},
+                {"name": "tags[bool_attr,boolean]", "type": "bool", "value": True},
                 {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
                 {
                     "name": "observed_timestamp",
@@ -331,7 +331,7 @@ class ProjectTraceItemDetailsEndpointTest(
         timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data == {
             "attributes": [
-                {"name": "bool_attr", "type": "bool", "value": True},
+                {"name": "tags[bool_attr,boolean]", "type": "bool", "value": True},
                 {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
                 {
                     "name": "observed_timestamp",


### PR DESCRIPTION
This PR exposes boolean attributes on the trace item endpoint, and also ensures that when querying with an explicit boolean attribute that it functions correctly.

Ticket: EXP-688