### PR TITLE
feat(aci): Add info about all issues exclusions

### DIFF
--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -53,7 +53,7 @@ describe('EditConnectedMonitors', () => {
 
     expect(screen.getByText('Source')).toBeInTheDocument();
     expect(
-      await screen.findByRole('radio', {name: 'Alert on all issues in a project'})
+      await screen.findByRole('radio', {name: 'Alert on all issues in selected projects'})
     ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', {name: 'Alert on specific monitors'})
@@ -65,7 +65,7 @@ describe('EditConnectedMonitors', () => {
     render(<EditConnectedMonitors connectedIds={[]} setConnectedIds={setConnectedIds} />);
 
     expect(
-      await screen.findByRole('radio', {name: 'Alert on all issues in a project'})
+      await screen.findByRole('radio', {name: 'Alert on all issues in selected projects'})
     ).toBeChecked();
     expect(
       screen.getByRole('radio', {name: 'Alert on specific monitors'})
@@ -188,7 +188,7 @@ describe('EditConnectedMonitors', () => {
     // Wait for the initial mode to be determined
     await waitFor(() => {
       expect(
-        screen.getByRole('radio', {name: 'Alert on all issues in a project'})
+        screen.getByRole('radio', {name: 'Alert on all issues in selected projects'})
       ).toBeChecked();
     });
   });
@@ -199,7 +199,7 @@ describe('EditConnectedMonitors', () => {
 
     // Initially in "all project issues" mode
     expect(
-      await screen.findByRole('radio', {name: 'Alert on all issues in a project'})
+      await screen.findByRole('radio', {name: 'Alert on all issues in selected projects'})
     ).toBeChecked();
 
     // Switch to specific monitors mode
@@ -212,11 +212,11 @@ describe('EditConnectedMonitors', () => {
 
     // Switch back to all project issues mode
     await userEvent.click(
-      screen.getByRole('radio', {name: 'Alert on all issues in a project'})
+      screen.getByRole('radio', {name: 'Alert on all issues in selected projects'})
     );
 
     expect(
-      screen.getByRole('radio', {name: 'Alert on all issues in a project'})
+      screen.getByRole('radio', {name: 'Alert on all issues in selected projects'})
     ).toBeChecked();
   });
 

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
+
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex, Stack} from 'sentry/components/core/layout';
@@ -213,22 +215,29 @@ function AllProjectIssuesSection({
   }, [connectedIds, form, issueStreamDetectorsQuery.data]);
 
   return (
-    <Container maxWidth="400px">
-      <SentryProjectSelectorField
-        name="projectIds"
-        label={t('Projects')}
-        placeholder={t('Select projects')}
-        projects={projects}
-        groupProjects={p => (p.isMember ? 'member' : 'all')}
-        groups={PROJECT_GROUPS}
-        onChange={(values: string[]) => onProjectChange(values)}
-        inline={false}
-        flexibleControlStateSize
-        stacked
-        multiple
-        disabled={issueStreamDetectorsQuery.isPending}
-      />
-    </Container>
+    <Stack gap="md">
+      <Container maxWidth="400px">
+        <SentryProjectSelectorField
+          name="projectIds"
+          label={t('Projects')}
+          placeholder={t('Select projects')}
+          projects={projects}
+          groupProjects={p => (p.isMember ? 'member' : 'all')}
+          groups={PROJECT_GROUPS}
+          onChange={(values: string[]) => onProjectChange(values)}
+          inline={false}
+          flexibleControlStateSize
+          stacked
+          multiple
+          disabled={issueStreamDetectorsQuery.isPending}
+        />
+      </Container>
+      <Alert variant="muted">
+        {t(
+          '‘All issues’ excludes Metric, Cron, and Uptime. Select specific monitors to alert on these issue types.'
+        )}
+      </Alert>
+    </Stack>
   );
 }
 
@@ -351,7 +360,7 @@ function EditConnectedMonitorsContent({
             label={t('Connected monitors mode')}
             value={monitorMode}
             choices={[
-              ['project', t('Alert on all issues in a project')],
+              ['project', t('Alert on all issues in selected projects')],
               ['specific', t('Alert on specific monitors')],
             ]}
             onChange={handleModeChange}

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -234,7 +234,7 @@ function AllProjectIssuesSection({
       </Container>
       <Alert variant="muted">
         {t(
-          '‘All issues’ excludes Metric, Cron, and Uptime. Select specific monitors to alert on these issue types.'
+          '‘All issues’ includes Error, Feedback, and Performance issue types. Select specific monitors to alert on Metric, Cron, and Uptime.'
         )}
       </Alert>
     </Stack>


### PR DESCRIPTION
For now, issue stream monitors will not be triggered by metric/cron/uptime issues. Therefore, we are displaying a message to clarify that:

<img width="2286" height="486" alt="CleanShot 2026-01-14 at 10 52 21@2x" src="https://github.com/user-attachments/assets/5052f524-9997-4ad6-a32b-45856739b4e1" />

