### PR TITLE
perf(issues): Avoid repeated org fetch in issue search

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -371,7 +371,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             pinned_query_partial,
             selected_columns,
             aggregations,
-            organization.id,
+            organization,
             project_ids,
             environments,
             group_ids,


### PR DESCRIPTION
Pass the organization object through search strategies to reuse the already-loaded instance and skip per-category DB lookups when building issue-platform queries.

n+1 issue 
https://sentry.sentry.io/issues/6883673271/
https://sentry.sentry.io/issues/6907107311/
