### PR TITLE
feat(ACI): Document data conditions index GET endpoint

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -185,3 +185,83 @@ class WorkflowEngineExamples:
             response_only=True,
         )
     ]
+
+    LIST_DATA_CONDITIONS = [
+        OpenApiExample(
+            "List all data conditions for the given grouping",
+            value=[
+                {
+                    "type": "anomaly_detection",
+                    "handlerGroup": "detector_trigger",
+                    "comparisonJsonSchema": {
+                        "type": "object",
+                        "properties": {
+                            "sensitivity": {"type": "string", "enum": ["low", "medium", "high"]},
+                            "seasonality": {
+                                "type": "string",
+                                "enum": [
+                                    "auto",
+                                    "hourly",
+                                    "daily",
+                                    "weekly",
+                                    "hourly_daily",
+                                    "hourly_weekly",
+                                    "hourly_daily_weekly",
+                                    "daily_weekly",
+                                ],
+                            },
+                            "threshold_type": {"type": "integer", "enum": [0, 1, 2]},
+                        },
+                        "required": ["sensitivity", "seasonality", "threshold_type"],
+                        "additionalProperties": False,
+                    },
+                },
+                {
+                    "type": "first_seen_event",
+                    "handlerGroup": "workflow_trigger",
+                    "comparisonJsonSchema": {"type": "boolean"},
+                },
+                {
+                    "type": "issue_resolved_trigger",
+                    "handlerGroup": "workflow_trigger",
+                    "comparisonJsonSchema": {"type": "boolean"},
+                },
+                {
+                    "type": "reappeared_event",
+                    "handlerGroup": "workflow_trigger",
+                    "comparisonJsonSchema": {"type": "boolean"},
+                },
+                {
+                    "type": "regression_event",
+                    "handlerGroup": "workflow_trigger",
+                    "comparisonJsonSchema": {"type": "boolean"},
+                },
+                {
+                    "type": "assigned_to",
+                    "handlerGroup": "action_filter",
+                    "comparisonJsonSchema": {
+                        "type": "object",
+                        "properties": {
+                            "target_type": {
+                                "type": "string",
+                                "enum": ["Unassigned", "Team", "Member"],
+                            },
+                            "target_identifier": {"type": ["integer", "string"]},
+                        },
+                        "required": ["target_type"],
+                        "additionalProperties": False,
+                        "allOf": [
+                            {
+                                "if": {"properties": {"target_type": {"const": "Unassigned"}}},
+                                "then": {"required": ["target_type"]},
+                                "else": {"required": ["target_type", "target_identifier"]},
+                            }
+                        ],
+                    },
+                    "handlerSubgroup": "issue_attributes",
+                },
+            ],
+            status_codes=["201"],
+            response_only=True,
+        )
+    ]

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -526,6 +526,23 @@ class DetectorWorkflowParams:
     )
 
 
+class DataConditionParams:
+    GROUP = OpenApiParameter(
+        name="group",
+        location="query",
+        required=True,
+        type=int,
+        description="""The type of data conditions to return.
+
+Available fields are:
+- `detector_trigger`
+- `workflow_trigger`
+- `action_filter`
+
+        """,
+    )
+
+
 class IssueAlertParams:
     ISSUE_RULE_ID = OpenApiParameter(
         name="rule_id",

--- a/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
@@ -13,7 +13,8 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
-from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
+from sentry.apidocs.parameters import DataConditionParams, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.workflow_engine.endpoints.serializers.data_condition_handler_serializer import (
     DataConditionHandlerResponse,
@@ -25,6 +26,7 @@ from sentry.workflow_engine.types import DataConditionHandler
 
 
 @region_silo_endpoint
+@extend_schema(tags=["Workflows"])
 class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
@@ -35,6 +37,7 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
         operation_id="Fetch Data Conditions",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
+            DataConditionParams.GROUP,
         ],
         responses={
             201: inline_sentry_response_serializer(
@@ -45,10 +48,11 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=WorkflowEngineExamples.LIST_DATA_CONDITIONS,
     )
     def get(self, request, organization):
         """
-        Returns a list of data conditions for a given org
+        Returns a list of data conditions for a given organization
         """
         group = request.GET.get("group")
         try:


### PR DESCRIPTION
Add documentation for fetching data conditions for an organization. 

This will not be actually published yet, but to prepare all of the new workflow engine endpoints we're keeping them marked as experimental and not adding the new sidebar item just yet.

<img width="983" height="686" alt="Screenshot 2026-01-14 at 11 26 46 AM" src="https://github.com/user-attachments/assets/a24e11f2-c5af-406d-aaab-04727732d199" />

Marking this one as a draft as I have some hesitations about publication, it doesn't seem to be the most user friendly API. 