### PR TITLE
fix(crons): Enable pointer events on incident indicator

### DIFF
--- a/static/app/views/insights/crons/components/serviceIncidents.tsx
+++ b/static/app/views/insights/crons/components/serviceIncidents.tsx
@@ -157,6 +157,7 @@ const IncidentIndicator = styled('div')`
   align-items: center;
   z-index: 2;
   height: 20px;
+  pointer-events: auto;
 
   > svg,
   &:before {


### PR DESCRIPTION
Fixes a bug where pointer events were disabled on the incident indicator in the crons monitor timeline, preventing user interaction with the tooltip/indicator.

Added `pointer-events: auto` to the `IncidentIndicator` styled component to enable mouse events on the incident indicator