### PR TITLE
chore(aci): default tests to dual write

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -184,6 +184,7 @@ from sentry.users.models.userpermission import UserPermission
 from sentry.users.models.userrole import UserRole
 from sentry.users.services.user import RpcUser
 from sentry.utils import loremipsum
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import (
     Action,
     ActionAlertRuleTriggerAction,
@@ -654,12 +655,16 @@ class Factories:
         if actions:
             data["actions"] = actions
 
-        return Rule.objects.create(
+        rule = Rule.objects.create(
             label=name,
             project=project,
             data=data,
             **kwargs,
         )
+        # dual write the rule to the workflow engine
+        IssueAlertMigrator(rule).run()
+
+        return rule
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -29,7 +29,6 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
@@ -1527,7 +1526,6 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 },
             ],
         )
-        IssueAlertMigrator(rule, user_id=self.user.id).run()
 
         alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
         workflow = alert_rule_workflow.workflow
@@ -1548,11 +1546,3 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not DataConditionGroup.objects.filter(id=if_dcg.id).exists()
         assert not DataCondition.objects.filter(condition_group=when_dcg).exists()
         assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
-
-    def test_dual_delete_workflow_engine_no_migrated_models(self) -> None:
-        rule = self.create_project_rule(self.project)
-        self.get_success_response(
-            self.organization.slug, rule.project.slug, rule.id, status_code=202
-        )
-
-        assert not AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists()

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -54,9 +54,10 @@ class TestUpdater(TestCase):
         assert self.rule.owner_user_id is None
 
     def test_update_environment(self) -> None:
-        self.updater.environment = 3
+        new_env = self.create_environment(project=self.project)
+        self.updater.environment = new_env.id
         self.updater.run()
-        assert self.rule.environment_id == 3
+        assert self.rule.environment_id == new_env.id
 
     def test_update_environment_when_none(self) -> None:
         self.rule.environment_id = 3
@@ -120,8 +121,6 @@ class TestUpdater(TestCase):
         assert self.rule.data["frequency"] == 5
 
     def test_dual_update_workflow_engine(self) -> None:
-        IssueAlertMigrator(self.rule, user_id=self.user.id).run()
-
         conditions = [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -7,7 +7,7 @@ from sentry.rules.history.base import RuleGroupHistory
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.models import AlertRuleWorkflow, WorkflowFireHistory
+from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow, WorkflowFireHistory
 
 pytestmark = [requires_snuba]
 
@@ -198,9 +198,9 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when feature flag is enabled"""
         rule = self.create_project_rule(project=self.event.project)
-        workflow = self.create_workflow(organization=self.event.project.organization)
-
-        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+        workflow = Workflow.objects.get(
+            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
+        )
 
         # Create some RuleFireHistory entries
         rule_history = []
@@ -336,9 +336,9 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory for hourly stats when feature flag is enabled"""
         rule = self.create_project_rule(project=self.event.project)
-        workflow = self.create_workflow(organization=self.event.project.organization)
-
-        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+        workflow = Workflow.objects.get(
+            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
+        )
 
         rule_history = []
         # Hour 1: 2 rule fire entries

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -730,8 +730,7 @@ class ApplyDelayedTest(ProcessDelayedAlertConditionsTestBase):
         env3 = self.create_environment(project=project_three)
         rule_1 = self.create_project_rule(
             project=project_three,
-            condition_data=[self.event_frequency_condition],
-            filter_match=[self.tag_filter],
+            condition_data=[self.event_frequency_condition, self.tag_filter],
             environment_id=env3.id,
         )
         rule_2 = self.create_project_rule(
@@ -1204,8 +1203,7 @@ class ApplyDelayedTest(ProcessDelayedAlertConditionsTestBase):
         buffer.backend.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=project_three.id)
         rule_1 = self.create_project_rule(
             project=project_three,
-            condition_data=[self.event_frequency_condition],
-            filter_match=[self.tag_filter],
+            condition_data=[self.event_frequency_condition, self.tag_filter],
             environment_id=env3.id,
         )
         rule_2 = self.create_project_rule(

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -69,7 +70,7 @@ class IssueAlertMigratorTest(TestCase):
                 "channel_id": "C01234567890",
             },
         ]
