### PR TITLE
feat(sentry-apps): Add create_issue_link to region RPC service

### DIFF
--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -1,9 +1,19 @@
+from typing import Any
+
+from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
-from sentry.sentry_apps.services.region.model import RpcSelectRequesterResult, RpcSentryAppError
+from sentry.sentry_apps.services.region.model import (
+    RpcPlatformExternalIssue,
+    RpcPlatformExternalIssueResult,
+    RpcSelectRequesterResult,
+    RpcSentryAppError,
+)
 from sentry.sentry_apps.services.region.service import SentryAppRegionService
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+from sentry.users.services.user import RpcUser
 
 
 class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
@@ -46,4 +56,60 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         return RpcSelectRequesterResult(
             choices=list(result.get("choices", [])),
             default_value=result.get("defaultValue"),
+        )
+
+    def create_issue_link(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        group_id: int,
+        action: str,
+        fields: dict[str, Any],
+        uri: str,
+        user: RpcUser,
+    ) -> RpcPlatformExternalIssueResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py @ POST
+        """
+        try:
+            group = Group.objects.get(
+                id=group_id,
+                project_id__in=Project.objects.filter(organization_id=organization_id),
+            )
+        except Group.DoesNotExist:
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message="Could not find the corresponding issue for the given groupId",
+                    webhook_context={},
+                    status_code=404,
+                )
+            )
+
+        try:
+            external_issue = IssueLinkCreator(
+                install=installation,
+                group=group,
+                action=action,
+                fields=fields,
+                uri=uri,
+                user=user,
+            ).run()
+        except (SentryAppIntegratorError, SentryAppSentryError) as e:
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message=e.message,
+                    webhook_context=e.webhook_context,
+                    status_code=e.status_code,
+                )
+            )
+
+        return RpcPlatformExternalIssueResult(
+            external_issue=RpcPlatformExternalIssue(
+                id=str(external_issue.id),
+                issue_id=str(external_issue.group_id),
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            )
         )

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -22,3 +22,16 @@ class RpcSelectRequesterResult(RpcModel):
     choices: list[list[str]] = Field(default_factory=list)
     default_value: str | None = None
     error: RpcSentryAppError | None = None
+
+
+class RpcPlatformExternalIssue(RpcModel):
+    id: str
+    issue_id: str
+    service_type: str
+    display_name: str
+    web_url: str
+
+
+class RpcPlatformExternalIssueResult(RpcModel):
+    external_issue: RpcPlatformExternalIssue | None = None
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -4,12 +4,17 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
+from typing import Any
 
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
-from sentry.sentry_apps.services.region.model import RpcSelectRequesterResult
+from sentry.sentry_apps.services.region.model import (
+    RpcPlatformExternalIssueResult,
+    RpcSelectRequesterResult,
+)
 from sentry.silo.base import SiloMode
+from sentry.users.services.user import RpcUser
 
 
 class SentryAppRegionService(RpcService):
@@ -43,6 +48,22 @@ class SentryAppRegionService(RpcService):
         dependent_data: str | None = None,
     ) -> RpcSelectRequesterResult:
         """Invokes SelectRequester to get select options."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def create_issue_link(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        group_id: int,
+        action: str,
+        fields: dict[str, Any],
+        uri: str,
+        user: RpcUser,
+    ) -> RpcPlatformExternalIssueResult:
+        """Invokes IssueLinkCreator to create an issue link."""
         pass
 
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -3,10 +3,12 @@ import responses
 from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.region import sentry_app_region_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import all_silo_test
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
+from sentry.users.services.user.serial import serialize_rpc_user
 
 
 @all_silo_test
@@ -15,6 +17,7 @@ class TestSentryAppRegionService(TestCase):
         self.user = self.create_user(email="boop@example.com")
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
+        self.group = self.create_group(project=self.project)
 
         self.sentry_app = self.create_sentry_app(
             name="Testin", organization=self.org, webhook_url="https://example.com"
@@ -77,4 +80,63 @@ class TestSentryAppRegionService(TestCase):
             "Something went wrong while getting options for Select FormField"
         )
         assert result.error.webhook_context["error_type"] == "select_options.requested.bad_response"
+        assert result.error.status_code == 500
+
+    @responses.activate
+    def test_create_issue_link(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={
+                "project": "Projectname",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists() is False
+        result = sentry_app_region_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=self.group.id,
+            action="create",
+            fields={"title": "An Issue"},
+            uri="/link-issue",
+            user=serialize_rpc_user(self.user),
+        )
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
+        assert result.error is None
+        assert result.external_issue is not None
+        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.web_url == "https://example.com/project/issue-id"
+        assert result.external_issue.display_name == "Projectname#issue-1"
+
+    @responses.activate
+    def test_create_issue_link_error(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={"error": "something went wrong"},
+            status=500,
+            content_type="application/json",
+        )
+
+        result = sentry_app_region_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=self.group.id,
+            action="create",
+            fields={},
+            uri="/link-issue",
+            user=serialize_rpc_user(self.user),
+        )
+
+        assert result.error is not None
+        assert result.external_issue is None
+        assert result.error.webhook_context["error_type"] == "external_issue.linked.bad_response"
         assert result.error.status_code == 500


### PR DESCRIPTION
Adds the create_issue_link method which allows control silo endpoints
to create issue links for Sentry Apps via RPC. This mirrors the
functionality in installation_external_issue_actions.py POST.

**Stack:**
1. #106276 - get_select_options
2. **#106277** - create_issue_link ← You are here
3. #106278 - create_external_issue
4. #106279 - delete_external_issue
5. #106281 - get_service_hook_projects
6. #106282 - record_interaction