### PR TITLE
fix(aci): Use organization slug in notification links for single-written workflows

### DIFF
--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -294,7 +294,7 @@ def build_footer(
         key, value = get_rule_or_workflow_id(rules[0])
         match key:
             case "workflow_id":
-                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.slug, value))
             case "legacy_rule_id":
                 rule_url = build_rule_url(rules[0], group, project)
 

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -49,7 +49,7 @@ class OpsgenieClient(ApiClient):
             # fetch the workflow_id from the rule.data
             workflow_id = get_key_from_rule_data(rule, "workflow_id")
             workflow_urls.append(
-                organization.absolute_url(create_link_to_workflow(organization.id, workflow_id))
+                organization.absolute_url(create_link_to_workflow(organization.slug, workflow_id))
             )
         return workflow_urls
 

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -21,7 +21,7 @@ def build_slack_footer(
         key, value = get_rule_or_workflow_id(rules[0])
         match key:
             case "workflow_id":
-                rule_url = absolute_uri(create_link_to_workflow(group.organization.id, value))
+                rule_url = absolute_uri(create_link_to_workflow(group.organization.slug, value))
             case "legacy_rule_id":
                 rule_url = build_rule_url(rules[0], group, project)
         # If this notification is triggered via the "Send Test Notification"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -302,7 +302,7 @@ class AlertRuleNotification(ProjectNotification):
 
             match key:
                 case "workflow_id":
-                    rule_url = absolute_uri(create_link_to_workflow(self.organization.id, value))
+                    rule_url = absolute_uri(create_link_to_workflow(self.organization.slug, value))
                 case "legacy_rule_id":
                     rule_url = build_rule_url(self.rules[0], self.group, self.project)
 

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -23,11 +23,11 @@ We can use this as a basepoint to build out our templating system in the future
 """
 
 
-def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
+def create_link_to_workflow(organization_slug: str, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """
-    return f"/organizations/{organization_id}/monitors/alerts/{workflow_id}/"
+    return f"/organizations/{organization_slug}/monitors/alerts/{workflow_id}/"
 
 
 def get_email_link_extra_params(
@@ -152,9 +152,9 @@ def get_workflow_links(
             NotificationRuleDetails(
                 int(workflow_id),
                 rule.label,
-                create_link_to_workflow(organization.id, workflow_id),
+                create_link_to_workflow(organization.slug, workflow_id),
                 # TODO(iamrajjoshi): Add status url (whatever it is)
-                create_link_to_workflow(organization.id, workflow_id),
+                create_link_to_workflow(organization.slug, workflow_id),
             )
         )
     return workflow_links

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -80,7 +80,7 @@ def build_description_workflow_engine_ui(
     generate_footer: Callable[[str], str],
 ) -> str:
     project = event.group.project
-    workflow_url = create_link_to_workflow(project.organization.id, str(workflow_id))
+    workflow_url = create_link_to_workflow(project.organization.slug, str(workflow_id))
 
     description: str = installation.get_group_description(event.group, event) + generate_footer(
         workflow_url

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -235,7 +235,7 @@ class OpsgenieClientTest(APITestCase):
             "details": {
                 "Project Name": self.project.name,
                 "Triggering Workflows": rule.label,
-                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/monitors/alerts/{123}/",
+                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.slug}/monitors/alerts/{123}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
                 "Logger": "",

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -303,7 +303,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # Assert we are using the workflow id and created a link to the workflow
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.id}/monitors/alerts/1234567890/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/1234567890/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
 

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -38,7 +38,7 @@ class CreateTicketUtilsTest(TestCase):
             self.event, workflow_id, installation, generate_footer
         )
 
-        expected_url = f"/organizations/{self.organization.id}/monitors/alerts/{workflow_id}/"
+        expected_url = f"/organizations/{self.organization.slug}/monitors/alerts/{workflow_id}/"
         assert (
             description
             == f"Test description\n\nThis issue was created by a workflow: {expected_url}"


### PR DESCRIPTION
Fixes ISWF-867

When the workflow is single-written we use the new URL structure, but it was using organization ID in the URL instead of the slug, which resulted in a broken link.

<img width="770" height="144" alt="image" src="https://github.com/user-attachments/assets/700fecf1-610e-454b-a096-570a239facb4" />
