### PR TITLE
feat(eco): Adds integration debug table for displaying customer integration install info

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -41,6 +41,7 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/customers/[^/]+/subscription/usage-logs/$'),
   new RegExp('^api/0/customers/[^/]+/policies/$'),
   new RegExp('^api/0/customers/[^/]+/migrate-google-domain/$'),
+  new RegExp('^api/0/customers/[^/]+/integrations/$'),
   new RegExp('^api/0/users/[^/]+/merge-accounts/$'),
   new RegExp('^api/0/organizations/[^/]+/partnership-agreements/$'),
   new RegExp('^api/0/policies/$'),

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -61,7 +61,7 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
       inPanel
       panelTitle="Integration Debug Details"
       path={`/_admin/customers/${orgId}/`}
-      endpoint={`/api/0/customers/${orgId}/integrations/`}
+      endpoint={`/customers/${orgId}/integrations/`}
       method="GET"
       defaultParams={{per_page: 25}}
       useQueryString={false}
@@ -153,7 +153,6 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
 const MetadataContent = styled('pre')`
   margin: 0;
   padding: ${space(1.5)};
-  background-color: ${p => p.theme.backgroundSecondary};
   border-radius: 4px;
   overflow-x: auto;
   font-size: ${p => p.theme.fontSize.sm};

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -1,0 +1,178 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment-timezone';
+
+import {Button} from 'sentry/components/core/button';
+import {IconChevron} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+
+import ResultGrid from 'admin/components/resultGrid';
+
+type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
+  orgId: string;
+};
+
+type IntegrationRow = {
+  dateAdded: string;
+  gracePeriodEnd: string | null;
+  id: number;
+  integration: {
+    externalId: string;
+    id: number;
+    metadata: Record<string, any>;
+    name: string;
+    provider: string;
+    status: number;
+  };
+  status: number;
+};
+
+const STATUS_LABELS: Record<number, string> = {
+  0: 'Active',
+  1: 'Disabled',
+  2: 'Pending Deletion',
+  3: 'Deletion In Progress',
+};
+
+function getStatusLabel(status: number): string {
+  return STATUS_LABELS[status] ?? `Unknown (${status})`;
+}
+
+function CustomerIntegrationDebugDetails({orgId}: Props) {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
+  const toggleRow = (id: number) => {
+    setExpandedRows(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(id)) {
+        newSet.delete(id);
+      } else {
+        newSet.add(id);
+      }
+      return newSet;
+    });
+  };
+
+  return (
+    <ResultGrid
+      inPanel
+      panelTitle="Integration Debug Details"
+      path={`/_admin/customers/${orgId}/`}
+      endpoint={`/api/0/customers/${orgId}/integrations/`}
+      method="GET"
+      defaultParams={{per_page: 25}}
+      useQueryString={false}
+      rowsFromData={(data: IntegrationRow[]) => {
+        const transformedRows: any[] = [];
+        data.forEach(row => {
+          transformedRows.push(row);
+          transformedRows.push({
+            _isExpansionRow: true,
+            _parentId: row.id,
+            _parentData: row,
+          });
+        });
+        return transformedRows;
+      }}
+      keyForRow={row => (row._isExpansionRow ? `expand-${row._parentId}` : row.id)}
+      columns={[
+        <th key="expand" style={{width: 40}} />,
+        <th key="provider">Provider</th>,
+        <th key="integrationStatus">Integration Status</th>,
+        <th key="orgIntegrationStatus">Org Integration Status</th>,
+        <th key="id" style={{textAlign: 'right'}}>
+          ID
+        </th>,
+        <th key="gracePeriodEnd" style={{textAlign: 'right'}}>
+          Grace Period End
+        </th>,
+        <th key="externalId" style={{textAlign: 'right'}}>
+          External ID
+        </th>,
+      ]}
+      columnsForRow={(row: any) => {
+        // Handle expansion rows
+        if (row._isExpansionRow) {
+          const parentRow = row._parentData;
+          const isExpanded = expandedRows.has(parentRow.id);
+          const hasMetadata =
+            parentRow.integration.metadata &&
+            Object.keys(parentRow.integration.metadata).length > 0;
+
+          if (!isExpanded || !hasMetadata) {
+            return [<td key="empty" colSpan={7} style={{padding: 0, height: 0}} />];
+          }
+
+          return [
+            <td key="metadata" colSpan={7}>
+              <MetadataContainer>
+                <MetadataTitle>Integration Metadata</MetadataTitle>
+                <MetadataContent>
+                  {JSON.stringify(parentRow.integration.metadata, null, 2)}
+                </MetadataContent>
+              </MetadataContainer>
+            </td>,
+          ];
+        }
+
+        // Handle regular rows
+        const isExpanded = expandedRows.has(row.id);
+        const hasMetadata =
+          row.integration.metadata && Object.keys(row.integration.metadata).length > 0;
+
+        return [
+          <td key="expand">
+            <Button
+              size="zero"
+              borderless
+              onClick={() => toggleRow(row.id)}
+              icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
+              aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
+              disabled={!hasMetadata}
+            />
+          </td>,
+          <td key="provider">{row.integration.provider}</td>,
+          <td key="integrationStatus">{getStatusLabel(row.integration.status)}</td>,
+          <td key="orgIntegrationStatus">{getStatusLabel(row.status)}</td>,
+          <td key="id" style={{textAlign: 'right'}}>
+            {row.id}
+          </td>,
+          <td key="gracePeriodEnd" style={{textAlign: 'right'}}>
+            {row.gracePeriodEnd ? moment(row.gracePeriodEnd).fromNow() : 'n/a'}
+          </td>,
+          <td key="externalId" style={{textAlign: 'right'}}>
+            {row.integration.externalId || 'n/a'}
+          </td>,
+        ];
+      }}
+      // {...props}
+    />
+  );
+}
+
+const MetadataContainer = styled('div')`
+  padding: ${space(2)};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: 4px;
+  margin: ${space(1)} 0;
+`;
+
+const MetadataTitle = styled('div')`
+  font-weight: 600;
+  margin-bottom: ${space(1)};
+  font-size: ${p => p.theme.fontSize.md};
+`;
+
+const MetadataContent = styled('pre')`
+  margin: 0;
+  padding: ${space(1.5)};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: ${p => p.theme.fontSize.sm};
+  font-family: ${p => p.theme.text.familyMono};
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`;
+
+export default CustomerIntegrationDebugDetails;

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -105,11 +105,11 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
             Object.keys(parentRow.integration.metadata).length > 0;
 
           if (!isExpanded || !hasMetadata) {
-            return [<td key="empty" colSpan={7} style={{padding: 0, height: 0}} />];
+            return [<td key="empty" colSpan={8} style={{padding: 0, height: 0}} />];
           }
 
           return [
-            <td key="metadata" colSpan={7}>
+            <td key="metadata" colSpan={8}>
               <Container>
                 <Heading as="h6">Integration Metadata</Heading>
                 <MetadataContent>

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -2,6 +2,9 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
+import {Container} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
 import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
@@ -91,7 +94,6 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
         </th>,
       ]}
       columnsForRow={(row: any) => {
-        // Handle expansion rows
         if (row._isExpansionRow) {
           const parentRow = row._parentData;
           const isExpanded = expandedRows.has(parentRow.id);
@@ -105,17 +107,16 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
 
           return [
             <td key="metadata" colSpan={7}>
-              <MetadataContainer>
-                <MetadataTitle>Integration Metadata</MetadataTitle>
+              <Container>
+                <Heading as="h6">Integration Metadata</Heading>
                 <MetadataContent>
                   {JSON.stringify(parentRow.integration.metadata, null, 2)}
                 </MetadataContent>
-              </MetadataContainer>
+              </Container>
             </td>,
           ];
         }
 
-        // Handle regular rows
         const isExpanded = expandedRows.has(row.id);
         const hasMetadata =
           row.integration.metadata && Object.keys(row.integration.metadata).length > 0;
@@ -145,23 +146,9 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
           </td>,
         ];
       }}
-      // {...props}
     />
   );
 }
-
-const MetadataContainer = styled('div')`
-  padding: ${space(2)};
-  background-color: ${p => p.theme.backgroundSecondary};
-  border-radius: 4px;
-  margin: ${space(1)} 0;
-`;
-
-const MetadataTitle = styled('div')`
-  font-weight: 600;
-  margin-bottom: ${space(1)};
-  font-size: ${p => p.theme.fontSize.md};
-`;
 
 const MetadataContent = styled('pre')`
   margin: 0;

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -84,7 +84,10 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
         <th key="integrationStatus">Integration Status</th>,
         <th key="orgIntegrationStatus">Org Integration Status</th>,
         <th key="id" style={{textAlign: 'right'}}>
