### PR TITLE
perf(releases): Batch CommitAuthor queries in set_commits

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -297,11 +297,11 @@ def create_commit_authors(commit_list, release):
             # Lowercase to match CommitAuthorManager.get_or_create behavior
             author_email = author_email.lower()
 
-        # Store normalized email back in data for later lookup
-        data["_normalized_email"] = author_email
+            # Store normalized email back in data for later lookup
+            data["_normalized_email"] = author_email
 
-        if author_email and author_email not in author_data_by_email:
-            author_data_by_email[author_email] = {"name": data.get("author_name")}
+            if author_email not in author_data_by_email:
+                author_data_by_email[author_email] = {"name": data.get("author_name")}
 
     if not author_data_by_email:
         # No authors to process, set all to None

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -283,8 +283,8 @@ def update_group_resolutions(release, commit_author_by_commit):
 
 
 def create_commit_authors(commit_list, release):
-    authors = {}
-
+    # Step 1: Collect unique emails and their author data
+    author_data_by_email = {}
     for data in commit_list:
         author_email = data.get("author_email")
         if author_email is None and data.get("author_name"):
@@ -293,23 +293,70 @@ def create_commit_authors(commit_list, release):
             )
 
         author_email = truncatechars(author_email, 75)
+        if author_email:
+            # Lowercase to match CommitAuthorManager.get_or_create behavior
+            author_email = author_email.lower()
 
-        if not author_email:
-            author = None
-        elif author_email not in authors:
-            author_data = {"name": data.get("author_name")}
-            author, created = CommitAuthor.objects.get_or_create(
+        # Store normalized email back in data for later lookup
+        data["_normalized_email"] = author_email
+
+        if author_email and author_email not in author_data_by_email:
+            author_data_by_email[author_email] = {"name": data.get("author_name")}
+
+    if not author_data_by_email:
+        # No authors to process, set all to None
+        for data in commit_list:
+            data["author_model"] = None
+        return
+
+    # Step 2: Batch fetch existing authors (1 query instead of N)
+    existing_authors = {
+        author.email: author
+        for author in CommitAuthor.objects.filter(
+            organization_id=release.organization_id,
+            email__in=author_data_by_email.keys(),
+        )
+    }
+
+    # Step 3: Identify authors needing creation
+    emails_to_create = set(author_data_by_email.keys()) - set(existing_authors.keys())
+
+    if emails_to_create:
+        # Step 4: Batch create missing authors (1 query)
+        authors_to_create = [
+            CommitAuthor(
                 organization_id=release.organization_id,
-                email=author_email,
-                defaults=author_data,
+                email=email,
+                name=author_data_by_email[email]["name"],
             )
-            if author.name != author_data["name"]:
-                author.update(name=author_data["name"])
-            authors[author_email] = author
-        else:
-            author = authors[author_email]
+            for email in emails_to_create
+        ]
+        CommitAuthor.objects.bulk_create(authors_to_create, ignore_conflicts=True)
 
-        data["author_model"] = author
+        # Re-fetch to get IDs (needed because bulk_create with ignore_conflicts
+        # doesn't populate IDs on PostgreSQL for conflicting rows)
+        newly_created = CommitAuthor.objects.filter(
+            organization_id=release.organization_id,
+            email__in=emails_to_create,
+        )
+        for author in newly_created:
+            existing_authors[author.email] = author
+
+    # Step 5: Batch update names where needed (1 query)
+    authors_to_update = []
+    for email, author in existing_authors.items():
+        expected_name = author_data_by_email[email]["name"]
+        if author.name != expected_name:
+            author.name = expected_name
+            authors_to_update.append(author)
+
+    if authors_to_update:
+        CommitAuthor.objects.bulk_update(authors_to_update, ["name"])
+
+    # Step 6: Assign author models to commit data
+    for data in commit_list:
+        author_email = data.pop("_normalized_email", None)
+        data["author_model"] = existing_authors.get(author_email) if author_email else None
 
 
 def create_repositories(commit_list, release):

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -283,7 +283,7 @@ def update_group_resolutions(release, commit_author_by_commit):
 
 
 def create_commit_authors(commit_list, release):
-    # Step 1: Collect unique emails and their author data
+    # Collect unique emails and their author data
     author_data_by_email = {}
     for data in commit_list:
         author_email = data.get("author_email")
@@ -309,7 +309,7 @@ def create_commit_authors(commit_list, release):
             data["author_model"] = None
         return
 
-    # Step 2: Batch fetch existing authors (1 query instead of N)
+    # Batch fetch existing authors
     existing_authors = {
         author.email: author
         for author in CommitAuthor.objects.filter(
@@ -318,11 +318,11 @@ def create_commit_authors(commit_list, release):
         )
     }
 
-    # Step 3: Identify authors needing creation
+    # Identify authors needing creation
     emails_to_create = set(author_data_by_email.keys()) - set(existing_authors.keys())
 
     if emails_to_create:
-        # Step 4: Batch create missing authors (1 query)
+        # Batch create missing authors
         authors_to_create = [
             CommitAuthor(
                 organization_id=release.organization_id,
@@ -342,7 +342,7 @@ def create_commit_authors(commit_list, release):
         for author in newly_created:
             existing_authors[author.email] = author
 
-    # Step 5: Batch update names where needed (1 query)
+    # Batch update names where needed
     authors_to_update = []
     for email, author in existing_authors.items():
         expected_name = author_data_by_email[email]["name"]
@@ -353,7 +353,7 @@ def create_commit_authors(commit_list, release):
     if authors_to_update:
         CommitAuthor.objects.bulk_update(authors_to_update, ["name"])
 
-    # Step 6: Assign author models to commit data
+    # Assign author models to commit data
     for data in commit_list:
         author_email = data.pop("_normalized_email", None)
         data["author_model"] = existing_authors.get(author_email) if author_email else None


### PR DESCRIPTION
Replace N+1 get_or_create queries with batch operations:
- Batch fetch existing authors with single filter(email__in=...)
- Batch create missing authors with bulk_create(ignore_conflicts=True)
- Batch update changed names with bulk_update

Reduces query count from 2N+ to at most 4 queries regardless of author count, improving performance for releases with many unique commit authors.

n+1 issue  
https://sentry.sentry.io/issues/6234355863/
