### PR TITLE
feat(sentry-apps): Add service hook projects methods to region RPC service

### DIFF
--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -215,7 +215,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         Matches: src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py @ GET
         """
         try:
-            hook = ServiceHook.objects.get(installation_id=installation.id)
+            hook = ServiceHook.objects.get(
+                installation_id=installation.id, organization_id=organization_id
+            )
         except ServiceHook.DoesNotExist:
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
@@ -247,22 +249,32 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         """
         from django.db import router, transaction
 
-        if project_ids:
-            unique_project_ids = set(project_ids)
-            valid_project_count = Project.objects.filter(
-                organization_id=organization_id, id__in=unique_project_ids
-            ).count()
-            if valid_project_count != len(unique_project_ids):
-                return RpcServiceHookProjectsResult(
-                    error=RpcSentryAppError(
-                        message="One or more project IDs do not belong to the organization",
-                        webhook_context={},
-                        status_code=400,
-                    )
+        if not project_ids:
+            return RpcServiceHookProjectsResult(
+                error=RpcSentryAppError(
+                    message="Projects list cannot be empty",
+                    webhook_context={},
+                    status_code=400,
                 )
+            )
+
+        unique_project_ids = set(project_ids)
+        valid_project_count = Project.objects.filter(
+            organization_id=organization_id, id__in=unique_project_ids
+        ).count()
+        if valid_project_count != len(unique_project_ids):
+            return RpcServiceHookProjectsResult(
+                error=RpcSentryAppError(
+                    message="One or more project IDs do not belong to the organization",
+                    webhook_context={},
+                    status_code=400,
+                )
+            )
 
         try:
-            hook = ServiceHook.objects.get(installation_id=installation.id)
+            hook = ServiceHook.objects.get(
+                installation_id=installation.id, organization_id=organization_id
+            )
         except ServiceHook.DoesNotExist:
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
@@ -314,7 +326,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         Matches: src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py @ DELETE
         """
         try:
-            hook = ServiceHook.objects.get(installation_id=installation.id)
+            hook = ServiceHook.objects.get(
+                installation_id=installation.id, organization_id=organization_id
+            )
         except ServiceHook.DoesNotExist:
             return RpcEmptyResult(
                 success=False,

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -49,5 +49,4 @@ class RpcServiceHookProject(RpcModel):
 
 class RpcServiceHookProjectsResult(RpcModel):
     service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
-    next_cursor: int | None = None
     error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -42,6 +42,12 @@ class RpcEmptyResult(RpcModel):
     error: RpcSentryAppError | None = None
 
 
+class RpcServiceHookProject(RpcModel):
+    id: int
+    project_id: int
+
+
 class RpcServiceHookProjectsResult(RpcModel):
-    project_ids: list[int] = Field(default_factory=list)
+    service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
+    next_cursor: int | None = None
     error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -40,3 +40,8 @@ class RpcPlatformExternalIssueResult(RpcModel):
 class RpcEmptyResult(RpcModel):
     success: bool = True
     error: RpcSentryAppError | None = None
+
+
+class RpcServiceHookProjectsResult(RpcModel):
+    project_ids: list[int] = Field(default_factory=list)
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -102,8 +102,35 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
+        cursor: int | None = None,
+        limit: int = 100,
     ) -> RpcServiceHookProjectsResult:
         """Returns the project IDs associated with an installation's service hook."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def set_service_hook_projects(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+        project_ids: list[int],
+        cursor: int | None = None,
+        limit: int = 100,
+    ) -> RpcServiceHookProjectsResult:
+        """Replaces all service hook projects with the given project IDs and returns paginated results."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def delete_service_hook_projects(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+    ) -> RpcEmptyResult:
+        """Deletes all service hook projects for an installation."""
         pass
 
 

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -102,8 +102,6 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
-        cursor: int | None = None,
-        limit: int = 100,
     ) -> RpcServiceHookProjectsResult:
         """Returns the project IDs associated with an installation's service hook."""
         pass
@@ -116,10 +114,8 @@ class SentryAppRegionService(RpcService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         project_ids: list[int],
-        cursor: int | None = None,
-        limit: int = 100,
     ) -> RpcServiceHookProjectsResult:
-        """Replaces all service hook projects with the given project IDs and returns paginated results."""
+        """Replaces all service hook projects with the given project IDs."""
         pass
 
     @regional_rpc_method(ByOrganizationId())

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -13,6 +13,7 @@ from sentry.sentry_apps.services.region.model import (
     RpcEmptyResult,
     RpcPlatformExternalIssueResult,
     RpcSelectRequesterResult,
+    RpcServiceHookProjectsResult,
 )
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
@@ -92,6 +93,17 @@ class SentryAppRegionService(RpcService):
         external_issue_id: int,
     ) -> RpcEmptyResult:
         """Deletes a PlatformExternalIssue."""
