### PR TITLE
feat(sentry-apps): Add region RPC service with get_select_options

### DIFF
--- a/src/sentry/sentry_apps/services/region/__init__.py
+++ b/src/sentry/sentry_apps/services/region/__init__.py
@@ -1,0 +1,2 @@
+from .model import *  # noqa
+from .service import *  # noqa

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -1,0 +1,49 @@
+from sentry.models.project import Project
+from sentry.sentry_apps.external_requests.select_requester import SelectRequester
+from sentry.sentry_apps.services.app import RpcSentryAppInstallation
+from sentry.sentry_apps.services.region.model import RpcSelectRequesterResult, RpcSentryAppError
+from sentry.sentry_apps.services.region.service import SentryAppRegionService
+from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+
+
+class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
+    def get_select_options(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        uri: str,
+        project_id: int | None = None,
+        query: str | None = None,
+        dependent_data: str | None = None,
+    ) -> RpcSelectRequesterResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_requests.py @ GET
+        """
+
+        project_slug: str | None = None
+        if project_id is not None:
+            project = Project.objects.filter(id=project_id, organization_id=organization_id).first()
+            if project:
+                project_slug = project.slug
+
+        try:
+            result = SelectRequester(
+                install=installation,
+                uri=uri,
+                query=query,
+                dependent_data=dependent_data,
+                project_slug=project_slug,
+            ).run()
+        except (SentryAppIntegratorError, SentryAppSentryError) as e:
+            error = RpcSentryAppError(
+                message=e.message,
+                webhook_context=e.webhook_context,
+                status_code=e.status_code,
+            )
+            return RpcSelectRequesterResult(error=error)
+
+        return RpcSelectRequesterResult(
+            choices=list(result.get("choices", [])),
+            default_value=result.get("defaultValue"),
+        )

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -1,0 +1,24 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from typing import Any
+
+from pydantic.fields import Field
+
+from sentry.hybridcloud.rpc import RpcModel
+
+
+# XXX: Normally RPCs wouldn't return errors like this, but we need to surface these errors to Sentry
+# Apps and by moving operation into these services, we'd lose the helpful errors without this.
+class RpcSentryAppError(RpcModel):
+    message: str
+    webhook_context: dict[str, Any]
+    status_code: int | None = None
+
+
+class RpcSelectRequesterResult(RpcModel):
+    choices: list[list[str]] = Field(default_factory=list)
+    default_value: str | None = None
+    error: RpcSentryAppError | None = None

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -1,0 +1,80 @@
+import orjson
+import responses
+from django.utils.http import urlencode
+from responses.matchers import query_string_matcher
+
+from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.region import sentry_app_region_service
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test
+
+
+@all_silo_test
+class TestSentryAppRegionService(TestCase):
+    def setUp(self) -> None:
+        self.user = self.create_user(email="boop@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+
+        self.sentry_app = self.create_sentry_app(
+            name="Testin", organization=self.org, webhook_url="https://example.com"
+        )
+
+        self.install = self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app.slug, user=self.user
+        )
+        self.rpc_installation = app_service.get_many(filter=dict(uuids=[self.install.uuid]))[0]
+
+    @responses.activate
+    def test_get_select_options(self) -> None:
+        options = [{"label": "Project Name", "value": "1234"}]
+        dependent_data = orjson.dumps({"org_id": "A"}).decode()
+        qs = urlencode(
+            {
+                "projectSlug": self.project.slug,
+                "installationId": self.install.uuid,
+                "query": "proj",
+                "dependentData": dependent_data,
+            }
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://example.com/get-projects",
+            match=[query_string_matcher(qs)],
+            json=options,
+            status=200,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.get_select_options(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            uri="/get-projects",
+            project_id=self.project.id,
+            query="proj",
+            dependent_data=dependent_data,
+        )
+
+        assert result.error is None
+        assert result.choices == [["1234", "Project Name"]]
+
+    @responses.activate
+    def test_get_select_options_error(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://example.com/get-projects?installationId={self.install.uuid}",
+            status=500,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.get_select_options(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            uri="/get-projects",
+        )
+        assert result.error is not None
+        assert result.error.message.startswith(
+            "Something went wrong while getting options for Select FormField"
+        )
+        assert result.error.webhook_context["error_type"] == "select_options.requested.bad_response"
+        assert result.error.status_code == 500


### PR DESCRIPTION
Introduces a new region RPC service (`sentry_app_region`) for Sentry App
operations that require access to region-specific data.

This PR adds the base service structure and the first method:
`get_select_options` which allows control silo endpoints to fetch select
options from Sentry Apps.

**Stack:**
1. **#106276** - get_select_options ← You are here
2. #106277 - create_issue_link
3. #106278 - create_external_issue
4. #106279 - delete_external_issue
5. #106281 - get_service_hook_projects
6. #106282 - record_interaction