### PR TITLE
feat: Show details when there are any for sending test notifications

### DIFF
--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -335,7 +335,7 @@ export function useSendTestNotification(
       const message = typeof detail === 'string' ? detail : detail?.message;
 
       addErrorMessage(
-        message ?? tn('Notification failed', 'Notifications failed', variables.length)
+        message || tn('Notification failed', 'Notifications failed', variables.length)
       );
       options?.onError?.(error, variables, context);
     },

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t, tn} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
@@ -337,11 +335,7 @@ export function useSendTestNotification(
       const message = typeof detail === 'string' ? detail : detail?.message;
 
       addErrorMessage(
-        message ? (
-          <Fragment>{message}</Fragment>
-        ) : (
-          tn('Notification failed', 'Notifications failed', variables.length)
-        )
+        message ?? tn('Notification failed', 'Notifications failed', variables.length)
       );
       options?.onError?.(error, variables, context);
     },

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t, tn} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
@@ -331,8 +333,15 @@ export function useSendTestNotification(
       options?.onSuccess?.(data, variables, context);
     },
     onError: (error, variables, context) => {
+      const detail = error.responseJSON?.detail;
+      const message = typeof detail === 'string' ? detail : detail?.message;
+
       addErrorMessage(
-        tn('Notification failed', 'Notifications failed', variables.length)
+        message ? (
+          <Fragment>{message}</Fragment>
+        ) : (
+          tn('Notification failed', 'Notifications failed', variables.length)
+        )
       );
       options?.onError?.(error, variables, context);
     },


### PR DESCRIPTION
Sending test notifications showed only "Notification failed" even though there is a detailed message in the response. With that PR it is now using the message directly

<img width="1106" height="872" alt="Screenshot 2026-01-15 at 13 52 57" src="https://github.com/user-attachments/assets/0a5f1efd-d446-4ea6-9cbd-002c3b07ab2f" />
