### PR TITLE
feat(autopilot): POC UI for instrumentation issues

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2636,6 +2636,10 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/issueList/pages/warnings')),
     },
     {
+      path: 'instrumentation/',
+      component: make(() => import('sentry/views/issueList/pages/instrumentation')),
+    },
+    {
       path: 'views/',
       component: make(
         () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -106,6 +106,8 @@ export enum IssueCategory {
   AI_DETECTED = 'ai_detected',
 
   PREPROD = 'preprod',
+
+  INSTRUMENTATION = 'instrumentation',
 }
 
 /**
@@ -141,6 +143,9 @@ export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {
   [IssueCategory.UPTIME]: '',
   [IssueCategory.AI_DETECTED]: t('AI detected issues.'),
   [IssueCategory.PREPROD]: t('Problems detected via static analysis.'),
+  [IssueCategory.INSTRUMENTATION]: t(
+    'Improvements to your instrumentation and SDK usage.'
+  ),
 };
 
 export enum IssueType {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -11,6 +11,7 @@ import {
 import feedbackConfig from 'sentry/utils/issueTypeConfig/feedbackConfig';
 import frontendConfig from 'sentry/utils/issueTypeConfig/frontendConfig';
 import httpClientConfig from 'sentry/utils/issueTypeConfig/httpClientConfig';
+import instrumentationConfig from 'sentry/utils/issueTypeConfig/instrumentationConfig';
 import metricConfig from 'sentry/utils/issueTypeConfig/metricConfig';
 import metricIssueConfig from 'sentry/utils/issueTypeConfig/metricIssueConfig';
 import mobileConfig from 'sentry/utils/issueTypeConfig/mobileConfig';
@@ -107,6 +108,7 @@ const issueTypeConfig: Config = {
   [IssueCategory.METRIC]: metricConfig,
   [IssueCategory.AI_DETECTED]: aiDetectedConfig,
   [IssueCategory.PREPROD]: preprodConfig,
+  [IssueCategory.INSTRUMENTATION]: instrumentationConfig,
 };
 
 /**

--- a/static/app/utils/issueTypeConfig/instrumentationConfig.tsx
+++ b/static/app/utils/issueTypeConfig/instrumentationConfig.tsx
@@ -1,0 +1,42 @@
+import {t} from 'sentry/locale';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+const instrumentationConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    usesIssuePlatform: true,
+    evidence: {title: t('Details')},
+    issueSummary: {enabled: true},
+    // Instrumentation issues don't have traditional stacktraces
+    stacktrace: {enabled: false},
+    // Disable features that don't apply to instrumentation suggestions
+    autofix: true,
+    similarIssues: {enabled: false},
+    mergedIssues: {enabled: false},
+    regression: {enabled: false},
+    // Hide tags since these issues aren't tied to specific events
+    tags: {enabled: false},
+    stats: {enabled: false},
+    header: {
+      filterBar: {enabled: false},
+      graph: {enabled: false},
+      tagDistribution: {enabled: false},
+      occurrenceSummary: {enabled: false},
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: false},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: false},
+      tagsTab: {enabled: false},
+    },
+    discover: {enabled: false},
+    groupingInfo: {enabled: false},
+  },
+};
+
+export default instrumentationConfig;

--- a/static/app/views/issueList/pages/instrumentation.tsx
+++ b/static/app/views/issueList/pages/instrumentation.tsx
@@ -1,0 +1,32 @@
+import Feature from 'sentry/components/acl/feature';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {t} from 'sentry/locale';
+import {IssueCategory} from 'sentry/types/group';
+import useOrganization from 'sentry/utils/useOrganization';
+import IssueListContainer from 'sentry/views/issueList';
+import IssueListOverview from 'sentry/views/issueList/overview';
+
+const QUERY = `is:unresolved issue.category:${IssueCategory.INSTRUMENTATION}`;
+
+export default function InstrumentationPage() {
+  const organization = useOrganization();
+
+  return (
+    <Feature features="seer-autopilot" renderDisabled>
+      <IssueListContainer title={t('Instrumentation')}>
+        <PageFiltersContainer>
+          <NoProjectMessage organization={organization}>
+            <IssueListOverview
+              initialQuery={QUERY}
+              title={t('Instrumentation')}
+              titleDescription={t(
+                'Issues suggesting improvements to your instrumentation and SDK usage'
+              )}
+            />
+          </NoProjectMessage>
+        </PageFiltersContainer>
+      </IssueListContainer>
+    </Feature>
+  );
+}

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -54,6 +54,14 @@ export function IssuesSecondaryNav() {
           >
             {t('User Feedback')}
           </SecondaryNav.Item>
+          {organization.features.includes('seer-autopilot') && (
+            <SecondaryNav.Item
+              to={`${baseUrl}/instrumentation/`}
+              analyticsItemName="issues_instrumentation"
+            >
+              {t('Instrumentation')}
+            </SecondaryNav.Item>
+          )}
         </SecondaryNav.Section>
         <SecondaryNav.Section id="issues-views-all">
           <SecondaryNav.Item


### PR DESCRIPTION
Add a separate issues list for instrumentation issues using existing utils and components in the issues codebase.

**Note:** This UI implementation is experimental and minimalistic. It enables us to test autopilot use-cases end-to-end before refining the details.

All changes are guarded by the feature flag `organizations:seer-autopilot`

<img width="1465" height="698" alt="Screenshot 2026-01-15 at 12 02 53" src="https://github.com/user-attachments/assets/a84bb323-d5ee-41ec-b363-097e21e59b90" />

<img width="1465" height="698" alt="Screenshot 2026-01-15 at 12 03 13" src="https://github.com/user-attachments/assets/5bd5f96f-71f0-4f0d-87df-c97d71ebfe43" />