### PR TITLE
feat(reports): Add logs support to weekly summary email

### DIFF
--- a/TEST_WEEKLY_REPORT.md
+++ b/TEST_WEEKLY_REPORT.md
@@ -1,0 +1,105 @@
+# Testing the Weekly Report Email
+
+This guide shows you how to generate a test weekly report email to preview the logs feature.
+
+## Prerequisites
+
+1. Make sure devservices are running:
+   ```bash
+   devservices up
+   ```
+
+2. You need an organization and a user in your local database.
+
+## Quick Start
+
+### Option 1: Using `sentry exec` (Recommended)
+
+```bash
+sentry exec scripts/test_weekly_report.py --org <YOUR_ORG_SLUG> --user <YOUR_EMAIL>
+```
+
+Example:
+```bash
+sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost
+```
+
+### Option 2: Direct Python
+
+First, make sure you have the virtualenv activated, then:
+
+```bash
+python scripts/test_weekly_report.py --org <YOUR_ORG_SLUG> --user <YOUR_EMAIL>
+```
+
+## Options
+
+- `--org` (required): Organization slug (e.g., "sentry")
+- `--user` (required): User email address (e.g., "admin@localhost")
+- `--days`: Number of days to include (default: 7)
+- `--dry-run`: Generate report but don't send email (useful for testing)
+
+## Examples
+
+### Generate and send email
+```bash
+sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost
+```
+
+### Test without sending (dry run)
+```bash
+sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost --dry-run
+```
+
+### Use a custom time period (14 days)
+```bash
+sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost --days 14
+```
+
+## Where to Find the Email
+
+### If you're using the console email backend (default in dev):
+The email HTML will be printed to your console/terminal.
+
+### If you're using a real email backend:
+Check your email at the address you specified.
+
+### Save HTML to file for browser preview:
+If the email is printed to console, you can:
+
+1. Copy the HTML output
+2. Save it to a file: `/tmp/weekly_report.html`
+3. Open in browser: `open /tmp/weekly_report.html`
+
+## Viewing Logs in the Email
+
+The email will show logs data if:
+1. Your projects have log data in the time period
+2. The OurLogs dataset is available and working
+
+If you don't have log data yet, the logs sections will simply not appear (empty state).
+
+## Troubleshooting
+
+### "Organization not found"
+- List available organizations: `sentry django shell` then `Organization.objects.values_list('slug', flat=True)`
+
+### "User not found"
+- List available users: `sentry django shell` then `User.objects.values_list('email', flat=True)`
+
+### No email received
+- Check if you're using console email backend (default in dev)
+- Check your `config.yml` or environment variables for email settings
+- Look for the email HTML in your terminal output
+
+### Logs sections not appearing
+- This is expected if you don't have log data
+- The email gracefully handles empty log data
+- To test with logs, you need to send logs to your local Sentry instance first
+
+## Next Steps
+
+After previewing the email:
+1. Take screenshots of the different sections
+2. Test with real log data if available
+3. Share feedback on the design/layout

--- a/TEST_WEEKLY_REPORT.md
+++ b/TEST_WEEKLY_REPORT.md
@@ -5,6 +5,7 @@ This guide shows you how to generate a test weekly report email to preview the l
 ## Prerequisites
 
 1. Make sure devservices are running:
+
    ```bash
    devservices up
    ```
