### PR TITLE
fix(code-review): Use a flag that works in control region

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -690,9 +690,17 @@ register("overwatch.enabled-regions", default=[], flags=FLAG_AUTOMATOR_MODIFIABL
 # enable verbose debug logging for overwatch webhook forwarding
 register("overwatch.forward-webhooks.verbose", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Control forwarding of GitHub webhook events to Overwatch
-register("github.webhook.issue-comment", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# List of regions that should send directly to Seer (bypass Overwatch) per event type
+register(
+    "seer.code-review.direct-to-seer-regions.issue-comment",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "seer.code-review.direct-to-seer-regions.pull-request",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # List of GitHub org names that should always send directly to Seer (bypass Overwatch)
 register(

--- a/src/sentry/seer/code_review/webhooks/config.py
+++ b/src/sentry/seer/code_review/webhooks/config.py
@@ -1,7 +1,0 @@
-from sentry.integrations.github.webhook_types import GithubWebhookType
-
-# Mapping of webhook types to their corresponding option keys
-WEBHOOK_TYPE_TO_OPTION_KEY = {
-    GithubWebhookType.ISSUE_COMMENT: "github.webhook.issue-comment",
-    GithubWebhookType.PULL_REQUEST: "github.webhook.pr",
-}

--- a/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
+++ b/tests/sentry/overwatch_webhooks/test_webhook_forwarder.py
@@ -53,12 +53,16 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
             GithubWebhookType.INSTALLATION_REPOSITORIES,
         ]:
             headers = {GITHUB_WEBHOOK_TYPE_HEADER_KEY: event_type}
-            assert self.forwarder.should_forward_to_overwatch(headers) is True
+            is_forwardable, returned_event_type = self.forwarder.is_event_forwardable(headers)
+            assert is_forwardable is True
+            assert returned_event_type == event_type
 
         # Test events controlled by options
         for event_type in [GithubWebhookType.PULL_REQUEST, GithubWebhookType.ISSUE_COMMENT]:
             headers = {GITHUB_WEBHOOK_TYPE_HEADER_KEY: event_type}
-            assert self.forwarder.should_forward_to_overwatch(headers) is True
+            is_forwardable, returned_event_type = self.forwarder.is_event_forwardable(headers)
+            assert is_forwardable is True
+            assert returned_event_type == event_type
 
     def test_should_forward_to_overwatch_with_invalid_events(self):
         invalid_events = [
@@ -70,7 +74,9 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
         ]
 
         for event in invalid_events:
-            assert self.forwarder.should_forward_to_overwatch(event) is False
+            is_forwardable, returned_event_type = self.forwarder.is_event_forwardable(event)
+            assert is_forwardable is False
+            assert returned_event_type is None
 
     def test_get_organizations_no_org_integrations(self):
         orgs = self.forwarder._get_org_summaries_by_region_for_integration(self.integration)
@@ -466,59 +472,80 @@ class OverwatchGithubWebhookForwarderTest(TestCase):
             "request_type": DEFAULT_REQUEST_TYPE,
         }
 
+    @responses.activate
+    @override_options(
+        {
+            "overwatch.enabled-regions": ["us", "de"],
+            "seer.code-review.direct-to-seer-regions.pull-request": ["de"],
+        }
+    )
+    @override_settings(
+        OVERWATCH_REGION_URLS={
+            "us": "https://us.example.com/api",
+            "de": "https://de.example.com/api",
+        },
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+    )
+    def test_skips_direct_to_seer_regions(self):
+        """Test that regions in direct-to-seer list are skipped from Overwatch forwarding."""
+        responses.add(
+            responses.POST,
+            "https://us.example.com/api/webhooks/sentry",
+            status=200,
+        )
+        responses.add(
+            responses.POST,
+            "https://de.example.com/api/webhooks/sentry",
+            status=200,
+        )
+
+        organization_us = self.create_organization(name="US Org", slug="us-org", region="us")
+        self.create_organization_integration(
+            integration=self.integration,
+            organization_id=organization_us.id,
+        )
+        organization_de = self.create_organization(name="DE Org", slug="de-org", region="de")
+        self.create_organization_integration(
+            integration=self.integration,
+            organization_id=organization_de.id,
+        )
+
+        event = {"action": "opened", "repository": {"owner": {"login": "some-org"}}}
+
+        self.forwarder.forward_if_applicable(
+            event,
+            headers={
+                GITHUB_WEBHOOK_TYPE_HEADER_KEY: "pull_request",
+                GITHUB_INSTALLATION_TARGET_ID_HEADER: "987654",
+            },
+        )
+
+        # Only US should receive the webhook, DE is in the direct-to-seer list
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == "https://us.example.com/api/webhooks/sentry"
+
     def test_default_events_included(self):
         """Test that default events should always be forwarded."""
         # Installation events are always forwarded
-        assert self.forwarder.should_forward_to_overwatch(
+        is_forwardable, _ = self.forwarder.is_event_forwardable(
             {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.INSTALLATION}
         )
-        assert self.forwarder.should_forward_to_overwatch(
+        assert is_forwardable
+        is_forwardable, _ = self.forwarder.is_event_forwardable(
             {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.INSTALLATION_REPOSITORIES}
         )
-        # Events controlled by options should be forwarded when enabled
-        assert self.forwarder.should_forward_to_overwatch(
+        assert is_forwardable
+        # PR and issue_comment events are forwardable to Overwatch
+        is_forwardable, _ = self.forwarder.is_event_forwardable(
             {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.PULL_REQUEST}
         )
-        assert self.forwarder.should_forward_to_overwatch(
+        assert is_forwardable
+        is_forwardable, _ = self.forwarder.is_event_forwardable(
             {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.ISSUE_COMMENT}
         )
+        assert is_forwardable
 
-    @override_options({"github.webhook.issue-comment": False, "github.webhook.pr": False})
-    def test_disabling_options_excludes_events(self):
-        """Test that disabling options excludes events from forwarding."""
-        # Events controlled by options should NOT be forwarded when disabled
-        assert not self.forwarder.should_forward_to_overwatch(
-            {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.ISSUE_COMMENT}
+        is_forwardable, _ = self.forwarder.is_event_forwardable(
+            {GITHUB_WEBHOOK_TYPE_HEADER_KEY: "some-unknown-event"}
         )
-        assert not self.forwarder.should_forward_to_overwatch(
-            {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.PULL_REQUEST}
-        )
-        # Installation events are always forwarded regardless of options
-        assert self.forwarder.should_forward_to_overwatch(
-            {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.INSTALLATION}
-        )
-        assert self.forwarder.should_forward_to_overwatch(
-            {GITHUB_WEBHOOK_TYPE_HEADER_KEY: GithubWebhookType.INSTALLATION_REPOSITORIES}
-        )
-
-    @override_options(
-        {
-            "overwatch.enabled-regions": ["us"],
-            "github.webhook.issue-comment": False,
-        }
-    )
-    def test_forward_if_applicable_with_disabled_webhook_type(self):
-        """Test that disabled webhook types are not forwarded even when region is enabled."""
-        organization = self.create_organization(name="Test Org", slug="test-org", region="us")
-        self.create_organization_integration(
-            integration=self.integration,
-            organization_id=organization.id,
-        )
-
-        event = {"action": "created", "comment": {"body": "test comment"}}
-
-        with patch.object(OverwatchWebhookPublisher, "enqueue_webhook") as mock_enqueue:
-            self.forwarder.forward_if_applicable(
-                event, headers={GITHUB_WEBHOOK_TYPE_HEADER_KEY: "issue_comment"}
-            )
-            mock_enqueue.assert_not_called()
+        assert not is_forwardable


### PR DESCRIPTION
The old flags (`github.webhook.issue-comment`, `github.webhook.pr`) were booleans that were read from control, but their values were only declared in downstream regions. We incorrectly assumed that setting the flag in downstream regions (e.g. DE/US) was sufficient. But actually control must have its own explicit value, otherwise it falls back to the default (True).

However, a boolean isn’t expressive enough for control - i.e., control needs to decide per event, per region whether to forward to Overwatch or send directly to Seer, and that requires multiple values, not on/off.

This PR fixes that by replacing the booleans with event-specific lists of regions
`seer.code-review.direct-to-seer-regions.issue-comment`
`seer.code-review.direct-to-seer-regions.pull-request`
We can declare these values in the options automator default.yaml so the same values are written to all regions (control, us, de, s4s2...)

Paired with https://github.com/getsentry/sentry-options-automator/pull/6137