### PR TITLE
Add more stuff to the API Access Logs

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -106,6 +106,11 @@ def _create_api_access_log(
             # if its an internal request, no need to log
             return
 
+        impersonator_user_id = None
+        actual_user = getattr(request, "actual_user", None)
+        if actual_user is not None:
+            impersonator_user_id = getattr(actual_user, "id", None)
+
         request_user = getattr(request, "user", None)
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
@@ -131,6 +136,7 @@ def _create_api_access_log(
             rate_limit_category=getattr(request, "rate_limit_category", None),
             request_duration_seconds=access_log_metadata.get_request_duration(),
             gateway_proxy=request.headers.get(PROXY_APIGATEWAY_HEADER, None),
+            impersonator_user_id=impersonator_user_id,
             **_get_rate_limit_stats_dict(request),
         )
         auth = get_authorization_header(request).split()


### PR DESCRIPTION
This grabs the request's `actual_user` to log in the API access logs, which is set in the `ViewAsHookMiddleware`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
