### PR TITLE
feat(preprod): support min aggregation and standardize enum naming

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -75,7 +75,7 @@ class DashboardWidgetTypes(TypesClass):
     """
     Mobile app size metrics from preprod item type on the EAP dataset.
     """
-    MOBILE_APP_SIZE = 105
+    PREPROD_APP_SIZE = 105
 
     TYPES = [
         (DISCOVER, "discover"),
@@ -89,7 +89,7 @@ class DashboardWidgetTypes(TypesClass):
         (SPANS, "spans"),
         (LOGS, "logs"),
         (TRACEMETRICS, "tracemetrics"),
-        (MOBILE_APP_SIZE, "mobile-app-size"),
+        (PREPROD_APP_SIZE, "preprod-app-size"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 

--- a/src/sentry/search/eap/preprod_size/aggregates.py
+++ b/src/sentry/search/eap/preprod_size/aggregates.py
@@ -17,4 +17,17 @@ PREPROD_SIZE_AGGREGATE_DEFINITIONS = {
             )
         ],
     ),
+    "min": AggregateDefinition(
+        internal_function=Function.FUNCTION_MIN,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "number",
+                    "integer",
+                    *constants.SIZE_TYPE,
+                },
+            )
+        ],
+    ),
 }


### PR DESCRIPTION
Figured if we support `max()` we should support the complement `min()` as well.