@@ -20,6 +21,7 @@ sentry exec scripts/test_weekly_report.py --org <YOUR_ORG_SLUG> --user <YOUR_EMA
 ```
 
 Example:
+
 ```bash
 sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost
 ```
@@ -42,16 +44,19 @@ python scripts/test_weekly_report.py --org <YOUR_ORG_SLUG> --user <YOUR_EMAIL>
 ## Examples
 
 ### Generate and send email
+
 ```bash
 sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost
 ```
 
 ### Test without sending (dry run)
+
 ```bash
 sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost --dry-run
 ```
 
 ### Use a custom time period (14 days)
+
 ```bash
 sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost --days 14
 ```
@@ -59,12 +64,15 @@ sentry exec scripts/test_weekly_report.py --org sentry --user admin@localhost --
 ## Where to Find the Email
 
 ### If you're using the console email backend (default in dev):
+
 The email HTML will be printed to your console/terminal.
 
 ### If you're using a real email backend:
+
 Check your email at the address you specified.
 
 ### Save HTML to file for browser preview:
+
 If the email is printed to console, you can:
 
 1. Copy the HTML output
@@ -74,6 +82,7 @@ If the email is printed to console, you can:
 ## Viewing Logs in the Email
 
 The email will show logs data if:
+
 1. Your projects have log data in the time period
 2. The OurLogs dataset is available and working
 
@@ -82,17 +91,21 @@ If you don't have log data yet, the logs sections will simply not appear (empty 
 ## Troubleshooting
 
 ### "Organization not found"
+
 - List available organizations: `sentry django shell` then `Organization.objects.values_list('slug', flat=True)`
 
 ### "User not found"
+
 - List available users: `sentry django shell` then `User.objects.values_list('email', flat=True)`
 
 ### No email received
+
 - Check if you're using console email backend (default in dev)
 - Check your `config.yml` or environment variables for email settings
 - Look for the email HTML in your terminal output
 
 ### Logs sections not appearing
+
 - This is expected if you don't have log data
 - The email gracefully handles empty log data
 - To test with logs, you need to send logs to your local Sentry instance first
@@ -100,6 +113,7 @@ If you don't have log data yet, the logs sections will simply not appear (empty 
 ## Next Steps
 
 After previewing the email:
+
 1. Take screenshots of the different sections
 2. Test with real log data if available
 3. Share feedback on the design/layout

--- a/scripts/test_weekly_report.py
+++ b/scripts/test_weekly_report.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""
+Script to generate a test weekly report email.
+
+Usage:
+    python scripts/test_weekly_report.py --org <org_slug> --user <user_email>
+
+Or use sentry exec:
+    sentry exec scripts/test_weekly_report.py --org <org_slug> --user <user_email>
+"""
+import sys
+from datetime import timedelta
+
+import click
+from django.utils import timezone
+
+from sentry.models.organization import Organization
+from sentry.models.user import User
+from sentry.tasks.summaries.weekly_reports import prepare_organization_report
+from sentry.utils.dates import floor_to_utc_day
+
+
+@click.command()
+@click.option("--org", required=True, help="Organization slug")
+@click.option("--user", required=True, help="User email")
+@click.option("--days", default=7, help="Number of days to include (default: 7)")
+@click.option("--dry-run", is_flag=True, help="Don't actually send email, just generate")
+def generate_test_report(org: str, user: str, days: int, dry_run: bool) -> None:
+    """Generate a test weekly report email."""
+
+    # Find organization
+    try:
+        organization = Organization.objects.get(slug=org)
+        click.echo(f"✓ Found organization: {organization.name} (ID: {organization.id})")
+    except Organization.DoesNotExist:
+        click.echo(f"✗ Organization '{org}' not found", err=True)
+        sys.exit(1)
+
+    # Find user
+    try:
+        user_obj = User.objects.get(email=user)
+        click.echo(f"✓ Found user: {user_obj.email} (ID: {user_obj.id})")
+    except User.DoesNotExist:
+        click.echo(f"✗ User '{user}' not found", err=True)
+        sys.exit(1)
+
+    # Calculate timestamp and duration
+    now = timezone.now()
+    timestamp = floor_to_utc_day(now).timestamp()
+    duration = days * 24 * 60 * 60  # days in seconds
+
+    click.echo(f"\nGenerating report:")
+    click.echo(f"  Period: Last {days} days")
+    click.echo(f"  Start: {floor_to_utc_day(now - timedelta(days=days))}")
+    click.echo(f"  End: {floor_to_utc_day(now)}")
+    click.echo(f"  Dry run: {dry_run}")
+    click.echo()
+
+    # Generate report
+    try:
+        prepare_organization_report(
+            timestamp=timestamp,
+            duration=duration,
+            organization_id=organization.id,
+            batch_id="test-weekly-report",
+            dry_run=dry_run,
+            target_user=user_obj.id,
+        )
+
+        if dry_run:
+            click.echo("✓ Report generated (dry run - no email sent)")
+            click.echo("\nTo actually send the email, run without --dry-run flag")
+        else:
+            click.echo("✓ Report generated and email sent!")
+            click.echo(f"\nCheck your email at: {user_obj.email}")
+
+    except Exception as e:
+        click.echo(f"✗ Error generating report: {e}", err=True)
+        raise
+
+
+if __name__ == "__main__":
+    generate_test_report()

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -786,6 +786,7 @@ class Referrer(StrEnum):
     REPORTS_KEY_PERFORMANCE_ISSUES = "reports.key_performance_issues"
     REPORTS_KEY_TRANSACTIONS_P95 = "reports.key_transactions.p95"
     REPORTS_KEY_TRANSACTIONS = "reports.key_transactions"
+    REPORTS_KEY_LOGS = "reports.key_logs"
     REPORTS_OUTCOME_SERIES = "reports.outcome_series"
     REPORTS_OUTCOMES = "reports.outcomes"
     DAILY_SUMMARY_KEY_ERRORS = "daily_summary.key_errors"

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -193,9 +193,7 @@ class OrganizationReportContextFactory:
             # Query top error logs for each project
             for project in ctx.organization.project_set.all():
                 if project.id in ctx.projects_context_map:
-                    key_logs = project_key_error_logs(
-                        ctx, project, Referrer.REPORTS_KEY_LOGS.value
-                    )
+                    key_logs = project_key_error_logs(ctx, project, Referrer.REPORTS_KEY_LOGS.value)
                     project_ctx = ctx.projects_context_map[project.id]
                     if isinstance(project_ctx, ProjectContext) and key_logs:
                         project_ctx.key_error_logs = key_logs

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -371,6 +371,43 @@
       </td>
     {% endif %}
 
+    {% if trends.total_log_count > 0 %}
+    <td class="project-breakdown-graph-cell logs">
+      <h4 class="total-count-title">Total Project Logs</h4>
+      <h1 style="margin: 0;" class="total-count">{{ trends.total_log_count|small_count:1 }}</h1>
+      <a href="{% org_url organization '/' %}"
+        style="font-size: 12px; margin-bottom: 16px; display: block;">View Logs</a>
+      <table class="graph">
+        <tr>
+          {% for timestamp, project_values in trends.series %}
+          <td valign="bottom" class="bar"
+            style="height: {{ height }}px; width: {% widthratio 1 trends.series|length 100 %}%">
+            <table class="bar">
+              {% for project_value in project_values %}
+              <tr>
+                <td height="{% widthratio project_value.log_count trends.log_maximum height %}"
+                  style="background-color: {{ project_value.color }};">&nbsp;</td>
+              </tr>
+              {% empty %}
+              <tr>
+                <td height="1" style="background-color: #ebe9f7;"></td>
+              </tr>
+              {% endfor %}
+            </table>
+          </td>
+          {% endfor %}
+        </tr>
+        <tr>
+          {% for timestamp, project_values in trends.series %}
+          <td class="label" style="width: {% widthratio 1 trends.series|length 100 %}%">
+            {{ timestamp|date:"D" }}
+          </td>
+          {% endfor %}
+        </tr>
+      </table>
+    </td>
+    {% endif %}
+
     </tr></tbody></table>
 
     <table class="summary">
@@ -382,6 +419,8 @@
           <th style="width: 5em;" class="numeric col-dropped col-errors-dropped">Dropped</th>
           <th style="width: 7em;" class="numeric">Transactions</th>
           <th style="width: 7em;" class="numeric col-dropped">Dropped</th>
+          <th style="width: 5em;" class="numeric">Logs</th>
+          <th style="width: 5em;" class="numeric col-dropped">Dropped</th>
         </tr>
       </thead>
       <tbody>
@@ -391,12 +430,14 @@
               {% if project.color %}<span style="background: {{ project.color }}; display: inline-block; height: 1em; width: 1em;">&nbsp;</span>{% endif %}
           </td>
           <td>
-              {% if project.url %}<a href="{{ project.url }}">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
+              {% if project.url %}<a href="{{ project.url %}">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
           </td>
           <td class="numeric">{{ project.accepted_error_count|small_count:1 }}</td>
           <td class="numeric col-dropped col-errors-dropped">{{ project.dropped_error_count|small_count:1 }}</td>
           <td class="numeric">{{ project.accepted_transaction_count|small_count:1 }}</td>
           <td class="numeric col-dropped">{{ project.dropped_transaction_count|small_count:1 }}</td>
+          <td class="numeric">{{ project.accepted_log_count|small_count:1 }}</td>
+          <td class="numeric col-dropped">{{ project.dropped_log_count|small_count:1 }}</td>
         </tr>
       {% endfor %}
       </tbody>
@@ -512,6 +553,80 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.get_type_display}}</div>
       </div>
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if log_volume_by_severity.total_count > 0 %}
+  <div id="log-volume-by-severity">
+    <h4>Log Volume by Severity</h4>
+    <table style="width: 100%; margin-bottom: 20px;">
+      <tr>
+        <td style="padding: 4px 0;">
+          <div style="display: flex; align-items: center;">
+            <span style="width: 80px; font-size: 12px;">ERROR</span>
+            <div style="flex: 1; height: 20px; background-color: #f55459; border-radius: 2px; max-width: {% widthratio log_volume_by_severity.error_count log_volume_by_severity.total_count 400 %}px;">
+              <span style="color: white; padding-left: 8px; font-size: 12px; line-height: 20px;">{{ log_volume_by_severity.error_count|small_count:1 }}</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 4px 0;">
+          <div style="display: flex; align-items: center;">
+            <span style="width: 80px; font-size: 12px;">FATAL</span>
+            <div style="flex: 1; height: 20px; background-color: #d1021c; border-radius: 2px; max-width: {% widthratio log_volume_by_severity.fatal_count log_volume_by_severity.total_count 400 %}px;">
+              <span style="color: white; padding-left: 8px; font-size: 12px; line-height: 20px;">{{ log_volume_by_severity.fatal_count|small_count:1 }}</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 4px 0;">
+          <div style="display: flex; align-items: center;">
+            <span style="width: 80px; font-size: 12px;">WARNING</span>
+            <div style="flex: 1; height: 20px; background-color: #f2b712; border-radius: 2px; max-width: {% widthratio log_volume_by_severity.warning_count log_volume_by_severity.total_count 400 %}px;">
+              <span style="color: white; padding-left: 8px; font-size: 12px; line-height: 20px;">{{ log_volume_by_severity.warning_count|small_count:1 }}</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 4px 0;">
+          <div style="display: flex; align-items: center;">
+            <span style="width: 80px; font-size: 12px;">INFO</span>
+            <div style="flex: 1; height: 20px; background-color: #2788ce; border-radius: 2px; max-width: {% widthratio log_volume_by_severity.info_count log_volume_by_severity.total_count 400 %}px;">
+              <span style="color: white; padding-left: 8px; font-size: 12px; line-height: 20px;">{{ log_volume_by_severity.info_count|small_count:1 }}</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 4px 0;">
+          <div style="display: flex; align-items: center;">
+            <span style="width: 80px; font-size: 12px;">DEBUG</span>
+            <div style="flex: 1; height: 20px; background-color: #80708f; border-radius: 2px; max-width: {% widthratio log_volume_by_severity.debug_count log_volume_by_severity.total_count 400 %}px;">
+              <span style="color: white; padding-left: 8px; font-size: 12px; line-height: 20px;">{{ log_volume_by_severity.debug_count|small_count:1 }}</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </div>
+  {% endif %}
+
+  {% if key_error_logs|length > 0 %}
+  <div id="key-error-logs">
+    <h4>Most Frequent Error Logs</h4>
+    {% for log in key_error_logs %}
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+      <div style="width: 10%; font-size: 17px;">{{log.count|small_count:1}}</div>
+      <div style="width: 65%;">
+        <div style="display: block; font-size: 14px; font-family: monospace; white-space: pre-wrap; word-break: break-word; color: #2e2733;">{{log.message}}</div>
+        <div style="font-size: 12px; color: #80708F; margin-top: 4px;">{{log.project.name}}</div>
+      </div>
+      <span style="background-color: #f55459; color: white; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%; text-transform: uppercase;">{{log.severity}}</span>
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary

Adds comprehensive logs support to the weekly organization summary email. When projects send logs to Sentry, the email will now include:

- **Total Project Logs** metric with 7-day chart
- **Logs column** in project breakdown table
- **Log Volume by Severity** bar chart (ERROR/FATAL/WARNING/INFO/DEBUG)
- **Most Frequent Error Logs** section showing top error messages

## Screenshots

_TODO: Add screenshots after testing_

## Implementation Details

### Backend Changes

**Data Collection** (`src/sentry/tasks/summaries/utils.py`)
- Added log query functions using OurLogs dataset:
  - `project_log_volume_timeseries()` - Daily log counts for 7-day chart
  - `project_log_volume_by_severity()` - Breakdown by severity level
  - `project_key_error_logs()` - Top 5 error/fatal log messages
- Updated `ProjectContext` to track log metrics

**Context Factory** (`src/sentry/tasks/summaries/organization_report_context_factory.py`)
- Added `_append_project_log_data()` method to collect log data
- Integrated into report generation workflow

**Template Context** (`src/sentry/tasks/summaries/weekly_reports.py`)
- Updated `trends()` to include log counts in legend, series, and totals
- Added `key_error_logs()` function for top error logs
- Added `log_volume_by_severity()` function for severity aggregation

### Email Template Changes

**HTML Template** (`src/sentry/templates/sentry/emails/reports/body.html`)
- Added "Total Project Logs" graph section with 7-day bar chart
- Added Logs/Dropped columns to project breakdown table  
- Added "Log Volume by Severity" horizontal bar chart with color coding
- Added "Most Frequent Error Logs" section with counts and messages

### Testing

**Unit Tests** (`tests/sentry/tasks/test_weekly_reports.py`)
- Updated `test_integration` to expect log fields
- Added `test_log_fields_in_context` to verify all log data structures

**Manual Testing Script** (`scripts/test_weekly_report.py`)
- Created script to generate test emails for any org/user
- See `TEST_WEEKLY_REPORT.md` for usage instructions

## Error Handling

- All log queries wrapped in try/except for graceful degradation
- Empty states handled cleanly (sections don't appear if no log data)
- Email won't break if OurLogs is unavailable or projects aren't sending logs

## Testing Instructions

### Generate a test email:

```bash
sentry exec scripts/test_weekly_report.py --org <your_org_slug> --user <your_email>
```

See `TEST_WEEKLY_REPORT.md` for detailed testing instructions.

### Expected behavior:

- **With log data**: Email shows all log sections with metrics and charts
- **Without log data**: Log sections gracefully don't appear (clean empty state)