-          ID
+          Org Integration ID
+        </th>,
+        <th key="integrationId" style={{textAlign: 'right'}}>
+          Integration ID
         </th>,
         <th key="gracePeriodEnd" style={{textAlign: 'right'}}>
           Grace Period End
@@ -135,8 +138,11 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
           <td key="provider">{row.integration.provider}</td>,
           <td key="integrationStatus">{getStatusLabel(row.integration.status)}</td>,
           <td key="orgIntegrationStatus">{getStatusLabel(row.status)}</td>,
-          <td key="id" style={{textAlign: 'right'}}>
+          <td key="orgIntegrationId" style={{textAlign: 'right'}}>
             {row.id}
+          </td>,
+          <td key="integrationId" style={{textAlign: 'right'}}>
+            {row.integration.id}
           </td>,
           <td key="gracePeriodEnd" style={{textAlign: 'right'}}>
             {row.gracePeriodEnd ? moment(row.gracePeriodEnd).fromNow() : 'n/a'}

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -41,7 +41,7 @@ function getStatusLabel(status: number): string {
   return STATUS_LABELS[status] ?? `Unknown (${status})`;
 }
 
-function CustomerIntegrationDebugDetails({orgId}: Props) {
+function CustomerIntegrationDebugDetails({orgId, ...props}: Props) {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
 
   const toggleRow = (id: number) => {
@@ -152,6 +152,7 @@ function CustomerIntegrationDebugDetails({orgId}: Props) {
           </td>,
         ];
       }}
+      {...props}
     />
   );
 }

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -674,6 +674,10 @@ function setUpMocks(
     url: `/organizations/${organization.slug}/projects/`,
     body: [],
   });
