### PR TITLE
ref(automations): Remove deprecatedRouteProps from automation redirect components

### DIFF
--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,3 +1,5 @@
+import {Outlet} from 'react-router-dom';
+
 import Redirect from 'sentry/components/redirect';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import type {SentryRouteObject} from 'sentry/router/types';
@@ -9,7 +11,6 @@ export const automationRoutes: SentryRouteObject = {
   children: [
     {
       component: RedirectToRuleList,
-      deprecatedRouteProps: true,
       children: [
         {index: true, component: make(() => import('sentry/views/automations/list'))},
       ],
@@ -17,7 +18,6 @@ export const automationRoutes: SentryRouteObject = {
     {
       path: 'new',
       component: RedirectToNewRule,
-      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -28,7 +28,6 @@ export const automationRoutes: SentryRouteObject = {
     {
       path: ':automationId/',
       component: RedirectToRuleList,
-      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -43,7 +42,7 @@ export const automationRoutes: SentryRouteObject = {
   ],
 };
 
-function RedirectToRuleList({children}: {children: React.ReactNode}) {
+function RedirectToRuleList() {
   const organization = useOrganization();
 
   const hasRedirectOptOut = organization.features.includes(
@@ -63,10 +62,10 @@ function RedirectToRuleList({children}: {children: React.ReactNode}) {
     );
   }
 
-  return children;
+  return <Outlet />;
 }
 
-function RedirectToNewRule({children}: {children: React.ReactNode}) {
+function RedirectToNewRule() {
   const organization = useOrganization();
 
   const hasRedirectOptOut = organization.features.includes(
@@ -86,5 +85,5 @@ function RedirectToNewRule({children}: {children: React.ReactNode}) {
     );
   }
 
-  return children;
+  return <Outlet />;
 }


### PR DESCRIPTION
## Summary

Update automation redirect components to use React Router v6 patterns by removing `deprecatedRouteProps: true` from 3 route definitions.

## Changes

- **RedirectToRuleList**: Removed `children` prop, replaced with `<Outlet />`
- **RedirectToNewRule**: Removed `children` prop, replaced with `<Outlet />`
- **Route definitions**: Removed `deprecatedRouteProps: true` from all 3 automation route definitions

## Testing

- ✅ All automation tests pass (11 test suites, 67 tests)
- ✅ TypeScript type checking passes
- ⏳ Manual testing needed: Navigate to automation routes at `/organizations/:orgId/automations/alerts/` to verify redirect behavior works correctly

## Context

These components already use the `useOrganization()` hook and don't require any legacy router props. The redirect logic remains unchanged - we're only updating how child routes are rendered.

This is the first PR in a series to migrate all routes away from `deprecatedRouteProps: true`. See the broader plan at `/fixing-deprecated-route-props.md`.