### PR TITLE
feat(autofix): Add GitHub Copilot agent provider UI

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -222,6 +222,33 @@ describe('AutofixRootCause', () => {
     expect(await screen.findByText('Find Solution with Seer')).toBeInTheDocument();
   });
 
+  it('shows Cursor as primary when using legacy cursor: prefix (backwards compatibility)', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {
+        integrations: [
+          {
+            id: 'cursor-integration-id',
+            name: 'Cursor',
+            provider: 'cursor',
+          },
+        ],
+      },
+    });
+
+    // Use the legacy 'cursor:' prefix that existing users may have stored
+    localStorage.setItem(
+      'autofix:rootCauseActionPreference',
+      JSON.stringify('cursor:cursor-integration-id')
+    );
+
+    render(<AutofixRootCause {...defaultProps} />);
+
+    expect(
+      await screen.findByRole('button', {name: 'Send to Cursor'})
+    ).toBeInTheDocument();
+  });
+
   it('both options accessible in dropdown', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/coding-agents/',

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -150,7 +150,7 @@ describe('AutofixRootCause', () => {
     await userEvent.click(await screen.findByText('Send to Cursor'));
 
     expect(JSON.parse(localStorage.getItem('autofix:rootCauseActionPreference')!)).toBe(
-      'cursor:cursor-integration-id'
+      'agent:cursor-integration-id'
     );
   });
 
@@ -204,7 +204,7 @@ describe('AutofixRootCause', () => {
 
     localStorage.setItem(
       'autofix:rootCauseActionPreference',
-      JSON.stringify('cursor:cursor-integration-id')
+      JSON.stringify('agent:cursor-integration-id')
     );
 
     render(<AutofixRootCause {...defaultProps} />);

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -286,11 +286,13 @@ function SolutionActionButton({
 
   const isSeerPreferred = effectivePreference === 'seer_solution';
 
+  // Check if there are duplicate names among integrations (need to show ID to distinguish)
   const hasDuplicateNames =
     codingAgentIntegrations.length > 1 &&
     new Set(codingAgentIntegrations.map(i => i.name)).size <
       codingAgentIntegrations.length;
 
+  // If no integrations, show simple Seer button
   if (codingAgentIntegrations.length === 0) {
     return (
       <Button
@@ -316,6 +318,7 @@ function SolutionActionButton({
             disabled: isSelectingRootCause,
           },
         ]),
+    // Show all integrations except the currently preferred one
     ...codingAgentIntegrations
       .filter(integration => {
         // Compare by key to handle both 'agent:' and legacy 'cursor:' prefixes
@@ -434,6 +437,7 @@ function AutofixRootCauseDisplay({
     'seer_solution'
   );
 
+  // Simulate a click on the description to trigger the text selection
   const handleSelectDescription = () => {
     if (descriptionRef.current) {
       const clickEvent = new MouseEvent('click', {
@@ -451,6 +455,7 @@ function AutofixRootCauseDisplay({
       return;
     }
 
+    // Save user preference
     setPreferredAction('seer_solution');
 
     const instruction = solutionText.trim();
@@ -476,6 +481,7 @@ function AutofixRootCauseDisplay({
   };
 
   const handleLaunchCodingAgent = (integration: CodingAgentIntegration) => {
+    // Save user preference with specific integration ID
     setPreferredAction(`agent:${integration.id ?? integration.provider}`);
 
     addLoadingMessage(t('Launching %s...', integration.name), {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -248,13 +248,6 @@ function CopyRootCauseButton({
   );
 }
 
-function getPluginIdForProvider(provider: string): string {
-  if (provider === 'github_copilot') {
-    return 'github';
-  }
-  return provider;
-}
-
 function SolutionActionButton({
   codingAgentIntegrations,
   preferredAction,
@@ -334,10 +327,7 @@ function SolutionActionButton({
         key: `agent:${integration.id ?? integration.provider}`,
         label: (
           <Flex gap="md" align="center">
-            <PluginIcon
-              pluginId={getPluginIdForProvider(integration.provider)}
-              size={20}
-            />
+            <PluginIcon pluginId={integration.provider} size={20} />
             <div>{t('Send to %s', integration.name)}</div>
             {hasDuplicateNames && (
               <SmallIntegrationIdText>
@@ -371,12 +361,7 @@ function SolutionActionButton({
     : {
         onClick: () => handleLaunchCodingAgent(preferredIntegration!),
         busy: isLaunchingAgent,
-        icon: (
-          <PluginIcon
-            pluginId={getPluginIdForProvider(preferredIntegration!.provider)}
-            size={16}
-          />
-        ),
+        icon: <PluginIcon pluginId={preferredIntegration!.provider} size={16} />,
         children: primaryButtonLabel,
       };
 

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -276,9 +276,12 @@ function SolutionActionButton({
   primaryButtonPriority: React.ComponentProps<typeof Button>['priority'];
   submitFindSolution: () => void;
 }) {
-  const preferredIntegration = preferredAction.startsWith('agent:')
+  // Support both 'agent:' (new) and 'cursor:' (legacy) prefixes for backwards compatibility
+  const isAgentPreference =
+    preferredAction.startsWith('agent:') || preferredAction.startsWith('cursor:');
+  const preferredIntegration = isAgentPreference
     ? codingAgentIntegrations.find(i => {
-        const key = preferredAction.replace('agent:', '');
+        const key = preferredAction.replace(/^(agent|cursor):/, '');
         return i.id === key || (i.id === null && i.provider === key);
       })
     : null;
@@ -321,10 +324,12 @@ function SolutionActionButton({
           },
         ]),
     ...codingAgentIntegrations
-      .filter(
-        integration =>
-          `agent:${integration.id ?? integration.provider}` !== effectivePreference
-      )
+      .filter(integration => {
+        // Compare by key to handle both 'agent:' and legacy 'cursor:' prefixes
+        const integrationKey = integration.id ?? integration.provider;
+        const effectiveKey = effectivePreference.replace(/^(agent|cursor):/, '');
+        return integrationKey !== effectiveKey;
+      })
       .map(integration => ({
         key: `agent:${integration.id ?? integration.provider}`,
         label: (

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -248,8 +248,15 @@ function CopyRootCauseButton({
   );
 }
 
+function getPluginIdForProvider(provider: string): string {
+  if (provider === 'github_copilot') {
+    return 'github';
+  }
+  return provider;
+}
+
 function SolutionActionButton({
-  cursorIntegrations,
+  codingAgentIntegrations,
   preferredAction,
   primaryButtonPriority,
   isSelectingRootCause,
@@ -259,9 +266,9 @@ function SolutionActionButton({
   handleLaunchCodingAgent,
   findSolutionTitle,
 }: {
-  cursorIntegrations: CodingAgentIntegration[];
+  codingAgentIntegrations: CodingAgentIntegration[];
   findSolutionTitle: string;
-  handleLaunchCodingAgent: (integrationId: string, integrationName: string) => void;
+  handleLaunchCodingAgent: (integration: CodingAgentIntegration) => void;
   isLaunchingAgent: boolean;
   isLoadingAgents: boolean;
   isSelectingRootCause: boolean;
@@ -269,8 +276,11 @@ function SolutionActionButton({
   primaryButtonPriority: React.ComponentProps<typeof Button>['priority'];
   submitFindSolution: () => void;
 }) {
-  const preferredIntegration = preferredAction.startsWith('cursor:')
-    ? cursorIntegrations.find(i => i.id === preferredAction.replace('cursor:', ''))
+  const preferredIntegration = preferredAction.startsWith('agent:')
+    ? codingAgentIntegrations.find(i => {
+        const key = preferredAction.replace('agent:', '');
+        return i.id === key || (i.id === null && i.provider === key);
+      })
     : null;
 
   const effectivePreference =
@@ -280,13 +290,12 @@ function SolutionActionButton({
 
   const isSeerPreferred = effectivePreference === 'seer_solution';
 
-  // Check if there are duplicate names among integrations (need to show ID to distinguish)
   const hasDuplicateNames =
-    cursorIntegrations.length > 1 &&
-    new Set(cursorIntegrations.map(i => i.name)).size < cursorIntegrations.length;
+    codingAgentIntegrations.length > 1 &&
+    new Set(codingAgentIntegrations.map(i => i.name)).size <
+      codingAgentIntegrations.length;
 
-  // If no integrations, show simple Seer button
-  if (cursorIntegrations.length === 0) {
+  if (codingAgentIntegrations.length === 0) {
     return (
       <Button
         size="sm"
@@ -311,21 +320,28 @@ function SolutionActionButton({
             disabled: isSelectingRootCause,
           },
         ]),
-    // Show all integrations except the currently preferred one
-    ...cursorIntegrations
-      .filter(integration => `cursor:${integration.id}` !== effectivePreference)
+    ...codingAgentIntegrations
+      .filter(
+        integration =>
+          `agent:${integration.id ?? integration.provider}` !== effectivePreference
+      )
       .map(integration => ({
-        key: `cursor:${integration.id}`,
+        key: `agent:${integration.id ?? integration.provider}`,
         label: (
           <Flex gap="md" align="center">
-            <PluginIcon pluginId="cursor" size={20} />
+            <PluginIcon
+              pluginId={getPluginIdForProvider(integration.provider)}
+              size={20}
+            />
             <div>{t('Send to %s', integration.name)}</div>
             {hasDuplicateNames && (
-              <SmallIntegrationIdText>({integration.id})</SmallIntegrationIdText>
+              <SmallIntegrationIdText>
+                ({integration.id ?? integration.provider})
+              </SmallIntegrationIdText>
             )}
           </Flex>
         ),
-        onAction: () => handleLaunchCodingAgent(integration.id, integration.name),
+        onAction: () => handleLaunchCodingAgent(integration),
         disabled: isLoadingAgents || isLaunchingAgent,
       })),
   ];
@@ -333,7 +349,11 @@ function SolutionActionButton({
   const primaryButtonLabel = isSeerPreferred
     ? t('Find Solution with Seer')
     : hasDuplicateNames
-      ? t('Send to %s (%s)', preferredIntegration!.name, preferredIntegration!.id)
+      ? t(
+          'Send to %s (%s)',
+          preferredIntegration!.name,
+          preferredIntegration!.id ?? preferredIntegration!.provider
+        )
       : t('Send to %s', preferredIntegration!.name);
 
   const primaryButtonProps = isSeerPreferred
@@ -344,10 +364,14 @@ function SolutionActionButton({
         children: primaryButtonLabel,
       }
     : {
-        onClick: () =>
-          handleLaunchCodingAgent(preferredIntegration!.id, preferredIntegration!.name),
+        onClick: () => handleLaunchCodingAgent(preferredIntegration!),
         busy: isLaunchingAgent,
-        icon: <PluginIcon pluginId="cursor" size={16} />,
+        icon: (
+          <PluginIcon
+            pluginId={getPluginIdForProvider(preferredIntegration!.provider)}
+            size={16}
+          />
+        ),
         children: primaryButtonLabel,
       };
 
@@ -414,7 +438,7 @@ function AutofixRootCauseDisplay({
     runId
   );
 
-  // Stores 'seer_solution' or an integration ID (e.g., 'cursor:123')
+  // Stores 'seer_solution' or an integration ID (e.g., 'agent:123')
   const [preferredAction, setPreferredAction] = useLocalStorageState<string>(
     'autofix:rootCauseActionPreference',
     'seer_solution'
@@ -422,7 +446,6 @@ function AutofixRootCauseDisplay({
 
   const handleSelectDescription = () => {
     if (descriptionRef.current) {
-      // Simulate a click on the description to trigger the text selection
       const clickEvent = new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
@@ -438,7 +461,6 @@ function AutofixRootCauseDisplay({
       return;
     }
 
-    // Save user preference
     setPreferredAction('seer_solution');
 
     const instruction = solutionText.trim();
@@ -463,29 +485,19 @@ function AutofixRootCauseDisplay({
     });
   };
 
-  const cursorIntegrations = codingAgentIntegrations.filter(
-    integration => integration.provider === 'cursor'
-  );
+  const handleLaunchCodingAgent = (integration: CodingAgentIntegration) => {
+    setPreferredAction(`agent:${integration.id ?? integration.provider}`);
 
-  const handleLaunchCodingAgent = (integrationId: string, integrationName: string) => {
-    const targetIntegration = cursorIntegrations.find(i => i.id === integrationId);
-
-    if (!targetIntegration) {
-      return;
-    }
-
-    // Save user preference with specific integration ID
-    setPreferredAction(`cursor:${integrationId}`);
-
-    addLoadingMessage(t('Launching %s...', integrationName), {
+    addLoadingMessage(t('Launching %s...', integration.name), {
       duration: 60000,
     });
 
     const instruction = solutionText.trim();
 
     launchCodingAgent({
-      integrationId: targetIntegration.id,
-      agentName: targetIntegration.name,
+      integrationId: integration.id,
+      provider: integration.provider,
+      agentName: integration.name,
       triggerSource: 'root_cause',
       instruction: instruction || undefined,
     });
@@ -619,7 +631,7 @@ function AutofixRootCauseDisplay({
         <ButtonBar>
           <CopyRootCauseButton cause={cause} event={event} />
           <SolutionActionButton
-            cursorIntegrations={cursorIntegrations}
+            codingAgentIntegrations={codingAgentIntegrations}
             preferredAction={preferredAction}
             primaryButtonPriority={primaryButtonPriority}
             isSelectingRootCause={isSelectingRootCause}

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -112,6 +112,7 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                   </Stack>
 
                   <Stack gap="sm">
+                    {/* Show results for completed or failed agents */}
                     {codingAgentState.results && codingAgentState.results.length > 0 && (
                       <ResultsSection>
                         {codingAgentState.status === CodingAgentStatus.FAILED && (

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -8,7 +8,6 @@ import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {ExternalLink} from 'sentry/components/core/link';
-import {Text} from 'sentry/components/core/text';
 import {DateTime} from 'sentry/components/dateTime';
 import {
   CodingAgentProvider,
@@ -19,7 +18,6 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCode, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import testableTransition from 'sentry/utils/testableTransition';
 
 const animationProps: MotionNodeAnimationOptions = {
@@ -71,6 +69,8 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
     switch (provider) {
       case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
         return t('Cursor Cloud Agent');
+      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
+        return t('GitHub Copilot');
       default:
         return t('Coding Agent');
     }
@@ -110,7 +110,6 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                   </Stack>
 
                   <Stack gap="sm">
-                    {/* Show results for completed or failed agents */}
                     {codingAgentState.results && codingAgentState.results.length > 0 && (
                       <ResultsSection>
                         {codingAgentState.status === CodingAgentStatus.FAILED && (
@@ -165,7 +164,10 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                               analyticsEventName="Autofix: Open Coding Agent"
                               analyticsEventKey="autofix.coding_agent.open"
                             >
-                              {t('Open in Cursor')}
+                              {codingAgentState.provider ===
+                              CodingAgentProvider.CURSOR_BACKGROUND_AGENT
+                                ? t('Open in Cursor')
+                                : t('View Agent')}
                             </Button>
                           </ExternalLink>
                         )}
@@ -283,30 +285,6 @@ const Value = styled('span')`
   color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
-`;
-
-const ResultsSection = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.md};
-  margin-bottom: ${p => p.theme.space.md};
-`;
-
-const ResultItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.xs};
-  padding: ${p => p.theme.space.md} 0;
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
-  }
-`;
-
-const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
-  color: ${p =>
-    p.status === CodingAgentStatus.FAILED
-      ? p.theme.tokens.content.danger
-      : p.theme.tokens.content.primary};
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -290,6 +290,30 @@ const Value = styled('span')`
   font-size: ${p => p.theme.fontSize.sm};
 `;
 
+const ResultsSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const ResultItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.md} 0;
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
+  color: ${p =>
+    p.status === CodingAgentStatus.FAILED
+      ? p.theme.tokens.content.danger
+      : p.theme.tokens.content.primary};
+`;
+
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   height: ${p => p.size}px;
   width: ${p => p.size}px;
@@ -306,23 +330,4 @@ const BottomButtonContainer = styled('div')`
   justify-content: flex-end;
   padding-top: ${p => p.theme.space.xl};
   padding-bottom: ${p => p.theme.space.xl};
-`;
-
-const ResultsSection = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const ResultItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.xs};
-`;
-
-const ResultDescription = styled('span')<{status: CodingAgentStatus}>`
-  color: ${p =>
-    p.status === CodingAgentStatus.FAILED
-      ? p.theme.tokens.content.danger
-      : p.theme.tokens.content.primary};
 `;

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-motion';
 
 import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
@@ -18,6 +19,7 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCode, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import testableTransition from 'sentry/utils/testableTransition';
 
 const animationProps: MotionNodeAnimationOptions = {
@@ -303,4 +305,23 @@ const BottomButtonContainer = styled('div')`
   justify-content: flex-end;
   padding-top: ${p => p.theme.space.xl};
   padding-bottom: ${p => p.theme.space.xl};
+`;
+
+const ResultsSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const ResultItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const ResultDescription = styled('span')<{status: CodingAgentStatus}>`
+  color: ${p =>
+    p.status === CodingAgentStatus.FAILED
+      ? p.theme.tokens.content.danger
+      : p.theme.tokens.content.primary};
 `;

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -44,7 +44,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
   const isConfigured = Boolean(preference?.automation_handoff) && isAutomationEnabled;
 
   const handleSetupClick = useCallback(async () => {
-    if (!cursorIntegration) {
+    if (!cursorIntegration || cursorIntegration.id === null) {
       throw new Error('Cursor integration not found');
     }
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -44,7 +44,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
   const isConfigured = Boolean(preference?.automation_handoff) && isAutomationEnabled;
 
   const handleSetupClick = useCallback(async () => {
-    if (!cursorIntegration || cursorIntegration.id === null) {
+    if (!cursorIntegration?.id) {
       throw new Error('Cursor integration not found');
     }
 

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,0 +1,104 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {ExternalLink} from 'sentry/components/core/link';
+import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import Placeholder from 'sentry/components/placeholder';
+import {t, tct} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function GithubCopilotIntegrationCta() {
+  const organization = useOrganization();
+
+  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
+    useCodingAgentIntegrations();
+
+  const githubCopilotIntegration = codingAgentIntegrations?.integrations.find(
+    integration => integration.provider === 'github_copilot'
+  );
+
+  const hasGithubCopilotFeatureFlag = organization.features.includes(
+    'integrations-github-copilot'
+  );
+  const hasGithubCopilotIntegration = Boolean(githubCopilotIntegration);
+
+  if (!hasGithubCopilotFeatureFlag) {
+    return null;
+  }
+
+  if (isLoadingIntegrations) {
+    return (
+      <Card>
+        <Placeholder height="120px" />
+      </Card>
+    );
+  }
+
+  if (!hasGithubCopilotIntegration) {
+    return (
+      <Card>
+        <Flex direction="column" gap="lg">
+          <Heading as="h3">
+            <Flex direction="row" gap="sm" align="center">
+              <PluginIcon pluginId="github" /> <span>GitHub Copilot Integration</span>
+            </Flex>
+          </Heading>
+          <Text>
+            {tct(
+              'Connect GitHub Copilot to hand off Seer root cause analysis to GitHub Copilot coding agent for seamless code fixes. [docsLink:Read the docs] to learn more.',
+              {
+                docsLink: (
+                  <ExternalLink href="https://docs.sentry.io/organization/integrations/github-copilot/" />
+                ),
+              }
+            )}
+          </Text>
+          <div>
+            <LinkButton
+              to={`/settings/${organization.slug}/integrations/github_copilot/`}
+              priority="default"
+              size="sm"
+            >
+              {t('Install GitHub Copilot Integration')}
+            </LinkButton>
+          </div>
+        </Flex>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Flex direction="column" gap="lg">
+        <Heading as="h3">
+          <Flex direction="row" gap="sm" align="center">
+            <PluginIcon pluginId="github" /> <span>GitHub Copilot Integration</span>
+          </Flex>
+        </Heading>
+        <Text>
+          {tct(
+            'GitHub Copilot integration is installed. You can trigger GitHub Copilot from Issue Fix to create pull requests. [docsLink:Read the docs] to learn more.',
+            {
+              docsLink: (
+                <ExternalLink href="https://docs.sentry.io/organization/integrations/github-copilot/" />
+              ),
+            }
+          )}
+        </Text>
+      </Flex>
+    </Card>
+  );
+}
+
+const Card = styled('div')`
+  position: relative;
+  padding: ${p => p.theme.space.xl};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.radius.md};
+  margin-top: ${p => p.theme.space['2xl']};
+  margin-bottom: ${p => p.theme.space['2xl']};
+`;

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -33,7 +33,7 @@ export function GithubCopilotIntegrationCta() {
       <Container
         padding="xl"
         border="primary"
-        borderRadius="md"
+        radius="md"
         marginTop="2xl"
         marginBottom="2xl"
       >
@@ -47,7 +47,7 @@ export function GithubCopilotIntegrationCta() {
       <Container
         padding="xl"
         border="primary"
-        borderRadius="md"
+        radius="md"
         marginTop="2xl"
         marginBottom="2xl"
       >
@@ -85,7 +85,7 @@ export function GithubCopilotIntegrationCta() {
     <Container
       padding="xl"
       border="primary"
-      borderRadius="md"
+      radius="md"
       marginTop="2xl"
       marginBottom="2xl"
     >

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,6 +1,4 @@
-import styled from '@emotion/styled';
-
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -32,15 +30,27 @@ export function GithubCopilotIntegrationCta() {
 
   if (isLoadingIntegrations) {
     return (
-      <Card>
+      <Container
+        padding="xl"
+        border="primary"
+        borderRadius="md"
+        marginTop="2xl"
+        marginBottom="2xl"
+      >
         <Placeholder height="120px" />
-      </Card>
+      </Container>
     );
   }
 
   if (!hasGithubCopilotIntegration) {
     return (
-      <Card>
+      <Container
+        padding="xl"
+        border="primary"
+        borderRadius="md"
+        marginTop="2xl"
+        marginBottom="2xl"
+      >
         <Flex direction="column" gap="lg">
           <Heading as="h3">
             <Flex direction="row" gap="sm" align="center">
@@ -67,12 +77,18 @@ export function GithubCopilotIntegrationCta() {
             </LinkButton>
           </div>
         </Flex>
-      </Card>
+      </Container>
     );
   }
 
   return (
-    <Card>
+    <Container
+      padding="xl"
+      border="primary"
+      borderRadius="md"
+      marginTop="2xl"
+      marginBottom="2xl"
+    >
       <Flex direction="column" gap="lg">
         <Heading as="h3">
           <Flex direction="row" gap="sm" align="center">
@@ -90,15 +106,6 @@ export function GithubCopilotIntegrationCta() {
           )}
         </Text>
       </Flex>
-    </Card>
+    </Container>
   );
 }
-
-const Card = styled('div')`
-  position: relative;
-  padding: ${p => p.theme.space.xl};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.radius.md};
-  margin-top: ${p => p.theme.space['2xl']};
-  margin-bottom: ${p => p.theme.space['2xl']};
-`;

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -20,7 +20,7 @@ export function GithubCopilotIntegrationCta() {
   );
 
   const hasGithubCopilotFeatureFlag = organization.features.includes(
-    'integrations-github-copilot'
+    'integrations-github-copilot-agent'
   );
   const hasGithubCopilotIntegration = Boolean(githubCopilotIntegration);
 

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -63,6 +63,7 @@ export enum CodingAgentStatus {
 
 export enum CodingAgentProvider {
   CURSOR_BACKGROUND_AGENT = 'cursor_background_agent',
+  GITHUB_COPILOT_AGENT = 'github_copilot_agent',
 }
 
 export interface CodingAgentState {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -311,9 +311,10 @@ export const useAiAutofix = (
 };
 
 export type CodingAgentIntegration = {
-  id: string;
+  id: string | null;
   name: string;
   provider: string;
+  requires_identity?: boolean;
 };
 
 export function useCodingAgentIntegrations() {
@@ -328,7 +329,8 @@ export function useCodingAgentIntegrations() {
 
 interface LaunchCodingAgentParams {
   agentName: string;
-  integrationId: string;
+  integrationId: string | null;
+  provider: string;
   instruction?: string;
   triggerSource?: 'root_cause' | 'solution';
 }
@@ -353,21 +355,37 @@ function getErrorMessage(error: RequestError, agentName: string): string {
   return t('Failed to launch %s', agentName);
 }
 
+function needsGitHubAuth(error: RequestError): boolean {
+  const detail = error.responseJSON?.detail;
+  return (
+    typeof detail === 'string' &&
+    detail.toLowerCase().includes('github') &&
+    detail.toLowerCase().includes('authorization')
+  );
+}
+
 export function useLaunchCodingAgent(groupId: string, runId: string) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
   return useMutation<LaunchCodingAgentResponse, RequestError, LaunchCodingAgentParams>({
     mutationFn: (params: LaunchCodingAgentParams) => {
+      const data: Record<string, string | number | undefined> = {
+        run_id: parseInt(runId, 10),
+        trigger_source: params.triggerSource,
+        instruction: params.instruction,
+      };
+
+      if (params.integrationId === null) {
+        data.provider = params.provider;
+      } else {
+        data.integration_id = parseInt(params.integrationId, 10);
+      }
+
       return fetchMutation({
         url: `/organizations/${organization.slug}/integrations/coding-agents/`,
         method: 'POST',
-        data: {
-          integration_id: parseInt(params.integrationId, 10),
-          run_id: parseInt(runId, 10),
-          trigger_source: params.triggerSource,
-          instruction: params.instruction,
-        },
+        data,
       });
     },
     onSuccess: (data, params) => {
@@ -399,6 +417,15 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
       });
     },
     onError: (error, params) => {
+      if (needsGitHubAuth(error)) {
+        addErrorMessage(
+          t('Please connect your GitHub account. Redirecting to authorization...')
+        );
+        setTimeout(() => {
+          window.open('/remote/github-copilot/oauth/', '_blank');
+        }, 1000);
+        return;
+      }
       const message = getErrorMessage(error, params.agentName);
       addErrorMessage(message);
     },

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -116,7 +116,7 @@ function StepButton({
   isBusy: boolean;
   onStepClick: () => void;
   step: AutofixExplorerStep;
-  codingAgentIntegrations?: Array<{id: string | null; name: string; provider: string}>;
+  codingAgentIntegrations?: Array<{id: string; name: string; provider: string}>;
   isLoading?: boolean;
   onCodingAgentHandoff?: (integrationId: number) => void;
 }) {
@@ -136,19 +136,17 @@ function StepButton({
     );
   }
 
-  // Build dropdown items for coding agent integrations (filter out those without IDs)
-  const dropdownItems = codingAgentIntegrations
-    .filter(integration => integration.id !== null)
-    .map(integration => ({
-      key: `agent:${integration.id}`,
-      label: (
-        <Flex gap="md" align="center">
-          <PluginIcon pluginId="cursor" size={16} />
-          <span>{t('Send to %s', integration.name)}</span>
-        </Flex>
-      ),
-      onAction: () => onCodingAgentHandoff?.(parseInt(integration.id!, 10)),
-    }));
+  // Build dropdown items for coding agent integrations
+  const dropdownItems = codingAgentIntegrations.map(integration => ({
+    key: `agent:${integration.id}`,
+    label: (
+      <Flex gap="md" align="center">
+        <PluginIcon pluginId="cursor" size={16} />
+        <span>{t('Send to %s', integration.name)}</span>
+      </Flex>
+    ),
+    onAction: () => onCodingAgentHandoff?.(parseInt(integration.id, 10)),
+  }));
 
   return (
     <ButtonBar merged gap="0">

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -116,7 +116,8 @@ function StepButton({
   isBusy: boolean;
   onStepClick: () => void;
   step: AutofixExplorerStep;
-  codingAgentIntegrations?: Array<{id: string; name: string; provider: string}>;
+  // TODO(autofix): Handle GitHub Copilot in explore autofix
+  codingAgentIntegrations?: Array<{id: string | null; name: string; provider: string}>;
   isLoading?: boolean;
   onCodingAgentHandoff?: (integrationId: number) => void;
 }) {
@@ -136,17 +137,19 @@ function StepButton({
     );
   }
 
-  // Build dropdown items for coding agent integrations
-  const dropdownItems = codingAgentIntegrations.map(integration => ({
-    key: `agent:${integration.id}`,
-    label: (
-      <Flex gap="md" align="center">
-        <PluginIcon pluginId="cursor" size={16} />
-        <span>{t('Send to %s', integration.name)}</span>
-      </Flex>
-    ),
-    onAction: () => onCodingAgentHandoff?.(parseInt(integration.id, 10)),
-  }));
+  // Build dropdown items for coding agent integrations (filter out those without IDs for now)
+  const dropdownItems = codingAgentIntegrations
+    .filter(integration => integration.id !== null)
+    .map(integration => ({
+      key: `agent:${integration.id}`,
+      label: (
+        <Flex gap="md" align="center">
+          <PluginIcon pluginId="cursor" size={16} />
+          <span>{t('Send to %s', integration.name)}</span>
+        </Flex>
+      ),
+      onAction: () => onCodingAgentHandoff?.(parseInt(integration.id!, 10)),
+    }));
 
   return (
     <ButtonBar merged gap="0">

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -116,7 +116,7 @@ function StepButton({
   isBusy: boolean;
   onStepClick: () => void;
   step: AutofixExplorerStep;
-  codingAgentIntegrations?: Array<{id: string; name: string; provider: string}>;
+  codingAgentIntegrations?: Array<{id: string | null; name: string; provider: string}>;
   isLoading?: boolean;
   onCodingAgentHandoff?: (integrationId: number) => void;
 }) {
@@ -136,17 +136,19 @@ function StepButton({
     );
   }
 
-  // Build dropdown items for coding agent integrations
-  const dropdownItems = codingAgentIntegrations.map(integration => ({
-    key: `agent:${integration.id}`,
-    label: (
-      <Flex gap="md" align="center">
-        <PluginIcon pluginId="cursor" size={16} />
-        <span>{t('Send to %s', integration.name)}</span>
-      </Flex>
-    ),
-    onAction: () => onCodingAgentHandoff?.(parseInt(integration.id, 10)),
-  }));
+  // Build dropdown items for coding agent integrations (filter out those without IDs)
+  const dropdownItems = codingAgentIntegrations
+    .filter(integration => integration.id !== null)
+    .map(integration => ({
+      key: `agent:${integration.id}`,
+      label: (
+        <Flex gap="md" align="center">
+          <PluginIcon pluginId="cursor" size={16} />
+          <span>{t('Send to %s', integration.name)}</span>
+        </Flex>
+      ),
+      onAction: () => onCodingAgentHandoff?.(parseInt(integration.id!, 10)),
+    }));
 
   return (
     <ButtonBar merged gap="0">

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -51,6 +51,7 @@ const PLUGIN_ICONS = {
   bitbucket_server: bitbucketserver,
   discord,
   github,
+  github_copilot: github,
   github_enterprise: githubEnterprise,
   gitlab,
   heroku,

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -167,7 +167,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   ];
 
   const handleSetupCursorHandoff = useCallback(async () => {
-    if (!cursorIntegration) {
+    if (!cursorIntegration || cursorIntegration.id === null) {
       return;
     }
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -167,7 +167,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   ];
 
   const handleSetupCursorHandoff = useCallback(async () => {
-    if (!cursorIntegration || cursorIntegration.id === null) {
+    if (!cursorIntegration?.id) {
       return;
     }
 

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -233,7 +233,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
       value: 'root_cause' | 'solution' | 'code_changes' | 'open_pr' | 'cursor_handoff'
     ) => {
       if (value === 'cursor_handoff') {
-        if (!cursorIntegration || cursorIntegration.id === null) {
+        if (!cursorIntegration?.id) {
           throw new Error('Cursor integration not found');
         }
         updateProjectSeerPreferences({
@@ -334,7 +334,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const handleCursorHandoffChange = useCallback(
     (value: boolean) => {
       if (value) {
-        if (!cursorIntegration || cursorIntegration.id === null) {
+        if (!cursorIntegration?.id) {
           addErrorMessage(
             t('Cursor integration not found. Please refresh the page and try again.')
           );

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -10,6 +10,7 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
 import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
+import {GithubCopilotIntegrationCta} from 'sentry/components/events/autofix/githubCopilotIntegrationCta';
 import {
   makeProjectSeerPreferencesQueryKey,
   useProjectSeerPreferences,
@@ -232,7 +233,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
       value: 'root_cause' | 'solution' | 'code_changes' | 'open_pr' | 'cursor_handoff'
     ) => {
       if (value === 'cursor_handoff') {
-        if (!cursorIntegration) {
+        if (!cursorIntegration || cursorIntegration.id === null) {
           throw new Error('Cursor integration not found');
         }
         updateProjectSeerPreferences({
@@ -333,7 +334,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const handleCursorHandoffChange = useCallback(
     (value: boolean) => {
       if (value) {
-        if (!cursorIntegration) {
+        if (!cursorIntegration || cursorIntegration.id === null) {
           addErrorMessage(
             t('Cursor integration not found. Please refresh the page and try again.')
           );
@@ -656,6 +657,7 @@ function ProjectSeer({
       />
       <ProjectSeerGeneralForm project={project} />
       <CursorIntegrationCta project={project} />
+      <GithubCopilotIntegrationCta />
       <AutofixRepositories project={project} />
       <Flex justify="center" marginTop="lg">
         <LinkButton


### PR DESCRIPTION
## Summary
- Add frontend support for GitHub Copilot as a coding agent provider
- New CodingAgentProvider enum value for GitHub Copilot
- GitHub Copilot integration CTA component
- Update coding agent card to display Copilot branding
- Settings page integration for Copilot setup


Note that this only contains changes for the non-explorer autofix, explorer autofix changes to be done in a follow up PR. Auth works differently and is per user. if a user is not authed for github copilot, we'll redirect them to our oauth flow for github copilot which has already been built.
<img width="333" height="122" alt="Screenshot 2026-01-20 at 9 45 00 PM" src="https://github.com/user-attachments/assets/c2041701-ef63-41b8-88f2-33d6ffa06b0f" />
<img width="717" height="163" alt="Screenshot 2026-01-20 at 9 45 12 PM" src="https://github.com/user-attachments/assets/0e916344-c248-42dd-a77f-8a841abe5849" />
<img width="1236" height="108" alt="Screenshot 2026-01-20 at 9 48 03 PM" src="https://github.com/user-attachments/assets/da2fe870-a94d-4f00-bffc-8194eb3cb956" />


