### PR TITLE
fix(dashboard): Add to Dashboard fails widget builder add when first visit

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -713,13 +713,19 @@ class DashboardDetail extends Component<Props, State> {
     const baseWidget = defined(index) ? currentDashboard.widgets[index] : {};
     const mergedWidget = assignTempId({...baseWidget, ...widget});
 
-    const newWidgets = defined(index)
-      ? [
-          ...currentDashboard.widgets.slice(0, index),
-          mergedWidget,
-          ...currentDashboard.widgets.slice(index + 1),
-        ]
-      : [...currentDashboard.widgets, mergedWidget];
+    // Always ensure added widgets in the save flow have a layout
+    // This sets the layout for the request, as well as the optimistic
+    // update on save
+    const newWidgets = assignDefaultLayout(
+      defined(index)
+        ? [
+            ...currentDashboard.widgets.slice(0, index),
+            mergedWidget,
+            ...currentDashboard.widgets.slice(index + 1),
+          ]
+        : [...currentDashboard.widgets, mergedWidget],
+      calculateColumnDepths(getDashboardLayout(currentDashboard.widgets))
+    );
 
     try {
       if (this.isEditingDashboard) {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -734,7 +734,7 @@ class DashboardDetail extends Component<Props, State> {
         newlyAddedWidget: mergedWidget,
       });
 
-      this.handleCloseWidgetBuilder();
+      this.handleCloseWidgetBuilder(newWidgets);
     } catch (error) {
       addErrorMessage(t('Failed to save widget'));
     }
@@ -759,8 +759,9 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
-  handleCloseWidgetBuilder = () => {
+  handleCloseWidgetBuilder = (newWidgets?: Widget[]) => {
     const {organization, navigate, location, params} = this.props;
+    const {dashboardState} = this.state;
 
     this.setState({
       isWidgetBuilderOpen: false,
@@ -772,7 +773,15 @@ class DashboardDetail extends Component<Props, State> {
         dashboardId: params.dashboardId,
         location,
       }),
-      {preventScrollReset: true}
+      {
+        preventScrollReset: true,
+
+        // Persist the widgets through the route change to use location.state if we're
+        // creating a new dashboard, otherwise the navigation may remount the component and
+        // lose the widgets
+        state:
+          dashboardState === DashboardState.CREATE ? {widgets: newWidgets} : undefined,
+      }
     );
   };
 

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -30,7 +30,8 @@ interface OrgDashboardsProps {
   children: (props: OrgDashboardsChildrenProps) => React.ReactNode;
   /**
    * Initial dashboard state to use for optimistic updates.
-   * This is used when navigating from widget builder to show the new widget immediately.
+   * This is used when navigating from widget builder to show the new widget immediately
+   * since there are scenarios where the component fully remounts and loses its modified state.
    */
   initialDashboard?: DashboardDetails;
 }

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -28,9 +28,14 @@ type OrgDashboardsChildrenProps = {
 
 interface OrgDashboardsProps {
   children: (props: OrgDashboardsChildrenProps) => React.ReactNode;
+  /**
+   * Initial dashboard state to use for optimistic updates.
+   * This is used when navigating from widget builder to show the new widget immediately.
+   */
+  initialDashboard?: DashboardDetails;
 }
 
-function OrgDashboards({children}: OrgDashboardsProps) {
+function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) {
   const location = useLocation();
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -40,9 +45,10 @@ function OrgDashboards({children}: OrgDashboardsProps) {
 
   const ENDPOINT = `/organizations/${organization.slug}/dashboards/`;
 
-  // The currently selected dashboard
+  // The currently selected dashboard. Use initialDashboard for optimistic updates
+  // when navigating from widget builder (passed via location.state).
   const [selectedDashboardState, setSelectedDashboardState] =
-    useState<DashboardDetails | null>(null);
+    useState<DashboardDetails | null>(initialDashboard ?? null);
 
   const {
     data: dashboards,

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -10,9 +10,10 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {DashboardState} from 'sentry/views/dashboards/types';
+import {DashboardState, type DashboardDetails} from 'sentry/views/dashboards/types';
 import {useTimeseriesVisualizationEnabled} from 'sentry/views/dashboards/utils/useTimeseriesVisualizationEnabled';
 
 import DashboardDetail from './detail';
@@ -22,6 +23,7 @@ export default function ViewEditDashboard() {
   const api = useApi();
   const organization = useOrganization();
   const {dashboardId} = useParams<{dashboardId: string}>();
+  const location = useLocation();
 
   const orgSlug = organization.slug;
 
@@ -33,9 +35,13 @@ export default function ViewEditDashboard() {
 
   const useTimeseriesVisualization = useTimeseriesVisualizationEnabled();
 
+  // Get optimistic dashboard from location.state if available (e.g., after adding a widget)
+  const optimisticDashboard = (location.state as {dashboard?: DashboardDetails} | null)
+    ?.dashboard;
+
   return (
     <DashboardBasicFeature organization={organization}>
-      <OrgDashboards>
+      <OrgDashboards initialDashboard={optimisticDashboard}>
         {({dashboard, dashboards, error, onDashboardUpdate}) => {
           return error ? (
             <NotFound />


### PR DESCRIPTION
When submitting a widget to a dashboard when navigated by the Add to Dashboard flow, the widget can be lost due to the navigation from widget builder -> dashboard. The URL change results in a re-mount, which throws away the modified state.

This is a workaround at the moment until we can make a better fix where we will persist the relevant state in the location navigation state. For the create flow, we can just save the widgets and use the existing flow for that. For the view mode, it's safer to just save the entire dashboard because we are optimistically updating the widget and set that as the initial state when the first time we use the widget builder in Add to Dashboard happens

To reproduce the problematic behaviour:
- Refresh and do not open a dashboard
- Go to any page with "Add to Dashboard"
- Trigger the Add to Dashboard modal
- Select a new or existing dashboard
- Click "Open in Widget Builder"
- When navigated, click "Add Widget"
- See that the widget was not added in create mode, or if in an existing dashboard, the widget isn't on the page. You need to refresh to get it to show up