### PR TITLE
fix(top-issues): Swap Title and Subtitle in Drawer to match Cluster Card

### DIFF
--- a/static/app/views/issueList/pages/topIssuesDrawer.tsx
+++ b/static/app/views/issueList/pages/topIssuesDrawer.tsx
@@ -854,12 +854,11 @@ export function ClusterDetailDrawer({cluster}: {cluster: ClusterSummary}) {
               <Heading as="h2" size="lg">
                 {renderWithInlineCode(cluster.impact || cluster.title)}
               </Heading>
-              <Text size="sm" variant="muted">
-                {cluster.impact ? (
-                  <Fragment>{renderWithInlineCode(cluster.title)} </Fragment>
-                ) : null}
-                [CLUSTER-{cluster.cluster_id}]
-              </Text>
+              {cluster.impact ? (
+                <Text size="sm" variant="muted">
+                  {renderWithInlineCode(cluster.title)}
+                </Text>
+              ) : null}
             </Flex>
             <Flex wrap="wrap" align="center" gap="md">
               {relevancePercent !== null && (

--- a/static/app/views/issueList/pages/topIssuesDrawer.tsx
+++ b/static/app/views/issueList/pages/topIssuesDrawer.tsx
@@ -852,7 +852,7 @@ export function ClusterDetailDrawer({cluster}: {cluster: ClusterSummary}) {
           <Container padding="2xl" borderBottom="muted">
             <Flex direction="column" gap="xs" style={{marginBottom: theme.space.lg}}>
               <Heading as="h2" size="lg">
-                {renderWithInlineCode(cluster.impact ?? cluster.title)}
+                {renderWithInlineCode(cluster.impact || cluster.title)}
               </Heading>
               <Text size="sm" variant="muted">
                 {cluster.impact ? (

--- a/static/app/views/issueList/pages/topIssuesDrawer.tsx
+++ b/static/app/views/issueList/pages/topIssuesDrawer.tsx
@@ -852,10 +852,12 @@ export function ClusterDetailDrawer({cluster}: {cluster: ClusterSummary}) {
           <Container padding="2xl" borderBottom="muted">
             <Flex direction="column" gap="xs" style={{marginBottom: theme.space.lg}}>
               <Heading as="h2" size="lg">
-                {renderWithInlineCode(cluster.title)}
+                {renderWithInlineCode(cluster.impact ?? cluster.title)}
               </Heading>
               <Text size="sm" variant="muted">
-                {cluster.impact ? `${cluster.impact} ` : ''}
+                {cluster.impact ? (
+                  <Fragment>{renderWithInlineCode(cluster.title)} </Fragment>
+                ) : null}
                 [CLUSTER-{cluster.cluster_id}]
               </Text>
             </Flex>


### PR DESCRIPTION
The title and subtitle are swapped inside the drawer from the card, as we actually use the "Impact" field as the top title in the Cluster Card, swapped it.