### PR TITLE
chore(alerts): increase max rollup constants

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -82,7 +82,7 @@ PROJECT_SLUG_MAX_LENGTH = 100
 
 # Maximum number of results we are willing to fetch when calculating rollup
 # Clients should adapt the interval width based on their display width.
-MAX_ROLLUP_POINTS = 10081
+MAX_ROLLUP_POINTS = 10100
 
 
 # Organization slugs which may not be used. Generally these are top level URL patterns

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -117,9 +117,9 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 }
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
-# The RPC limits us to 10081 points per timeseries
-# MAX 1 minute granularity over 7 days (10080 buckets) + 1 bucket to allow for partial time buckets on
-MAX_ROLLUP_POINTS = 10081
+# The RPC limits us to 10100 points per timeseries
+# MAX 1 minute granularity over 7 days (10080 buckets) + extra buckets to allow for partial time buckets on
+MAX_ROLLUP_POINTS = 10100
 # Copied from snuba, a number of total seconds
 VALID_GRANULARITIES = frozenset(
     {


### PR DESCRIPTION
follow up to this pr: https://github.com/getsentry/snuba/pull/7641

Basically fixing the issue where alerts timeseries charts with 7d period and 1m interval receive a code 500 from the events-stats endpoint due to number of buckets being over the max. [Sentry issue](https://sentry.sentry.io/issues/7084207705/?project=1&query=is%3Aunresolved%20user.email%3Awilliam.mak%40sentry.io&referrer=issue-stream) and [alert example ](https://sentry.sentry.io/monitors/2809118/?project=-1&statsPeriod=7d)

We're changing the constants here to stay consistent with the snuba constants
Closes [EXP-700](https://linear.app/getsentry/issue/EXP-700/events-stats-buckets-going-over-max-for-1m-interval)