### PR TITLE
fix(settings): Handle stats API failure on Data Forwarding page

### DIFF
--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -20,6 +20,7 @@ import {DataForwarderOnboarding} from 'sentry/views/settings/organizationDataFor
 import {DataForwarderRow} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderRow';
 import {useDataForwarders} from 'sentry/views/settings/organizationDataForwarding/util/hooks';
 import {
+  DATA_FORWARDING_DOCS_URL,
   DATA_FORWARDING_FEATURES,
   DataForwarderProviderSlug,
 } from 'sentry/views/settings/organizationDataForwarding/util/types';
@@ -109,7 +110,7 @@ export default function OrganizationDataForwarding() {
                 {
                   link: (
                     <ExternalLink
-                      href="https://docs.sentry.io/organization/integrations/data-forwarding/"
+                      href={DATA_FORWARDING_DOCS_URL}
                       onClick={() => {
                         trackAnalytics('data_forwarding.docs_link_clicked', {
                           organization,

--- a/static/app/views/settings/organizationDataForwarding/util/types.ts
+++ b/static/app/views/settings/organizationDataForwarding/util/types.ts
@@ -4,6 +4,8 @@ import type {AvatarProject} from 'sentry/types/project';
 // During release, we gate this check elsewhere by the
 // data-forwarding-revamp-access flag, so it's fine to omit here.
 export const DATA_FORWARDING_FEATURES = ['organizations:data-forwarding'];
+export const DATA_FORWARDING_DOCS_URL =
+  'https://docs.sentry.io/organization/integrations/data-forwarding/';
 
 export enum DataForwarderProviderSlug {
   SEGMENT = 'segment',

--- a/static/app/views/settings/projectDataForwarding/index.tsx
+++ b/static/app/views/settings/projectDataForwarding/index.tsx
@@ -24,6 +24,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
+import {DATA_FORWARDING_DOCS_URL} from 'sentry/views/settings/organizationDataForwarding/util/types';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -44,22 +45,13 @@ function DataForwardingStats({organization, project}: DataForwardingStatsProps) 
     },
   };
 
-  const {
-    data: stats,
-    isPending,
-    isError,
-    refetch,
-  } = useApiQuery<TimeseriesValue[]>(
+  const {data: stats = [], isPending} = useApiQuery<TimeseriesValue[]>(
     [`/projects/${organization.slug}/${project.slug}/stats/`, options],
-    {staleTime: 0}
+    {staleTime: 0, retry: false}
   );
 
   if (isPending) {
     return <LoadingIndicator />;
-  }
-
-  if (isError) {
-    return <LoadingError onRetry={refetch} />;
   }
 
   const series: Series = {
@@ -151,19 +143,26 @@ export default function ProjectDataForwarding() {
                 }
               )}
             </TextBlock>
-            <ProjectPermissionAlert project={project} />
-
-            <Alert.Container>
-              <Alert variant="info">
-                {tct(
-                  `Sentry forwards [em:all applicable error events] to the provider, in
+            <TextBlock>
+              {tct(
+                `Sentry forwards [em:all applicable error events] to the provider, in
                 some cases this may be a significant volume of data.`,
+                {
+                  em: <strong />,
+                }
+              )}
+            </TextBlock>
+            <Alert.Container>
+              <Alert variant="warning">
+                {tct(
+                  'This project-level feature is deprecated, and will be replaced by organization-level [docs:Data Forwarding]. Existing configurations will be auto-migrated when the feature is available to your organization.',
                   {
-                    em: <strong />,
+                    docs: <ExternalLink href={DATA_FORWARDING_DOCS_URL} />,
                   }
                 )}
               </Alert>
             </Alert.Container>
+            <ProjectPermissionAlert project={project} />
 
             {!hasFeature && (
               <FeatureDisabled


### PR DESCRIPTION
Gracefully handle stats API errors on the project Data Forwarding page
so the rest of the page still loads. Also adds deprecation warning for
project-level data forwarding and extracts docs URL to shared constant.