### PR TITLE
Migration lock file check

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -92,6 +92,8 @@ class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModelExisting):
     # How to sample traces for this monitor. Note that we always send a trace_id, so any errors will
     # be associated, this just controls the span sampling.
     trace_sampling = models.BooleanField(default=False, db_default=False)
+    # Test field to verify CI catches missing migrations
+    test_migration_check = models.CharField(max_length=100, null=True, default=None)
 
     objects: ClassVar[BaseManager[Self]] = BaseManager(
         cache_fields=["pk", "subscription_id"],


### PR DESCRIPTION
This PR introduces a model change to `UptimeSubscription` without generating a corresponding migration file.

The purpose is to test if existing CI checks in the `sentry` repo successfully detect the missing migration. This will help determine if additional migration checks (like those in PR #106253) are necessary for `sentry` or only for `getsentry`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/CUHS29QJ0/p1768404390032119?thread_ts=1768404390.032119&cid=CUHS29QJ0)

<a href="https://cursor.com/background-agent?bcId=bc-365f8422-db58-4194-ada6-8b945e7a253a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-365f8422-db58-4194-ada6-8b945e7a253a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

