### PR TITLE
feat(quotas): add has_usage_quota interface method for usage-based categories

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -699,6 +699,27 @@ class Quota(Service):
         """
         return True
 
+    def has_usage_quota(self, org_id: int, data_category: DataCategory) -> bool:
+        """
+        Check if organization has available quota for a usage-based category.
+
+        This is for categories with TallyType.USAGE (not SEAT-based). Unlike
+        has_available_reserved_budget (which is for cost-based Reserved Budgets
+        where reserved=-2), this checks usage-based quotas where reserved=N
+        means N events are allocated.
+
+        Use for usage-based categories like SIZE_ANALYSIS, INSTALLABLE_BUILD, and
+        similar categories that are not rate-limited in Relay.
+
+        Args:
+            org_id: The organization ID
+            data_category: The data category to check quota for
+
+        Returns:
+            bool: True if the organization has quota available, False otherwise.
+        """
+        return True
+
     def record_seer_run(
         self,
         org_id: int,


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1980/quota-method-for-emerge

Add a new quota checking method for categories with TallyType.USAGE. This is distinct from has_available_reserved_budget which is for cost-based Reserved Budgets (where reserved=-2).

The method checks if an organization has available quota for usage-based categories like SIZE_ANALYSIS, INSTALLABLE_BUILD, and similar categories that are not rate-limited in Relay.

Default implementation returns True; actual logic is in getsentry.

