### PR TITLE
refactor(dashboards): Convert GenericWidgetQueries consumers to use hook

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -86,7 +86,6 @@ describe('add to dashboard modal', () => {
       ],
     };
 
-    // Initialize PageFiltersStore with defaultSelection for widget query hooks
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(defaultSelection);
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -6,6 +6,7 @@ import selectEvent from 'sentry-test/selectEvent';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import AddToDashboardModal from 'sentry/components/modals/widgetBuilder/addToDashboardModal';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {DashboardCreateLimitWrapper} from 'sentry/views/dashboards/createLimitWrapper';
 import type {
   DashboardDetails,
@@ -84,6 +85,10 @@ describe('add to dashboard modal', () => {
         },
       ],
     };
+
+    // Initialize PageFiltersStore with defaultSelection for widget query hooks
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(defaultSelection);
 
     // Default behaviour for dashboard create limit wrapper
     mockDashboardCreateLimitWrapper.mockImplementation(({children}: {children: any}) =>

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -100,7 +100,7 @@ import {
   DashboardsMEPProvider,
   useDashboardsMEPContext,
 } from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
-import type {GenericWidgetQueriesChildrenProps} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import type {GenericWidgetQueriesResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import IssueWidgetQueries from 'sentry/views/dashboards/widgetCard/issueWidgetQueries';
 import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
@@ -453,11 +453,7 @@ function WidgetViewerModal(props: Props) {
     });
   }
 
