### PR TITLE
feat(oauth): Add RFC 6750 Bearer token compliance

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -189,6 +189,12 @@ class StandardAuthentication(QuietBasicAuthentication):
     def accepts_auth(self, auth: list[bytes]) -> bool:
         return bool(auth) and auth[0].lower() == self.token_name
 
+    def authenticate_header(self, request: Request) -> str:
+        """
+        Return WWW-Authenticate header value for 401 responses per RFC 6750 Section 3.
+        """
+        return self.token_name.decode().title()
+
     def authenticate_token(self, request: Request, token_str: str) -> tuple[Any, Any]:
         raise NotImplementedError
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -190,10 +190,8 @@ class StandardAuthentication(QuietBasicAuthentication):
         return bool(auth) and auth[0].lower() == self.token_name
 
     def authenticate_header(self, request: Request) -> str:
-        """
-        Return WWW-Authenticate header value for 401 responses per RFC 6750 Section 3.
-        """
-        return self.token_name.decode().title()
+        """Return WWW-Authenticate header value for 401 responses per RFC 6750 Section 3."""
+        return f'{self.token_name.decode().title()} realm="api"'
 
     def authenticate_token(self, request: Request, token_str: str) -> tuple[Any, Any]:
         raise NotImplementedError

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -1,20 +1,63 @@
 from rest_framework import status
 from rest_framework.authentication import get_authorization_header
+from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
-from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist, SentryAPIException
 from sentry.models.apitoken import ApiToken
 from sentry.users.models.useremail import UserEmail
 
 
-class InsufficientScopesError(SentryAPIException):
+class BearerTokenError(APIException):
+    """Base class for RFC 6750 Bearer token errors."""
+
+    auth_header: str = 'Bearer realm="api"'
+
+
+class BearerTokenMissing(BearerTokenError):
+    """
+    401 when no auth or unsupported scheme - RFC 6750 Section 3.1.
+
+    Per RFC 6750: "If the request lacks any authentication information
+    (e.g., the client was unaware that authentication is necessary or
+    attempted using an unsupported authentication method), the resource
+    server SHOULD NOT include an error code or other error information."
+    """
+
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = "Bearer token required"
+
+
+class BearerTokenInvalid(BearerTokenError):
+    """
+    401 when token is invalid/expired - RFC 6750 Section 3.1.
+
+    Per RFC 6750: "invalid_token - The access token provided is expired,
+    revoked, malformed, or invalid for other reasons."
+    """
+
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = {"error": "invalid_token", "error_description": "Access token not found"}
+    auth_header = 'Bearer realm="api", error="invalid_token"'
+
+
+class BearerTokenInsufficientScope(BearerTokenError):
+    """
+    403 when token lacks required scope - RFC 6750 Section 3.1.
+
+    Per RFC 6750: "insufficient_scope - The request requires higher privileges
+    than provided by the access token."
+    """
+
     status_code = status.HTTP_403_FORBIDDEN
-    code = "insufficient-scope"
-    message = "openid scope is required for userinfo access"
+    default_detail = {
+        "error": "insufficient_scope",
+        "error_description": "openid scope is required",
+    }
+    auth_header = 'Bearer realm="api", error="insufficient_scope", scope="openid"'
 
 
 @control_silo_endpoint
@@ -27,40 +70,37 @@ class OAuthUserInfoEndpoint(Endpoint):
     permission_classes = ()
 
     def get(self, request: Request) -> Response:
-        # RFC 6750 Section 2.1: Bearer tokens MUST use the "Bearer" scheme.
         auth_header = get_authorization_header(request).split()
 
         if len(auth_header) < 2:
-            raise ParameterValidationError("Bearer token not found in authorization header")
+            raise BearerTokenMissing()
 
         scheme = auth_header[0].decode("utf-8")
         if scheme.lower() != "bearer":
-            raise ParameterValidationError(
-                f"Invalid authentication scheme '{scheme}', expected 'Bearer'"
-            )
+            raise BearerTokenMissing()
 
         access_token = auth_header[1].decode("utf-8")
         try:
             token_details = ApiToken.objects.get(token=access_token)
         except ApiToken.DoesNotExist:
-            raise ResourceDoesNotExist("Access token not found")
+            raise BearerTokenInvalid()
 
         scopes = token_details.get_scopes()
         if "openid" not in scopes:
-            raise InsufficientScopesError
+            raise BearerTokenInsufficientScope()
 
         user = token_details.user
         user_output: dict[str, object] = {"sub": user.id}
         if "profile" in scopes:
-            profile_details = {
-                "name": user.name,
-                "avatar_type": user.avatar_type,
-                "avatar_url": user.avatar_url,
-                "date_joined": user.date_joined,
-            }
-            user_output.update(profile_details)
+            user_output.update(
+                {
+                    "name": user.name,
+                    "avatar_type": user.avatar_type,
+                    "avatar_url": user.avatar_url,
+                    "date_joined": user.date_joined,
+                }
+            )
         if "email" in scopes:
