### PR TITLE
ref(ui): Remove MarkedText from SentryApp overview description

### DIFF
--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -21,7 +21,6 @@ import {
   trackIntegrationAnalytics,
 } from 'sentry/utils/integrationUtil';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import {recordInteraction} from 'sentry/utils/recordSentryAppInteraction';
 
@@ -165,7 +164,7 @@ export default function SentryAppDetailsModal(props: Props) {
           {!!features.length && <Features>{featureTags(features)}</Features>}
         </HeadingInfo>
       </Heading>
-      <Description text={overview} />
+      <Description>{overview}</Description>
       <FeatureList {...featureProps} provider={{...sentryApp, key: sentryApp.slug}} />
       <IntegrationFeatures {...featureProps}>
         {({disabled, disabledReason}) => (
@@ -224,12 +223,9 @@ const Name = styled('div')`
   font-size: 1.4em;
 `;
 
-const Description = styled(MarkedText)`
+const Description = styled('div')`
   margin-bottom: ${space(2)};
-
-  li {
-    margin-bottom: 6px;
-  }
+  white-space: pre-wrap;
 `;
 
 const Author = styled('div')`


### PR DESCRIPTION
[VULN-870](https://linear.app/getsentry/issue/VULN-870)

Removes `MarkedText` component usage for the SentryApp overview description, replacing it with plain text rendering. 

We did not see legitimate use cases of custom CSS, only weird hacking attempts. Plain text rendering is simpler and more appropriate for this field.

[VULN-870]: https://getsentry.atlassian.net/browse/VULN-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