### PR TITLE
fix(alerts): Validate targetIdentifier is an int before we try to query with it as one

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -92,6 +92,19 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
         access: Access = self.context["access"]
         identifier = attrs.get("target_identifier")
 
+        # Validate that target_identifier is an integer for USER and TEAM target types
+        if target_type in (
+            AlertRuleTriggerAction.TargetType.USER,
+            AlertRuleTriggerAction.TargetType.TEAM,
+        ):
+            if identifier is not None:
+                try:
+                    int(identifier)
+                except (ValueError, TypeError):
+                    raise serializers.ValidationError(
+                        {"target_identifier": "Must be a valid integer for user or team targets"}
+                    )
+
         if type is not None:
             type_info = AlertRuleTriggerAction.get_registered_factory(type)
             if target_type not in type_info.supported_target_types:

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -1117,6 +1117,24 @@ class TestAlertRuleTriggerActionSerializer(TestAlertRuleSerializerBase):
         ]
         self.run_fail_validation_test({"target_type": 50}, {"targetType": invalid_values})
 
+    def test_target_identifier_must_be_integer_for_user(self) -> None:
+        self.run_fail_validation_test(
+            {
+                "target_type": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.USER],
+                "target_identifier": "not-a-number",
+            },
+            {"targetIdentifier": ["Must be a valid integer for user or team targets"]},
+        )
+
+    def test_target_identifier_must_be_integer_for_team(self) -> None:
+        self.run_fail_validation_test(
+            {
+                "target_type": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.TEAM],
+                "target_identifier": "abc123",
+            },
+            {"targetIdentifier": ["Must be a valid integer for user or team targets"]},
+        )
+
     def test_user_perms(self) -> None:
         self.run_fail_validation_test(
             {


### PR DESCRIPTION
The correct response is a 400 with a helpful message.

Should fix SENTRY-5G4R.