-        self.issue_alert_data = {
+        self.issue_alert_data: dict[str, Any] = {
             "conditions": self.rule_conditions,
             "actions": self.action_data,
             "action_match": "any",

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,7 +49,7 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 class IssueAlertMigratorTest(TestCase):
     def setUp(self) -> None:
-        conditions = [
+        self.rule_conditions = [
             {"id": ReappearedEventCondition.id},
             {"id": RegressionEventCondition.id},
             {
@@ -68,15 +69,14 @@ class IssueAlertMigratorTest(TestCase):
                 "channel_id": "C01234567890",
             },
         ]
-        self.issue_alert = self.create_project_rule(
-            name="test",
-            condition_data=conditions,
-            action_match="any",
-            filter_match="any",
-            action_data=self.action_data,
-        )
-        self.issue_alert.data["frequency"] = 5
-        self.issue_alert.save()
+        self.issue_alert_data = {
+            "conditions": self.rule_conditions,
+            "actions": self.action_data,
+            "action_match": "any",
+            "filter_match": "any",
+            "frequency": 5,
+            "group_type": IssueStreamGroupType.slug,
+        }
 
         self.filters = [
             {
@@ -119,6 +119,18 @@ class IssueAlertMigratorTest(TestCase):
                 "value": self.filters[2]["value"],
             },
         ]
+
+    @cached_property
+    def issue_alert(self):
+        # create_project_rule runs the IssueAlertMigrator
+        return self.create_project_rule(
+            name="test",
+            condition_data=self.rule_conditions,
+            action_match="any",
+            filter_match="any",
+            action_data=self.action_data,
+            frequency=5,
+        )
 
     def assert_nothing_migrated(self, issue_alert):
         assert not AlertRuleWorkflow.objects.filter(rule_id=issue_alert.id).exists()
@@ -207,8 +219,6 @@ class IssueAlertMigratorTest(TestCase):
         ).exists()
 
     def test_run(self) -> None:
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
         self.assert_issue_alert_migrated(self.issue_alert)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
@@ -216,72 +226,106 @@ class IssueAlertMigratorTest(TestCase):
         assert action.type == Action.Type.SLACK
 
     def test_run__issue_stream_detector(self) -> None:
-        self.issue_alert.data["group_type"] = IssueStreamGroupType.slug
-        self.issue_alert.save()
-
-        workflow = IssueAlertMigrator(self.issue_alert, self.user.id).run()
-        self.assert_issue_stream_detector_migrated(self.issue_alert.project_id, workflow)
+        self.issue_alert_data["group_type"] = IssueStreamGroupType.slug
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        workflow = IssueAlertMigrator(issue_alert, self.user.id).run()
+        self.assert_issue_stream_detector_migrated(issue_alert.project_id, workflow)
 
     def test_run__missing_matches(self) -> None:
-        data = self.issue_alert.data
-        del data["action_match"]
-        del data["filter_match"]
-        self.issue_alert.update(data=data)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
-        self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.ALL)
+        del self.issue_alert_data["action_match"]
+        del self.issue_alert_data["filter_match"]
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        self.assert_issue_alert_migrated(issue_alert, logic_type=DataConditionGroup.Type.ALL)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
     def test_run__none_matches(self) -> None:
-        data = self.issue_alert.data
-        data["action_match"] = None
-        data["filter_match"] = None
-        self.issue_alert.update(data=data)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        self.issue_alert_data["action_match"] = None
+        self.issue_alert_data["filter_match"] = None
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
-        self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.ALL)
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        self.assert_issue_alert_migrated(issue_alert, logic_type=DataConditionGroup.Type.ALL)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
     def test_run__disabled_rule(self) -> None:
