### PR TITLE
ref(ownership): Remove backwards compatibility logic for issue owners debounce cache

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -198,7 +198,7 @@ class GroupOwner(Model):
         """
         cache.delete(ISSUE_OWNERS_DEBOUNCE_KEY(group_id))
 
-    # TODO(shashank): can make this O(1) cache invalidation by using the project ownership version timestamp (follow-up PR)
+    # TODO(shashank): can make this O(1) cache invalidation by using the project ownership version timestamp (follow-up PR), prob will need to update some tests in test_post_process.py as well
     @classmethod
     def invalidate_assignee_exists_cache(cls, project_id, group_id=None):
         """

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -38,7 +38,6 @@ from sentry.models.groupinbox import GroupInbox, GroupInboxReason
 from sentry.models.groupowner import (
     ASSIGNEE_EXISTS_DURATION,
     ASSIGNEE_EXISTS_KEY,
-    ISSUE_OWNERS_DEBOUNCE_DURATION,
     ISSUE_OWNERS_DEBOUNCE_KEY,
     GroupOwner,
     GroupOwnerType,
@@ -1376,11 +1375,8 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             project_id=self.project.id,
         )
 
-        assignee_cache_key = "assignee_exists:1:%s" % event.group.id
-        owner_cache_key = "owner_exists:1:%s" % event.group.id
-
-        for key in [assignee_cache_key, owner_cache_key]:
-            cache.set(key, True)
+        cache.set(ASSIGNEE_EXISTS_KEY(event.group.id), True)
+        cache.set(ISSUE_OWNERS_DEBOUNCE_KEY(event.group.id), timezone.now().timestamp())
 
         self.call_post_process_group(
             is_new=False,
@@ -1435,26 +1431,6 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache.set(ISSUE_OWNERS_DEBOUNCE_KEY(event.group_id), True, ISSUE_OWNERS_DEBOUNCE_DURATION)
-        self.call_post_process_group(
-            is_new=False,
-            is_regression=False,
-            is_new_group_environment=False,
-            event=event,
-        )
-        mock_incr.assert_any_call("sentry.tasks.post_process.handle_owner_assignment.debounce")
-
-    @patch("sentry.utils.metrics.incr")
-    def test_debounces_with_timestamp_format(self, mock_incr: MagicMock) -> None:
-        self.make_ownership()
-        event = self.create_event(
-            data={
-                "message": "oh no",
-                "platform": "python",
-                "stacktrace": {"frames": [{"filename": "src/app.py"}]},
-            },
-            project_id=self.project.id,
-        )
         debounce_time = cache.get(ISSUE_OWNERS_DEBOUNCE_KEY(event.group_id))
         assert debounce_time is None
 
@@ -1479,7 +1455,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         mock_incr.assert_any_call("sentry.tasks.post_process.handle_owner_assignment.debounce")
 
     @patch("sentry.utils.metrics.incr")
-    def test_timestamp_invalidation_when_ownership_changes(self, mock_incr: MagicMock) -> None:
+    def test_no_debounce_when_ownership_changes(self, mock_incr: MagicMock) -> None:
         self.make_ownership()
         event = self.create_event(
             data={
@@ -1519,7 +1495,9 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         )
 
     @patch("sentry.utils.metrics.incr")
-    def test_timestamp_debounce_when_ownership_older(self, mock_incr: MagicMock) -> None:
+    def test_debounces_handle_owner_assignments_when_ownership_older(
+        self, mock_incr: MagicMock
+    ) -> None:
         self.make_ownership()
         event = self.create_event(
             data={


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/106108.

It's been >24 hours since the PR above was deployed and the issue owners debounce cache values were migrated to the new format. We can therefore remove the backwards compatibility logic, since all cache values will now correctly be timestamps.

Updates tests & documentation as well.