-  function renderTable({
-    tableResults,
-    loading,
-    pageLinks,
-  }: GenericWidgetQueriesChildrenProps) {
+  function renderTable({tableResults, loading, pageLinks}: GenericWidgetQueriesResult) {
     return ViewerTableV2({
       tableResults,
       loading,
@@ -484,7 +480,7 @@ function WidgetViewerModal(props: Props) {
     loading,
     pageLinks,
     totalCount,
-  }: GenericWidgetQueriesChildrenProps) => {
+  }: GenericWidgetQueriesResult) => {
     if (totalResults === undefined && totalCount) {
       setTotalResults(totalCount);
     }

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -548,8 +548,6 @@ function WidgetViewerModal(props: Props) {
         }
         return (
           <IssueWidgetQueries
-            api={api}
-            organization={organization}
             widget={tableWidget}
             selection={modalSelection}
             limit={
@@ -597,8 +595,6 @@ function WidgetViewerModal(props: Props) {
         }
         return (
           <WidgetQueries
-            api={api}
-            organization={organization}
             widget={tableWidget}
             selection={modalSelection}
             limit={

--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -16,7 +16,7 @@ type QueueItem = {
   fetchDataRef: RefObject<FetchDataFn>;
 };
 
-export type WidgetQueryQueue = ReactAsyncQueuer<QueueItem>;
+type WidgetQueryQueue = ReactAsyncQueuer<QueueItem>;
 
 type Context = {
   queue: WidgetQueryQueue;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -84,13 +84,13 @@ import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
-import type {GenericWidgetQueriesChildrenProps} from './genericWidgetQueries';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 const OTHER = 'Other';
 const PERCENTAGE_DECIMAL_POINTS = 3;
 
 type TableComponentProps = Pick<
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   'errorMessage' | 'loading' | 'tableResults'
 > & {
   selection: PageFilters;
@@ -102,7 +102,7 @@ type TableComponentProps = Pick<
   onWidgetTableSort?: (sort: Sort) => void;
 };
 
-type WidgetCardChartProps = Pick<GenericWidgetQueriesChildrenProps, 'timeseriesResults'> &
+type WidgetCardChartProps = Pick<GenericWidgetQueriesResult, 'timeseriesResults'> &
   TableComponentProps & {
     widgetLegendState: WidgetLegendSelectionState;
     chartGroup?: string;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -65,9 +65,8 @@ export type GenericWidgetQueriesChildrenProps = {
   totalCount?: string;
 };
 
-export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
+export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   api: Client;
-  children: (props: GenericWidgetQueriesChildrenProps) => React.ReactNode;
   config: DatasetConfig<SeriesResponse, TableResponse>;
   organization: Organization;
   selection: PageFilters;
@@ -79,8 +78,8 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   ) => void | {totalIssuesCount?: string};
   cursor?: string;
   customDidUpdateComparator?: (
-    prevProps: GenericWidgetQueriesProps<SeriesResponse, TableResponse>,
-    nextProps: GenericWidgetQueriesProps<SeriesResponse, TableResponse>
+    prevProps: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>,
+    nextProps: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>
   ) => boolean;
   dashboardFilters?: DashboardFilters;
   disabled?: boolean;
@@ -104,12 +103,16 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   skipDashboardFilterParens?: boolean;
 };
 
-function GenericWidgetQueries<SeriesResponse, TableResponse>(
-  props: GenericWidgetQueriesProps<SeriesResponse, TableResponse>
-) {
+export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> =
+  UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> & {
+    children: (props: GenericWidgetQueriesChildrenProps) => React.ReactNode;
+  };
+
+export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
+  props: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>
+): GenericWidgetQueriesChildrenProps {
   const {
     api,
-    children,
     config,
     organization,
     selection,
@@ -152,7 +155,7 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
   const isMountedRef = useRef(false);
   const queryFetchIDRef = useRef<symbol | undefined>(undefined);
   const prevPropsRef = useRef<
-    GenericWidgetQueriesProps<SeriesResponse, TableResponse> | undefined
+    UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> | undefined
   >(undefined);
   const rawResultsRef = useRef<SeriesResponse[] | undefined>(undefined);
   const hasInitialFetchRef = useRef(false);
@@ -580,7 +583,7 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
     props,
   ]);
 
-  return children({
+  return {
     loading,
     tableResults,
     timeseriesResults,
@@ -588,7 +591,15 @@ function GenericWidgetQueries<SeriesResponse, TableResponse>(
     pageLinks,
     timeseriesResultsTypes,
     timeseriesResultsUnits,
-  });
+  };
+}
+
+function GenericWidgetQueries<SeriesResponse, TableResponse>(
+  props: GenericWidgetQueriesProps<SeriesResponse, TableResponse>
+) {
+  const {children, ...hookProps} = props;
+  const result = useGenericWidgetQueries(hookProps);
+  return children(result);
 }
 
 export function cleanWidgetForRequest(widget: Widget): Widget {

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -6,6 +6,7 @@ import omit from 'lodash/omit';
 import type {ResponseMeta} from 'sentry/api';
 import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
 import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
@@ -99,7 +100,7 @@ export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   // Optional selection override - if not provided, usePageFilters hook will be used
   // This is needed for the widget viewer modal where local zoom state (modalSelection)
   // needs to override global PageFiltersStore
-  selection?: any;
+  selection?: PageFilters;
   // Skips adding parens before applying dashboard filters
   // Used for datasets that do not support parens/boolean logic
   skipDashboardFilterParens?: boolean;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -96,6 +96,10 @@ export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   }: OnDataFetchedProps) => void;
   onDemandControlContext?: OnDemandControlContext;
   samplingMode?: SamplingMode;
+  // Optional selection override - if not provided, usePageFilters hook will be used
+  // This is needed for the widget viewer modal where local zoom state (modalSelection)
+  // needs to override global PageFiltersStore
+  selection?: any;
   // Skips adding parens before applying dashboard filters
   // Used for datasets that do not support parens/boolean logic
   skipDashboardFilterParens?: boolean;
@@ -121,13 +125,17 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     onDataFetched,
     onDemandControlContext,
     samplingMode,
+    selection: propsSelection,
     skipDashboardFilterParens,
   } = props;
 
   const api = useApi();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  const hookPageFilters = usePageFilters();
   const {queue} = useWidgetQueryQueue();
+
+  // Use override selection if provided (for modal zoom), otherwise use hook
+  const selection = propsSelection ?? hookPageFilters.selection;
 
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -103,11 +103,6 @@ export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   skipDashboardFilterParens?: boolean;
 };
 
-export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> =
-  UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> & {
-    children: (props: GenericWidgetQueriesChildrenProps) => React.ReactNode;
-  };
-
 export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
   props: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>
 ): GenericWidgetQueriesChildrenProps {
@@ -594,14 +589,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
   };
 }
 
-function GenericWidgetQueries<SeriesResponse, TableResponse>(
-  props: GenericWidgetQueriesProps<SeriesResponse, TableResponse>
-) {
-  const {children, ...hookProps} = props;
-  const result = useGenericWidgetQueries(hookProps);
-  return children(result);
-}
-
 export function cleanWidgetForRequest(widget: Widget): Widget {
   const _widget = cloneDeep(widget);
   _widget.queries.forEach(query => {
@@ -611,5 +598,3 @@ export function cleanWidgetForRequest(widget: Widget): Widget {
 
   return _widget;
 }
-
-export default GenericWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -52,7 +52,7 @@ export type OnDataFetchedProps = {
   totalIssuesCount?: string;
 };
 
-export type GenericWidgetQueriesChildrenProps = {
+export type GenericWidgetQueriesResult = {
   loading: boolean;
   confidence?: Confidence;
   errorMessage?: string;
@@ -103,7 +103,7 @@ export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
 
 export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
   props: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>
-): GenericWidgetQueriesChildrenProps {
+): GenericWidgetQueriesResult {
   const {
     config,
     widget,
@@ -124,7 +124,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     skipDashboardFilterParens,
   } = props;
 
-  // Use hooks to get required dependencies
   const api = useApi();
   const organization = useOrganization();
   const {selection} = usePageFilters();

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -13,6 +13,7 @@ import {
 
 import * as modal from 'sentry/actionCreators/modal';
 import * as LineChart from 'sentry/components/charts/lineChart';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {MINUTE, SECOND} from 'sentry/utils/formatters';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {Widget} from 'sentry/views/dashboards/types';
@@ -132,6 +133,8 @@ describe('Dashboards > WidgetCard', () => {
   });
 
   beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: {meta: {isMetricsData: false}},

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -1,7 +1,6 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {
   DashboardFilterKeys,
@@ -22,8 +21,10 @@ describe('IssueWidgetQueries', () => {
     },
   };
 
-  const organization = OrganizationFixture();
-  const api = new MockApiClient();
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
+  });
   describe('table display type', () => {
     const widget: Widget = {
       id: '1',
@@ -74,25 +75,7 @@ describe('IssueWidgetQueries', () => {
         ],
       });
 
-      render(
-        <IssueWidgetQueries
-          api={api}
-          organization={organization}
-          widget={widget}
-          selection={{
-            projects: [1],
-            environments: ['prod'],
-            datetime: {
-              period: '14d',
-              start: null,
-              end: null,
-              utc: false,
-            },
-          }}
-        >
-          {mockFunction}
-        </IssueWidgetQueries>
-      );
+      render(<IssueWidgetQueries widget={widget}>{mockFunction}</IssueWidgetQueries>);
 
       await waitFor(() =>
         expect(mockFunction).toHaveBeenCalledWith(
@@ -125,10 +108,7 @@ describe('IssueWidgetQueries', () => {
       });
       render(
         <IssueWidgetQueries
-          api={api}
-          organization={organization}
           widget={widget}
-          selection={selection}
           dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.2.0', 'abc@1.3.0']}}
         >
           {() => <div data-test-id="child" />}
@@ -195,16 +175,7 @@ describe('IssueWidgetQueries', () => {
       const mockFunction = jest.fn(() => {
         return <div />;
       });
-      render(
-        <IssueWidgetQueries
-          api={api}
-          organization={organization}
-          widget={widget}
-          selection={selection}
-        >
-          {mockFunction}
-        </IssueWidgetQueries>
-      );
+      render(<IssueWidgetQueries widget={widget}>{mockFunction}</IssueWidgetQueries>);
 
       expect(issuesTimeseriesMock).toHaveBeenCalledWith(
         '/organizations/org-slug/issues-timeseries/',

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react';
 
 import type {ResponseMeta} from 'sentry/api';
 import MemberListStore from 'sentry/stores/memberListStore';
+import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {
@@ -25,7 +26,7 @@ type Props = {
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
   // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
+  selection?: PageFilters;
 };
 
 function IssueWidgetQueries({

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -17,7 +17,7 @@ import type {
   GenericWidgetQueriesChildrenProps,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
-import GenericWidgetQueries from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type Props = {
   api: Client;
@@ -62,31 +62,27 @@ function IssueWidgetQueries({
     return {totalIssuesCount: response?.getResponseHeader('X-Hits') ?? undefined};
   };
 
+  const {loading, ...rest} = useGenericWidgetQueries<IssuesSeriesResponse, Group[]>({
+    queue,
+    config,
+    api,
+    organization,
+    selection,
+    widget,
+    cursor,
+    limit,
+    dashboardFilters,
+    onDataFetched,
+    onDataFetchStart,
+    afterFetchTableData,
+    skipDashboardFilterParens: true, // Issue widgets do not support parens in search
+  });
+
   return getDynamicText({
-    value: (
-      <GenericWidgetQueries<IssuesSeriesResponse, Group[]>
-        queue={queue}
-        config={config}
-        api={api}
-        organization={organization}
-        selection={selection}
-        widget={widget}
-        cursor={cursor}
-        limit={limit}
-        dashboardFilters={dashboardFilters}
-        onDataFetched={onDataFetched}
-        onDataFetchStart={onDataFetchStart}
-        afterFetchTableData={afterFetchTableData}
-        skipDashboardFilterParens // Issue widgets do not support parens in search
-      >
-        {({loading, ...rest}) =>
-          children({
-            loading: loading || !memberListStoreLoaded,
-            ...rest,
-          })
-        }
-      </GenericWidgetQueries>
-    ),
+    value: children({
+      loading: loading || !memberListStoreLoaded,
+      ...rest,
+    }),
     fixed: <div />,
   });
 }

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -1,17 +1,14 @@
 import {useEffect, useState} from 'react';
 
-import type {Client, ResponseMeta} from 'sentry/api';
+import type {ResponseMeta} from 'sentry/api';
 import MemberListStore from 'sentry/stores/memberListStore';
-import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {
   IssuesConfig,
   type IssuesSeriesResponse,
 } from 'sentry/views/dashboards/datasetConfig/issues';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
-import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 
 import type {
   GenericWidgetQueriesChildrenProps,
@@ -20,25 +17,17 @@ import type {
 import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type Props = {
-  api: Client;
   children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
-  organization: Organization;
-  selection: PageFilters;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;
   limit?: number;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
-  queue?: WidgetQueryQueue;
 };
 
 function IssueWidgetQueries({
-  queue,
   children,
-  api,
-  organization,
-  selection,
   widget,
   cursor,
   limit,
@@ -63,11 +52,7 @@ function IssueWidgetQueries({
   };
 
   const {loading, ...rest} = useGenericWidgetQueries<IssuesSeriesResponse, Group[]>({
-    queue,
     config,
-    api,
-    organization,
-    selection,
     widget,
     cursor,
     limit,

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -24,6 +24,8 @@ type Props = {
   limit?: number;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 function IssueWidgetQueries({
@@ -34,6 +36,7 @@ function IssueWidgetQueries({
   dashboardFilters,
   onDataFetched,
   onDataFetchStart,
+  selection,
 }: Props) {
   const [memberListStoreLoaded, setMemberListStoreLoaded] = useState(false);
 
@@ -59,6 +62,7 @@ function IssueWidgetQueries({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
+    selection,
     afterFetchTableData,
     skipDashboardFilterParens: true, // Issue widgets do not support parens in search
   });

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -11,13 +11,13 @@ import {
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 
 import type {
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type Props = {
-  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -7,6 +7,7 @@ import {SessionsFieldFixture} from 'sentry-fixture/sessions';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {
   DashboardFilterKeys,
   DisplayType,
@@ -70,6 +71,8 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
 
   beforeEach(() => {
     setMockDate(new Date('2022-08-02'));
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
   });
   afterEach(() => {
     MockApiClient.clearMockResponses();
@@ -84,9 +87,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const children = jest.fn(() => <div />);
 
     render(
-      <ReleaseWidgetQueries widget={singleQueryWidget} selection={selection}>
-        {children}
-      </ReleaseWidgetQueries>
+      <ReleaseWidgetQueries widget={singleQueryWidget}>{children}</ReleaseWidgetQueries>
     );
 
     expect(mock).toHaveBeenCalledTimes(1);
@@ -137,10 +138,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     ];
 
     render(
-      <ReleaseWidgetQueries
-        widget={{...singleQueryWidget, queries}}
-        selection={selection}
-      >
+      <ReleaseWidgetQueries widget={{...singleQueryWidget, queries}}>
         {children}
       </ReleaseWidgetQueries>
     );
@@ -195,10 +193,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     ];
 
     render(
-      <ReleaseWidgetQueries
-        widget={{...singleQueryWidget, queries}}
-        selection={selection}
-      >
+      <ReleaseWidgetQueries widget={{...singleQueryWidget, queries}}>
         {children}
       </ReleaseWidgetQueries>
     );
@@ -229,7 +224,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     render(
       <ReleaseWidgetQueries
         widget={singleQueryWidget}
-        selection={selection}
         dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.3.0']}}
       >
         {() => <div data-test-id="child" />}
@@ -273,9 +267,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     };
 
     render(
-      <ReleaseWidgetQueries widget={injectedOrderby} selection={selection}>
-        {children}
-      </ReleaseWidgetQueries>
+      <ReleaseWidgetQueries widget={injectedOrderby}>{children}</ReleaseWidgetQueries>
     );
     expect(mock).toHaveBeenCalledTimes(1);
 
@@ -453,7 +445,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     render(
       <ReleaseWidgetQueries
         widget={{...singleQueryWidget, displayType: DisplayType.TABLE}}
-        selection={selection}
       >
         {children}
       </ReleaseWidgetQueries>
@@ -556,7 +547,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     render(
       <ReleaseWidgetQueries
         widget={{...singleQueryWidget, displayType: DisplayType.BIG_NUMBER}}
-        selection={selection}
       >
         {children}
       </ReleaseWidgetQueries>
@@ -603,7 +593,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
       ],
     });
     render(
-      <ReleaseWidgetQueries widget={multipleQueryWidget} selection={selection}>
+      <ReleaseWidgetQueries widget={multipleQueryWidget}>
         {() => <div data-test-id="child" />}
       </ReleaseWidgetQueries>
     );
@@ -661,9 +651,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const children = jest.fn(() => <div data-test-id="child" />);
 
     render(
-      <ReleaseWidgetQueries widget={multipleQueryWidget} selection={selection}>
-        {children}
-      </ReleaseWidgetQueries>
+      <ReleaseWidgetQueries widget={multipleQueryWidget}>{children}</ReleaseWidgetQueries>
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -682,11 +670,13 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
       body: SessionsFieldFixture(`session.all`),
     });
 
+    PageFiltersStore.onInitializeUrlState({
+      ...selection,
+      datetime: {...selection.datetime, period: '14d'},
+    });
+
     render(
-      <ReleaseWidgetQueries
-        widget={{...singleQueryWidget, interval: '1m'}}
-        selection={{...selection, datetime: {...selection.datetime, period: '14d'}}}
-      >
+      <ReleaseWidgetQueries widget={{...singleQueryWidget, interval: '1m'}}>
         {() => <div data-test-id="child" />}
       </ReleaseWidgetQueries>
     );
@@ -714,9 +704,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const children = jest.fn(() => <div />);
 
     const {rerender} = render(
-      <ReleaseWidgetQueries widget={singleQueryWidget} selection={selection}>
-        {children}
-      </ReleaseWidgetQueries>
+      <ReleaseWidgetQueries widget={singleQueryWidget}>{children}</ReleaseWidgetQueries>
     );
 
     await waitFor(() => {
@@ -735,7 +723,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
             },
           ],
         }}
-        selection={selection}
       >
         {children}
       </ReleaseWidgetQueries>
@@ -757,7 +744,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const {rerender} = render(
       <ReleaseWidgetQueries
         widget={singleQueryWidget}
-        selection={selection}
         dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.3.0']}}
       >
         {children}
@@ -771,7 +757,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     rerender(
       <ReleaseWidgetQueries
         widget={singleQueryWidget}
-        selection={selection}
         dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.3.0']}}
       >
         {children}
@@ -818,9 +803,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const children = jest.fn(() => <div />);
 
     const {rerender} = render(
-      <ReleaseWidgetQueries widget={releasesWidget} selection={selection}>
-        {children}
-      </ReleaseWidgetQueries>
+      <ReleaseWidgetQueries widget={releasesWidget}>{children}</ReleaseWidgetQueries>
     );
 
     await waitFor(() => {
@@ -840,7 +823,6 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
             },
           ],
         }}
-        selection={selection}
       >
         {children}
       </ReleaseWidgetQueries>
@@ -881,10 +863,7 @@ describe('Dashboards > ReleaseWidgetQueries', () => {
     const children = jest.fn(() => <div />);
 
     render(
-      <ReleaseWidgetQueries
-        widget={{...singleQueryWidget, queries}}
-        selection={selection}
-      >
+      <ReleaseWidgetQueries widget={{...singleQueryWidget, queries}}>
         {children}
       </ReleaseWidgetQueries>
     );

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -37,7 +37,7 @@ import {
 
 import type {
   GenericWidgetQueriesChildrenProps,
-  GenericWidgetQueriesProps,
+  UseGenericWidgetQueriesProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
 
@@ -155,8 +155,8 @@ function getLimit(displayType: DisplayType, limit?: number) {
 }
 
 function customDidUpdateComparator(
-  prevProps: GenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>,
-  nextProps: GenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>
+  prevProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>,
+  nextProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>
 ) {
   const {loading, limit, widget, cursor, organization, selection, dashboardFilters} =
     nextProps;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -391,7 +391,7 @@ function ReleaseWidgetQueries({
     limit: getLimit(widget.displayType, limit),
     onDataFetched,
     onDataFetchStart,
-    selection: propsSelection,
+    selection,
     loading: requiresCustomReleaseSorting(widget.queries[0]!) ? !releases : undefined,
     customDidUpdateComparator,
     afterFetchTableData: afterFetchData,

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -156,7 +156,7 @@ function customDidUpdateComparator(
   prevProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>,
   nextProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>
 ) {
-  const {loading, limit, widget, cursor, dashboardFilters} = nextProps;
+  const {loading, limit, widget, cursor, dashboardFilters, selection} = nextProps;
   const ignoredWidgetProps: Array<Partial<keyof Widget>> = [
     'queries',
     'title',
@@ -175,7 +175,10 @@ function customDidUpdateComparator(
   return (
     limit !== prevProps.limit ||
     !isEqual(dashboardFilters, prevProps.dashboardFilters) ||
-    // organization and selection are now handled internally by the hook
+    // Compare selection changes (if selection override is provided, compare it; otherwise hook handles it)
+    (selection !== undefined &&
+      prevProps.selection !== undefined &&
+      !isEqual(selection, prevProps.selection)) ||
     // If the widget changed (ignore unimportant fields, + queries as they are handled lower)
     !isEqual(
       omit(widget, ignoredWidgetProps),

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -39,7 +39,7 @@ import type {
   GenericWidgetQueriesChildrenProps,
   GenericWidgetQueriesProps,
 } from './genericWidgetQueries';
-import GenericWidgetQueries from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 interface ReleaseWidgetQueriesProps {
   children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
@@ -377,32 +377,31 @@ function ReleaseWidgetQueries({
     [transformWidget, widget]
   );
 
-  return (
-    <GenericWidgetQueries<SessionApiResponse, SessionApiResponse>
-      queue={queue}
-      config={config}
-      api={api}
-      organization={organization}
-      selection={selection}
-      widget={transformedWidget}
-      dashboardFilters={dashboardFilters}
-      cursor={cursor}
-      limit={getLimit(widget.displayType, limit)}
-      onDataFetched={onDataFetched}
-      onDataFetchStart={onDataFetchStart}
-      loading={requiresCustomReleaseSorting(widget.queries[0]!) ? !releases : undefined}
-      customDidUpdateComparator={customDidUpdateComparator}
-      afterFetchTableData={afterFetchData}
-      afterFetchSeriesData={afterFetchData}
-    >
-      {({errorMessage, ...rest}) =>
-        children({
-          errorMessage: requestErrorMessage ?? errorMessage,
-          ...rest,
-        })
-      }
-    </GenericWidgetQueries>
-  );
+  const {errorMessage, ...rest} = useGenericWidgetQueries<
+    SessionApiResponse,
+    SessionApiResponse
+  >({
+    queue,
+    config,
+    api,
+    organization,
+    selection,
+    widget: transformedWidget,
+    dashboardFilters,
+    cursor,
+    limit: getLimit(widget.displayType, limit),
+    onDataFetched,
+    onDataFetchStart,
+    loading: requiresCustomReleaseSorting(widget.queries[0]!) ? !releases : undefined,
+    customDidUpdateComparator,
+    afterFetchTableData: afterFetchData,
+    afterFetchSeriesData: afterFetchData,
+  });
+
+  return children({
+    errorMessage: requestErrorMessage ?? errorMessage,
+    ...rest,
+  });
 }
 
 export default ReleaseWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -34,13 +34,13 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 
 import type {
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   UseGenericWidgetQueriesProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 interface ReleaseWidgetQueriesProps {
-  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -50,6 +50,8 @@ interface ReleaseWidgetQueriesProps {
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
   }) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 }
 
 export function derivedMetricsToField(field: string): string {
@@ -209,6 +211,7 @@ function ReleaseWidgetQueries({
   limit,
   onDataFetched,
   onDataFetchStart,
+  selection: propsSelection,
   children,
 }: ReleaseWidgetQueriesProps) {
   const config = ReleasesConfig;
@@ -217,7 +220,10 @@ function ReleaseWidgetQueries({
   const allProjects = useProjects();
   const api = useApi();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  const hookPageFilters = usePageFilters();
+
+  // Use override selection if provided (for modal zoom), otherwise use hook
+  const selection = propsSelection ?? hookPageFilters.selection;
 
   const [requestErrorMessage, setRequestErrorMessage] = useState<string | undefined>(
     undefined
@@ -382,6 +388,7 @@ function ReleaseWidgetQueries({
     limit: getLimit(widget.displayType, limit),
     onDataFetched,
     onDataFetchStart,
+    selection: propsSelection,
     loading: requiresCustomReleaseSorting(widget.queries[0]!) ? !releases : undefined,
     customDidUpdateComparator,
     afterFetchTableData: afterFetchData,

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -4,19 +4,21 @@ import {WidgetFixture} from 'sentry-fixture/widget';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import SpansWidgetQueries from './spansWidgetQueries';
 
 describe('spansWidgetQueries', () => {
   const {organization} = initializeOrg();
-  const api = new MockApiClient();
   let widget = WidgetFixture();
   const selection = PageFiltersFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     widget = WidgetFixture();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
   });
 
   it('calculates the confidence for a single series', async () => {
@@ -41,14 +43,10 @@ describe('spansWidgetQueries', () => {
     });
 
     render(
-      <SpansWidgetQueries
-        api={api}
-        widget={widget}
-        selection={selection}
-        dashboardFilters={{}}
-      >
+      <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
         {({confidence}) => <div>{confidence}</div>}
-      </SpansWidgetQueries>
+      </SpansWidgetQueries>,
+      {organization}
     );
 
     expect(await screen.findByText('low')).toBeInTheDocument();
@@ -106,14 +104,10 @@ describe('spansWidgetQueries', () => {
     });
 
     render(
-      <SpansWidgetQueries
-        api={api}
-        widget={widget}
-        selection={selection}
-        dashboardFilters={{}}
-      >
+      <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
         {({confidence}) => <div>{confidence}</div>}
-      </SpansWidgetQueries>
+      </SpansWidgetQueries>,
+      {organization}
     );
 
     expect(await screen.findByText('high')).toBeInTheDocument();
@@ -150,16 +144,13 @@ describe('spansWidgetQueries', () => {
       ],
     });
 
+    PageFiltersStore.onInitializeUrlState({
+      ...selection,
+      datetime: {period: '24hr', end: null, start: null, utc: null},
+    });
+
     render(
-      <SpansWidgetQueries
-        api={api}
-        widget={widget}
-        selection={{
-          ...selection,
-          datetime: {period: '24hr', end: null, start: null, utc: null},
-        }}
-        dashboardFilters={{}}
-      >
+      <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
         {({timeseriesResults}) => <div>{timeseriesResults?.[0]?.data?.[0]?.value}</div>}
       </SpansWidgetQueries>,
       {organization}
@@ -204,16 +195,13 @@ describe('spansWidgetQueries', () => {
       ],
     });
 
+    PageFiltersStore.onInitializeUrlState({
+      ...selection,
+      datetime: {period: '24hr', end: null, start: null, utc: null},
+    });
+
     render(
-      <SpansWidgetQueries
-        api={api}
-        widget={widget}
-        selection={{
-          ...selection,
-          datetime: {period: '24hr', end: null, start: null, utc: null},
-        }}
-        dashboardFilters={{}}
-      >
+      <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
         {({tableResults}) => <div>{tableResults?.[0]?.data?.[0]?.a}</div>}
       </SpansWidgetQueries>,
       {organization}

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -40,6 +40,8 @@ type SpansWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
@@ -107,6 +109,7 @@ function SpansWidgetQueriesSingleRequestImpl({
   dashboardFilters,
   onDataFetched,
   onDataFetchStart,
+  selection,
   getConfidenceInformation,
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
@@ -136,6 +139,7 @@ function SpansWidgetQueriesSingleRequestImpl({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
+    selection,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
   });

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -1,7 +1,5 @@
 import {useCallback, useState} from 'react';
 
-import type {Client} from 'sentry/api';
-import type {PageFilters} from 'sentry/types/core';
 import type {
   Confidence,
   EventsStats,
@@ -12,13 +10,11 @@ import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import useOrganization from 'sentry/utils/useOrganization';
 import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {isEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
-import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 import {
@@ -36,9 +32,7 @@ type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEve
 type TableResult = TableData | EventsTableData;
 
 type SpansWidgetQueriesProps = {
-  api: Client;
   children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
-  selection: PageFilters;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;
@@ -46,7 +40,6 @@ type SpansWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
-  queue?: WidgetQueryQueue;
 };
 
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
@@ -108,9 +101,6 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
 
 function SpansWidgetQueriesSingleRequestImpl({
   children,
-  api,
-  queue,
-  selection,
   widget,
   cursor,
   limit,
@@ -120,7 +110,6 @@ function SpansWidgetQueriesSingleRequestImpl({
   getConfidenceInformation,
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
-  const organization = useOrganization();
   const [confidence, setConfidence] = useState<Confidence | null>(null);
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
@@ -141,10 +130,6 @@ function SpansWidgetQueriesSingleRequestImpl({
 
   const props = useGenericWidgetQueries<SeriesResult, TableResult>({
     config,
-    api,
-    queue,
-    organization,
-    selection,
     widget,
     cursor,
     limit,

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
 import type {
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
@@ -32,7 +32,7 @@ type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEve
 type TableResult = TableData | EventsTableData;
 
 type SpansWidgetQueriesProps = {
-  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useState} from 'react';
 
+import type {PageFilters} from 'sentry/types/core';
 import type {
   Confidence,
   EventsStats,
@@ -41,7 +42,7 @@ type SpansWidgetQueriesProps = {
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
   // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
+  selection?: PageFilters;
 };
 
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -30,7 +30,7 @@ import type {
   GenericWidgetQueriesChildrenProps,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
-import GenericWidgetQueries from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats;
 type TableResult = TableData | EventsTableData;
@@ -139,33 +139,29 @@ function SpansWidgetQueriesSingleRequestImpl({
     });
   };
 
+  const props = useGenericWidgetQueries<SeriesResult, TableResult>({
+    config,
+    api,
+    queue,
+    organization,
+    selection,
+    widget,
+    cursor,
+    limit,
+    dashboardFilters,
+    onDataFetched,
+    onDataFetchStart,
+    afterFetchSeriesData,
+    samplingMode: SAMPLING_MODE.NORMAL,
+  });
+
   return getDynamicText({
-    value: (
-      <GenericWidgetQueries<SeriesResult, TableResult>
-        config={config}
-        api={api}
-        queue={queue}
-        organization={organization}
-        selection={selection}
-        widget={widget}
-        cursor={cursor}
-        limit={limit}
-        dashboardFilters={dashboardFilters}
-        onDataFetched={onDataFetched}
-        onDataFetchStart={onDataFetchStart}
-        afterFetchSeriesData={afterFetchSeriesData}
-        samplingMode={SAMPLING_MODE.NORMAL}
-      >
-        {props =>
-          children({
-            ...props,
-            confidence,
-            sampleCount,
-            isSampled,
-          })
-        }
-      </GenericWidgetQueries>
-    ),
+    value: children({
+      ...props,
+      confidence,
+      sampleCount,
+      isSampled,
+    }),
     fixed: <div />,
   });
 }

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -40,6 +40,8 @@ type SpansWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
@@ -108,6 +110,7 @@ function SpansWidgetQueriesSingleRequestImpl({
   onDataFetched,
   onDataFetchStart,
   getConfidenceInformation,
+  selection,
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
@@ -138,6 +141,7 @@ function SpansWidgetQueriesSingleRequestImpl({
     onDataFetchStart,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
+    selection,
   });
 
   return getDynamicText({

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -40,8 +40,6 @@ type SpansWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
-  // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
 };
 
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
@@ -109,7 +107,6 @@ function SpansWidgetQueriesSingleRequestImpl({
   dashboardFilters,
   onDataFetched,
   onDataFetchStart,
-  selection,
   getConfidenceInformation,
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
@@ -139,7 +136,6 @@ function SpansWidgetQueriesSingleRequestImpl({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
-    selection,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
   });

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -1,18 +1,14 @@
 import {useCallback, useState} from 'react';
 
-import type {Client} from 'sentry/api';
-import type {PageFilters} from 'sentry/types/core';
 import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
-import useOrganization from 'sentry/utils/useOrganization';
 import {
   EMPTY_METRIC_SELECTION,
   TraceMetricsConfig,
 } from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
-import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import type {
@@ -25,9 +21,7 @@ type SeriesResult = EventsTimeSeriesResponse;
 type TableResult = EventsTableData;
 
 type TraceMetricsWidgetQueriesProps = {
-  api: Client;
   children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
-  selection: PageFilters;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;
@@ -35,7 +29,6 @@ type TraceMetricsWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
-  queue?: WidgetQueryQueue;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
@@ -66,9 +59,6 @@ function TraceMetricsWidgetQueries(props: TraceMetricsWidgetQueriesProps) {
 
 function TraceMetricsWidgetQueriesSingleRequestImpl({
   children,
-  api,
-  queue,
-  selection,
   widget,
   cursor,
   limit,
@@ -78,7 +68,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   getConfidenceInformation,
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
-  const organization = useOrganization();
   const [confidence, setConfidence] = useState<Confidence | null>(null);
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
@@ -106,10 +95,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
 
   const props = useGenericWidgetQueries<SeriesResult, TableResult>({
     config,
-    api,
-    queue,
-    organization,
-    selection,
     widget,
     cursor,
     limit,

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -29,6 +29,8 @@ type TraceMetricsWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
@@ -66,6 +68,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   onDataFetched,
   onDataFetchStart,
   getConfidenceInformation,
+  selection,
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
@@ -105,6 +108,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     samplingMode: SAMPLING_MODE.NORMAL,
     disabled,
     loading: disabled,
+    selection,
   });
 
   return getDynamicText({

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -19,7 +19,7 @@ import type {
   GenericWidgetQueriesChildrenProps,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
-import GenericWidgetQueries from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type SeriesResult = EventsTimeSeriesResponse;
 type TableResult = EventsTableData;
@@ -104,35 +104,31 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     q.aggregates.includes(EMPTY_METRIC_SELECTION)
   );
 
+  const props = useGenericWidgetQueries<SeriesResult, TableResult>({
+    config,
+    api,
+    queue,
+    organization,
+    selection,
+    widget,
+    cursor,
+    limit,
+    dashboardFilters,
+    onDataFetched,
+    onDataFetchStart,
+    afterFetchSeriesData,
+    samplingMode: SAMPLING_MODE.NORMAL,
+    disabled,
+    loading: disabled,
+  });
+
   return getDynamicText({
-    value: (
-      <GenericWidgetQueries<SeriesResult, TableResult>
-        config={config}
-        api={api}
-        queue={queue}
-        organization={organization}
-        selection={selection}
-        widget={widget}
-        cursor={cursor}
-        limit={limit}
-        dashboardFilters={dashboardFilters}
-        onDataFetched={onDataFetched}
-        onDataFetchStart={onDataFetchStart}
-        afterFetchSeriesData={afterFetchSeriesData}
-        samplingMode={SAMPLING_MODE.NORMAL}
-        disabled={disabled}
-        loading={disabled}
-      >
-        {props =>
-          children({
-            ...props,
-            confidence,
-            sampleCount,
-            isSampled,
-          })
-        }
-      </GenericWidgetQueries>
-    ),
+    value: children({
+      ...props,
+      confidence,
+      sampleCount,
+      isSampled,
+    }),
     fixed: <div />,
   });
 }

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useState} from 'react';
 
+import type {PageFilters} from 'sentry/types/core';
 import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
@@ -30,7 +31,7 @@ type TraceMetricsWidgetQueriesProps = {
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
   // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
+  selection?: PageFilters;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -12,7 +12,7 @@ import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import type {
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
@@ -21,7 +21,7 @@ type SeriesResult = EventsTimeSeriesResponse;
 type TableResult = EventsTableData;
 
 type TraceMetricsWidgetQueriesProps = {
-  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -29,8 +29,6 @@ type TraceMetricsWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
-  // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
@@ -67,7 +65,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   dashboardFilters,
   onDataFetched,
   onDataFetchStart,
-  selection,
   getConfidenceInformation,
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
@@ -104,7 +101,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
-    selection,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
     disabled,

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -29,6 +29,8 @@ type TraceMetricsWidgetQueriesProps = {
   onBestEffortDataFetched?: () => void;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
@@ -65,6 +67,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   dashboardFilters,
   onDataFetched,
   onDataFetchStart,
+  selection,
   getConfidenceInformation,
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
@@ -101,6 +104,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
+    selection,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
     disabled,

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -52,6 +52,7 @@ export function VisualizationWidget({
   return (
     <WidgetCardDataLoader
       widget={widget}
+      selection={selection}
       dashboardFilters={dashboardFilters}
       onDataFetched={onDataFetched}
       onDataFetchStart={onDataFetchStart}

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -53,7 +53,6 @@ export function VisualizationWidget({
     <WidgetCardDataLoader
       widget={widget}
       dashboardFilters={dashboardFilters}
-      selection={selection}
       onDataFetched={onDataFetched}
       onDataFetchStart={onDataFetchStart}
       tableItemLimit={tableItemLimit}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -110,7 +110,6 @@ export function WidgetCardChartContainer({
     <WidgetCardDataLoader
       widget={widget}
       dashboardFilters={dashboardFilters}
-      selection={selection}
       onDataFetched={onDataFetched}
       onWidgetSplitDecision={onWidgetSplitDecision}
       onDataFetchStart={onDataFetchStart}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -109,6 +109,7 @@ export function WidgetCardChartContainer({
   return (
     <WidgetCardDataLoader
       widget={widget}
+      selection={selection}
       dashboardFilters={dashboardFilters}
       onDataFetched={onDataFetched}
       onWidgetSplitDecision={onWidgetSplitDecision}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -116,7 +116,6 @@ export function WidgetCardDataLoader({
     return (
       <SpansWidgetQueries
         widget={widget}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -131,7 +130,6 @@ export function WidgetCardDataLoader({
     return (
       <TraceMetricsWidgetQueries
         widget={widget}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetchStart={onDataFetchStart}
         onDataFetched={onDataFetched}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -116,6 +116,7 @@ export function WidgetCardDataLoader({
     return (
       <SpansWidgetQueries
         widget={widget}
+        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -130,6 +131,7 @@ export function WidgetCardDataLoader({
     return (
       <TraceMetricsWidgetQueries
         widget={widget}
+        selection={selection}
         limit={tableItemLimit}
         onDataFetchStart={onDataFetchStart}
         onDataFetched={onDataFetched}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -55,16 +55,18 @@ type Props = {
 export function WidgetCardDataLoader({
   children,
   widget,
+  selection,
   dashboardFilters,
   tableItemLimit,
   onDataFetched,
   onWidgetSplitDecision,
   onDataFetchStart,
-}: Omit<Props, 'selection'>) {
+}: Props) {
   if (widget.widgetType === WidgetType.ISSUE) {
     return (
       <IssueWidgetQueries
         widget={widget}
+        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -95,6 +97,7 @@ export function WidgetCardDataLoader({
     return (
       <ReleaseWidgetQueries
         widget={widget}
+        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -140,6 +143,7 @@ export function WidgetCardDataLoader({
   return (
     <WidgetQueries
       widget={widget}
+      selection={selection}
       limit={tableItemLimit}
       onDataFetched={onDataFetched}
       onDataFetchStart={onDataFetchStart}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -5,12 +5,9 @@ import type {Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
-import useApi from 'sentry/utils/useApi';
-import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {shouldForceQueryToSpans} from 'sentry/views/dashboards/utils/shouldForceQueryToSpans';
-import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQueries';
 import TraceMetricsWidgetQueries from 'sentry/views/dashboards/widgetCard/traceMetricsWidgetQueries';
 
@@ -58,25 +55,16 @@ type Props = {
 export function WidgetCardDataLoader({
   children,
   widget,
-  selection,
   dashboardFilters,
   tableItemLimit,
   onDataFetched,
   onWidgetSplitDecision,
   onDataFetchStart,
-}: Props) {
-  const api = useApi();
-  const organization = useOrganization();
-  const {queue} = useWidgetQueryQueue();
-
+}: Omit<Props, 'selection'>) {
   if (widget.widgetType === WidgetType.ISSUE) {
     return (
       <IssueWidgetQueries
-        api={api}
-        queue={queue}
-        organization={organization}
         widget={widget}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -107,8 +95,6 @@ export function WidgetCardDataLoader({
     return (
       <ReleaseWidgetQueries
         widget={widget}
-        queue={queue}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -126,10 +112,7 @@ export function WidgetCardDataLoader({
   if (widget.widgetType === WidgetType.SPANS || shouldForceQueryToSpans(widget)) {
     return (
       <SpansWidgetQueries
-        api={api}
-        queue={queue}
         widget={widget}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
@@ -143,10 +126,7 @@ export function WidgetCardDataLoader({
   if (widget.widgetType === WidgetType.TRACEMETRICS) {
     return (
       <TraceMetricsWidgetQueries
-        api={api}
-        queue={queue}
         widget={widget}
-        selection={selection}
         limit={tableItemLimit}
         onDataFetchStart={onDataFetchStart}
         onDataFetched={onDataFetched}
@@ -159,11 +139,7 @@ export function WidgetCardDataLoader({
 
   return (
     <WidgetQueries
-      api={api}
-      queue={queue}
-      organization={organization}
       widget={widget}
-      selection={selection}
       limit={tableItemLimit}
       onDataFetched={onDataFetched}
       onDataFetchStart={onDataFetchStart}

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -4,6 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {PageFilters} from 'sentry/types/core';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -19,7 +20,16 @@ import WidgetQueries from 'sentry/views/dashboards/widgetCard/widgetQueries';
 describe('Dashboards > WidgetQueries', () => {
   const initialData = initializeOrg();
 
-  const renderWithProviders = (component: React.ReactNode) =>
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
+  });
+
+  const renderWithProviders = (component: React.ReactNode, options?: any) =>
     render(
       <MetricsResultsMetaProvider>
         <DashboardsMEPProvider>
@@ -27,7 +37,8 @@ describe('Dashboards > WidgetQueries', () => {
             <WidgetQueryQueueProvider>{component}</WidgetQueryQueueProvider>
           </MEPSettingProvider>
         </DashboardsMEPProvider>
-      </MetricsResultsMetaProvider>
+      </MetricsResultsMetaProvider>,
+      options
     );
 
   const multipleQueryWidget = {
@@ -110,14 +121,10 @@ describe('Dashboards > WidgetQueries', () => {
       match: [MockApiClient.matchQuery({query: 'event.type:default'})],
     });
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={multipleQueryWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={multipleQueryWidget}>
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -133,14 +140,12 @@ describe('Dashboards > WidgetQueries', () => {
     });
     renderWithProviders(
       <WidgetQueries
-        api={new MockApiClient()}
         widget={singleQueryWidget}
-        organization={initialData.organization}
-        selection={selection}
         dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.2.0', 'abc@1.3.0']}}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     await screen.findByTestId('child');
@@ -161,14 +166,12 @@ describe('Dashboards > WidgetQueries', () => {
     });
     renderWithProviders(
       <WidgetQueries
-        api={new MockApiClient()}
         widget={tableWidget}
-        organization={initialData.organization}
-        selection={selection}
         dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.3.0']}}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     await screen.findByTestId('child');
@@ -197,17 +200,13 @@ describe('Dashboards > WidgetQueries', () => {
 
     let error: string | undefined;
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={multipleQueryWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={multipleQueryWidget}>
         {({errorMessage}: {errorMessage?: string}) => {
           error = errorMessage;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -237,15 +236,12 @@ describe('Dashboards > WidgetQueries', () => {
       },
     };
 
+    // Initialize PageFiltersStore with the specific selection for this test
+    PageFiltersStore.onInitializeUrlState(longSelection);
+
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={widget}
-        organization={initialData.organization}
-        selection={longSelection}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      <WidgetQueries widget={widget}>{() => <div data-test-id="child" />}</WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and interval bumped up.
@@ -272,14 +268,8 @@ describe('Dashboards > WidgetQueries', () => {
     const widget = {...singleQueryWidget, interval: '1m'};
 
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={widget}
-        organization={initialData.organization}
-        selection={selection}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      <WidgetQueries widget={widget}>{() => <div data-test-id="child" />}</WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and interval bumped up.
@@ -302,19 +292,18 @@ describe('Dashboards > WidgetQueries', () => {
       },
     });
 
+    // Initialize PageFiltersStore with selection
+    PageFiltersStore.onInitializeUrlState(selection);
+
     let childProps: GenericWidgetQueriesChildrenProps | undefined;
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={tableWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={tableWidget}>
         {props => {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 1 requests should be sent.
@@ -381,17 +370,13 @@ describe('Dashboards > WidgetQueries', () => {
 
     let childProps: GenericWidgetQueriesChildrenProps | undefined;
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={widget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={widget}>
         {props => {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -413,10 +398,12 @@ describe('Dashboards > WidgetQueries', () => {
       },
     });
 
+    // Initialize PageFiltersStore with selection
+    PageFiltersStore.onInitializeUrlState(selection);
+
     let childProps: GenericWidgetQueriesChildrenProps | undefined;
     renderWithProviders(
       <WidgetQueries
-        api={new MockApiClient()}
         widget={{
           title: 'SDK',
           interval: '5m',
@@ -432,14 +419,13 @@ describe('Dashboards > WidgetQueries', () => {
             },
           ],
         }}
-        organization={initialData.organization}
-        selection={selection}
       >
         {props => {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 1 requests should be sent.
@@ -505,17 +491,13 @@ describe('Dashboards > WidgetQueries', () => {
 
     let childProps: GenericWidgetQueriesChildrenProps | undefined;
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={widget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={widget}>
         {props => {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -539,14 +521,10 @@ describe('Dashboards > WidgetQueries', () => {
       interval: '5m',
     };
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={barWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={barWidget}>
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 1 requests should be sent.
@@ -601,16 +579,9 @@ describe('Dashboards > WidgetQueries', () => {
       interval: '5m',
     };
     const child = jest.fn(() => <div data-test-id="child" />);
-    renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={barWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
-        {child}
-      </WidgetQueries>
-    );
+    renderWithProviders(<WidgetQueries widget={barWidget}>{child}</WidgetQueries>, {
+      organization: initialData.organization,
+    });
 
     await screen.findByTestId('child');
     expect(defaultMock).toHaveBeenCalledTimes(1);
@@ -637,23 +608,25 @@ describe('Dashboards > WidgetQueries', () => {
       displayType: DisplayType.AREA,
       interval: '5m',
     };
+
+    const longSelection = {
+      ...selection,
+      datetime: {
+        period: '90d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    };
+
+    // Initialize PageFiltersStore with longSelection
+    PageFiltersStore.onInitializeUrlState(longSelection);
+
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={areaWidget}
-        organization={initialData.organization}
-        selection={{
-          ...selection,
-          datetime: {
-            period: '90d',
-            start: null,
-            end: null,
-            utc: false,
-          },
-        }}
-      >
+      <WidgetQueries widget={areaWidget}>
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     // Child should be rendered and 1 requests should be sent.
@@ -677,17 +650,13 @@ describe('Dashboards > WidgetQueries', () => {
     };
     let childProps!: GenericWidgetQueriesChildrenProps;
     const {rerender} = renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={lineWidget}
-        organization={initialData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={lineWidget}>
         {props => {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: initialData.organization}
     );
 
     expect(eventsStatsMock).toHaveBeenCalledTimes(1);
@@ -700,7 +669,6 @@ describe('Dashboards > WidgetQueries', () => {
           <MEPSettingProvider forceTransactions={false}>
             <WidgetQueryQueueProvider>
               <WidgetQueries
-                api={new MockApiClient()}
                 widget={{
                   ...lineWidget,
                   queries: [
@@ -714,8 +682,6 @@ describe('Dashboards > WidgetQueries', () => {
                     },
                   ],
                 }}
-                organization={initialData.organization}
-                selection={selection}
               >
                 {props => {
                   childProps = props;
@@ -766,18 +732,14 @@ describe('Dashboards > WidgetQueries', () => {
           setIsMetricsData: setIsMetricsMock,
         }}
       >
-        <WidgetQueries
-          api={new MockApiClient()}
-          widget={singleQueryWidget}
-          organization={{
-            ...organization,
-            features: [...organization.features, 'dashboards-mep'],
-          }}
-          selection={selection}
-        >
-          {children}
-        </WidgetQueries>
-      </DashboardsMEPContext>
+        <WidgetQueries widget={singleQueryWidget}>{children}</WidgetQueries>
+      </DashboardsMEPContext>,
+      {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'dashboards-mep'],
+        },
+      }
     );
 
     expect(mock).toHaveBeenCalledWith(
@@ -812,18 +774,16 @@ describe('Dashboards > WidgetQueries', () => {
           setIsMetricsData: setIsMetricsMock,
         }}
       >
-        <WidgetQueries
-          api={new MockApiClient()}
-          widget={{...singleQueryWidget, displayType: DisplayType.TABLE}}
-          organization={{
-            ...organization,
-            features: [...organization.features, 'dashboards-mep'],
-          }}
-          selection={selection}
-        >
+        <WidgetQueries widget={{...singleQueryWidget, displayType: DisplayType.TABLE}}>
           {children}
         </WidgetQueries>
-      </DashboardsMEPContext>
+      </DashboardsMEPContext>,
+      {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'dashboards-mep'],
+        },
+      }
     );
 
     expect(mock).toHaveBeenCalledWith(
@@ -864,14 +824,10 @@ describe('Dashboards > WidgetQueries', () => {
       ],
     };
     renderWithProviders(
-      <WidgetQueries
-        api={new MockApiClient()}
-        widget={areaWidget}
-        organization={testData.organization}
-        selection={selection}
-      >
+      <WidgetQueries widget={areaWidget}>
         {() => <div data-test-id="child" />}
-      </WidgetQueries>
+      </WidgetQueries>,
+      {organization: testData.organization}
     );
 
     // Child should be rendered and 1 requests should be sent.

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -14,7 +14,7 @@ import {
   DashboardsMEPContext,
   DashboardsMEPProvider,
 } from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
-import type {GenericWidgetQueriesChildrenProps} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import type {GenericWidgetQueriesResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import WidgetQueries from 'sentry/views/dashboards/widgetCard/widgetQueries';
 
 describe('Dashboards > WidgetQueries', () => {
@@ -295,7 +295,7 @@ describe('Dashboards > WidgetQueries', () => {
     // Initialize PageFiltersStore with selection
     PageFiltersStore.onInitializeUrlState(selection);
 
-    let childProps: GenericWidgetQueriesChildrenProps | undefined;
+    let childProps: GenericWidgetQueriesResult | undefined;
     renderWithProviders(
       <WidgetQueries widget={tableWidget}>
         {props => {
@@ -368,7 +368,7 @@ describe('Dashboards > WidgetQueries', () => {
       ],
     };
 
-    let childProps: GenericWidgetQueriesChildrenProps | undefined;
+    let childProps: GenericWidgetQueriesResult | undefined;
     renderWithProviders(
       <WidgetQueries widget={widget}>
         {props => {
@@ -401,7 +401,7 @@ describe('Dashboards > WidgetQueries', () => {
     // Initialize PageFiltersStore with selection
     PageFiltersStore.onInitializeUrlState(selection);
 
-    let childProps: GenericWidgetQueriesChildrenProps | undefined;
+    let childProps: GenericWidgetQueriesResult | undefined;
     renderWithProviders(
       <WidgetQueries
         widget={{
@@ -489,7 +489,7 @@ describe('Dashboards > WidgetQueries', () => {
       ],
     };
 
-    let childProps: GenericWidgetQueriesChildrenProps | undefined;
+    let childProps: GenericWidgetQueriesResult | undefined;
     renderWithProviders(
       <WidgetQueries widget={widget}>
         {props => {
@@ -648,7 +648,7 @@ describe('Dashboards > WidgetQueries', () => {
       displayType: DisplayType.LINE,
       interval: '5m',
     };
-    let childProps!: GenericWidgetQueriesChildrenProps;
+    let childProps!: GenericWidgetQueriesResult;
     const {rerender} = renderWithProviders(
       <WidgetQueries widget={lineWidget}>
         {props => {

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -35,6 +35,8 @@ type Props = {
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
+  // Optional selection override for widget viewer modal zoom functionality
+  selection?: any;
 };
 
 function WidgetQueriesWithOnDemandControl({
@@ -45,15 +47,13 @@ function WidgetQueriesWithOnDemandControl({
   limit,
   onDataFetched,
   onDataFetchStart,
+  selection,
   config,
   afterFetchSeriesData,
   afterFetchTableData,
   mepSettingContext,
   OnDemandControlContext,
-}: Omit<
-  Props,
-  'onWidgetSplitDecision' | 'api' | 'queue' | 'organization' | 'selection'
-> & {
+}: Omit<Props, 'onWidgetSplitDecision'> & {
   OnDemandControlContext: any;
   afterFetchSeriesData: (rawResults: SeriesResult) => void;
   afterFetchTableData: (rawResults: TableResult) => void;
@@ -70,6 +70,7 @@ function WidgetQueriesWithOnDemandControl({
     dashboardFilters,
     onDataFetched,
     onDataFetchStart,
+    selection,
     afterFetchSeriesData,
     afterFetchTableData,
     mepSetting: mepSettingContext.metricSettingState,
@@ -89,7 +90,8 @@ function WidgetQueries({
   onDataFetched,
   onWidgetSplitDecision,
   onDataFetchStart,
-}: Omit<Props, 'api' | 'queue' | 'organization' | 'selection'>) {
+  selection,
+}: Props) {
   // Discover and Errors datasets are the only datasets processed in this component
   const config = getDatasetConfig(
     widget.widgetType as WidgetType.DISCOVER | WidgetType.ERRORS | WidgetType.TRANSACTIONS
@@ -202,6 +204,7 @@ function WidgetQueries({
           limit={limit}
           onDataFetched={onDataFetched}
           onDataFetchStart={onDataFetchStart}
+          selection={selection}
           config={config}
           afterFetchSeriesData={afterFetchSeriesData}
           afterFetchTableData={afterFetchTableData}

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -18,7 +18,7 @@ import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 import type {
-  GenericWidgetQueriesChildrenProps,
+  GenericWidgetQueriesResult,
   OnDataFetchedProps,
 } from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
@@ -27,7 +27,7 @@ type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEve
 type TableResult = TableData | EventsTableData;
 
 type Props = {
-  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   cursor?: string;
   dashboardFilters?: DashboardFilters;

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -1,3 +1,4 @@
+import type {PageFilters} from 'sentry/types/core';
 import type {
   EventsStats,
   GroupedMultiSeriesEventsStats,
@@ -36,7 +37,7 @@ type Props = {
   onDataFetched?: (results: OnDataFetchedProps) => void;
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
   // Optional selection override for widget viewer modal zoom functionality
-  selection?: any;
+  selection?: PageFilters;
 };
 
 function WidgetQueriesWithOnDemandControl({


### PR DESCRIPTION
Update all consumers of GenericWidgetQueries to use the new useGenericWidgetQueries hook instead of the render props pattern. No need to pass down org, selection, api, etc, now that we are using a hook pattern.

This resolves some tech debt and moves us closer to using `useQuery` instead of the current approach