-            email = UserEmail.objects.get(user=user)
-            email_details = {"email": email.email, "email_verified": email.is_verified}
-            user_output.update(email_details)
+            email = UserEmail.objects.get_primary_email(user)
+            user_output.update({"email": email.email, "email_verified": email.is_verified})
         return Response(user_output)

--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -34,4 +34,10 @@ def custom_exception_handler(exc, context):
             detail="Rate limit exceeded. Please try your query with a smaller date range or fewer projects."
         )
 
-    return exception_handler(exc, context)
+    response = exception_handler(exc, context)
+
+    # RFC 6750 Section 3: Add WWW-Authenticate header if exception defines one
+    if response is not None and hasattr(exc, "auth_header"):
+        response["WWW-Authenticate"] = exc.auth_header
+
+    return response

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -27,6 +27,16 @@ class OAuthUserInfoTest(APITestCase):
             response.data["detail"]["message"] == "Bearer token not found in authorization header"
         )
 
+    def test_rejects_non_bearer_scheme(self) -> None:
+        token = ApiToken.objects.create(user=self.user, scope_list=["openid"])
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.token}")
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 400
+        assert response.data["detail"]["code"] == "parameter-validation-error"
+        assert "expected 'Bearer'" in response.data["detail"]["message"]
+
     def test_declines_invalid_token(self) -> None:
         self.client.credentials(HTTP_AUTHORIZATION="Bearer  abcd")
         response = self.client.get(self.path)

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -3,7 +3,6 @@ import datetime
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -21,43 +20,46 @@ class OAuthUserInfoTest(APITestCase):
     def test_requires_access_token(self) -> None:
         response = self.client.get(self.path)
 
-        assert response.status_code == 400
-        assert response.data["detail"]["code"] == "parameter-validation-error"
-        assert (
-            response.data["detail"]["message"] == "Bearer token not found in authorization header"
-        )
+        assert response.status_code == 401
+        assert response.data["detail"] == "Bearer token required"
+        assert response["WWW-Authenticate"] == 'Bearer realm="api"'
 
     def test_rejects_non_bearer_scheme(self) -> None:
-        token = ApiToken.objects.create(user=self.user, scope_list=["openid"])
+        token = self.create_user_auth_token(user=self.user, scope_list=["openid"])
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.token}")
 
         response = self.client.get(self.path)
 
-        assert response.status_code == 400
-        assert response.data["detail"]["code"] == "parameter-validation-error"
-        assert "expected 'Bearer'" in response.data["detail"]["message"]
+        assert response.status_code == 401
+        assert response.data["detail"] == "Bearer token required"
+        assert response["WWW-Authenticate"] == 'Bearer realm="api"'
 
     def test_declines_invalid_token(self) -> None:
-        self.client.credentials(HTTP_AUTHORIZATION="Bearer  abcd")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer abcd")
+
         response = self.client.get(self.path)
-        assert response.status_code == 404
-        assert response.data["detail"] == "Access token not found"
+
+        assert response.status_code == 401
+        assert response.data["error"] == "invalid_token"
+        assert response.data["error_description"] == "Access token not found"
+        assert response["WWW-Authenticate"] == 'Bearer realm="api", error="invalid_token"'
 
     def test_declines_if_no_openid_scope(self) -> None:
-        token_without_openid_scope = ApiToken.objects.create(user=self.user, scope_list=[])
+        token_without_openid_scope = self.create_user_auth_token(user=self.user, scope_list=[])
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token_without_openid_scope.token)
 
         response = self.client.get(self.path)
 
         assert response.status_code == 403
-        assert response.data["detail"]["code"] == "insufficient-scope"
-        assert response.data["detail"]["message"] == "openid scope is required for userinfo access"
+        assert response.data["error"] == "insufficient_scope"
+        assert response.data["error_description"] == "openid scope is required"
+        assert (
+            response["WWW-Authenticate"]
+            == 'Bearer realm="api", error="insufficient_scope", scope="openid"'
+        )
 
     def test_gets_sub_with_openid_scope(self) -> None:
-        """
-        Ensures we get `sub`, and only `sub`, if the only scope is openid.
-        """
-        openid_only_token = ApiToken.objects.create(user=self.user, scope_list=["openid"])
+        openid_only_token = self.create_user_auth_token(user=self.user, scope_list=["openid"])
 
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + openid_only_token.token)
 
@@ -67,7 +69,7 @@ class OAuthUserInfoTest(APITestCase):
         assert response.data == {"sub": self.user.id}
 
     def test_gets_email_information(self) -> None:
-        email_token = ApiToken.objects.create(user=self.user, scope_list=["openid", "email"])
+        email_token = self.create_user_auth_token(user=self.user, scope_list=["openid", "email"])
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + email_token.token)
 
         response = self.client.get(self.path)
@@ -80,7 +82,9 @@ class OAuthUserInfoTest(APITestCase):
         }
 
     def test_gets_profile_information(self) -> None:
-        profile_token = ApiToken.objects.create(user=self.user, scope_list=["openid", "profile"])
+        profile_token = self.create_user_auth_token(
+            user=self.user, scope_list=["openid", "profile"]
+        )
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + profile_token.token)
 
         response = self.client.get(self.path)
