### PR TITLE
feat(code_review): Support sending closed pull request events to Seer

### DIFF
--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -26,23 +26,23 @@ class RequestType(StrEnum):
     PR_CLOSED = "pr-closed"
 
 
+class ClientError(Exception):
+    "Non-retryable client error from Seer"
+
+    pass
+
+
 # XXX: This needs to be a shared enum with the Seer repository
 # In Seer, src/seer/automation/codegen/types.py:PrReviewTrigger
-class PrReviewTrigger(StrEnum):
+class SeerCodeReviewTrigger(StrEnum):
     UNKNOWN = "unknown"
     ON_COMMAND_PHRASE = "on_command_phrase"
     ON_READY_FOR_REVIEW = "on_ready_for_review"
     ON_NEW_COMMIT = "on_new_commit"
 
     @classmethod
-    def _missing_(cls: type[PrReviewTrigger], value: object) -> PrReviewTrigger:
+    def _missing_(cls: type[SeerCodeReviewTrigger], value: object) -> SeerCodeReviewTrigger:
         return cls.UNKNOWN
-
-
-class ClientError(Exception):
-    "Non-retryable client error from Seer"
-
-    pass
 
 
 # These values need to match the value defined in the Seer API.
@@ -216,16 +216,16 @@ def transform_webhook_to_codegen_request(
     if github_event == GithubWebhookType.PULL_REQUEST and github_event_action == "closed":
         request_type = RequestType.PR_CLOSED
 
-    review_request_trigger = PrReviewTrigger.UNKNOWN
+    review_request_trigger = SeerCodeReviewTrigger.UNKNOWN
     match github_event_action:
         case "opened" | "ready_for_review":
-            review_request_trigger = PrReviewTrigger.ON_READY_FOR_REVIEW
+            review_request_trigger = SeerCodeReviewTrigger.ON_READY_FOR_REVIEW
         case "synchronize":
-            review_request_trigger = PrReviewTrigger.ON_NEW_COMMIT
+            review_request_trigger = SeerCodeReviewTrigger.ON_NEW_COMMIT
 
     # We know that we only schedule a task if the comment contains the command phrase
     if github_event == GithubWebhookType.ISSUE_COMMENT:
-        review_request_trigger = PrReviewTrigger.ON_COMMAND_PHRASE
+        review_request_trigger = SeerCodeReviewTrigger.ON_COMMAND_PHRASE
 
     # Extract pull request number
     # Different event types have PR info in different locations

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
@@ -15,28 +17,32 @@ from sentry.net.http import connection_from_url
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 
 
+# XXX: This needs to be a shared enum with the Seer repository
+# Look at CodecovTaskRequest.request_type in Seer repository for the possible request types
 class RequestType(StrEnum):
+    # It triggers PR review events on Seer side
     PR_REVIEW = "pr-review"
+    # It triggers PR closed events on Seer side
     PR_CLOSED = "pr-closed"
+
+
+# XXX: This needs to be a shared enum with the Seer repository
+# In Seer, src/seer/automation/codegen/types.py:PrReviewTrigger
+class PrReviewTrigger(StrEnum):
+    UNKNOWN = "unknown"
+    ON_COMMAND_PHRASE = "on_command_phrase"
+    ON_READY_FOR_REVIEW = "on_ready_for_review"
+    ON_NEW_COMMIT = "on_new_commit"
+
+    @classmethod
+    def _missing_(cls: type[PrReviewTrigger], value: object) -> PrReviewTrigger:
+        return cls.UNKNOWN
 
 
 class ClientError(Exception):
     "Non-retryable client error from Seer"
 
     pass
-
-
-class SeerCodeReviewTrigger(StrEnum):
-    """
-    Internal code review trigger type used for Seer flows.
-
-    This includes all user-configurable CodeReviewTrigger values, plus on_command_phrase,
-    which is always enabled and cannot be turned off by users.
-    """
-
-    ON_COMMAND_PHRASE = "on_command_phrase"
-    ON_NEW_COMMIT = "on_new_commit"
-    ON_READY_FOR_REVIEW = "on_ready_for_review"
 
 
 # These values need to match the value defined in the Seer API.
@@ -134,22 +140,6 @@ def _get_trigger_metadata_for_issue_comment(event_payload: Mapping[str, Any]) ->
     }
 
 
