### PR TITLE
fix(uptime): Make verification section smaller in uptime monitor editor

### DIFF
--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -1,7 +1,4 @@
-import styled from '@emotion/styled';
-
 import {ExternalLink} from 'sentry/components/core/link';
-import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import RangeField from 'sentry/components/forms/fields/rangeField';
@@ -17,6 +14,7 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import {HTTPSnippet} from 'sentry/views/alerts/rules/uptime/httpSnippet';
 import {UptimeHeadersField} from 'sentry/views/detectors/components/forms/uptime/detect/uptimeHeadersField';
 import {UPTIME_DEFAULT_DOWNTIME_THRESHOLD} from 'sentry/views/detectors/components/forms/uptime/fields';
+import {UptimeSectionGrid} from 'sentry/views/detectors/components/forms/uptime/styles';
 
 const HTTP_METHOD_OPTIONS = ['GET', 'POST', 'HEAD', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
 const HTTP_METHODS_NO_BODY = ['GET', 'HEAD', 'OPTIONS'];
@@ -62,7 +60,7 @@ export function UptimeDetectorFormDetectSection() {
   return (
     <Container>
       <Section title={t('Detect')}>
-        <ConfigurationFieldsContainer>
+        <UptimeSectionGrid>
           <SelectField
             options={VALID_INTERVALS_SEC.map(value => ({
               value,
@@ -177,36 +175,9 @@ export function UptimeDetectorFormDetectSection() {
             label={t('Failure Threshold')}
             flexibleControlStateSize
           />
-        </ConfigurationFieldsContainer>
+        </UptimeSectionGrid>
         <ConnectedHttpSnippet />
       </Section>
     </Container>
   );
 }
-
-const ConfigurationFieldsContainer = styled('div')`
-  display: grid;
-  gap: 0 ${p => p.theme.space.xl};
-  grid-template-columns: fit-content(250px) 1fr;
-  align-items: center;
-
-  ${FieldWrapper} {
-    display: grid;
-    grid-template-columns: subgrid;
-    grid-column: 1 / -1;
-    padding-left: 0;
-
-    label {
-      width: auto;
-    }
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    ${FieldWrapper} {
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      gap: ${p => p.theme.space.md};
-    }
-  }
-`;

--- a/static/app/views/detectors/components/forms/uptime/styles.tsx
+++ b/static/app/views/detectors/components/forms/uptime/styles.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
+
+export const UptimeSectionGrid = styled('div')`
+  display: grid;
+  gap: 0 ${p => p.theme.space.xl};
+  grid-template-columns: fit-content(250px) 1fr;
+  align-items: center;
+
+  ${FieldWrapper} {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    padding-left: 0;
+
+    label {
+      width: auto;
+    }
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    ${FieldWrapper} {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: ${p => p.theme.space.md};
+    }
+  }
+`;

--- a/static/app/views/detectors/components/forms/uptime/verification.tsx
+++ b/static/app/views/detectors/components/forms/uptime/verification.tsx
@@ -3,6 +3,7 @@ import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {UptimeAssertionsField} from 'sentry/views/alerts/rules/uptime/assertions/field';
+import {UptimeSectionGrid} from 'sentry/views/detectors/components/forms/uptime/styles';
 
 export function UptimeDetectorVerificationSection() {
   const org = useOrganization();
@@ -14,14 +15,16 @@ export function UptimeDetectorVerificationSection() {
   return (
     <Container>
       <Section title={t('Verification')}>
-        <UptimeAssertionsField
-          name="assertion"
-          label={t('Assertions')}
-          help={t(
-            'Define conditions that must be met for the check to be considered successful.'
-          )}
-          flexibleControlStateSize
-        />
+        <UptimeSectionGrid>
+          <UptimeAssertionsField
+            name="assertion"
+            label={t('Assertions')}
+            help={t(
+              'Define conditions that must be met for the check to be considered successful.'
+            )}
+            flexibleControlStateSize
+          />
+        </UptimeSectionGrid>
       </Section>
     </Container>
   );


### PR DESCRIPTION
In the uptime monitor editor, the Verification section layout feels unbalanced because the left-hand column is too wide relative to the right-hand configuration. This differs from the 'Detect' section above it, which uses a more compact left column.

Update the Verification section layout to match the Detect section's grid pattern. This aligns the two sections visually, creating style consistency across the form and reducing unused whitespace in the Verification section.

This is achieved by centralizing the grid layout logic into `UptimeSectionGrid` (using `fit-content(250px)` for the left column) and reusing it in both the Detect and Verification sections.