### PR TITLE
fix(top-issues): Fix TopIssuesDrawer unconstrained width on long error messages in stacktrace

### DIFF
--- a/static/app/views/issueList/pages/topIssuesDrawer.tsx
+++ b/static/app/views/issueList/pages/topIssuesDrawer.tsx
@@ -351,7 +351,7 @@ function ClusterStackTrace({groupId}: ClusterStackTraceProps) {
 
   if (!stacktrace) {
     return (
-      <Flex direction="column" gap="sm">
+      <StackTraceWrapper>
         <IssuePreview
           event={event}
           group={group}
@@ -360,7 +360,7 @@ function ClusterStackTrace({groupId}: ClusterStackTraceProps) {
         <Text size="sm" variant="muted">
           {t('No stack trace available for this issue.')}
         </Text>
-      </Flex>
+      </StackTraceWrapper>
     );
   }
 
@@ -380,26 +380,26 @@ function ClusterStackTrace({groupId}: ClusterStackTraceProps) {
 
   if (isNativePlatform(platform)) {
     return (
-      <Flex direction="column" gap="sm">
+      <StackTraceWrapper>
         <IssuePreview
           event={event}
           group={group}
           issueUrl={`/organizations/${organization.slug}/issues/${groupId}/`}
         />
         <NativeContent {...commonProps} hideIcon maxDepth={5} />
-      </Flex>
+      </StackTraceWrapper>
     );
   }
 
   return (
-    <Flex direction="column" gap="sm">
+    <StackTraceWrapper>
       <IssuePreview
         event={event}
         group={group}
         issueUrl={`/organizations/${organization.slug}/issues/${groupId}/`}
       />
       <StackTraceContent {...commonProps} expandFirstFrame hideIcon />
-    </Flex>
+    </StackTraceWrapper>
   );
 }
 
@@ -1107,6 +1107,14 @@ const IssuePreviewLink = styled(Link)`
 
 const DrawerContentBody = styled(DrawerBody)`
   padding: 0;
+`;
+
+const StackTraceWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+  width: 100%;
+  contain: inline-size;
 `;
 
 const TagsTableHeader = styled('div')`


### PR DESCRIPTION
Currently in the Top Issues Drawer when you expand the `Example Stack Trace` section and the error message at the top is really long it will overflow and the drawer will extend to the right and have horizontal scrolling - not what we want.

In this screenshot I opened one such instance scrolled to the right:
<img width="932" height="718" alt="Screenshot 2026-01-14 at 3 05 25 PM" src="https://github.com/user-attachments/assets/18f32057-0cd3-4816-8893-c491ac2d8f4e" />

Added a fix to stop overflow
<img width="954" height="827" alt="Screenshot 2026-01-16 at 10 14 55 AM" src="https://github.com/user-attachments/assets/be722746-f85a-413b-8d0b-a0b744d2dcb7" />

The text now cuts off, but I think thats ok, thats the way it behaves in the main page as well as this line can get really long, and if someone really wants they can dig in and find the full line.