-        self.issue_alert.update(status=ObjectStatus.DISABLED)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
-        self.assert_issue_alert_migrated(self.issue_alert, is_enabled=False)
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+            status=ObjectStatus.DISABLED,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        self.assert_issue_alert_migrated(issue_alert, is_enabled=False)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
     def test_run__snoozed_rule(self) -> None:
-        RuleSnooze.objects.create(rule=self.issue_alert)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        # create_project_rule runs the IssueAlertMigrator
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=self.rule_conditions,
+            action_match="any",
+            filter_match="any",
+            action_data=self.action_data,
+            frequency=5,
+        )
+        RuleSnooze.objects.create(rule=issue_alert)
 
-        self.assert_issue_alert_migrated(self.issue_alert, is_enabled=False)
+        self.assert_issue_alert_migrated(issue_alert, is_enabled=False)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
     def test_run__snoozed_rule_for_user(self) -> None:
-        RuleSnooze.objects.create(rule=self.issue_alert, user_id=self.user.id)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        # create_project_rule runs the IssueAlertMigrator
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=self.rule_conditions,
+            action_match="any",
+            filter_match="any",
+            action_data=self.action_data,
+            frequency=5,
+        )
+        RuleSnooze.objects.create(rule=issue_alert, user_id=self.user.id)
 
-        self.assert_issue_alert_migrated(self.issue_alert, is_enabled=True)
+        self.assert_issue_alert_migrated(issue_alert, is_enabled=True)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
     def test_run__skip_actions(self) -> None:
-        IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
+        del self.issue_alert_data["actions"]
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id, should_create_actions=False).run()
 
-        self.assert_issue_alert_migrated(self.issue_alert)
+        self.assert_issue_alert_migrated(issue_alert)
 
         assert DataConditionGroupAction.objects.all().count() == 0
         assert Action.objects.all().count() == 0
@@ -296,12 +340,16 @@ class IssueAlertMigratorTest(TestCase):
             },
             {"id": RegressionEventCondition.id},
         ]
-        self.issue_alert.data["conditions"] = invalid_conditions
-        self.issue_alert.save()
+        self.issue_alert_data["conditions"] = invalid_conditions
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
-        IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
+        IssueAlertMigrator(issue_alert, self.user.id, should_create_actions=False).run()
 
-        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=issue_alert.id)
 
         workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
 
@@ -324,21 +372,28 @@ class IssueAlertMigratorTest(TestCase):
                 "comparisonType": "asdf",
             },
         ]
-        self.issue_alert.data["conditions"] = conditions
-        self.issue_alert.save()
+        self.issue_alert_data["conditions"] = conditions
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
         with pytest.raises(Exception):
-            IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
+            IssueAlertMigrator(issue_alert, self.user.id, should_create_actions=False).run()
 
         assert Workflow.objects.all().count() == 0
 
     def test_run__no_triggers(self) -> None:
-        self.issue_alert.data["conditions"] = []
-        self.issue_alert.save()
+        self.issue_alert_data["conditions"] = []
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id, should_create_actions=False).run()
 
-        IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
-
-        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=issue_alert.id)
         workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
 
         assert workflow.when_condition_group
@@ -347,8 +402,6 @@ class IssueAlertMigratorTest(TestCase):
         )
 
     def test_run__no_double_migrate(self) -> None:
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
         # there should be only 1
         issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
         issue_alert_detector = AlertRuleDetector.objects.get(rule_id=self.issue_alert.id)
@@ -360,10 +413,7 @@ class IssueAlertMigratorTest(TestCase):
         other_project_detector = self.create_detector(
             project=self.project, type=IssueStreamGroupType.slug
         )
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
         # does not create a new error detector
-
         error_detector = Detector.objects.get(project_id=self.project.id, type=ErrorGroupType.slug)
         assert error_detector.id == project_detector.id
 
