### PR TITLE
feat(ACI): Document detector workflow details endpoint

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -185,3 +185,10 @@ class WorkflowEngineExamples:
             response_only=True,
         )
     ]
+
+    GET_DETECTOR_WORKFLOW = [
+        OpenApiExample(
+            "Fetch a detector workflow connection",
+            value={"id": "123", "detectorId": "456", "workflowId": "789"},
+        )
+    ]

--- a/src/sentry/workflow_engine/endpoints/organization_detector_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_workflow_details.py
@@ -19,6 +19,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
 from sentry.apidocs.parameters import DetectorWorkflowParams, GlobalParams
 from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
@@ -32,6 +33,7 @@ from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 
 
 @region_silo_endpoint
+@extend_schema(tags=["Workflows"])
 class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
     def convert_args(self, request: Request, detector_workflow_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
@@ -52,7 +54,7 @@ class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDetectorPermission,)
 
     @extend_schema(
-        operation_id="Fetch a Detector-Workflow Connection",
+        operation_id="Fetch a Monitor-Alert Connection",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             DetectorWorkflowParams.DETECTOR_WORKFLOW_ID,
@@ -64,12 +66,13 @@ class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=WorkflowEngineExamples.GET_DETECTOR_WORKFLOW,
     )
     def get(
         self, request: Request, organization: Organization, detector_workflow: DetectorWorkflow
     ):
         """
-        Returns a DetectorWorkflow
+        Returns a connection between a Monitor and an Alert
         """
         serialized_detector_workflow = serialize(
             detector_workflow,
@@ -79,7 +82,7 @@ class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
         return Response(serialized_detector_workflow)
 
     @extend_schema(
-        operation_id="Remove a Detector-Workflow Connection",
+        operation_id="Remove a Monitor-Alert Connection",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             DetectorWorkflowParams.DETECTOR_WORKFLOW_ID,
@@ -95,7 +98,7 @@ class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
         self, request: Request, organization: Organization, detector_workflow: DetectorWorkflow
     ):
         """
-        Delete a DetectorWorkflow
+        Delete a connection between a Monitor and an Alert
         """
         if not can_edit_detector_workflow_connections(detector_workflow.detector, request):
             raise PermissionDenied


### PR DESCRIPTION
Add documentation for the detector workflow details endpoint.

This will not be actually published yet, but to prepare all of the new workflow engine endpoints we're keeping them marked as experimental and not adding the new sidebar item just yet.

I have noted and will be creating follow up tickets for the fact that the GET results are not paginated and it would be much more useful if you could provide the detector and/or workflow ID as query params.

<img width="871" height="684" alt="Screenshot 2026-01-14 at 12 12 02 PM" src="https://github.com/user-attachments/assets/e84ca85c-07f7-4441-a10b-c22676ae0079" />
<img width="858" height="647" alt="Screenshot 2026-01-14 at 12 12 18 PM" src="https://github.com/user-attachments/assets/bb6c1398-5103-4e75-a74b-f02c9272b286" />
<img width="479" height="342" alt="Screenshot 2026-01-14 at 12 12 25 PM" src="https://github.com/user-attachments/assets/2c2a6aa7-f24f-44a8-8da7-48de855056de" />
