### PR TITLE
fix(insights): Display user misery loading state

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -76,7 +76,7 @@ function UserMiseryChart({
       <EventsRequest
         {...requestCommonProps}
         organization={organization}
-        showLoading={false}
+        showLoading
         includePrevious={false}
         yAxis={yAxis}
         partial


### PR DESCRIPTION
Currently collapses the component instead of holding it for the loading space

<img width="1139" height="299" alt="image" src="https://github.com/user-attachments/assets/c61b3214-eb87-4ccb-9f3e-1eb3d85ccc58" />

example https://sentry.sentry.io/insights/summary/?display=usermisery&project=1&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fevents-stats%2F&unselectedSeries=avg%28%29&unselectedSeries=p100%28%29&unselectedSeries=p99%28%29