@@ -373,22 +423,25 @@ class IssueAlertMigratorTest(TestCase):
         assert other_project_detector.id == issue_stream_detector.id
 
     def test_run__detector_lookup_exists(self) -> None:
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
         AlertRuleDetector.objects.create(
             detector=self.create_detector(project=self.project),
-            rule_id=self.issue_alert.id,
+            rule_id=issue_alert.id,
         )
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-        AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id).workflow
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        AlertRuleWorkflow.objects.get(rule_id=issue_alert.id).workflow
 
     def test_run__with_conditions(self) -> None:
-        issue_alert = self.create_project_rule(
+        self.create_project_rule(
             condition_data=self.conditions,
             action_match="all",
             filter_match="any",
             action_data=self.action_data,
         )
-
-        IssueAlertMigrator(issue_alert, self.user.id).run()
         assert DataCondition.objects.all().count() == 1
         dc = DataCondition.objects.get(type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
         assert dc.comparison == {
@@ -403,14 +456,12 @@ class IssueAlertMigratorTest(TestCase):
             {"id": EveryEventCondition.id},
             {"id": RegressionEventCondition.id},
         ]
-        issue_alert = self.create_project_rule(
+        self.create_project_rule(
             condition_data=conditions,
             action_match="any",
             filter_match="any",
             action_data=self.action_data,
         )
-
-        IssueAlertMigrator(issue_alert, self.user.id).run()
         assert DataCondition.objects.all().count() == 1
         dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
         assert dc.condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
@@ -420,25 +471,28 @@ class IssueAlertMigratorTest(TestCase):
             {"id": EveryEventCondition.id},
             {"id": RegressionEventCondition.id},
         ]
-        issue_alert = self.create_project_rule(
+        self.create_project_rule(
             condition_data=conditions,
             action_match="all",
             filter_match="any",
             action_data=self.action_data,
         )
-
-        IssueAlertMigrator(issue_alert, self.user.id).run()
         assert DataCondition.objects.all().count() == 1
         dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
         assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
 
     def test_run__cron_rule(self) -> None:
         # cron rule should not be connected to the error detector
-        self.issue_alert.source = RuleSource.CRON_MONITOR
-        self.issue_alert.save()
+        self.issue_alert_data["group_type"] = IssueStreamGroupType.slug
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+            source=RuleSource.CRON_MONITOR,
+        )
+        workflow = IssueAlertMigrator(issue_alert, self.user.id).run()
 
-        workflow = IssueAlertMigrator(self.issue_alert, self.user.id).run()
-        assert AlertRuleWorkflow.objects.filter(rule_id=self.issue_alert.id).exists()
+        assert AlertRuleWorkflow.objects.filter(rule_id=issue_alert.id).exists()
         assert not DetectorWorkflow.objects.filter(workflow=workflow).exists()
 
     def test_run__cron_rule_with_monitor(self) -> None:
@@ -455,8 +509,8 @@ class IssueAlertMigratorTest(TestCase):
         ensure_cron_detector(monitor)
 
         # Update rule to be cron monitor source with monitor.slug filter
-        self.issue_alert.source = RuleSource.CRON_MONITOR
-        self.issue_alert.data["conditions"].append(
+        self.issue_alert_data["group_type"] = IssueStreamGroupType.slug
+        self.issue_alert_data["conditions"].append(
             {
                 "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
                 "key": "monitor.slug",
@@ -464,12 +518,16 @@ class IssueAlertMigratorTest(TestCase):
                 "value": "test-monitor",
             }
         )
-        self.issue_alert.save()
-
-        workflow = IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+            source=RuleSource.CRON_MONITOR,
+        )
+        workflow = IssueAlertMigrator(issue_alert, self.user.id).run()
 
         # Verify workflow created
-        assert AlertRuleWorkflow.objects.filter(rule_id=self.issue_alert.id).exists()
+        assert AlertRuleWorkflow.objects.filter(rule_id=issue_alert.id).exists()
 
         # Verify detector is linked to workflow
         detector = get_detector_for_monitor(monitor)
@@ -477,18 +535,28 @@ class IssueAlertMigratorTest(TestCase):
         assert DetectorWorkflow.objects.filter(detector=detector, workflow=workflow).exists()
 
     def test_dry_run(self) -> None:
-        IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
 
-        self.assert_nothing_migrated(self.issue_alert)
+        self.assert_nothing_migrated(issue_alert)
 
     def test_dry_run__already_exists(self) -> None:
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
+        IssueAlertMigrator(issue_alert, self.user.id).run()
 
         with pytest.raises(Exception):
-            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+            IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
 
-        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
-        issue_alert_detector = AlertRuleDetector.objects.get(rule_id=self.issue_alert.id)
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=issue_alert.id)
+        issue_alert_detector = AlertRuleDetector.objects.get(rule_id=issue_alert.id)
         Workflow.objects.get(id=issue_alert_workflow.workflow.id)
         Detector.objects.get(id=issue_alert_detector.detector.id)
 
@@ -498,29 +566,45 @@ class IssueAlertMigratorTest(TestCase):
     def test_dry_run__data_condition_validation_fails(self, mock_enforce: MagicMock) -> None:
         mock_enforce.side_effect = ValidationError("oopsie")
 
-        with pytest.raises(ValidationError):
-            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
-        self.assert_nothing_migrated(self.issue_alert)
+        with pytest.raises(ValidationError):
+            IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
+
+        self.assert_nothing_migrated(issue_alert)
 
     def test_dry_run__dcg_validation_fails(self) -> None:
-        self.issue_alert.data["action_match"] = "asdf"
+        self.issue_alert_data["action_match"] = "asdf"
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
         with pytest.raises(ValueError):
-            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+            IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
 
-        self.assert_nothing_migrated(self.issue_alert)
+        self.assert_nothing_migrated(issue_alert)
 
     def test_dry_run__workflow_validation_fails(self) -> None:
-        self.issue_alert.data["frequency"] = -1
+        self.issue_alert_data["frequency"] = -1
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
         with pytest.raises(ValidationError):
-            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+            IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
 
-        self.assert_nothing_migrated(self.issue_alert)
+        self.assert_nothing_migrated(issue_alert)
 
     def test_dry_run__action_validation_fails(self) -> None:
-        self.issue_alert.data["actions"] = [
+        self.issue_alert_data["actions"] = [
             {
                 "channel": "#my-channel",
                 "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
@@ -528,11 +612,16 @@ class IssueAlertMigratorTest(TestCase):
                 "channel_id": "C01234567890",
             },
         ]
+        issue_alert = Rule.objects.create(
+            label="Test Alert",
+            project=self.project,
+            data=self.issue_alert_data,
+        )
 
         with pytest.raises(ValueError):
-            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+            IssueAlertMigrator(issue_alert, self.user.id, is_dry_run=True).run()
 
-        self.assert_nothing_migrated(self.issue_alert)
+        self.assert_nothing_migrated(issue_alert)
 
 
 class TestEnsureDefaultDetectors(TestCase):
@@ -562,8 +651,8 @@ class TestEnsureDefaultDetectors(TestCase):
             mock_lock.assert_not_called()
 
     def test_ensure_default_detector__lock_fails(self) -> None:
-        project = self.create_project()
         with patch("sentry.workflow_engine.processors.detector.locks.get") as mock_lock:
             mock_lock.return_value.blocking_acquire.side_effect = UnableToAcquireLock
             with pytest.raises(UnableToAcquireLockApiError):
+                project = self.create_project()
                 ensure_default_detectors(project)


### PR DESCRIPTION
Breaking up changes from https://github.com/getsentry/sentry/pull/106239

We should dual write in tests as we are doing this by default in code today