### PR TITLE
feat(sentry-apps): Add delete_external_issue to region RPC service

### DIFF
--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -35,3 +35,8 @@ class RpcPlatformExternalIssue(RpcModel):
 class RpcPlatformExternalIssueResult(RpcModel):
     external_issue: RpcPlatformExternalIssue | None = None
     error: RpcSentryAppError | None = None
+
+
+class RpcEmptyResult(RpcModel):
+    success: bool = True
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -10,6 +10,7 @@ from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
 from sentry.sentry_apps.services.region.model import (
+    RpcEmptyResult,
     RpcPlatformExternalIssueResult,
     RpcSelectRequesterResult,
 )
@@ -79,6 +80,18 @@ class SentryAppRegionService(RpcService):
         identifier: str,
     ) -> RpcPlatformExternalIssueResult:
         """Invokes ExternalIssueCreator to create an external issue."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def delete_external_issue(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        external_issue_id: int,
+    ) -> RpcEmptyResult:
+        """Deletes a PlatformExternalIssue."""
         pass
 
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -176,3 +176,35 @@ class TestSentryAppRegionService(TestCase):
         assert result.error is not None
         assert result.external_issue is None
         assert result.error.status_code == 404
+
+    def test_delete_external_issue(self) -> None:
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.create(
+                group_id=self.group.id,
+                project_id=self.project.id,
+                service_type=self.sentry_app.slug,
+                display_name="Test#123",
+                web_url="https://example.com/issue/123",
+            )
+
+        result = sentry_app_region_service.delete_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            external_issue_id=external_issue.id,
+        )
+
+        assert result.success is True
+        assert result.error is None
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.filter(id=external_issue.id).exists()
+
+    def test_delete_external_issue_not_found(self) -> None:
+        result = sentry_app_region_service.delete_external_issue(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            external_issue_id=99999999,
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert result.error.status_code == 404


### PR DESCRIPTION
Adds the delete_external_issue method which allows control silo endpoints
to delete external issues for Sentry Apps via RPC. This mirrors the
functionality in installation_external_issue_details.py DELETE.

Also adds RpcEmptyResult model for operations that return no data.

**Stack:**
1. #106276 - get_select_options
2. #106277 - create_issue_link
3. #106278 - create_external_issue
4. **#106279** - delete_external_issue ← You are here
5. #106281 - get_service_hook_projects
6. #106282 - record_interaction