### PR TITLE
chore(explore): Add attribute mapping endpoint description

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -213,6 +213,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_events_stats.py                      @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_events_timeseries.py                 @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_measurements_meta.py                 @getsentry/data-browsing
+src/sentry/api/endpoints/organization_attribute_mappings.py                 @getsentry/data-browsing
 
 /tests/snuba/api/endpoints/*                                                @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/data-browsing
@@ -225,6 +226,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /tests/sentry/api/endpoints/test_organization_events_trends_v2.py           @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/data-browsing
+tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @getsentry/data-browsing
 
 /src/sentry/api/serializers/snuba.py                                        @getsentry/data-browsing
 

--- a/src/sentry/api/endpoints/organization_attribute_mappings.py
+++ b/src/sentry/api/endpoints/organization_attribute_mappings.py
@@ -32,14 +32,17 @@ class AttributeMappingResponse(TypedDict):
     searchType: str
 
 
-# The role of this endpoint is to provide a list of attributes that include their
-# mappings from internal name to public alias and search type. This is used to make the
-# connection between internal names in the Sentry Conventions to their public aliases and
-# search types.
-
-
 @region_silo_endpoint
 class OrganizationAttributeMappingsEndpoint(OrganizationEndpoint):
+    """
+    Return a static list of attributes and their mappings to public aliases and search types.
+
+    The role of this endpoint is to provide a list of attributes that include their
+    mappings from internal name to public alias and search type. This is used to make the
+    connection between internal names in the Sentry Conventions to their public aliases
+    and search types.
+    """
+
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/endpoints/organization_attribute_mappings.py
+++ b/src/sentry/api/endpoints/organization_attribute_mappings.py
@@ -32,6 +32,12 @@ class AttributeMappingResponse(TypedDict):
     searchType: str
 
 
+# The role of this endpoint is to provide a list of attributes that include their
+# mappings from internal name to public alias and search type. This is used to make the
+# connection between internal names in the Sentry Conventions to their public aliases and
+# search types.
+
+
 @region_silo_endpoint
 class OrganizationAttributeMappingsEndpoint(OrganizationEndpoint):
     publish_status = {


### PR DESCRIPTION
Originally forgot to provide this description comment about this endpoint, as well as updating the codeowners to assign data browsing to own this endpoint.