@@ -94,7 +98,7 @@ class OAuthUserInfoTest(APITestCase):
         assert response.data["sub"] == self.user.id
 
     def test_gets_multiple_scopes(self) -> None:
-        all_access_token = ApiToken.objects.create(
+        all_access_token = self.create_user_auth_token(
             user=self.user, scope_list=["openid", "profile", "email"]
         )
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + all_access_token.token)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -902,12 +902,12 @@ class TestAuthenticateHeader:
 
     def test_user_auth_token_returns_bearer(self) -> None:
         auth = UserAuthTokenAuthentication()
-        assert auth.authenticate_header(None) == "Bearer"
+        assert auth.authenticate_header(_drf_request()) == "Bearer"
 
     def test_org_auth_token_returns_bearer(self) -> None:
         auth = OrgAuthTokenAuthentication()
-        assert auth.authenticate_header(None) == "Bearer"
+        assert auth.authenticate_header(_drf_request()) == "Bearer"
 
     def test_dsn_authentication_returns_dsn(self) -> None:
         auth = DSNAuthentication()
-        assert auth.authenticate_header(None) == "Dsn"
+        assert auth.authenticate_header(_drf_request()) == "Dsn"

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -893,3 +893,21 @@ class TestAuthTokens(TestCase):
             assert auth_token.allowed_origins == token.get_allowed_origins()
             assert auth_token.scopes == token.get_scopes()
             assert auth_token.audit_log_data == token.get_audit_log_data()
+
+
+class TestAuthenticateHeader:
+    """
+    Tests for RFC 6750 Section 3 compliance: WWW-Authenticate header.
+    """
+
+    def test_user_auth_token_returns_bearer(self) -> None:
+        auth = UserAuthTokenAuthentication()
+        assert auth.authenticate_header(None) == "Bearer"
+
+    def test_org_auth_token_returns_bearer(self) -> None:
+        auth = OrgAuthTokenAuthentication()
+        assert auth.authenticate_header(None) == "Bearer"
+
+    def test_dsn_authentication_returns_dsn(self) -> None:
+        auth = DSNAuthentication()
+        assert auth.authenticate_header(None) == "Dsn"

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -896,18 +896,16 @@ class TestAuthTokens(TestCase):
 
 
 class TestAuthenticateHeader:
-    """
-    Tests for RFC 6750 Section 3 compliance: WWW-Authenticate header.
-    """
+    """Tests for RFC 6750 Section 3 compliance: WWW-Authenticate header."""
 
-    def test_user_auth_token_returns_bearer(self) -> None:
+    def test_user_auth_token_returns_bearer_with_realm(self) -> None:
         auth = UserAuthTokenAuthentication()
-        assert auth.authenticate_header(_drf_request()) == "Bearer"
+        assert auth.authenticate_header(_drf_request()) == 'Bearer realm="api"'
 
-    def test_org_auth_token_returns_bearer(self) -> None:
+    def test_org_auth_token_returns_bearer_with_realm(self) -> None:
         auth = OrgAuthTokenAuthentication()
-        assert auth.authenticate_header(_drf_request()) == "Bearer"
+        assert auth.authenticate_header(_drf_request()) == 'Bearer realm="api"'
 
-    def test_dsn_authentication_returns_dsn(self) -> None:
+    def test_dsn_authentication_returns_dsn_with_realm(self) -> None:
         auth = DSNAuthentication()
-        assert auth.authenticate_header(_drf_request()) == "Dsn"
+        assert auth.authenticate_header(_drf_request()) == 'Dsn realm="api"'


### PR DESCRIPTION
Add RFC 6750 Bearer token compliance for the OAuth 2.1 migration.

This addresses the Bearer token audit item from the OAuth 2.1 checklist by:

## WWW-Authenticate Header (RFC 6750 Section 3)

- `StandardAuthentication.authenticate_header()` now returns `Bearer realm="api"` (with required auth-param per RFC 6750)
- Previously returned just `Bearer` which violated the RFC requirement for at least one auth-param
- Custom exception handler adds `WWW-Authenticate` header to error responses

## Bearer Scheme Validation (RFC 6750 Section 2.1)

The OAuth UserInfo endpoint validates the `Bearer` scheme and returns RFC-compliant error responses:

| Scenario | Status | WWW-Authenticate | Body |
|----------|--------|------------------|------|
| No auth header | 401 | `Bearer realm="api"` | No error code (per Section 3.1) |
| Wrong scheme (e.g., Token) | 401 | `Bearer realm="api"` | No error code (per Section 3.1) |
| Invalid/expired token | 401 | `Bearer realm="api", error="invalid_token"` | `{"error": "invalid_token", ...}` |
| Insufficient scope | 403 | `Bearer realm="api", error="insufficient_scope", scope="openid"` | `{"error": "insufficient_scope", ...}` |

## Implementation

- Created RFC 6750 exception classes (`BearerTokenMissing`, `BearerTokenInvalid`, `BearerTokenInsufficientScope`) with `auth_header` attribute
- Modified `custom_exception_handler` to add `WWW-Authenticate` header when exception defines `auth_header`
- Updated tests to verify correct status codes and headers

Refs #99002