### PR TITLE
chore(seer): add short id to cursor prompt

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -248,7 +248,11 @@ def _launch_agents_for_repos(
             "There are no repos in the Seer state to launch coding agents with, make sure you have repos connected to Seer and rerun this Issue Fix."
         )
 
-    prompt = get_coding_agent_prompt(run_id, trigger_source, instruction)
+    short_id = None
+    if autofix_state and auto_create_pr:
+        short_id = autofix_state.request.issue.get("short_id")
+
+    prompt = get_coding_agent_prompt(run_id, trigger_source, instruction, short_id)
 
     if not prompt:
         raise APIException("Issue fetching prompt to send to coding agents.")

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import orjson
 import pydantic
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 class AutofixIssue(TypedDict):
     id: int
     title: str
+    short_id: NotRequired[str | None]
 
 
 class AutofixStoppingPoint(StrEnum):
@@ -629,7 +630,10 @@ def get_autofix_prompt(run_id: int, include_root_cause: bool, include_solution: 
 
 
 def get_coding_agent_prompt(
-    run_id: int, trigger_source: AutofixTriggerSource, instruction: str | None = None
+    run_id: int,
+    trigger_source: AutofixTriggerSource,
+    instruction: str | None = None,
+    short_id: str | None = None,
 ) -> str:
     """Get the coding agent prompt with prefix from Seer API."""
     include_root_cause = trigger_source in [
@@ -641,6 +645,11 @@ def get_coding_agent_prompt(
     autofix_prompt = get_autofix_prompt(run_id, include_root_cause, include_solution)
 
     base_prompt = "Please fix the following issue. Ensure that your fix is fully working."
+
+    if short_id:
+        base_prompt = (
+            f"{base_prompt}\n\nInclude 'Fixes {short_id}' in the pull request description."
+        )
 
     if instruction and instruction.strip():
         base_prompt = f"{base_prompt}\n\n{instruction.strip()}"

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -593,7 +593,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             assert response.data["failed_count"] >= 0
 
             # Verify prompt was called with default trigger_source and no instruction
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, None)
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, None, None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1012,7 +1012,7 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             assert response.data["failed_count"] >= 0
 
             # Verify prompt was called with root_cause trigger_source and no instruction
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None)
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None, None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1090,7 +1090,7 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
             assert response.data["success"] is True
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None)
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None, None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1162,7 +1162,7 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             assert response.data["success"] is True
             assert response.data["launched_count"] >= 0
             assert response.data["failed_count"] >= 0
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None)
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.ROOT_CAUSE, None, None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1211,7 +1211,7 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             assert response.data["failed_count"] >= 0
 
             # Verify prompt was called with solution trigger_source and no instruction
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, None)
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, None, None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1346,7 +1346,7 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
 
             # Verify prompt was called with the instruction
             mock_get_prompt.assert_called_with(
-                123, AutofixTriggerSource.SOLUTION, "Use TypeScript instead of JavaScript"
+                123, AutofixTriggerSource.SOLUTION, "Use TypeScript instead of JavaScript", None
             )
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
@@ -1394,7 +1394,7 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
             assert response.data["success"] is True
 
             # CharField trims whitespace by default, so blank instruction becomes empty string
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, "")
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, "", None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1441,7 +1441,7 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
             assert response.data["success"] is True
 
             # Verify prompt was called with empty string instruction
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, "")
+            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, "", None)
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1491,7 +1491,9 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
             assert response.data["success"] is True
 
             # Verify prompt was called with the long instruction
-            mock_get_prompt.assert_called_with(123, AutofixTriggerSource.SOLUTION, long_instruction)
+            mock_get_prompt.assert_called_with(
+                123, AutofixTriggerSource.SOLUTION, long_instruction, None
+            )
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -1574,5 +1576,5 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
 
             # Verify prompt was called with both trigger_source and instruction
             mock_get_prompt.assert_called_with(
-                123, AutofixTriggerSource.ROOT_CAUSE, "Focus on the database queries"
+                123, AutofixTriggerSource.ROOT_CAUSE, "Focus on the database queries", None
             )


### PR DESCRIPTION
Addresses AIML-2267

Problem:
When seer RCA triggers the cursor integration to make a PR, we want it to include the Sentry short-id so it links back.

Solution:
Tell cursor in the prompt to include the short id if auto_create_pr is True

Testing:
Added unit tests to make sure the prompt is correct, but can only complete E2E testing once it is live for proper github/cursor integration. 
