### PR TITLE
fix(issues): Disable Export All CSV option without discover-query feature

### DIFF
--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
@@ -1,0 +1,56 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import TagExportDropdown from 'sentry/views/issueDetails/groupDistributions/tagExportDropdown';
+
+describe('TagExportDropdown', () => {
+  const group = GroupFixture();
+  const project = ProjectFixture();
+
+  it('shows Export All option when organization has discover-query feature', async () => {
+    const organization = OrganizationFixture({features: ['discover-query']});
+
+    render(
+      <TagExportDropdown
+        tagKey="user"
+        group={group}
+        organization={organization}
+        project={project}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Export options'}));
+
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Export Page to CSV'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Export All to CSV'})
+    ).toBeInTheDocument();
+  });
+
+  it('hides Export All option when organization does not have discover-query feature', async () => {
+    const organization = OrganizationFixture({features: []});
+
+    render(
+      <TagExportDropdown
+        tagKey="user"
+        group={group}
+        organization={organization}
+        project={project}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Export options'}));
+
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Export Page to CSV'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Export All to CSV'})
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
@@ -32,7 +32,7 @@ describe('TagExportDropdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('hides Export All option when organization does not have discover-query feature', async () => {
+  it('disables Export All option when organization does not have discover-query feature', async () => {
     const organization = OrganizationFixture({features: []});
 
     render(
@@ -50,7 +50,14 @@ describe('TagExportDropdown', () => {
       screen.getByRole('menuitemradio', {name: 'Export Page to CSV'})
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('menuitemradio', {name: 'Export All to CSV'})
-    ).not.toBeInTheDocument();
+      screen.getByRole('menuitemradio', {name: 'Export All to CSV'})
+    ).toBeInTheDocument();
+    const exportAllItem = screen.getByRole('menuitemradio', {name: 'Export All to CSV'});
+    expect(exportAllItem).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.hover(exportAllItem);
+    expect(
+      await screen.findByText('This feature is not available for your organization')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
@@ -30,32 +30,6 @@ export default function TagExportDropdown({tagKey, group, organization, project}
     },
   });
 
-  const items = [
-    {
-      key: 'export-page',
-      label: t('Export Page to CSV'),
-      // TODO(issues): Dropdown menu doesn't support hrefs yet
-      onAction: () => {
-        window.open(
-          `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
-          '_blank'
-        );
-      },
-    },
-  ];
-
-  if (hasDiscoverQuery) {
-    items.push({
-      key: 'export-all',
-      label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
-      onAction: () => {
-        handleDataExport();
-        setIsExportDisabled(true);
-      },
-      disabled: isExportDisabled,
-    });
-  }
-
   return (
     <DropdownMenu
       size="xs"
@@ -68,7 +42,31 @@ export default function TagExportDropdown({tagKey, group, organization, project}
           icon={<IconDownload />}
         />
       )}
-      items={items}
+      items={[
+        {
+          key: 'export-page',
+          label: t('Export Page to CSV'),
+          // TODO(issues): Dropdown menu doesn't support hrefs yet
+          onAction: () => {
+            window.open(
+              `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+              '_blank'
+            );
+          },
+        },
+        {
+          key: 'export-all',
+          label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
+          onAction: () => {
+            handleDataExport();
+            setIsExportDisabled(true);
+          },
+          disabled: isExportDisabled || !hasDiscoverQuery,
+          tooltip: hasDiscoverQuery
+            ? undefined
+            : t('This feature is not available for your organization'),
+        },
+      ]}
     />
   );
 }

--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
@@ -18,6 +18,7 @@ interface Props {
 
 export default function TagExportDropdown({tagKey, group, organization, project}: Props) {
   const [isExportDisabled, setIsExportDisabled] = useState(false);
+  const hasDiscoverQuery = organization.features.includes('discover-query');
   const handleDataExport = useDataExport({
     payload: {
       queryType: ExportQueryType.ISSUES_BY_TAG,
@@ -28,6 +29,32 @@ export default function TagExportDropdown({tagKey, group, organization, project}
       },
     },
   });
+
+  const items = [
+    {
+      key: 'export-page',
+      label: t('Export Page to CSV'),
+      // TODO(issues): Dropdown menu doesn't support hrefs yet
+      onAction: () => {
+        window.open(
+          `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+          '_blank'
+        );
+      },
+    },
+  ];
+
+  if (hasDiscoverQuery) {
+    items.push({
+      key: 'export-all',
+      label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
+      onAction: () => {
+        handleDataExport();
+        setIsExportDisabled(true);
+      },
+      disabled: isExportDisabled,
+    });
+  }
 
   return (
     <DropdownMenu
@@ -41,28 +68,7 @@ export default function TagExportDropdown({tagKey, group, organization, project}
           icon={<IconDownload />}
         />
       )}
-      items={[
-        {
-          key: 'export-page',
-          label: t('Export Page to CSV'),
-          // TODO(issues): Dropdown menu doesn't support hrefs yet
-          onAction: () => {
-            window.open(
-              `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
-              '_blank'
-            );
-          },
-        },
-        {
-          key: 'export-all',
-          label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
-          onAction: () => {
-            handleDataExport();
-            setIsExportDisabled(true);
-          },
-          disabled: isExportDisabled,
-        },
-      ]}
+      items={items}
     />
   );
 }


### PR DESCRIPTION
Disable the "Export All to CSV" button in the tag export dropdown when an
organization doesn't have the `discover-query` feature flag. Previously
users could click the button and receive a 404 error from the backend.

Now the button appears disabled with a tooltip explaining the feature is
not available for their organization.

<img width="240" height="124" alt="image" src="https://github.com/user-attachments/assets/99eda02c-2165-4593-8711-83bd02463a65" />
