### PR TITLE
fix(profiling): Fix pluralization of "samples" in flamegraph tooltip

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -4,7 +4,7 @@ import type {vec2} from 'gl-matrix';
 
 import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
 import {IconLightning} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -111,7 +111,7 @@ function DifferentialFlamegraphTooltip(props: DifferentialFlamegraphTooltipProps
           backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
         />
         {PROFILING_SAMPLES_FORMATTER.format(props.frame.node.totalWeight)}{' '}
-        {t('samples, ') + formattedChange}{' '}
+        {tn('sample, ', 'samples, ', props.frame.node.totalWeight) + formattedChange}{' '}
         {`(${formatWeightToProfileDuration(props.frame.node, flamegraph)})`}{' '}
         {props.frame.frame.name}
       </FlamegraphTooltipFrameMainInfo>
@@ -144,7 +144,7 @@ function AggregateFlamegraphTooltip(props: AggregateFlamegraphTooltipProps) {
           backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
         />
         {PROFILING_SAMPLES_FORMATTER.format(props.frame.node.totalWeight)}{' '}
-        {t('samples') + ' '}
+        {tn('sample', 'samples', props.frame.node.totalWeight) + ' '}
         {`(${formatWeightToProfileDuration(
           props.frame.node,
           props.flamegraphRenderer.flamegraph


### PR DESCRIPTION
Use tn() instead of t() to properly pluralize "sample/samples" based on the count, so "1 sample" displays correctly instead of "1 samples".