+  MockApiClient.addMockResponse({
+    url: `/customers/${organization.slug}/integrations/`,
+    body: [],
+  });
 }
 
 describe('Customer Details', () => {

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -42,6 +42,7 @@ import triggerChangePlanAction from 'admin/components/changePlanAction';
 import CloseAccountInfo from 'admin/components/closeAccountInfo';
 import CustomerCharges from 'admin/components/customers/customerCharges';
 import CustomerHistory from 'admin/components/customers/customerHistory';
+import CustomerIntegrationDebugDetails from 'admin/components/customers/customerIntegrationDebugDetails';
 import CustomerIntegrations from 'admin/components/customers/customerIntegrations';
 import CustomerInvoices from 'admin/components/customers/customerInvoices';
 import CustomerMembers from 'admin/components/customers/customerMembers';
@@ -891,6 +892,10 @@ export default function CustomerDetails() {
           {
             noPanel: true,
             content: <CustomerProjects orgId={orgId} />,
+          },
+          {
+            noPanel: true,
+            content: <CustomerIntegrationDebugDetails orgId={orgId} />,
           },
           {
             noPanel: true,


### PR DESCRIPTION
Adds new Admin component to list debug information for integrations, using the new admin endpoint.

The table is pretty basic, but each row can be expanded to show non-sensitive metadata information:
<img width="1231" height="628" alt="Screenshot 2026-01-14 at 5 08 06 PM" src="https://github.com/user-attachments/assets/25af7468-3bbe-41c8-85e9-af1d2a9838fe" />


