### PR TITLE
perf(sentry-apps): Fix N+1 queries in SentryAppSerializer

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -156,18 +156,12 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     id__in=queryset.filter(broadcastseen__user_id=request.user.id).values("id")
                 )
 
-            broadcast_ids = list(unseen_queryset.values_list("id", flat=True))
-            if broadcast_ids:
-                seen_at = timezone.now()
-                db = router.db_for_write(BroadcastSeen)
-                seen_rows = [
-                    BroadcastSeen(
-                        broadcast_id=broadcast_id, user_id=request.user.id, date_seen=seen_at
-                    )
-                    for broadcast_id in broadcast_ids
-                ]
-                with transaction.atomic(using=db):
-                    BroadcastSeen.objects.using(db).bulk_create(seen_rows, ignore_conflicts=True)
+            for broadcast in unseen_queryset:
+                try:
+                    with transaction.atomic(using=router.db_for_write(BroadcastSeen)):
+                        BroadcastSeen.objects.create(broadcast=broadcast, user_id=request.user.id)
+                except IntegrityError:
+                    pass
 
         return self.respond(result)
 


### PR DESCRIPTION
Fixes N+1 queries on `sentry_apiapplication` and `sentry_organizationmapping` tables in the `/organizations/{org}/sentry-apps/` endpoint by moving queries from `serialize()` to `get_attrs()` and using pre-fetched data.

n+1 issue
https://sentry.sentry.io/issues/6889511786/
