### PR TITLE
fix(dashboards): Ignore sort unless table or top-n

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -203,7 +203,9 @@ function AddToDashboardModal({
     const pathname =
       page === 'builder' ? `${dashboardsPath}${builderSuffix}` : dashboardsPath;
 
-    const widgetAsQueryParams = convertWidgetToBuilderStateParams(widget);
+    const widgetAsQueryParams = convertWidgetToBuilderStateParams(
+      normalizeWidgets([widget])[0]!
+    );
     navigate(
       normalizeUrl({
         pathname,

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -227,7 +227,7 @@ function AddToDashboardModal({
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
-      if (!(isChartDisplayType(w.displayType) && w.queries[0]!.columns.length)) {
+      if (isChartDisplayType(w.displayType) && w.queries[0]!.columns.length === 0) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
       }
       const queries = w.queries.map(query => ({

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -49,6 +49,7 @@ import type {
 } from 'sentry/views/dashboards/types';
 import {
   DEFAULT_WIDGET_NAME,
+  DisplayType,
   MAX_WIDGETS,
   WidgetType,
 } from 'sentry/views/dashboards/types';
@@ -227,7 +228,11 @@ function AddToDashboardModal({
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
-      if (isChartDisplayType(w.displayType) && w.queries[0]!.columns.length === 0) {
+      if (
+        w.displayType === DisplayType.BIG_NUMBER ||
+        w.displayType === DisplayType.WHEEL ||
+        (isChartDisplayType(w.displayType) && w.queries[0]!.columns.length === 0)
+      ) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
       }
       const queries = w.queries.map(query => ({

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -41,9 +41,11 @@ describe('convertBuilderStateToWidget', () => {
     });
   });
 
-  it('injects the orderby from the sort state into the widget queries', () => {
+  it('injects the orderby from the sort state into the widget queries for charts with columns', () => {
     const mockState: WidgetBuilderState = {
       query: ['transaction.duration:>100', 'transaction.duration:>50'],
+      displayType: DisplayType.LINE,
+      fields: [{field: 'geo.country', kind: FieldValueKind.FIELD}],
       sort: [{field: 'geo.country', kind: 'desc'}],
     };
 
@@ -56,6 +58,8 @@ describe('convertBuilderStateToWidget', () => {
   it('does not convert aggregates to aliased format', () => {
     const mockState: WidgetBuilderState = {
       query: ['transaction.duration:>100', 'transaction.duration:>50'],
+      displayType: DisplayType.LINE,
+      fields: [{field: 'geo.country', kind: FieldValueKind.FIELD}],
       sort: [{field: 'count()', kind: 'desc'}],
     };
 
@@ -227,5 +231,16 @@ describe('convertBuilderStateToWidget', () => {
     const widget = convertBuilderStateToWidget(mockState);
 
     expect(widget.limit).toBeUndefined();
+  });
+
+  it('supports the sort field for tables', () => {
+    const mockState: WidgetBuilderState = {
+      displayType: DisplayType.TABLE,
+      sort: [{field: 'count()', kind: 'desc'}],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.orderby).toBe('-count()');
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -98,8 +98,12 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       name: legendAlias[index] ?? '',
       selectedAggregate: state.selectedAggregate,
       linkedDashboards: state.linkedDashboards ?? [],
-      // Big number widgets don't support sorting, so always ignore the sort state
-      orderby: state.displayType === DisplayType.BIG_NUMBER ? '' : sort,
+      // Orderby is only applicable for tables or charts with columns (TOP-N queries)
+      orderby:
+        state.displayType === DisplayType.TABLE ||
+        (isChartDisplayType(state.displayType) && (columns?.length ?? 0) > 0)
+          ? sort
+          : '',
     };
   });
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -101,6 +101,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       // Orderby is only applicable for tables or charts with columns (TOP-N queries)
       orderby:
         state.displayType === DisplayType.TABLE ||
+        state.displayType === DisplayType.DETAILS ||
         (isChartDisplayType(state.displayType) && (columns?.length ?? 0) > 0)
           ? sort
           : '',


### PR DESCRIPTION
Discover can add in an irrelevant sort because it has a table which can affect the event view. Ignore it in the builder state -> widget conversion if we're not a table or a top-n type chart (i.e. yaxis with columns)