### PR TITLE
fix(detectors): Only render service incidents overlay on cron monitors

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -39,7 +39,6 @@ import {
 } from 'sentry/views/detectors/monitorViewContext';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {useCanEditDetectors} from 'sentry/views/detectors/utils/useCanEditDetector';
-import {CronServiceIncidents} from 'sentry/views/insights/crons/components/serviceIncidents';
 
 type DetectorListTableProps = {
   allResultsVisible: boolean;
@@ -144,7 +143,11 @@ function DetectorListTable({
   const timelineWidth = useDebouncedValue(containerWidth, 1000);
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
 
-  const {additionalColumns = [], renderVisualization} = useMonitorViewContext();
+  const {
+    additionalColumns = [],
+    renderVisualization,
+    renderTimelineOverlay,
+  } = useMonitorViewContext();
   const hasVisualization = defined(renderVisualization);
 
   return (
@@ -247,7 +250,7 @@ function DetectorListTable({
             allowZoom
             showCursor
             cursorOffsets={{right: 40}}
-            additionalUi={<CronServiceIncidents timeWindowConfig={timeWindowConfig} />}
+            additionalUi={renderTimelineOverlay?.({timeWindowConfig})}
             timeWindowConfig={timeWindowConfig}
             cursorOverlayAnchor="top"
             cursorOverlayAnchorOffset={10}

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -30,12 +30,15 @@ describe('CronDetectorsList', () => {
     },
   };
 
+  afterEach(() => {
+    fetchMock.resetMocks();
+  });
+
   beforeEach(() => {
     ConfigStore.set('statuspage', {
       id: 'sentry',
       api_host: 'status.sentry.io',
     });
-    fetchMock.resetMocks();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/1/',

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -15,6 +15,11 @@ import {
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import CronDetectorsList from 'sentry/views/detectors/list/cron';
 
+// Mock the service incidents component to verify it's rendered
+jest.mock('sentry/views/insights/crons/components/serviceIncidents', () => ({
+  CronServiceIncidents: () => <div data-test-id="cron-service-incidents" />,
+}));
+
 describe('CronDetectorsList', () => {
   const organization = OrganizationFixture({
     features: ['workflow-engine-ui'],
@@ -131,6 +136,9 @@ describe('CronDetectorsList', () => {
 
     // Environment name
     expect(within(row).getByText('production')).toBeInTheDocument();
+
+    // Should render service incidents overlay
+    expect(await screen.findByTestId('cron-service-incidents')).toBeInTheDocument();
 
     // Timeline visualization should render ticks once stats load
     expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -1,6 +1,8 @@
+import fetchMock from 'jest-fetch-mock';
 import {CronDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ServiceIncidentFixture} from 'sentry-fixture/serviceIncident';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
@@ -12,11 +14,10 @@ import {
   type RouterConfig,
 } from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import * as useServiceIncidentsModule from 'sentry/utils/useServiceIncidents';
+import {StatusPageComponent} from 'sentry/types/system';
 import CronDetectorsList from 'sentry/views/detectors/list/cron';
-
-jest.mock('sentry/utils/useServiceIncidents');
 
 describe('CronDetectorsList', () => {
   const organization = OrganizationFixture({
@@ -30,6 +31,11 @@ describe('CronDetectorsList', () => {
   };
 
   beforeEach(() => {
+    ConfigStore.set('statuspage', {
+      id: 'sentry',
+      api_host: 'status.sentry.io',
+    });
+    fetchMock.resetMocks();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/1/',
@@ -58,13 +64,6 @@ describe('CronDetectorsList', () => {
         return 50;
       },
     });
-
-    jest.mocked(useServiceIncidentsModule.useServiceIncidents).mockReturnValue({
-      data: null,
-      isLoading: false,
-      isError: false,
-      refetch: jest.fn(),
-    } as any);
   });
 
   it('displays empty state when no cron monitors are found', async () => {
@@ -94,7 +93,7 @@ describe('CronDetectorsList', () => {
     expect(screen.getByRole('button', {name: 'Manual Setup'})).toBeInTheDocument();
   });
 
-  it('loads cron monitors, renders timeline, and updates on time selection', async () => {
+  it('loads cron monitors, renders timeline, displays service incidents, and updates on time selection', async () => {
     // Detectors list returns a single cron monitor
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
@@ -124,24 +123,39 @@ describe('CronDetectorsList', () => {
       },
     });
 
-    jest.mocked(useServiceIncidentsModule.useServiceIncidents).mockReturnValue({
-      data: [
+    const incident = ServiceIncidentFixture({
+      id: 'incident-1',
+      name: 'Incident',
+      status: 'monitoring',
+      created_at: new Date(nowSec * 1000 - 3600 * 1000).toISOString(),
+      started_at: new Date(nowSec * 1000 - 3600 * 1000).toISOString(),
+      updated_at: new Date(nowSec * 1000).toISOString(),
+      shortlink: 'http://example.com',
+      components: [
         {
-          id: 'incident-1',
-          name: 'Incident',
-          status: 'investigating',
-          created_at: new Date(nowSec * 1000 - 3600 * 1000).toISOString(),
-          started_at: new Date(nowSec * 1000 - 3600 * 1000).toISOString(),
-          updated_at: new Date(nowSec * 1000).toISOString(),
-          shortlink: 'http://example.com',
-          components: [],
-          incident_updates: [],
-        } as any,
+          id: StatusPageComponent.US_CRON_MONITORING,
+          name: 'Crons',
+          created_at: '',
+          description: '',
+          group: false,
+          group_id: '',
+          only_show_if_degraded: false,
+          page_id: '',
+          position: 1,
+          showcase: false,
+          start_date: '',
+          status: 'major_outage',
+          updated_at: '',
+        },
       ],
-      isLoading: false,
-      isError: false,
-      refetch: jest.fn(),
-    } as any);
+      incident_updates: [],
+    });
+
+    fetchMock.mockResponse(req =>
+      req.url.includes('status.sentry.io/api/v2/incidents.json')
+        ? Promise.resolve(JSON.stringify({incidents: [incident]}))
+        : Promise.reject({status: 404})
+    );
 
     const {router} = render(<CronDetectorsList />, {organization, initialRouterConfig});
 

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -39,6 +39,7 @@ import {
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import MonitorEnvironmentLabel from 'sentry/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel';
 import {GlobalMonitorProcessingErrors} from 'sentry/views/insights/crons/components/processingErrors/globalMonitorProcessingErrors';
+import {CronServiceIncidents} from 'sentry/views/insights/crons/components/serviceIncidents';
 import {
   platformGuides,
   type SupportedPlatform,
@@ -216,6 +217,9 @@ export default function CronDetectorsList() {
   const contextValue = useMemo<MonitorViewContextValue>(() => {
     return {
       additionalColumns: ADDITIONAL_COLUMNS,
+      renderTimelineOverlay: ({timeWindowConfig}) => (
+        <CronServiceIncidents timeWindowConfig={timeWindowConfig} />
+      ),
       renderVisualization: ({detector}) => {
         if (!detector) {
           return (

--- a/static/app/views/detectors/list/uptime.spec.tsx
+++ b/static/app/views/detectors/list/uptime.spec.tsx
@@ -15,11 +15,6 @@ import {
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import UptimeDetectorsList from 'sentry/views/detectors/list/uptime';
 
-// Mock the service incidents component to verify it's NOT rendered
-jest.mock('sentry/views/insights/crons/components/serviceIncidents', () => ({
-  CronServiceIncidents: () => <div data-test-id="cron-service-incidents" />,
-}));
-
 describe('UptimeDetectorsList', () => {
   const organization = OrganizationFixture({
     features: ['workflow-engine-ui'],
@@ -110,9 +105,6 @@ describe('UptimeDetectorsList', () => {
 
     // Name
     expect(within(row).getByText('Uptime Detector')).toBeInTheDocument();
-
-    // Should NOT render service incidents overlay
-    expect(screen.queryByTestId('cron-service-incidents')).not.toBeInTheDocument();
 
     // Timeline visualization should render ticks once stats load
     expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);

--- a/static/app/views/detectors/list/uptime.spec.tsx
+++ b/static/app/views/detectors/list/uptime.spec.tsx
@@ -15,6 +15,11 @@ import {
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import UptimeDetectorsList from 'sentry/views/detectors/list/uptime';
 
+// Mock the service incidents component to verify it's NOT rendered
+jest.mock('sentry/views/insights/crons/components/serviceIncidents', () => ({
+  CronServiceIncidents: () => <div data-test-id="cron-service-incidents" />,
+}));
+
 describe('UptimeDetectorsList', () => {
   const organization = OrganizationFixture({
     features: ['workflow-engine-ui'],
@@ -105,6 +110,9 @@ describe('UptimeDetectorsList', () => {
 
     // Name
     expect(within(row).getByText('Uptime Detector')).toBeInTheDocument();
+
+    // Should NOT render service incidents overlay
+    expect(screen.queryByTestId('cron-service-incidents')).not.toBeInTheDocument();
 
     // Timeline visualization should render ticks once stats load
     expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -1,5 +1,6 @@
 import {createContext, useContext} from 'react';
 
+import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 
 export interface MonitorListAdditionalColumn {
@@ -21,6 +22,9 @@ export interface MonitorViewContextValue {
    * These appear to the right of the default columns and to the left of the visualization.
    */
   additionalColumns?: MonitorListAdditionalColumn[];
+  renderTimelineOverlay?: (props: {
+    timeWindowConfig: TimeWindowConfig;
+  }) => React.ReactNode;
   renderVisualization?: (params: RenderVisualizationParams) => React.ReactNode;
 }
 

--- a/static/app/views/insights/crons/components/serviceIncidents.tsx
+++ b/static/app/views/insights/crons/components/serviceIncidents.tsx
@@ -110,7 +110,10 @@ function CronServiceIncidents({timeWindowConfig}: CronServiceIncidentsProps) {
             </Fragment>
           }
         >
-          <IncidentIndicator css={position}>
+          <IncidentIndicator
+            css={position}
+            data-test-id="cron-service-incident-indicator"
+          >
             <StyledIconExclamation />
           </IncidentIndicator>
         </IncidentHovercard>


### PR DESCRIPTION
The CronServiceIncidents overlay was being rendered on all detector types including uptime monitors. This moves the overlay rendering to a context prop (renderTimelineOverlay) that is only provided by cron detectors, ensuring it doesn't appear on uptime monitors.