### PR TITLE
fix(autopilot): Fix issue fingerprint

### DIFF
--- a/src/sentry/autopilot/tasks.py
+++ b/src/sentry/autopilot/tasks.py
@@ -68,7 +68,7 @@ def create_instrumentation_issue(
         id=uuid.uuid4().hex,
         project_id=project_id,
         event_id=event_id,
-        fingerprint=[detector_name, title],
+        fingerprint=[f"{detector_name}:{title}"],
         issue_title=title,
         subtitle=subtitle,
         resource_id=None,


### PR DESCRIPTION
For issue grouping any of the fingerprint entries may be matched.
We want to force different groups for each title. Therefore we need to add it to the first and only fingerprint entry.