### PR TITLE
fix(dashboards): Update dashboard selects to use new TypeBadge

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -3,8 +3,6 @@ import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
-
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
 import {Button} from 'sentry/components/core/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -15,6 +13,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
+import type {FieldValueType} from 'sentry/utils/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -28,6 +27,7 @@ import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hook
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import type {generateFieldOptions} from 'sentry/views/discover/utils';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
 import {QueryField} from './queryField';
 import {SortableQueryField} from './sortableQueryField';
@@ -159,11 +159,7 @@ export function GroupBySelector({
         if (!('dataType' in meta)) {
           return null;
         }
-        return (
-          <Tag variant={meta.dataType === 'number' ? 'info' : 'warning'}>
-            {meta.dataType}
-          </Tag>
-        );
+        return <TypeBadge valueType={meta.dataType as FieldValueType} />;
       }
     : undefined;
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -8,7 +8,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import {Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
 
 import {openLinkToDashboardModal} from 'sentry/actionCreators/modal';
-import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {TriggerLabel} from 'sentry/components/core/compactSelect/control';
@@ -30,7 +29,12 @@ import {
   type QueryFieldValue,
   type ValidateColumnTypes,
 } from 'sentry/utils/discover/fields';
-import {classifyTagKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {
+  classifyTagKey,
+  FieldKind,
+  FieldValueType,
+  prettifyTagKey,
+} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
@@ -1016,54 +1020,14 @@ function Visualize({error, setError}: VisualizeProps) {
 export default Visualize;
 
 function renderTag(kind: FieldValueKind, label: string, dataType?: string) {
-  if (dataType) {
-    switch (dataType) {
-      case 'boolean':
-      case 'date':
-      case 'string':
-        return <Tag variant="info">{t('string')}</Tag>;
-      case 'duration':
-      case 'integer':
-      case 'percentage':
-      case 'number':
-        return <Tag variant="success">{t('number')}</Tag>;
-      default:
-        return <Tag variant="muted">{dataType}</Tag>;
-    }
-  }
-  let text: string | undefined, tagVariant: TagProps['variant'] | undefined;
-
-  switch (kind) {
-    case FieldValueKind.FUNCTION:
-      text = 'f(x)';
-      tagVariant = 'warning';
-      break;
-    case FieldValueKind.CUSTOM_MEASUREMENT:
-    case FieldValueKind.MEASUREMENT:
-      text = 'field';
-      tagVariant = 'info';
-      break;
-    case FieldValueKind.BREAKDOWN:
-      text = 'field';
-      tagVariant = 'info';
-      break;
-    case FieldValueKind.TAG:
-      text = kind;
-      tagVariant = 'warning';
-      break;
-    case FieldValueKind.NUMERIC_METRICS:
-      text = 'f(x)';
-      tagVariant = 'warning';
-      break;
-    case FieldValueKind.FIELD:
-      text = DEPRECATED_FIELDS.includes(label) ? 'deprecated' : 'field';
-      tagVariant = 'info';
-      break;
-    default:
-      text = kind;
-  }
-
-  return <Tag variant={tagVariant ?? 'muted'}>{text}</Tag>;
+  return (
+    <TypeBadge
+      label={label}
+      valueKind={kind}
+      valueType={dataType as FieldValueType}
+      deprecatedFields={DEPRECATED_FIELDS}
+    />
+  );
 }
 
 export const AggregateCompactSelect = styled(CompactSelect)<{

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -3,7 +3,6 @@ import {withTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
 import type {InputProps} from 'sentry/components/core/input';
 import {Input} from 'sentry/components/core/input';
 import type {ControlProps} from 'sentry/components/core/select';
@@ -25,7 +24,9 @@ import type {
   ValidateColumnTypes,
 } from 'sentry/utils/discover/fields';
 import {AGGREGATIONS, DEPRECATED_FIELDS} from 'sentry/utils/discover/fields';
+import type {FieldValueType} from 'sentry/utils/fields';
 import {SESSIONS_OPERATIONS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
 import ArithmeticInput from './arithmeticInput';
 import type {FieldValue, FieldValueColumns} from './types';
@@ -594,41 +595,19 @@ class _QueryField extends Component<Props> {
     if (renderTagOverride) {
       return renderTagOverride(kind, label, meta);
     }
-    let text: string;
-    let tagVariant:
-      | Extract<TagProps['variant'], 'success' | 'info' | 'warning'>
-      | undefined;
 
-    switch (kind) {
-      case FieldValueKind.FUNCTION:
-        text = 'f(x)';
-        tagVariant = 'success';
-        break;
-      case FieldValueKind.CUSTOM_MEASUREMENT:
-      case FieldValueKind.MEASUREMENT:
-        text = 'field';
-        tagVariant = 'info';
-        break;
-      case FieldValueKind.BREAKDOWN:
-        text = 'field';
-        tagVariant = 'info';
-        break;
-      case FieldValueKind.TAG:
-        text = kind;
-        tagVariant = 'warning';
-        break;
-      case FieldValueKind.NUMERIC_METRICS:
-        text = 'f(x)';
-        tagVariant = 'success';
-        break;
-      case FieldValueKind.FIELD:
-        text = DEPRECATED_FIELDS.includes(label) ? 'deprecated' : 'field';
-        tagVariant = 'info';
-        break;
-      default:
-        text = kind;
+    let valueType: FieldValueType | undefined = meta?.name as FieldValueType;
+    if ('dataType' in meta) {
+      valueType = meta.dataType as FieldValueType;
     }
-    return <Tag variant={tagVariant ?? 'muted'}>{text}</Tag>;
+    return (
+      <TypeBadge
+        label={label}
+        valueKind={kind}
+        valueType={valueType}
+        deprecatedFields={DEPRECATED_FIELDS}
+      />
+    );
   }
 
   render() {

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -596,10 +596,9 @@ class _QueryField extends Component<Props> {
       return renderTagOverride(kind, label, meta);
     }
 
-    let valueType: FieldValueType | undefined = meta?.name as FieldValueType;
-    if ('dataType' in meta) {
-      valueType = meta.dataType as FieldValueType;
-    }
+    const valueType =
+      meta && 'dataType' in meta ? (meta.dataType as FieldValueType) : undefined;
+
     return (
       <TypeBadge
         label={label}

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -28,7 +28,8 @@ export function TypeBadge({
   if (
     defined(func) ||
     kind === FieldKind.FUNCTION ||
-    valueKind === FieldValueKind.FUNCTION
+    valueKind === FieldValueKind.FUNCTION ||
+    valueKind === FieldValueKind.NUMERIC_METRICS
   ) {
     return <Text variant="success">{t('f(x)')}</Text>;
   }
@@ -76,8 +77,7 @@ export function TypeBadge({
   if (
     kind === FieldKind.MEASUREMENT ||
     valueType === FieldValueType.NUMBER ||
-    valueKind === FieldValueKind.MEASUREMENT ||
-    valueKind === FieldValueKind.CUSTOM_MEASUREMENT
+    valueKind === FieldValueKind.METRICS
   ) {
     return <Text variant="warning">{t('number')}</Text>;
   }
@@ -86,7 +86,16 @@ export function TypeBadge({
     return <Text variant="accent">{t('string')}</Text>;
   }
 
-  if (valueKind === FieldValueKind.BREAKDOWN) {
+  if (
+    valueKind === FieldValueKind.FIELD ||
+    valueKind === FieldValueKind.BREAKDOWN ||
+    valueKind === FieldValueKind.MEASUREMENT ||
+    valueKind === FieldValueKind.CUSTOM_MEASUREMENT
+  ) {
+    if (label && deprecatedFields?.includes(label)) {
+      return <Text variant="danger">{t('deprecated')}</Text>;
+    }
+
     return <Text variant="accent">{t('field')}</Text>;
   }
 
@@ -94,11 +103,8 @@ export function TypeBadge({
     return <Text variant="warning">{t('tag')}</Text>;
   }
 
-  if (valueKind === FieldValueKind.FIELD) {
-    if (label && deprecatedFields?.includes(label)) {
-      return <Text variant="danger">{t('deprecated')}</Text>;
-    }
-    return <Text variant="success">{t('field')}</Text>;
+  if (valueKind === FieldValueKind.EQUATION) {
+    return <Text variant="muted">{t('equation')}</Text>;
   }
 
   if (isLogicFilter) {

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -25,6 +25,10 @@ export function TypeBadge({
   deprecatedFields,
   label,
 }: TypeBadgeProps) {
+  if (label && deprecatedFields?.includes(label)) {
+    return <Text variant="danger">{t('deprecated')}</Text>;
+  }
+
   if (
     defined(func) ||
     kind === FieldKind.FUNCTION ||
@@ -92,10 +96,6 @@ export function TypeBadge({
     valueKind === FieldValueKind.MEASUREMENT ||
     valueKind === FieldValueKind.CUSTOM_MEASUREMENT
   ) {
-    if (label && deprecatedFields?.includes(label)) {
-      return <Text variant="danger">{t('deprecated')}</Text>;
-    }
-
     return <Text variant="accent">{t('field')}</Text>;
   }
 

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -4,16 +4,32 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {FieldKind, FieldValueType} from 'sentry/utils/fields';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 interface TypeBadgeProps {
+  deprecatedFields?: string[];
   func?: ParsedFunction;
   isLogicFilter?: boolean;
   kind?: FieldKind;
+  label?: string;
+  valueKind?: FieldValueKind;
   valueType?: FieldValueType;
 }
 
-export function TypeBadge({func, kind, valueType, isLogicFilter}: TypeBadgeProps) {
-  if (defined(func) || kind === FieldKind.FUNCTION) {
+export function TypeBadge({
+  func,
+  kind,
+  valueType,
+  isLogicFilter,
+  valueKind,
+  deprecatedFields,
+  label,
+}: TypeBadgeProps) {
+  if (
+    defined(func) ||
+    kind === FieldKind.FUNCTION ||
+    valueKind === FieldValueKind.FUNCTION
+  ) {
     return <Text variant="success">{t('f(x)')}</Text>;
   }
 
@@ -57,12 +73,32 @@ export function TypeBadge({func, kind, valueType, isLogicFilter}: TypeBadgeProps
     return <Text variant="success">{t('currency')}</Text>;
   }
 
-  if (valueType === FieldValueType.NUMBER || kind === FieldKind.MEASUREMENT) {
+  if (
+    kind === FieldKind.MEASUREMENT ||
+    valueType === FieldValueType.NUMBER ||
+    valueKind === FieldValueKind.MEASUREMENT ||
+    valueKind === FieldValueKind.CUSTOM_MEASUREMENT
+  ) {
     return <Text variant="warning">{t('number')}</Text>;
   }
 
   if (valueType === FieldValueType.STRING || kind === FieldKind.TAG) {
     return <Text variant="accent">{t('string')}</Text>;
+  }
+
+  if (valueKind === FieldValueKind.BREAKDOWN) {
+    return <Text variant="accent">{t('field')}</Text>;
+  }
+
+  if (valueKind === FieldValueKind.TAG) {
+    return <Text variant="warning">{t('tag')}</Text>;
+  }
+
+  if (valueKind === FieldValueKind.FIELD) {
+    if (label && deprecatedFields?.includes(label)) {
+      return <Text variant="danger">{t('deprecated')}</Text>;
+    }
+    return <Text variant="success">{t('field')}</Text>;
   }
 
   if (isLogicFilter) {


### PR DESCRIPTION
This PR updates the various selects in dashboard widget editor to use the new `TypeBadge` component.

Ticket: EXP-706

Screenshots:
<img width="734" height="219" alt="Screenshot 2026-01-15 at 11 39 08" src="https://github.com/user-attachments/assets/f663b250-9dac-41b1-8208-202b79214d5b" />

<img width="740" height="193" alt="Screenshot 2026-01-15 at 11 39 13" src="https://github.com/user-attachments/assets/5bbe6f96-9e88-41a0-96e6-f5d7f6e964fa" />

<img width="748" height="224" alt="Screenshot 2026-01-15 at 11 47 26" src="https://github.com/user-attachments/assets/df5ebf6a-a592-4c83-8d01-fd3e845471ef" />