### PR TITLE
fix(dashboards): Fix dashboard widget crosshair overlay synchronization

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -29,6 +29,7 @@ import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueu
 import type {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {trackEngagementAnalytics} from 'sentry/views/dashboards/widgetBuilder/utils/trackEngagementAnalytics';
 
+import {WidgetSyncContextProvider} from './contexts/widgetSyncContext';
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import type {Position} from './layoutUtils';
 import {
@@ -393,63 +394,65 @@ function Dashboard({
   const canModifyLayout = !isMobile && isEditingDashboard;
 
   return (
-    <GridLayout
-      breakpoints={BREAKPOINTS(theme)}
-      cols={COLUMNS}
-      rowHeight={ROW_HEIGHT}
-      margin={WIDGET_MARGINS}
-      draggableHandle={`.${DRAG_HANDLE_CLASS}`}
-      draggableCancel={`.${DRAG_RESIZE_CLASS}`}
-      layouts={layouts}
-      onLayoutChange={handleLayoutChange}
-      onBreakpointChange={handleBreakpointChange}
-      isDraggable={canModifyLayout}
-      isResizable={canModifyLayout}
-      resizeHandle={
-        <ResizeHandle
-          aria-label={t('Resize Widget')}
-          data-test-id="custom-resize-handle"
-          className={DRAG_RESIZE_CLASS}
-          size="xs"
-          borderless
-          icon={<IconResize />}
-        />
-      }
-      useCSSTransforms={false}
-      isBounded
-    >
-      {widgetsWithLayout.map((widget, index) => (
-        <div key={constructGridItemKey(widget)} data-grid={widget.layout}>
-          <SortableWidget
-            widget={widget}
-            widgetLegendState={widgetLegendState}
-            isEditingDashboard={isEditingDashboard}
-            widgetLimitReached={widgetLimitReached}
-            onDelete={handleDeleteWidget(widget)}
-            onEdit={handleEditWidget(index)}
-            onDuplicate={handleDuplicateWidget(widget)}
-            onSetTransactionsDataset={() => handleChangeSplitDataset(widget, index)}
-            isEmbedded={isEmbedded}
-            isPreview={isPreview}
-            isPrebuiltDashboard={defined(dashboard.prebuiltId)}
-            dashboardFilters={getDashboardFiltersFromURL(location) ?? dashboard.filters}
-            dashboardPermissions={dashboard.permissions}
-            dashboardCreator={dashboard.createdBy}
-            isMobile={isMobile}
-            windowWidth={windowWidth}
-            index={String(index)}
-            newlyAddedWidget={newlyAddedWidget}
-            onNewWidgetScrollComplete={onNewWidgetScrollComplete}
-            useTimeseriesVisualization={useTimeseriesVisualization}
+    <WidgetSyncContextProvider groupName={DASHBOARD_CHART_GROUP}>
+      <GridLayout
+        breakpoints={BREAKPOINTS(theme)}
+        cols={COLUMNS}
+        rowHeight={ROW_HEIGHT}
+        margin={WIDGET_MARGINS}
+        draggableHandle={`.${DRAG_HANDLE_CLASS}`}
+        draggableCancel={`.${DRAG_RESIZE_CLASS}`}
+        layouts={layouts}
+        onLayoutChange={handleLayoutChange}
+        onBreakpointChange={handleBreakpointChange}
+        isDraggable={canModifyLayout}
+        isResizable={canModifyLayout}
+        resizeHandle={
+          <ResizeHandle
+            aria-label={t('Resize Widget')}
+            data-test-id="custom-resize-handle"
+            className={DRAG_RESIZE_CLASS}
+            size="xs"
+            borderless
+            icon={<IconResize />}
           />
-        </div>
-      ))}
-      {isEditingDashboard && !widgetLimitReached && !isPreview && (
-        <AddWidgetWrapper key={ADD_WIDGET_BUTTON_DRAG_ID} data-grid={addWidgetLayout}>
-          <AddWidget onAddWidget={onAddWidget} />
-        </AddWidgetWrapper>
-      )}
-    </GridLayout>
+        }
+        useCSSTransforms={false}
+        isBounded
+      >
+        {widgetsWithLayout.map((widget, index) => (
+          <div key={constructGridItemKey(widget)} data-grid={widget.layout}>
+            <SortableWidget
+              widget={widget}
+              widgetLegendState={widgetLegendState}
+              isEditingDashboard={isEditingDashboard}
+              widgetLimitReached={widgetLimitReached}
+              onDelete={handleDeleteWidget(widget)}
+              onEdit={handleEditWidget(index)}
+              onDuplicate={handleDuplicateWidget(widget)}
+              onSetTransactionsDataset={() => handleChangeSplitDataset(widget, index)}
+              isEmbedded={isEmbedded}
+              isPreview={isPreview}
+              isPrebuiltDashboard={defined(dashboard.prebuiltId)}
+              dashboardFilters={getDashboardFiltersFromURL(location) ?? dashboard.filters}
+              dashboardPermissions={dashboard.permissions}
+              dashboardCreator={dashboard.createdBy}
+              isMobile={isMobile}
+              windowWidth={windowWidth}
+              index={String(index)}
+              newlyAddedWidget={newlyAddedWidget}
+              onNewWidgetScrollComplete={onNewWidgetScrollComplete}
+              useTimeseriesVisualization={useTimeseriesVisualization}
+            />
+          </div>
+        ))}
+        {isEditingDashboard && !widgetLimitReached && !isPreview && (
+          <AddWidgetWrapper key={ADD_WIDGET_BUTTON_DRAG_ID} data-grid={addWidgetLayout}>
+            <AddWidget onAddWidget={onAddWidget} />
+          </AddWidgetWrapper>
+        )}
+      </GridLayout>
+    </WidgetSyncContextProvider>
   );
 }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -150,7 +150,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const hasReleaseBubbles =
     props.showReleaseAs !== 'none' && props.showReleaseAs === 'bubble';
 
-  const {onDataZoom, ...chartZoomProps} = useChartZoom({
+  const {
+    onDataZoom,
+    onChartReady: onChartReadyZoom,
+    ...chartZoomProps
+  } = useChartZoom({
     saveOnZoom: true,
   });
 
@@ -429,19 +433,19 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         plottable.handleChartRef?.(e);
       }
 
-      const echartsInstance = e.getEchartsInstance();
-      registerWithWidgetSyncContext(echartsInstance);
-
       if (hasReleaseBubblesSeries) {
         connectReleaseBubbleChartRef(e);
       }
     },
-    [
-      hasReleaseBubblesSeries,
-      connectReleaseBubbleChartRef,
-      registerWithWidgetSyncContext,
-      props.plottables,
-    ]
+    [hasReleaseBubblesSeries, connectReleaseBubbleChartRef, props.plottables]
+  );
+
+  const handleChartReady = useCallback(
+    (instance: echarts.ECharts) => {
+      onChartReadyZoom(instance);
+      registerWithWidgetSyncContext(instance);
+    },
+    [onChartReadyZoom, registerWithWidgetSyncContext]
   );
 
   const showXAxisProp = props.showXAxis ?? 'auto';
@@ -652,6 +656,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         brush={brush}
         onBrushStart={onBrushStart}
         onBrushEnd={onBrushEnd}
+        onChartReady={handleChartReady}
         isGroupedByDate
         useMultilineDate
         start={start ? new Date(start) : undefined}


### PR DESCRIPTION
Fixes the crosshair overlay synchronization across dashboard widgets when using the new `TimeSeriesWidgetVisualization` component.

## Problem
The crosshair overlay that synchronizes cursor position across dashboard widgets was broken when the feature flag was enabled. It worked with the legacy chart components but not with the new visualization.

## Root Cause
1. The Dashboard component wasn't providing the `WidgetSyncContextProvider` needed by the new visualization components.
2. The `TimeSeriesWidgetVisualization` was registering charts in a ref callback that fires too early, before the chart is fully initialized.

## Solution
1. Wrapped the dashboard's `GridLayout` with `WidgetSyncContextProvider` using the same `DASHBOARD_CHART_GROUP` name for consistency.
2. Moved chart registration from the ref callback to the `onChartReady` callback, which fires after the chart is fully initialized. This matches the pattern used by legacy chart components.
3. Ensured both the zoom handler and sync context registration are called in the `onChartReady` callback.

Fixes DAIN-1155