### PR TITLE
feat(sentry-apps): Add create_external_issue to region RPC service

### DIFF
--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
@@ -96,6 +97,60 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 user=user,
             ).run()
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message=e.message,
+                    webhook_context=e.webhook_context,
+                    status_code=e.status_code,
+                )
+            )
+
+        return RpcPlatformExternalIssueResult(
+            external_issue=RpcPlatformExternalIssue(
+                id=str(external_issue.id),
+                issue_id=str(external_issue.group_id),
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            )
+        )
+
+    def create_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        group_id: int,
+        web_url: str,
+        project: str,
+        identifier: str,
+    ) -> RpcPlatformExternalIssueResult:
+        """
+        Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issues.py @ POST
+        """
+        try:
+            group = Group.objects.get(
+                id=group_id,
+                project_id__in=Project.objects.filter(organization_id=organization_id),
+            )
+        except Group.DoesNotExist:
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message="Could not find the corresponding issue for the given issueId",
+                    webhook_context={},
+                    status_code=404,
+                )
+            )
+
+        try:
+            external_issue = ExternalIssueCreator(
+                install=installation,
+                group=group,
+                web_url=web_url,
+                project=project,
+                identifier=identifier,
+            ).run()
+        except SentryAppSentryError as e:
             return RpcPlatformExternalIssueResult(
                 error=RpcSentryAppError(
                     message=e.message,

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -66,5 +66,20 @@ class SentryAppRegionService(RpcService):
         """Invokes IssueLinkCreator to create an issue link."""
         pass
 
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def create_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        group_id: int,
+        web_url: str,
+        project: str,
+        identifier: str,
+    ) -> RpcPlatformExternalIssueResult:
+        """Invokes ExternalIssueCreator to create an external issue."""
+        pass
+
 
 sentry_app_region_service = SentryAppRegionService.create_delegation()

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -140,3 +140,39 @@ class TestSentryAppRegionService(TestCase):
         assert result.external_issue is None
         assert result.error.webhook_context["error_type"] == "external_issue.linked.bad_response"
         assert result.error.status_code == 500
+
+    def test_create_external_issue(self) -> None:
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists() is False
+
+        result = sentry_app_region_service.create_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=self.group.id,
+            web_url="https://example.com/project/issue-1",
+            project="ProjectName",
+            identifier="issue-1",
+        )
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
+        assert result.error is None
+        assert result.external_issue is not None
+        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.web_url == "https://example.com/project/issue-1"
+        assert result.external_issue.display_name == "ProjectName#issue-1"
+
+    def test_create_external_issue_group_not_found(self) -> None:
+        result = sentry_app_region_service.create_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=99999999,
+            web_url="https://example.com/project/issue-1",
+            project="ProjectName",
+            identifier="issue-1",
+        )
+
+        assert result.error is not None
+        assert result.external_issue is None
+        assert result.error.status_code == 404


### PR DESCRIPTION
Adds the create_external_issue method which allows control silo endpoints
to create external issues for Sentry Apps via RPC. This mirrors the
functionality in installation_external_issues.py POST.

**Stack:**
1. #106276 - get_select_options
2. #106277 - create_issue_link
3. **#106278** - create_external_issue ← You are here
4. #106279 - delete_external_issue
5. #106281 - get_service_hook_projects
6. #106282 - record_interaction