### PR TITLE
feat(sentry-apps): Add interaction methods to region RPC service

### DIFF
--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -354,7 +354,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
     def get_interaction_stats(
         self,
         *,
-        organization_id: int,
         sentry_app: RpcSentryApp,
         component_types: list[str],
         since: float,
@@ -364,13 +363,14 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         """
         Matches: src/sentry/sentry_apps/api/endpoints/sentry_app_interaction.py @ GET
         """
+
         start_dt = datetime.fromtimestamp(since, tz=timezone.utc)
         end_dt = datetime.fromtimestamp(until, tz=timezone.utc)
 
         tsdb_kwargs: dict[str, Any] = {
             "start": start_dt,
             "end": end_dt,
-            "tenant_ids": {"organization_id": organization_id},
+            "tenant_ids": {"organization_id": sentry_app.owner_id},
         }
         if resolution is not None:
             tsdb_kwargs["rollup"] = resolution

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -403,7 +403,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
     def record_interaction(
         self,
         *,
-        organization_id: int,
         sentry_app: RpcSentryApp,
         tsdb_field: str,
         component_type: str | None = None,

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -412,7 +412,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         Matches: src/sentry/sentry_apps/api/endpoints/sentry_app_interaction.py @ POST
         """
         model = getattr(TSDBModel, tsdb_field, None)
-        key: int | str
 
         if model == TSDBModel.sentry_app_component_interacted:
             if component_type is None or component_type not in COMPONENT_TYPES:
@@ -425,8 +424,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                     ),
                 )
             key = self.get_component_interaction_key(sentry_app.slug, component_type)
+            tsdb.backend.incr(model, key)
         elif model == TSDBModel.sentry_app_viewed:
-            key = sentry_app.id
+            tsdb.backend.incr(model, sentry_app.id)
         else:
             return RpcEmptyResult(
                 success=False,
@@ -436,8 +436,5 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                     status_code=400,
                 ),
             )
-
-        # Timestamp is automatically created
-        tsdb.backend.incr(model, key)
 
         return RpcEmptyResult()

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -412,6 +412,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         Matches: src/sentry/sentry_apps/api/endpoints/sentry_app_interaction.py @ POST
         """
         model = getattr(TSDBModel, tsdb_field, None)
+        key: int | str
 
         if model == TSDBModel.sentry_app_component_interacted:
             if component_type is None or component_type not in COMPONENT_TYPES:

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -425,7 +425,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 )
             key = self.get_component_interaction_key(sentry_app.slug, component_type)
         elif model == TSDBModel.sentry_app_viewed:
-            key = str(sentry_app.id)
+            key = sentry_app.id
         else:
             return RpcEmptyResult(
                 success=False,

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -50,3 +50,14 @@ class RpcServiceHookProject(RpcModel):
 class RpcServiceHookProjectsResult(RpcModel):
     service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
     error: RpcSentryAppError | None = None
+
+
+class RpcTimeSeriesPoint(RpcModel):
+    time: int
+    count: int
+
+
+class RpcInteractionStatsResult(RpcModel):
+    views: list[RpcTimeSeriesPoint] = Field(default_factory=list)
+    component_interactions: dict[str, list[RpcTimeSeriesPoint]] = Field(default_factory=dict)
+    error: RpcSentryAppError | None = None

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -150,12 +150,13 @@ class SentryAppRegionService(RpcService):
         """Gets TSDB stats for Sentry App views and component interactions."""
         pass
 
-    @regional_rpc_method(ByOrganizationId())
+    @regional_rpc_method(
+        ByOrganizationIdAttribute(parameter_name="sentry_app", attribute_name="owner_id")
+    )
     @abc.abstractmethod
     def record_interaction(
         self,
         *,
-        organization_id: int,
         sentry_app: RpcSentryApp,
         tsdb_field: str,
         component_type: str | None = None,

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -129,5 +129,19 @@ class SentryAppRegionService(RpcService):
         """Deletes all service hook projects for an installation."""
         pass
 
+    @regional_rpc_method(ByOrganizationId())
+    @abc.abstractmethod
+    def record_interaction(
+        self,
+        *,
+        organization_id: int,
+        sentry_app_id: int,
+        sentry_app_slug: str,
+        tsdb_field: str,
+        component_type: str | None = None,
+    ) -> RpcEmptyResult:
+        """Records a TSDB metric for Sentry App interactions."""
+        pass
+
 
 sentry_app_region_service = SentryAppRegionService.create_delegation()

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -6,7 +6,7 @@
 import abc
 from typing import Any
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationIdAttribute
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryApp, RpcSentryAppInstallation
 from sentry.sentry_apps.services.region.model import (
@@ -134,6 +134,22 @@ class SentryAppRegionService(RpcService):
         """Deletes all service hook projects for an installation."""
         pass
 
+    @regional_rpc_method(
+        ByOrganizationIdAttribute(parameter_name="sentry_app", attribute_name="owner_id")
+    )
+    @abc.abstractmethod
+    def get_interaction_stats(
+        self,
+        *,
+        sentry_app: RpcSentryApp,
+        component_types: list[str],
+        since: float,
+        until: float,
+        resolution: int | None = None,
+    ) -> RpcInteractionStatsResult:
+        """Gets TSDB stats for Sentry App views and component interactions."""
+        pass
+
     @regional_rpc_method(ByOrganizationId())
     @abc.abstractmethod
     def record_interaction(
@@ -145,21 +161,6 @@ class SentryAppRegionService(RpcService):
         component_type: str | None = None,
     ) -> RpcEmptyResult:
         """Records a TSDB metric for Sentry App interactions."""
-        pass
-
-    @regional_rpc_method(ByOrganizationId())
-    @abc.abstractmethod
-    def get_interaction_stats(
-        self,
-        *,
-        organization_id: int,
-        sentry_app: RpcSentryApp,
-        component_types: list[str],
-        since: float,
-        until: float,
-        resolution: int | None = None,
-    ) -> RpcInteractionStatsResult:
-        """Gets TSDB stats for Sentry App views and component interactions."""
         pass
 
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import orjson
 import responses
 from django.utils.http import urlencode
@@ -8,6 +10,7 @@ from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProjec
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.region import sentry_app_region_service
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
 from sentry.users.services.user.serial import serialize_rpc_user
 
@@ -286,22 +289,34 @@ class TestSentryAppRegionService(TestCase):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             assert not ServiceHookProject.objects.filter(service_hook_id=hook.id).exists()
 
-    def test_record_interaction_sentry_app_viewed(self) -> None:
+    def test_get_interaction_stats(self) -> None:
+        now = before_now(days=1)
+        since = (now - timedelta(minutes=5)).timestamp()
+        result = sentry_app_region_service.get_interaction_stats(
+            organization_id=self.org.id,
+            sentry_app=self.rpc_installation.sentry_app,
+            component_types=["issue-link", "stacktrace-link"],
+            since=since,
+            until=now.timestamp(),
+        )
+
+        assert result.error is None
+        assert all(point.count == 0 for point in result.views)
+        assert set(result.component_interactions.keys()) == {"issue-link", "stacktrace-link"}
+
+    def test_record_interaction(self) -> None:
         result = sentry_app_region_service.record_interaction(
             organization_id=self.org.id,
-            sentry_app_id=self.sentry_app.id,
-            sentry_app_slug=self.sentry_app.slug,
+            sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_viewed",
         )
 
         assert result.success is True
         assert result.error is None
 
-    def test_record_interaction_component_interacted(self) -> None:
         result = sentry_app_region_service.record_interaction(
             organization_id=self.org.id,
-            sentry_app_id=self.sentry_app.id,
-            sentry_app_slug=self.sentry_app.slug,
+            sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_component_interacted",
             component_type="issue-link",
         )
@@ -309,11 +324,10 @@ class TestSentryAppRegionService(TestCase):
         assert result.success is True
         assert result.error is None
 
-    def test_record_interaction_invalid_tsdb_field(self) -> None:
+    def test_record_interaction_error(self) -> None:
         result = sentry_app_region_service.record_interaction(
             organization_id=self.org.id,
-            sentry_app_id=self.sentry_app.id,
-            sentry_app_slug=self.sentry_app.slug,
+            sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="invalid_field",
         )
 
@@ -322,15 +336,14 @@ class TestSentryAppRegionService(TestCase):
         assert result.error.status_code == 400
         assert "tsdbField must be one of" in result.error.message
 
-    def test_record_interaction_missing_component_type(self) -> None:
         result = sentry_app_region_service.record_interaction(
             organization_id=self.org.id,
-            sentry_app_id=self.sentry_app.id,
-            sentry_app_slug=self.sentry_app.slug,
+            sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_component_interacted",
         )
 
         assert result.success is False
         assert result.error is not None
         assert result.error.status_code == 400
+        assert "componentType is required" in result.error.message
         assert "componentType is required" in result.error.message

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -293,7 +293,6 @@ class TestSentryAppRegionService(TestCase):
         now = before_now(days=1)
         since = (now - timedelta(minutes=5)).timestamp()
         result = sentry_app_region_service.get_interaction_stats(
-            organization_id=self.org.id,
             sentry_app=self.rpc_installation.sentry_app,
             component_types=["issue-link", "stacktrace-link"],
             since=since,

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -305,7 +305,6 @@ class TestSentryAppRegionService(TestCase):
 
     def test_record_interaction(self) -> None:
         result = sentry_app_region_service.record_interaction(
-            organization_id=self.org.id,
             sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_viewed",
         )
@@ -314,7 +313,6 @@ class TestSentryAppRegionService(TestCase):
         assert result.error is None
 
         result = sentry_app_region_service.record_interaction(
-            organization_id=self.org.id,
             sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_component_interacted",
             component_type="issue-link",
@@ -325,7 +323,6 @@ class TestSentryAppRegionService(TestCase):
 
     def test_record_interaction_error(self) -> None:
         result = sentry_app_region_service.record_interaction(
-            organization_id=self.org.id,
             sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="invalid_field",
         )
@@ -336,7 +333,6 @@ class TestSentryAppRegionService(TestCase):
         assert "tsdbField must be one of" in result.error.message
 
         result = sentry_app_region_service.record_interaction(
-            organization_id=self.org.id,
             sentry_app=self.rpc_installation.sentry_app,
             tsdb_field="sentry_app_component_interacted",
         )


### PR DESCRIPTION
Adds the interaction methods to allow control silo endpoints to work with
Sentry App TSDB metrics via RPC:

- `record_interaction`: Records views and component interactions (POST)
- `get_interaction_stats`: Retrieves TSDB stats for views and component
  interactions over a time range (GET)

Also adds a shared `get_component_interaction_key` utility method on the
service for generating consistent TSDB keys.

**Stack:**
1. #106276 - get_select_options
2. #106277 - create_issue_link
3. #106278 - create_external_issue
4. #106279 - delete_external_issue
5. #106281 - get/set/delete_service_hook_projects
6. **#106282** - record_interaction + get_interaction_stats ← You are here