### PR TITLE
fix(groupsnooze): Set debounce on Snuba failure to prevent rate limits 

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -8,6 +8,7 @@ from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry import options, tsdb
+from sentry.utils.snuba import RateLimitExceeded
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -232,9 +233,18 @@ class GroupSnooze(Model):
 
         metrics.incr("groupsnooze.test_user_counts", tags={"cached": "true", "hit": "false"})
         metrics.incr("groupsnooze.test_user_counts.snuba_call")
-        real_count = group.count_users_seen(
-            referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE.value
-        )
+        try:
+            real_count = group.count_users_seen(
+                referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE.value
+            )
+        except RateLimitExceeded:
+            # Set debounce even on failure to prevent thundering herd when Snuba
+            # is rate-limited. Without this, every event would retry Snuba and fail,
+            # causing thousands of exceptions instead of just one per debounce period.
+            if snuba_debounce_ttl > 0:
+                cache.set(debounce_key, True, snuba_debounce_ttl)
+                metrics.incr("groupsnooze.test_user_counts.debounce_set_on_error")
+            raise
         if snuba_debounce_ttl > 0 and real_count < threshold * 0.95:
             cache.set(debounce_key, real_count, snuba_debounce_ttl)
         cache.set(cache_key, real_count, CACHE_TTL)

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -8,7 +8,6 @@ from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry import options, tsdb
-from sentry.utils.snuba import RateLimitExceeded
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -23,6 +22,7 @@ from sentry.issues.constants import get_issue_tsdb_group_model, get_issue_tsdb_u
 from sentry.snuba.referrer import Referrer
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.utils.snuba import RateLimitExceeded
 
 if TYPE_CHECKING:
     from sentry.models.group import Group

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -12,8 +12,8 @@ from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, Test
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
-from sentry.utils.snuba import RateLimitExceeded
 from sentry.utils.samples import load_data
+from sentry.utils.snuba import RateLimitExceeded
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -10,7 +10,9 @@ from sentry.models.group import Group
 from sentry.models.groupsnooze import GroupSnooze
 from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
+from sentry.utils.snuba import RateLimitExceeded
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -444,3 +446,35 @@ class GroupSnoozeTest(
             assert not snooze.is_valid(test_rates=True)
             assert mocked_get_timeseries_sums.call_count == 3
             cache_spy.set.assert_called_with(cache_key, 100, 3600)
+
+    @override_options({"snuba.groupsnooze.user-counts-debounce-seconds": 60})
+    def test_test_user_counts_sets_debounce_on_snuba_failure(self) -> None:
+        """
+        When Snuba call fails (e.g., rate limited), the debounce key should still be set
+        to prevent thundering herd - thousands of retries all failing.
+        """
+        from sentry.utils.cache import cache
+
+        snooze = GroupSnooze.objects.create(group=self.group, user_count=100)
+
+        cache_key = f"groupsnooze:v1:{snooze.id}:test_user_counts:events_seen_counter"
+        debounce_key = f"groupsnooze:v1:{snooze.id}:test_user_counts:snuba_cooldown"
+
+        # Force counter past threshold so we attempt Snuba call
+        cache.set(cache_key, 200, 3600)
+
+        with mock.patch.object(
+            snooze.group,
+            "count_users_seen",
+            side_effect=RateLimitExceeded("Snuba rate limited"),
+        ) as mocked_count_users_seen:
+            # First call should fail but set debounce
+            with pytest.raises(RateLimitExceeded):
+                snooze.is_valid(test_rates=True)
+
+            assert mocked_count_users_seen.call_count == 1
+            assert cache.get(debounce_key) is True
+
+            # Second call should hit debounce and NOT retry Snuba
+            assert snooze.is_valid(test_rates=True)
+            assert mocked_count_users_seen.call_count == 1


### PR DESCRIPTION
right now if we hit the snuba rate limit, we don't set the debounce which causes us to hit the rate limits more until we are below the rate limit threshold. now if we see it, we debounce again