### PR TITLE
fix(dashboard): Widget Builder uses location.state when closing

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -779,8 +779,10 @@ class DashboardDetail extends Component<Props, State> {
         // Persist the widgets through the route change to use location.state if we're
         // creating a new dashboard, otherwise the navigation may remount the component and
         // lose the widgets
-        state:
-          dashboardState === DashboardState.CREATE ? {widgets: newWidgets} : undefined,
+        ...(dashboardState === DashboardState.CREATE &&
+          defined(newWidgets) && {
+            state: {widgets: newWidgets},
+          }),
       }
     );
   };

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -734,7 +734,7 @@ class DashboardDetail extends Component<Props, State> {
         newlyAddedWidget: mergedWidget,
       });
 
-      this.handleCloseWidgetBuilder();
+      this.handleCloseWidgetBuilder(newWidgets);
     } catch (error) {
       addErrorMessage(t('Failed to save widget'));
     }
@@ -759,8 +759,9 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
-  handleCloseWidgetBuilder = () => {
+  handleCloseWidgetBuilder = (newWidgets?: Widget[]) => {
     const {organization, navigate, location, params} = this.props;
+    const {dashboardState} = this.state;
 
     this.setState({
       isWidgetBuilderOpen: false,
@@ -772,7 +773,15 @@ class DashboardDetail extends Component<Props, State> {
         dashboardId: params.dashboardId,
         location,
       }),
-      {preventScrollReset: true}
+      {
+        preventScrollReset: true,
+
+        // Persist the widgets through the route change to use location.state if we're
+        // creating a new dashboard, otherwise the navigation may remount the component and
+        // lose the widgets
+        state:
+          dashboardState === DashboardState.CREATE ? {widgets: newWidgets} : undefined,
+      }
     );
   };
 


### PR DESCRIPTION
When submitting a widget to a new dashboard when navigated by the Add to Dashboard flow, the widget can be lost due to the `create.tsx` component remounting. To avoid this, we persist the widgets in location state which the create view handles and ensures that data is persisted in its next render.