### PR TITLE
feat: Add cron job to schedule indexer job

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -952,6 +952,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.workflow_engine.tasks.delayed_workflows",
     "sentry.workflow_engine.tasks.workflows",
     "sentry.workflow_engine.tasks.actions",
+    "sentry.tasks.seer_explorer_index",
     # Used for tests
     "sentry.taskworker.tasks.examples",
 )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1120,6 +1120,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "performance:sentry.tasks.statistical_detectors.run_detection",
         "schedule": task_crontab("0", "*/1", "*", "*", "*"),
     },
+    "seer-explorer-index": {
+        "task": "seer:sentry.tasks.seer_explorer_index.schedule_explorer_index",
+        "schedule": task_crontab("0", "*/1", "*", "*", "*"),
+    },
     "refresh-artifact-bundles-in-use": {
         "task": "attachments:sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
         "schedule": task_crontab("*/1", "*", "*", "*", "*"),

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -404,6 +404,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-coding-agent-integrations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer panel for AI-powered data exploration
     manager.add("organizations:seer-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Seer Explorer Index job
+    manager.add("organizations:seer-explorer-index", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable streaming responses for Seer Explorer
     manager.add("organizations:seer-explorer-streaming", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Autofix to use Seer Explorer instead of legacy Celery pipeline

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1254,6 +1254,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "seer.explorer_index.enable",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}
 register(

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from datetime import datetime, timedelta
+
+import orjson
+import requests
+from django.conf import settings
+from django.utils import timezone as django_timezone
+
+from sentry import features, options
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.statistical_detectors import compute_delay
+from sentry.taskworker.namespaces import seer_tasks
+from sentry.utils.cache import cache
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = logging.getLogger("sentry.tasks.seer_explorer_indexer")
+
+CACHE_KEY = "seer:explorer_index:last_run"
+
+# Explorer indexing constants
+EXPLORER_INDEX_PROJECTS_PER_BATCH = 100  # Projects per batch sent to seer
+EXPLORER_INDEX_RUN_FREQUENCY = timedelta(hours=24)  # runs daily
+# Use a larger prime number to spread indexing tasks throughout the day
+EXPLORER_INDEX_DISPATCH_STEP = timedelta(seconds=127)
+
+
+def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
+    """
+    Get all active projects that belong to organizations with seer-explorer enabled.
+
+    Yields:
+        Tuple of (project_id, organization_id)
+    """
+    # Get all active projects with their organization
+    projects = Project.objects.filter(status=ObjectStatus.ACTIVE).select_related("organization")
+
+    for project in RangeQuerySetWrapper(
+        projects,
+        result_value_getter=lambda p: p.id,
+    ):
+        # Check if the organization has seer-explorer feature enabled
+        if features.has("organizations:seer-explorer-index", project.organization):
+            yield project.id, project.organization_id
+
+
+@instrumented_task(
+    name="sentry.tasks.seer_explorer_index.schedule_explorer_index",
+    namespace=seer_tasks,
+    processing_deadline_duration=30,
+)
+def schedule_explorer_index() -> None:
+    """
+    Main periodic task that runs daily to schedule explorer indexing for active projects
+    in seer-enabled organizations. Spreads the load throughout the day.
+    """
+    if not options.get("seer.explorer_index.enable"):
+        return
+
+    last_run = cache.get(CACHE_KEY)
+    if last_run and last_run > django_timezone.now() - EXPLORER_INDEX_RUN_FREQUENCY:
+        return
+
+    cache.set(CACHE_KEY, django_timezone.now())
+
+    now = django_timezone.now()
+
+    projects = get_seer_explorer_enabled_projects()
+    projects = dispatch_explorer_index_projects(projects, now)
+
+    # Make sure to consume the generator
+    for _ in projects:
+        pass
+
+
+def dispatch_explorer_index_projects(
+    all_projects: Generator[tuple[int, int]],
+    timestamp: datetime,
+) -> Generator[tuple[int, int]]:
+    """
+    Dispatch explorer indexing tasks for projects, batching them and spreading
+    the load throughout the day using countdown delays.
+
+    Args:
+        all_projects: Generator of (project_id, organization_id) tuples
+        timestamp: The timestamp when the dispatch started
+
+    Yields:
+        Each (project_id, organization_id) tuple as it's processed
+    """
+    batch: list[tuple[int, int]] = []
+    count = 0
+
+    for project_id, org_id in all_projects:
+        batch.append((project_id, org_id))
+        count += 1
+
+        if len(batch) >= EXPLORER_INDEX_PROJECTS_PER_BATCH:
+            run_explorer_index_for_projects.apply_async(
+                args=[batch, timestamp.isoformat()],
+                countdown=compute_delay(
+                    timestamp,
+                    (count - 1) // EXPLORER_INDEX_PROJECTS_PER_BATCH,
+                    duration=EXPLORER_INDEX_RUN_FREQUENCY,
+                    step=EXPLORER_INDEX_DISPATCH_STEP,
+                ),
+            )
+            batch = []
+
+        yield project_id, org_id
+
+    # Dispatch remaining projects
+    if batch:
+        run_explorer_index_for_projects.apply_async(
+            args=[batch, timestamp.isoformat()],
+            countdown=compute_delay(
+                timestamp,
+                (count - 1) // EXPLORER_INDEX_PROJECTS_PER_BATCH,
+                duration=EXPLORER_INDEX_RUN_FREQUENCY,
+                step=EXPLORER_INDEX_DISPATCH_STEP,
+            ),
+        )
+
+
+@instrumented_task(
+    name="sentry.tasks.seer_explorer_index.run_explorer_index_for_projects",
+    namespace=seer_tasks,
+    processing_deadline_duration=60,
+)
+def run_explorer_index_for_projects(
+    projects: list[tuple[int, int]], start: str, *args, **kwargs
+) -> None:
+    """
+    Call the seer /v1/automation/explorer/index endpoint to schedule indexing tasks
+    for a batch of projects.
+
+    Args:
+        projects: List of (project_id, organization_id) tuples
+        start: ISO format timestamp string for when this batch was scheduled
+    """
+    if not options.get("seer.explorer_index.enable"):
+        return
+
+    if not projects:
+        return
+
+    # Build the request payload
+    # The seer endpoint expects: {"projects": [{"org_id": int, "project_id": int}, ...]}
+    project_list = [{"org_id": org_id, "project_id": project_id} for project_id, org_id in projects]
+
+    payload = {"projects": project_list}
+    body = orjson.dumps(payload)
+
+    path = "/v1/automation/explorer/index"
+
+    try:
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        result = response.json()
+        scheduled_count = result.get("scheduled_count", 0)
+
+        logger.info(
+            "Successfully scheduled explorer index tasks in seer",
+            extra={
+                "scheduled_count": scheduled_count,
+                "requested_count": len(projects),
+            },
+        )
+
+    except requests.RequestException as e:
+        logger.exception(
+            "Failed to schedule explorer index tasks in seer",
+            extra={
+                "num_projects": len(projects),
+                "error": str(e),
+            },
+        )
+        # Re-raise to let the task framework handle retry logic
+        raise

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -145,12 +145,9 @@ def run_explorer_index_for_projects(
     if not projects:
         return
 
-    # The seer endpoint expects: {"projects": [{"org_id": int, "project_id": int}, ...]}
     project_list = [{"org_id": org_id, "project_id": project_id} for project_id, org_id in projects]
-
     payload = {"projects": project_list}
     body = orjson.dumps(payload)
-
     path = "/v1/automation/explorer/index"
 
     try:
@@ -164,18 +161,6 @@ def run_explorer_index_for_projects(
             timeout=30,
         )
         response.raise_for_status()
-
-        result = response.json()
-        scheduled_count = result.get("scheduled_count", 0)
-
-        logger.info(
-            "Successfully scheduled explorer index tasks in seer",
-            extra={
-                "scheduled_count": scheduled_count,
-                "requested_count": len(projects),
-            },
-        )
-
     except requests.RequestException as e:
         logger.exception(
             "Failed to schedule explorer index tasks in seer",
@@ -184,5 +169,15 @@ def run_explorer_index_for_projects(
                 "error": str(e),
             },
         )
-        # Re-raise to let the task framework handle retry logic
         raise
+
+    result = response.json()
+    scheduled_count = result.get("scheduled_count", 0)
+
+    logger.info(
+        "Successfully scheduled explorer index tasks in seer",
+        extra={
+            "scheduled_count": scheduled_count,
+            "requested_count": len(projects),
+        },
+    )

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta
 
 import orjson
@@ -76,7 +76,7 @@ def schedule_explorer_index() -> None:
 
 
 def dispatch_explorer_index_projects(
-    all_projects: Generator[tuple[int, int]],
+    all_projects: Iterator[tuple[int, int]],
     timestamp: datetime,
 ) -> Generator[tuple[int, int]]:
     """

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -21,7 +21,8 @@ from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger("sentry.tasks.seer_explorer_indexer")
 
-CACHE_KEY = "seer:explorer_index:last_run"
+LAST_RUN_CACHE_KEY = "seer:explorer_index:last_run"
+LAST_RUN_CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours
 
 EXPLORER_INDEX_PROJECTS_PER_BATCH = 100
 EXPLORER_INDEX_RUN_FREQUENCY = timedelta(hours=24)
@@ -59,11 +60,11 @@ def schedule_explorer_index() -> None:
     if not options.get("seer.explorer_index.enable"):
         return
 
-    last_run = cache.get(CACHE_KEY)
+    last_run = cache.get(LAST_RUN_CACHE_KEY)
     if last_run and last_run > django_timezone.now() - EXPLORER_INDEX_RUN_FREQUENCY:
         return
 
-    cache.set(CACHE_KEY, django_timezone.now())
+    cache.set(LAST_RUN_CACHE_KEY, django_timezone.now(), LAST_RUN_CACHE_TIMEOUT)
 
     now = django_timezone.now()
 

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -1,0 +1,182 @@
+from datetime import UTC, datetime
+from unittest import mock
+
+import orjson
+import pytest
+import responses
+from django.conf import settings
+
+from sentry.constants import ObjectStatus
+from sentry.tasks.seer_explorer_index import (
+    dispatch_explorer_index_projects,
+    get_seer_explorer_enabled_projects,
+    run_explorer_index_for_projects,
+    schedule_explorer_index,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.utils.cache import cache
+
+
+@django_db_all
+class TestGetSeerExplorerEnabledProjects(TestCase):
+    def test_returns_projects_with_feature_flag(self):
+        org1 = self.create_organization()
+        org2 = self.create_organization()
+
+        project1 = self.create_project(organization=org1)
+        project2 = self.create_project(organization=org1)
+        project3 = self.create_project(organization=org2)
+
+        def mock_features_has(feature_name, org, **kwargs):
+            return feature_name == "organizations:seer-explorer-index" and org.id == org1.id
+
+        with mock.patch(
+            "sentry.tasks.seer_explorer_index.features.has", side_effect=mock_features_has
+        ):
+            result = list(get_seer_explorer_enabled_projects())
+
+        project_ids = [p[0] for p in result]
+        assert project1.id in project_ids
+        assert project2.id in project_ids
+        assert project3.id not in project_ids
+        assert result[0] == (project1.id, org1.id)
+
+    def test_excludes_inactive_projects(self):
+        org = self.create_organization()
+        active_project = self.create_project(organization=org)
+        inactive_project = self.create_project(organization=org)
+
+        inactive_project.update(status=ObjectStatus.PENDING_DELETION)
+
+        with mock.patch("sentry.tasks.seer_explorer_index.features.has", return_value=True):
+            result = list(get_seer_explorer_enabled_projects())
+
+        project_ids = [p[0] for p in result]
+        assert active_project.id in project_ids
+        assert inactive_project.id not in project_ids
+
+    def test_returns_empty_without_feature_flag(self):
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        result = list(get_seer_explorer_enabled_projects())
+        assert len(result) == 0
+
+
+@django_db_all
+class TestScheduleExplorerIndex(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_skips_when_option_disabled(self):
+        with self.options({"seer.explorer_index.enable": False}):
+            with mock.patch(
+                "sentry.tasks.seer_explorer_index.get_seer_explorer_enabled_projects"
+            ) as mock_get_projects:
+                schedule_explorer_index()
+                mock_get_projects.assert_not_called()
+
+    @freeze_time("2024-01-15 12:00:00")
+    def test_schedules_projects_with_option_enabled(self):
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with self.options({"seer.explorer_index.enable": True}):
+            with mock.patch("sentry.tasks.seer_explorer_index.features.has", return_value=True):
+                with mock.patch(
+                    "sentry.tasks.seer_explorer_index.dispatch_explorer_index_projects"
+                ) as mock_dispatch:
+                    mock_dispatch.return_value = iter([])
+                    schedule_explorer_index()
+                    mock_dispatch.assert_called_once()
+
+    @freeze_time("2024-01-15 12:00:00")
+    def test_respects_cache_interval(self):
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with self.options({"seer.explorer_index.enable": True}):
+            with mock.patch("sentry.tasks.seer_explorer_index.features.has", return_value=True):
+                with mock.patch(
+                    "sentry.tasks.seer_explorer_index.dispatch_explorer_index_projects"
+                ) as mock_dispatch:
+                    mock_dispatch.return_value = iter([])
+
+                    schedule_explorer_index()
+                    assert mock_dispatch.call_count == 1
+
+                    schedule_explorer_index()
+                    assert mock_dispatch.call_count == 1
+
+
+@django_db_all
+class TestDispatchExplorerIndexProjects(TestCase):
+    @freeze_time("2024-01-15 12:00:00")
+    def test_batches_projects_with_delays(self):
+        timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+        projects = [(i, 1) for i in range(150)]
+
+        with mock.patch(
+            "sentry.tasks.seer_explorer_index.run_explorer_index_for_projects.apply_async"
+        ) as mock_task:
+            result = list(dispatch_explorer_index_projects(iter(projects), timestamp))
+
+        assert mock_task.call_count == 2
+        assert len(mock_task.call_args_list[0][1]["args"][0]) == 100
+        assert len(mock_task.call_args_list[1][1]["args"][0]) == 50
+
+        for call in mock_task.call_args_list:
+            assert "countdown" in call[1]
+            assert call[1]["countdown"] >= 0
+
+        assert len(result) == 150
+
+
+@django_db_all
+class TestRunExplorerIndexForProjects(TestCase):
+    @responses.activate
+    def test_calls_seer_endpoint_successfully(self):
+        projects = [(1, 100), (2, 100), (3, 200)]
+        start = "2024-01-15T12:00:00+00:00"
+
+        responses.add(
+            responses.POST,
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/index",
+            json={"scheduled_count": 3, "projects": []},
+            status=200,
+        )
+
+        with self.options({"seer.explorer_index.enable": True}):
+            run_explorer_index_for_projects(projects, start)
+
+        request_body = orjson.loads(responses.calls[0].request.body)
+        assert request_body["projects"] == [
+            {"org_id": 100, "project_id": 1},
+            {"org_id": 100, "project_id": 2},
+            {"org_id": 200, "project_id": 3},
+        ]
+
+    @responses.activate
+    def test_handles_request_error(self):
+        projects = [(1, 100)]
+        start = "2024-01-15T12:00:00+00:00"
+
+        responses.add(
+            responses.POST,
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/index",
+            json={"error": "Internal server error"},
+            status=500,
+        )
+
+        with self.options({"seer.explorer_index.enable": True}):
+            with pytest.raises(Exception):
+                run_explorer_index_for_projects(projects, start)
+
+    def test_skips_when_option_disabled(self):
+        with self.options({"seer.explorer_index.enable": False}):
+            with mock.patch("sentry.tasks.seer_explorer_index.requests.post") as mock_post:
+                run_explorer_index_for_projects([(1, 100)], "2024-01-15T12:00:00+00:00")
+                mock_post.assert_not_called()


### PR DESCRIPTION
Adds a periodic task to schedule Seer Explorer indexing
for projects in organizations with the `seer-explorer-index` 
feature flag enabled. The cron tab is set for every hour, 
just to make sure the task gets picked up in case a deploy or 
scheduler restart causes a missed window. 
Storing last_run in cache so it's only run every 24 hours.

This main task batches projects and for every batch of 100
spawns a task that calls seer's `/v1/automation/explorer/index`
endpoint with computed delays (same logic as statistical detectors).