### PR TITLE
fix(api): Add select_related to avoid N+1 query in releases POST

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -759,7 +759,9 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
 
             # In case of disabled Open Membership, we have to check for project-level
             # permissions on the existing release.
-            release_projects = ReleaseProject.objects.filter(release=release)
+            release_projects = ReleaseProject.objects.filter(release=release).select_related(
+                "project"
+            )
             existing_projects = [rp.project for rp in release_projects]
 
             if not request.access.has_projects_access(existing_projects):


### PR DESCRIPTION
When checking project-level permissions on an existing release, we iterate over ReleaseProject objects and access each project. You can see it calling `.project` on the next line.

n+1 issue  
https://sentry.sentry.io/issues/6639467495/