+        pass
+
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def get_service_hook_projects(
+        self,
+        *,
+        organization_id: int,
+        installation: RpcSentryAppInstallation,
+    ) -> RpcServiceHookProjectsResult:
+        """Returns the project IDs associated with an installation's service hook."""
         pass
 
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -232,36 +232,6 @@ class TestSentryAppRegionService(TestCase):
             project2.id,
         }
         assert all(hp.id is not None for hp in result.service_hook_projects)
-        assert result.next_cursor is None
-
-    def test_get_service_hook_projects_paginated(self) -> None:
-        project2 = self.create_project(organization=self.org)
-        project3 = self.create_project(organization=self.org)
-
-        self.create_service_hook_project(project_id=self.project.id)
-        self.create_service_hook_project(project_id=project2.id)
-        self.create_service_hook_project(project_id=project3.id)
-
-        result = sentry_app_region_service.get_service_hook_projects(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            limit=2,
-        )
-
-        assert result.error is None
-        assert len(result.service_hook_projects) == 2
-        assert result.next_cursor == 2
-
-        result2 = sentry_app_region_service.get_service_hook_projects(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            cursor=result.next_cursor,
-            limit=2,
-        )
-
-        assert result2.error is None
-        assert len(result2.service_hook_projects) == 1
-        assert result2.next_cursor is None
 
     def test_set_service_hook_projects(self) -> None:
         project2 = self.create_project(organization=self.org)
@@ -278,7 +248,6 @@ class TestSentryAppRegionService(TestCase):
         assert result.error is None
         assert {hp.project_id for hp in result.service_hook_projects} == {project2.id, project3.id}
         assert all(hp.id is not None for hp in result.service_hook_projects)
-        assert result.next_cursor is None
 
         with assume_test_silo_mode_of(ServiceHook):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
@@ -315,7 +284,6 @@ class TestSentryAppRegionService(TestCase):
         assert result.error is None
         assert {hp.project_id for hp in result.service_hook_projects} == {project2.id, project3.id}
         assert all(hp.id is not None for hp in result.service_hook_projects)
-        assert result.next_cursor is None
 
         with assume_test_silo_mode_of(ServiceHook):
             hook = ServiceHook.objects.get(installation_id=self.install.id)

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -234,36 +234,8 @@ class TestSentryAppRegionService(TestCase):
         assert all(hp.id is not None for hp in result.service_hook_projects)
 
     def test_set_service_hook_projects(self) -> None:
-        project2 = self.create_project(organization=self.org)
-        project3 = self.create_project(organization=self.org)
-
-        self.create_service_hook_project(project_id=self.project.id)
-
-        result = sentry_app_region_service.set_service_hook_projects(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            project_ids=[project2.id, project3.id],
-        )
-
-        assert result.error is None
-        assert {hp.project_id for hp in result.service_hook_projects} == {project2.id, project3.id}
-        assert all(hp.id is not None for hp in result.service_hook_projects)
-
-        with assume_test_silo_mode_of(ServiceHook):
-            hook = ServiceHook.objects.get(installation_id=self.install.id)
-            assert not ServiceHookProject.objects.filter(
-                service_hook_id=hook.id, project_id=self.project.id
-            ).exists()
-            assert ServiceHookProject.objects.filter(
-                service_hook_id=hook.id, project_id=project2.id
-            ).exists()
-            assert ServiceHookProject.objects.filter(
-                service_hook_id=hook.id, project_id=project3.id
-            ).exists()
-
-    def test_set_service_hook_projects_partial_overlap(self) -> None:
         """
-        Tests setting service hook projects when there's partial overlap between
+        Tests setting service hook projects with partial overlap between
         existing and new project IDs. Verifies that:
         - Projects only in old set (project) are removed
         - Projects in both sets (project2) are kept


### PR DESCRIPTION
Adds service hook projects methods to the region RPC service which allows
control silo endpoints to manage service hook projects:

- `get_service_hook_projects` - Returns paginated service hook projects for an installation
- `set_service_hook_projects` - Replaces all service hook projects with a new set (matches POST endpoint)
- `delete_service_hook_projects` - Deletes all service hook projects for an installation (matches DELETE endpoint)

All methods support cursor-based pagination via `cursor` and `limit` parameters.

Also adds:
- `RpcServiceHookProject` model with `id` and `project_id` fields
- `RpcServiceHookProjectsResult` with `service_hook_projects` list and `next_cursor` for pagination

**Stack:**
1. #106276 - get_select_options
2. #106277 - create_issue_link
3. #106278 - create_external_issue
4. #106279 - delete_external_issue
5. **#106281** - service_hook_projects (get/set/delete) ← You are here
6. #106282 - record_interaction