### PR TITLE
fix(aci): Handle ANY_SHORT_CIRCUIT condition in alert builder

### DIFF
--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -1,9 +1,19 @@
 import {t} from 'sentry/locale';
 import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 
-export const FILTER_MATCH_OPTIONS = [
+export const FILTER_MATCH_OPTIONS: Array<{
+  label: string;
+  value: DataConditionGroupLogicType;
+  alias?: DataConditionGroupLogicType;
+}> = [
   {value: DataConditionGroupLogicType.ALL, label: t('all')},
-  {value: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT, label: t('any')},
+  {
+    value: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+    label: t('any'),
+    // We do not expose ANY as a valid option because it should be equivalent to ANY_SHORT_CIRCUIT.
+    // However, it is valid, so we need to handle it in the UI.
+    alias: DataConditionGroupLogicType.ANY,
+  },
   {value: DataConditionGroupLogicType.NONE, label: t('none')},
 ];
 

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -11,11 +11,11 @@ import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextBu
 import {IconAdd, IconDelete, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
-import type {
-  DataConditionGroup,
+import {
   DataConditionGroupLogicType,
+  DataConditionHandlerGroupType,
+  type DataConditionGroup,
 } from 'sentry/types/workflowEngine/dataConditions';
-import {DataConditionHandlerGroupType} from 'sentry/types/workflowEngine/dataConditions';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -71,7 +71,12 @@ export default function AutomationBuilder() {
                       isSearchable={false}
                       isClearable={false}
                       name={`${state.triggers.id}.logicType`}
-                      value={state.triggers.logicType}
+                      value={
+                        // We do not expose ANY as a valid option, but it is
+                        state.triggers.logicType === DataConditionGroupLogicType.ANY
+                          ? DataConditionGroupLogicType.ANY_SHORT_CIRCUIT
+                          : state.triggers.logicType
+                      }
                       onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
                         actions.updateWhenLogicType(option.value)
                       }
@@ -187,7 +192,13 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
                     flexibleControlStateSize
                     options={FILTER_MATCH_OPTIONS}
                     size="xs"
-                    value={actionFilter.logicType}
+                    value={
+                      FILTER_MATCH_OPTIONS.find(
+                        choice =>
+                          choice.value === actionFilter.logicType ||
+                          choice.alias === actionFilter.logicType
+                      )?.value || actionFilter.logicType
+                    }
                     onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
                       actions.updateIfLogicType(actionFilter.id, option.value)
                     }

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -171,7 +171,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
     <IfThenWrapper>
       <Step>
         <Flex direction="column" gap="md">
-          <StepLead>
+          <StepLead data-test-id="action-filter-logic-type">
             {tct('[if: If] [selector] of these filters match', {
               if: <ConditionBadge />,
               selector: (

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -96,8 +96,11 @@ function ActionFilter({actionFilter, showDivider}: ActionFilterProps) {
         {tct('[if:If] [logicType] of these filters match', {
           if: <ConditionBadge />,
           logicType:
-            FILTER_MATCH_OPTIONS.find(choice => choice.value === actionFilter.logicType)
-              ?.label || actionFilter.logicType,
+            FILTER_MATCH_OPTIONS.find(
+              choice =>
+                choice.value === actionFilter.logicType ||
+                choice.alias === actionFilter.logicType
+            )?.label || actionFilter.logicType,
         })}
       </ConditionGroupHeader>
       {actionFilter.conditions.length > 0

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -1,4 +1,4 @@
-import {AutomationFixture} from 'sentry-fixture/automations';
+import {ActionFilterFixture, AutomationFixture} from 'sentry-fixture/automations';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -10,6 +10,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useParams} from 'sentry/utils/useParams';
 import AutomationEdit from 'sentry/views/automations/edit';
@@ -76,6 +77,29 @@ describe('EditAutomation', () => {
     jest.mocked(useParams).mockReturnValue({
       automationId: automation.id,
     });
+  });
+
+  it('displays `any` for ANY in the filter logic dropdown', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+      method: 'GET',
+      body: {
+        ...automation,
+        actionFilters: [
+          ActionFilterFixture({logicType: DataConditionGroupLogicType.ANY}),
+        ],
+      },
+    });
+
+    render(<AutomationEdit />, {
+      organization,
+    });
+
+    // Wait for the form to load
+    expect(await screen.findByRole('button', {name: 'Save'})).toBeInTheDocument();
+
+    const filterLogicType = screen.getByTestId('action-filter-logic-type');
+    expect(within(filterLogicType).getByText('any')).toBeInTheDocument();
   });
 
   it('calls delete mutation when deletion is confirmed', async () => {


### PR DESCRIPTION
Migrated metric alerts were using ANY instead of ANY_SHORT_CIRCUIT which has no corresponding value, so it displayed as an empty dropdown. This is a quick fix so that we show `any` in this case.

Before:

<img width="1130" height="404" alt="CleanShot 2026-01-14 at 12 32 26@2x" src="https://github.com/user-attachments/assets/3a908192-e308-4a60-b665-b72f70dc65a7" />

After:

<img width="1112" height="404" alt="CleanShot 2026-01-14 at 12 31 52@2x" src="https://github.com/user-attachments/assets/a261409f-32e0-42d5-833b-cc02c6fe89c1" />