-def _get_trigger_metadata_for_pull_request_review_comment(
-    event_payload: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Extract trigger metadata for pull_request_review_comment events."""
-    comment = event_payload.get("comment", {})
-    trigger_user = comment.get("user", {}).get("login")
-    trigger_comment_id = comment.get("id")
-    trigger_comment_type = "pull_request_review_comment"
-
-    return {
-        "trigger_user": trigger_user,
-        "trigger_comment_id": trigger_comment_id,
-        "trigger_comment_type": trigger_comment_type,
-    }
-
-
 def _get_trigger_metadata(
     github_event: GithubWebhookType, event_payload: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -159,9 +149,6 @@ def _get_trigger_metadata(
 
     if github_event == GithubWebhookType.ISSUE_COMMENT:
         return _get_trigger_metadata_for_issue_comment(event_payload)
-
-    if github_event == GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT:
-        return _get_trigger_metadata_for_pull_request_review_comment(event_payload)
 
     raise ValueError(f"unsupported-event-type-for-trigger-metadata: {github_event}")
 
@@ -197,18 +184,21 @@ def _get_target_commit_sha(
     raise ValueError("unsupported-event-for-sha")
 
 
+# XXX: Refactor this function to handle it at the handler level rather than during task execution
 def transform_webhook_to_codegen_request(
     github_event: GithubWebhookType,
+    github_event_action: str,  # XXX: This should be the enum
     event_payload: Mapping[str, Any],
     organization: Organization,
     repo: Repository,
     target_commit_sha: str,
-    trigger: SeerCodeReviewTrigger,
 ) -> dict[str, Any] | None:
     """
     Transform a GitHub webhook payload into CodecovTaskRequest format for Seer.
 
     Args:
+        github_event: The GitHub webhook event type
+        github_event_action: The action of the GitHub webhook event
         event_payload: The full webhook event payload from GitHub
         organization: The Sentry organization
         repo: The repository model
@@ -222,9 +212,20 @@ def transform_webhook_to_codegen_request(
     Raises:
         ValueError: If required fields are missing from the webhook payload
     """
-    # Determine request_type based on event_type
-    # For now, we only support pr-review for these webhook types
-    request_type: RequestType = RequestType.PR_REVIEW
+    request_type = RequestType.PR_REVIEW
+    if github_event == GithubWebhookType.PULL_REQUEST and github_event_action == "closed":
+        request_type = RequestType.PR_CLOSED
+
+    review_request_trigger = PrReviewTrigger.UNKNOWN
+    match github_event_action:
+        case "opened" | "ready_for_review":
+            review_request_trigger = PrReviewTrigger.ON_READY_FOR_REVIEW
+        case "synchronize":
+            review_request_trigger = PrReviewTrigger.ON_NEW_COMMIT
+
+    # We know that we only schedule a task if the comment contains the command phrase
+    if github_event == GithubWebhookType.ISSUE_COMMENT:
+        review_request_trigger = PrReviewTrigger.ON_COMMAND_PHRASE
 
     # Extract pull request number
     # Different event types have PR info in different locations
@@ -258,9 +259,12 @@ def transform_webhook_to_codegen_request(
 
     trigger_metadata = _get_trigger_metadata(github_event, event_payload)
 
-    # XXX: How can we share classes between Sentry and Seer?
+    # XXX: We will need to share classes between Sentry and Seer to avoid code duplication
+    # for the request payload.
+    # For now, we will use the same class names and fields as the Seer repository.
     # Build CodecovTaskRequest
     return {
+        # In Seer,src/seer/routes/automation_request.py:overwatch_request_endpoint
         "request_type": request_type.value,
         "external_owner_id": repo.external_id,
         "data": {
@@ -274,7 +278,10 @@ def transform_webhook_to_codegen_request(
                 "features": {
                     "bug_prediction": True,
                 },
-                "trigger": trigger.value,
+                # In Seer, used here:
+                # src/seer/automation/codegen/tasks.py
+                # src/seer/automation/codegen/pr_review_step.py
+                "trigger": review_request_trigger.value,
                 **trigger_metadata,
             },
         },

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -22,7 +22,7 @@ from ..metrics import (
     record_webhook_handler_error,
     record_webhook_received,
 )
-from ..utils import SeerCodeReviewTrigger, _get_target_commit_sha, should_forward_to_seer
+from ..utils import _get_target_commit_sha, should_forward_to_seer
 
 logger = logging.getLogger(__name__)
 
@@ -149,5 +149,4 @@ def handle_issue_comment_event(
             organization=organization,
             repo=repo,
             target_commit_sha=target_commit_sha,
-            trigger=SeerCodeReviewTrigger.ON_COMMAND_PHRASE,
         )

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -22,7 +22,7 @@ from ..metrics import (
     record_webhook_handler_error,
     record_webhook_received,
 )
-from ..utils import SeerCodeReviewTrigger, _get_target_commit_sha, should_forward_to_seer
+from ..utils import _get_target_commit_sha, should_forward_to_seer
 
 logger = logging.getLogger(__name__)
 
@@ -65,20 +65,11 @@ class PullRequestAction(enum.StrEnum):
 
 
 WHITELISTED_ACTIONS = {
+    PullRequestAction.CLOSED,
     PullRequestAction.OPENED,
     PullRequestAction.READY_FOR_REVIEW,
     PullRequestAction.SYNCHRONIZE,
 }
-
-
-def _get_trigger_for_action(action: PullRequestAction) -> SeerCodeReviewTrigger:
-    match action:
-        case PullRequestAction.OPENED | PullRequestAction.READY_FOR_REVIEW:
-            return SeerCodeReviewTrigger.ON_READY_FOR_REVIEW
-        case PullRequestAction.SYNCHRONIZE:
-            return SeerCodeReviewTrigger.ON_NEW_COMMIT
-        case _:
-            raise ValueError(f"Unsupported pull request action: {action}")
 
 
 def handle_pull_request_event(
@@ -143,5 +134,4 @@ def handle_pull_request_event(
             organization=organization,
             repo=repo,
             target_commit_sha=_get_target_commit_sha(github_event, event, repo, integration),
-            trigger=_get_trigger_for_action(action),
         )

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -19,7 +19,7 @@ from sentry.taskworker.state import current_task
 from sentry.utils import metrics
 
 from ..metrics import WebhookFilteredReason, record_webhook_enqueued, record_webhook_filtered
-from ..utils import SeerCodeReviewTrigger, get_seer_endpoint_for_event, make_seer_request
+from ..utils import get_seer_endpoint_for_event, make_seer_request
 
 logger = logging.getLogger(__name__)
 
@@ -38,18 +38,17 @@ def schedule_task(
     organization: Organization,
     repo: Repository,
     target_commit_sha: str,
-    trigger: SeerCodeReviewTrigger,
 ) -> None:
     """Transform and forward a webhook event to Seer for processing."""
     from .task import process_github_webhook_event
 
     transformed_event = transform_webhook_to_codegen_request(
         github_event=github_event,
+        github_event_action=github_event_action,
         event_payload=dict(event),
         organization=organization,
         repo=repo,
         target_commit_sha=target_commit_sha,
-        trigger=trigger,
     )
 
     if transformed_event is None:

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.seer.code_review.utils import (
-    PrReviewTrigger,
+    SeerCodeReviewTrigger,
     _get_target_commit_sha,
     _get_trigger_metadata,
     transform_webhook_to_codegen_request,
@@ -199,7 +199,7 @@ class TestTransformWebhookToCodegenRequest:
         }
         assert result["data"]["config"] == {
             "features": {"bug_prediction": True},
-            "trigger": PrReviewTrigger.ON_READY_FOR_REVIEW.value,
+            "trigger": SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value,
         } | {k: v for k, v in result["data"]["config"].items() if k not in ("features", "trigger")}
 
     def test_issue_comment_on_pr(
@@ -232,7 +232,7 @@ class TestTransformWebhookToCodegenRequest:
         data = result["data"]
         config = data["config"]
         assert data["pr_id"] == 42
-        assert config["trigger"] == PrReviewTrigger.ON_COMMAND_PHRASE.value
+        assert config["trigger"] == SeerCodeReviewTrigger.ON_COMMAND_PHRASE.value
         assert config["trigger_comment_id"] == 12345
         assert config["trigger_user"] == "commenter"
         assert config["trigger_comment_type"] == "issue_comment"

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.seer.code_review.utils import (
-    SeerCodeReviewTrigger,
+    PrReviewTrigger,
     _get_target_commit_sha,
     _get_trigger_metadata,
     transform_webhook_to_codegen_request,
@@ -29,19 +29,6 @@ class TestGetTriggerMetadata:
         assert result["trigger_comment_id"] == 12345
         assert result["trigger_user"] == "test-user"
         assert result["trigger_comment_type"] == "issue_comment"
-
-    def test_extracts_pull_request_review_comment_type(self) -> None:
-        event_payload = {
-            "comment": {
-                "id": 12345,
-                "user": {"login": "test-user"},
-                "pull_request_review_id": 67890,
-            }
-        }
-        result = _get_trigger_metadata(GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT, event_payload)
-        assert result["trigger_comment_type"] == "pull_request_review_comment"
-        assert result["trigger_comment_id"] == 12345
-        assert result["trigger_user"] == "test-user"
 
     def test_pull_request_uses_sender(self) -> None:
         event_payload = {
@@ -184,11 +171,11 @@ class TestTransformWebhookToCodegenRequest:
         }
         result = transform_webhook_to_codegen_request(
             GithubWebhookType.PULL_REQUEST,
+            "opened",
             event_payload,
             organization,
             repo,
             "abc123sha",
-            SeerCodeReviewTrigger.ON_READY_FOR_REVIEW,
         )
 
         expected_repo = {
@@ -212,7 +199,7 @@ class TestTransformWebhookToCodegenRequest:
         }
         assert result["data"]["config"] == {
             "features": {"bug_prediction": True},
-            "trigger": SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value,
+            "trigger": PrReviewTrigger.ON_READY_FOR_REVIEW.value,
         } | {k: v for k, v in result["data"]["config"].items() if k not in ("features", "trigger")}
 
     def test_issue_comment_on_pr(
@@ -234,18 +221,18 @@ class TestTransformWebhookToCodegenRequest:
         }
         result = transform_webhook_to_codegen_request(
             GithubWebhookType.ISSUE_COMMENT,
+            "created",
             event_payload,
             organization,
             repo,
             "def456sha",
-            SeerCodeReviewTrigger.ON_NEW_COMMIT,
         )
 
         assert isinstance(result, dict)
         data = result["data"]
         config = data["config"]
         assert data["pr_id"] == 42
-        assert config["trigger"] == SeerCodeReviewTrigger.ON_NEW_COMMIT.value
+        assert config["trigger"] == PrReviewTrigger.ON_COMMAND_PHRASE.value
         assert config["trigger_comment_id"] == 12345
         assert config["trigger_user"] == "commenter"
         assert config["trigger_comment_type"] == "issue_comment"
@@ -261,11 +248,11 @@ class TestTransformWebhookToCodegenRequest:
         }
         result = transform_webhook_to_codegen_request(
             GithubWebhookType.ISSUE_COMMENT,
+            "created",
             event_payload,
             organization,
             repo,
             "somesha",
-            SeerCodeReviewTrigger.ON_NEW_COMMIT,
         )
         assert result is None
 
@@ -285,9 +272,9 @@ class TestTransformWebhookToCodegenRequest:
         with pytest.raises(ValueError, match="Invalid repository name format"):
             transform_webhook_to_codegen_request(
                 GithubWebhookType.PULL_REQUEST,
+                "opened",
                 event_payload,
                 organization,
                 bad_repo,
                 "sha123",
-                SeerCodeReviewTrigger.ON_READY_FOR_REVIEW,
             )

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -6,7 +6,7 @@ import pytest
 
 from fixtures.github import PULL_REQUEST_OPENED_EVENT_EXAMPLE
 from sentry.integrations.github.webhook_types import GithubWebhookType
-from sentry.seer.code_review.utils import PrReviewTrigger, RequestType
+from sentry.seer.code_review.utils import RequestType, SeerCodeReviewTrigger
 from sentry.testutils.helpers.github import GitHubWebhookCodeReviewTestCase
 
 
@@ -266,7 +266,7 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert call_kwargs["path"] == "/v1/automation/overwatch-request"
             payload = call_kwargs["payload"]
             assert payload["request_type"] == RequestType.PR_CLOSED.value
-            assert payload["data"]["config"]["trigger"] == PrReviewTrigger.UNKNOWN.value
+            assert payload["data"]["config"]["trigger"] == SeerCodeReviewTrigger.UNKNOWN.value
             assert payload["data"]["config"]["trigger_user"] == "baxterthehacker"
             assert payload["data"]["config"]["trigger_comment_id"] is None
             assert payload["data"]["config"]["trigger_comment_type"] is None


### PR DESCRIPTION
Overwatch sends closed pull request events to Seer and Sentry should do so as well.

Fixes [https://linear.app/getsentry/issue/CW-309/](CW-309).