### PR TITLE
ref(core) improve type signature of core components

### DIFF
--- a/static/app/components/core/layout/container.spec.tsx
+++ b/static/app/components/core/layout/container.spec.tsx
@@ -49,6 +49,15 @@ describe('Container', () => {
     );
   });
 
+  it('as=label props are correctly inferred', () => {
+    render(
+      <Container as="label" htmlFor="test-id">
+        Hello World
+      </Container>
+    );
+    expect(screen.getByText('Hello World')).toHaveAttribute('htmlFor', 'test-id');
+  });
+
   it('passes attributes to the underlying element', () => {
     render(<Container data-test-id="container">Hello</Container>);
     expect(screen.getByTestId('container')).toBeInTheDocument();

--- a/static/app/components/core/layout/container.spec.tsx
+++ b/static/app/components/core/layout/container.spec.tsx
@@ -1,8 +1,9 @@
 import React, {createRef} from 'react';
+import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Container} from 'sentry/components/core/layout/container';
+import {Container, type ContainerProps} from 'sentry/components/core/layout/container';
 
 describe('Container', () => {
   it('renders children', () => {
@@ -55,7 +56,7 @@ describe('Container', () => {
         Hello World
       </Container>
     );
-    expect(screen.getByText('Hello World')).toHaveAttribute('htmlFor', 'test-id');
+    expectTypeOf<ContainerProps<'label'>>().toHaveProperty('htmlFor');
   });
 
   it('passes attributes to the underlying element', () => {

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -135,19 +135,30 @@ type ContainerPropsWithChildren<T extends ContainerElement = 'div'> =
   ContainerLayoutProps & {
     as?: T;
     children?: React.ReactNode;
+    htmlFor?: T extends 'label' ? string : never;
     ref?: React.Ref<HTMLElementTagNameMap[T] | null>;
-  } & React.HTMLAttributes<HTMLElementTagNameMap[T]>;
+  } & React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElementTagNameMap[T]>,
+      HTMLElementTagNameMap[T]
+    >;
 
 type ContainerPropsWithRenderProp<T extends ContainerElement = 'div'> =
   ContainerLayoutProps & {
     children: (props: {className: string}) => React.ReactNode | undefined;
     as?: never;
+    htmlFor?: never;
     ref?: never;
   } & Partial<
       Record<
         // HTMLAttributes extends from DOMAttributes which types children as React.ReactNode | undefined.
         // Therefore, we need to exclude it from the map, or the children will produce a never type.
-        Exclude<keyof React.HTMLAttributes<HTMLElementTagNameMap[T]>, 'children'>,
+        Exclude<
+          keyof React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLElementTagNameMap[T]>,
+            HTMLElementTagNameMap[T]
+          >,
+          'children'
+        >,
         never
       >
     >;

--- a/static/app/components/core/layout/flex.spec.tsx
+++ b/static/app/components/core/layout/flex.spec.tsx
@@ -51,6 +51,15 @@ describe('Flex', () => {
     );
   });
 
+  it('as=label props are correctly inferred', () => {
+    render(
+      <Flex as="label" htmlFor="test-id">
+        Hello World
+      </Flex>
+    );
+    expect(screen.getByText('Hello World')).toHaveAttribute('htmlFor', 'test-id');
+  });
+
   it('passes attributes to the underlying element', () => {
     render(<Flex data-test-id="container">Hello</Flex>);
     expect(screen.getByTestId('container')).toBeInTheDocument();

--- a/static/app/components/core/layout/flex.spec.tsx
+++ b/static/app/components/core/layout/flex.spec.tsx
@@ -57,7 +57,7 @@ describe('Flex', () => {
         Hello World
       </Flex>
     );
-    expect(screen.getByText('Hello World')).toHaveAttribute('htmlFor', 'test-id');
+    expectTypeOf<FlexProps<'label'>>().toHaveProperty('htmlFor');
   });
 
   it('passes attributes to the underlying element', () => {

--- a/static/app/components/core/layout/stack.spec.tsx
+++ b/static/app/components/core/layout/stack.spec.tsx
@@ -1,8 +1,9 @@
 import React, {createRef} from 'react';
+import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Stack} from 'sentry/components/core/layout/stack';
+import {Stack, type StackProps} from 'sentry/components/core/layout/stack';
 
 describe('Stack', () => {
   it('renders children', () => {
@@ -78,6 +79,15 @@ describe('Stack', () => {
   it('allows settings native html attributes', () => {
     render(<Stack style={{color: 'red'}}>Hello</Stack>);
     expect(screen.getByText('Hello')).toHaveStyle({color: 'red'});
+  });
+
+  it('as=label props are correctly inferred', () => {
+    render(
+      <Stack as="label" htmlFor="test-id">
+        Hello World
+      </Stack>
+    );
+    expectTypeOf<StackProps<'label'>>().toHaveProperty('htmlFor');
   });
 
   it('attaches ref to the underlying element', () => {

--- a/static/app/components/core/text/text.spec.tsx
+++ b/static/app/components/core/text/text.spec.tsx
@@ -1,7 +1,9 @@
-import {createRef} from 'react';
+import {createRef, Fragment} from 'react';
+import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import type {TextProps} from './text';
 import {Text} from './text';
 
 describe('Text', () => {
@@ -24,6 +26,19 @@ describe('Text', () => {
   it('forwards data-test-id', () => {
     render(<Text data-test-id="test-id">Hello World</Text>);
     expect(screen.getByText('Hello World')).toHaveAttribute('data-test-id', 'test-id');
+  });
+
+  it('as=label props are correctly inferred', () => {
+    render(
+      <Fragment>
+        {/* @ts-expect-error: htmlFor is not a valid prop for Text */}
+        <Text htmlFor="test-id">Hello World</Text>
+        <Text as="label" htmlFor="test-id">
+          Hello World
+        </Text>
+      </Fragment>
+    );
+    expectTypeOf<TextProps<'label'>>().toHaveProperty('htmlFor');
   });
 
   it('allows passing native HTML attributes', () => {

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -7,7 +7,6 @@ import type {ContentVariant, FontSize} from 'sentry/utils/theme';
 import {getFontSize, getLineHeight, getTextDecoration} from './styles';
 
 export interface BaseTextProps {
-  children: React.ReactNode;
   /**
    * Horizontal alignment of the text.
    *
@@ -100,20 +99,42 @@ export type ExclusiveTextEllipsisProps =
   | {ellipsis?: true; wrap?: never}
   | {ellipsis?: never; wrap?: BaseTextProps['wrap']};
 
-export type TextProps<T extends 'span' | 'p' | 'label' | 'div'> = BaseTextProps & {
+interface TextAttributes<T extends 'span' | 'p' | 'label' | 'div' = 'span'>
+  extends BaseTextProps,
+    React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElementTagNameMap[T]>,
+      HTMLElementTagNameMap[T]
+    > {
+  /**
+   * Our decision to make children required conflicts with the optional signature of the React.DetailedHTMLProps type.
+   * To resolve it, we move the children definition after the React.DetailedHTMLProps type,
+   * which narrows the type from optional to required as expected.
+   */
+  children: React.ReactNode;
   /**
    * The HTML element to render the text as - defaults to span.
    * @default span
    */
   as?: T;
-  ref?: React.Ref<HTMLElementTagNameMap[T] | null> | undefined;
-} & Omit<React.HTMLAttributes<HTMLElementTagNameMap[T]>, 'color'> &
+  /**
+   * Forbid color HTML attribute from being passed to the component, all usage should be variant-based.
+   */
+  color?: never;
+  /**
+   * This could have been avoided by using React.JSX.IntrinsicElements<T>, however doing so would be
+   * grosely inefficient, as it would cause type helpers like DistributedOmit to traverse the entire
+   * type HTML Attribute set of each element, slowing down our type compilation. In my test, using
+   * React.JSX.IntrinsicElements<T> caused native ts compilation to take 2x longer.
+   *
+   */
+  htmlFor?: T extends 'label' ? string : never;
+}
+
+export type TextProps<T extends 'span' | 'p' | 'label' | 'div'> = TextAttributes<T> &
   ExclusiveTextEllipsisProps;
 
 export const Text = styled(
-  <T extends 'span' | 'p' | 'label' | 'div' = 'span'>(
-    props: TextProps<T> & ExclusiveTextEllipsisProps
-  ) => {
+  <T extends 'span' | 'p' | 'label' | 'div' = 'span'>(props: TextProps<T>) => {
     const {children, ...rest} = props;
     const Component = props.as || 'span';
     return <Component {...(rest as any)}>{children}</Component>;
@@ -179,6 +200,6 @@ export const Text = styled(
    * By default, the generic type parameter <T> is lost, so we use 'as unknown as' to restore the correct typing.
    * https://github.com/styled-components/styled-components/issues/1803
    */
-` as unknown as <T extends 'span' | 'p' | 'label' | 'div'>(
+` as unknown as <T extends 'span' | 'p' | 'label' | 'div' = 'span'>(
   props: TextProps<T>
 ) => React.ReactElement;

--- a/static/app/components/emptyMessage.tsx
+++ b/static/app/components/emptyMessage.tsx
@@ -5,7 +5,7 @@ import {Container, Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 
-interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | 'color'> {
   action?: React.ReactNode;
   icon?: React.ReactNode;
   size?: 'lg' | 'md';

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -6,7 +6,7 @@ import {Alert, type AlertProps} from '@sentry/scraps/alert';
 import {Quote, type QuoteProps} from '@sentry/scraps/quote/quote';
 
 import {InlineCode} from 'sentry/components/core/code';
-import {Stack} from 'sentry/components/core/layout';
+import {Stack, type StackProps} from 'sentry/components/core/layout';
 import type {TextProps} from 'sentry/components/core/text/text';
 import {Text} from 'sentry/components/core/text/text';
 import * as Stories from 'sentry/stories';
@@ -60,7 +60,7 @@ export const storyMdxComponents = {
   p: (props: TextProps<'p'>) => (
     <Text as="p" size="md" density="comfortable" {...props} />
   ),
-  ul: (props: Omit<HTMLProps<HTMLUListElement>, 'wrap'>) => (
+  ul: (props: Pick<StackProps<'ul'>, 'as'>) => (
     <Stack margin="0" {...props} as="ul" gap="lg" />
   ),
   blockquote: (props: QuoteProps) => <Quote {...props} />,

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -125,14 +125,14 @@ export function CohortComparison({
           <Fragment>
             {selectedRangeToDates && (
               <Stack gap="xs">
-                <SelectionHint color={theme.chart.getColorPalette(0)?.[0]}>
+                <SelectionHint backgroundColor={theme.chart.getColorPalette(0)?.[0]}>
                   {t(
                     'Selection is data between %s - %s',
                     selectedRangeToDates.start,
                     selectedRangeToDates.end
                   )}
                 </SelectionHint>
-                <SelectionHint color="#A29FAA">
+                <SelectionHint backgroundColor="#A29FAA">
                   {t('Baseline is all other spans from your query')}
                 </SelectionHint>
               </Stack>
@@ -176,7 +176,7 @@ export function CohortComparison({
   );
 }
 
-const SelectionHint = styled(Text)<{color?: string}>`
+const SelectionHint = styled(Text)<{backgroundColor?: string}>`
   display: flex;
   align-items: center;
   color: ${p => p.theme.tokens.content.secondary};
@@ -187,7 +187,7 @@ const SelectionHint = styled(Text)<{color?: string}>`
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background-color: ${p => p.color || p.theme.colors.gray500};
+    background-color: ${p => p.backgroundColor || p.theme.colors.gray500};
     margin-right: ${space(0.5)};
     flex-shrink: 0;
   }


### PR DESCRIPTION
Improves type signature of Flex, Stack, Container and Text, such that the label props are correctly inferred