### PR TITLE
Uptime insights assertions

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -402,4 +402,106 @@ describe('Uptime Alert Form', () => {
     const pathName = input('Uptime rule name');
     expect(pathName).toHaveValue('Uptime check for example.com/with-path');
   });
+
+  it('sends assertion in create request when feature is enabled', async () => {
+    const orgWithAssertions = OrganizationFixture({
+      features: ['uptime-runtime-assertions'],
+    });
+    OrganizationStore.onUpdate(orgWithAssertions);
+
+    render(<UptimeAlertForm />, {organization: orgWithAssertions});
+    await screen.findByText('Configure Request');
+
+    // Verify the Verification section is shown
+    expect(screen.getByText('Verification')).toBeInTheDocument();
+
+    await selectEvent.select(input('Project'), project.slug);
+    await selectEvent.select(input('Environment'), 'prod');
+    await userEvent.clear(input('URL'));
+    await userEvent.type(input('URL'), 'http://example.com');
+
+    const name = input('Uptime rule name');
+    await userEvent.clear(name);
+    await userEvent.type(name, 'Rule with Assertion');
+
+    const createMock = MockApiClient.addMockResponse({
+      url: `/projects/${orgWithAssertions.slug}/${project.slug}/uptime/`,
+      method: 'POST',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create Rule'}));
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Rule with Assertion',
+          url: 'http://example.com',
+          assertion: {root: {op: 'and', children: [], id: expect.any(String)}},
+        }),
+      })
+    );
+  });
+
+  it('does not show assertions when feature is disabled', async () => {
+    const orgWithoutAssertions = OrganizationFixture({
+      features: [],
+    });
+    OrganizationStore.onUpdate(orgWithoutAssertions);
+
+    render(<UptimeAlertForm />, {organization: orgWithoutAssertions});
+    await screen.findByText('Configure Request');
+
+    // Verify the Verification section is NOT shown
+    expect(screen.queryByText('Verification')).not.toBeInTheDocument();
+  });
+
+  it('renders and updates assertion for existing rule', async () => {
+    const orgWithAssertions = OrganizationFixture({
+      features: ['uptime-runtime-assertions'],
+    });
+    OrganizationStore.onUpdate(orgWithAssertions);
+
+    const assertion = {
+      root: {
+        op: 'and' as const,
+        children: [
+          {
+            id: 'test-1',
+            op: 'status_code_check' as const,
+            operator: {cmp: 'equals' as const},
+            value: 200,
+          },
+        ],
+        id: 'root-1',
+      },
+    };
+
+    const rule = UptimeRuleFixture({
+      name: 'Rule with Assertion',
+      projectSlug: project.slug,
+      url: 'https://existing-url.com',
+      owner: ActorFixture(),
+      assertion,
+    });
+
+    render(<UptimeAlertForm rule={rule} />, {organization: orgWithAssertions});
+    await screen.findByText('Verification');
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/projects/${orgWithAssertions.slug}/${project.slug}/uptime/${rule.id}/`,
+      method: 'PUT',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save Rule'}));
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          assertion,
+        }),
+      })
+    );
+  });
 });

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -36,6 +36,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 
+import {UptimeAssertionsField} from './assertions/field';
 import {HTTPSnippet} from './httpSnippet';
 import {UptimeHeadersField} from './uptimeHeadersField';
 
@@ -81,6 +82,7 @@ function getFormDataFromRule(rule: UptimeRule) {
     owner: rule.owner ? `${rule.owner.type}:${rule.owner.id}` : null,
     recoveryThreshold: rule.recoveryThreshold,
     downtimeThreshold: rule.downtimeThreshold,
+    assertion: rule.assertion,
   };
 }
 
@@ -380,6 +382,35 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
             )}
           </Observer>
         </Configuration>
+        <Observer>
+          {() => {
+            const hasAssertionsFeature = organization.features.includes(
+              'uptime-runtime-assertions'
+            );
+            if (!hasAssertionsFeature) {
+              return null;
+            }
+            return (
+              <>
+                <AlertListItem>{t('Verification')}</AlertListItem>
+                <ListItemSubText>
+                  {t(
+                    'Define conditions that must be met for the check to be considered successful.'
+                  )}
+                </ListItemSubText>
+                <Configuration>
+                  <ConfigurationPanel>
+                    <UptimeAssertionsField
+                      name="assertion"
+                      label={t('Assertions')}
+                      flexibleControlStateSize
+                    />
+                  </ConfigurationPanel>
+                </Configuration>
+              </>
+            );
+          }}
+        </Observer>
         <AlertListItem>{t('Set thresholds')}</AlertListItem>
         <ListItemSubText>
           {t('Configure when an issue is created or resolved.')}

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import type {IReactionDisposer} from 'mobx';
 import {autorun} from 'mobx';
@@ -383,7 +383,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
           </Observer>
         </Configuration>
         {organization.features.includes('uptime-runtime-assertions') && (
-          <React.Fragment>
+          <Fragment>
             <AlertListItem>{t('Verification')}</AlertListItem>
             <ListItemSubText>
               {t(
@@ -399,7 +399,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
                 />
               </ConfigurationPanel>
             </Configuration>
-          </React.Fragment>
+          </Fragment>
         )}
         <AlertListItem>{t('Set thresholds')}</AlertListItem>
         <ListItemSubText>

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -383,7 +383,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
           </Observer>
         </Configuration>
         {organization.features.includes('uptime-runtime-assertions') && (
-          <>
+          <React.Fragment>
             <AlertListItem>{t('Verification')}</AlertListItem>
             <ListItemSubText>
               {t(
@@ -399,7 +399,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
                 />
               </ConfigurationPanel>
             </Configuration>
-          </>
+          </React.Fragment>
         )}
         <AlertListItem>{t('Set thresholds')}</AlertListItem>
         <ListItemSubText>

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -391,7 +391,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
               return null;
             }
             return (
-              <>
+              <React.Fragment>
                 <AlertListItem>{t('Verification')}</AlertListItem>
                 <ListItemSubText>
                   {t(
@@ -407,7 +407,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
                     />
                   </ConfigurationPanel>
                 </Configuration>
-              </>
+              </React.Fragment>
             );
           }}
         </Observer>

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -382,35 +382,25 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
             )}
           </Observer>
         </Configuration>
-        <Observer>
-          {() => {
-            const hasAssertionsFeature = organization.features.includes(
-              'uptime-runtime-assertions'
-            );
-            if (!hasAssertionsFeature) {
-              return null;
-            }
-            return (
-              <React.Fragment>
-                <AlertListItem>{t('Verification')}</AlertListItem>
-                <ListItemSubText>
-                  {t(
-                    'Define conditions that must be met for the check to be considered successful.'
-                  )}
-                </ListItemSubText>
-                <Configuration>
-                  <ConfigurationPanel>
-                    <UptimeAssertionsField
-                      name="assertion"
-                      label={t('Assertions')}
-                      flexibleControlStateSize
-                    />
-                  </ConfigurationPanel>
-                </Configuration>
-              </React.Fragment>
-            );
-          }}
-        </Observer>
+        {organization.features.includes('uptime-runtime-assertions') && (
+          <>
+            <AlertListItem>{t('Verification')}</AlertListItem>
+            <ListItemSubText>
+              {t(
+                'Define conditions that must be met for the check to be considered successful.'
+              )}
+            </ListItemSubText>
+            <Configuration>
+              <ConfigurationPanel>
+                <UptimeAssertionsField
+                  name="assertion"
+                  label={t('Assertions')}
+                  flexibleControlStateSize
+                />
+              </ConfigurationPanel>
+            </Configuration>
+          </>
+        )}
         <AlertListItem>{t('Set thresholds')}</AlertListItem>
         <ListItemSubText>
           {t('Configure when an issue is created or resolved.')}

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -1,0 +1,321 @@
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+
+import {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
+import {
+  UPTIME_DEFAULT_DOWNTIME_THRESHOLD,
+  UPTIME_DEFAULT_RECOVERY_THRESHOLD,
+  uptimeFormDataToEndpointPayload,
+  uptimeSavedDetectorToFormData,
+} from 'sentry/views/detectors/components/forms/uptime/fields';
+
+describe('uptimeFormDataToEndpointPayload', () => {
+  it('converts form data to endpoint payload', () => {
+    const formData = {
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: 'Test description',
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [['X-Test', 'value'] as [string, string]],
+      body: '',
+      assertion: null,
+      recoveryThreshold: 1,
+      downtimeThreshold: 3,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload).toEqual({
+      type: 'uptime_domain_failure',
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: 'Test description',
+      dataSources: [
+        {
+          intervalSeconds: 60,
+          method: 'GET',
+          timeoutMs: 10000,
+          traceSampling: false,
+          url: 'https://example.com',
+          headers: [['X-Test', 'value']],
+          body: null,
+          assertion: null,
+        },
+      ],
+      config: {
+        mode: UptimeMonitorMode.MANUAL,
+        recoveryThreshold: 1,
+        downtimeThreshold: 3,
+        environment: 'production',
+      },
+    });
+  });
+
+  it('includes assertion in payload when provided', () => {
+    const assertion = {
+      root: {
+        op: 'and' as const,
+        children: [
+          {
+            id: 'test-1',
+            op: 'status_code_check' as const,
+            operator: {cmp: 'equals' as const},
+            value: 200,
+          },
+        ],
+        id: 'root-1',
+      },
+    };
+
+    const formData = {
+      name: 'Test Monitor with Assertion',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: null,
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '',
+      assertion,
+      recoveryThreshold: 1,
+      downtimeThreshold: 3,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload.dataSources[0].assertion).toEqual(assertion);
+  });
+
+  it('converts body to null when empty string', () => {
+    const formData = {
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: null,
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '',
+      assertion: null,
+      recoveryThreshold: 1,
+      downtimeThreshold: 3,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload.dataSources[0].body).toBe(null);
+  });
+
+  it('includes non-empty body in payload', () => {
+    const formData = {
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: null,
+      intervalSeconds: 60,
+      method: 'POST',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '{"key": "value"}',
+      assertion: null,
+      recoveryThreshold: 1,
+      downtimeThreshold: 3,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload.dataSources[0].body).toBe('{"key": "value"}');
+  });
+
+  it('uses default thresholds when not provided', () => {
+    const formData = {
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: null,
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '',
+      assertion: null,
+      recoveryThreshold: undefined as any,
+      downtimeThreshold: undefined as any,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload.config.recoveryThreshold).toBe(UPTIME_DEFAULT_RECOVERY_THRESHOLD);
+    expect(payload.config.downtimeThreshold).toBe(UPTIME_DEFAULT_DOWNTIME_THRESHOLD);
+  });
+});
+
+describe('uptimeSavedDetectorToFormData', () => {
+  it('converts detector to form data', () => {
+    const detector = UptimeDetectorFixture({
+      name: 'Saved Monitor',
+      owner: {type: 'user', id: '1'},
+      projectId: '123',
+      config: {
+        environment: 'production',
+        recoveryThreshold: 2,
+        downtimeThreshold: 5,
+        mode: UptimeMonitorMode.MANUAL,
+      },
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData).toMatchObject({
+      name: 'Saved Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      environment: 'production',
+      recoveryThreshold: 2,
+      downtimeThreshold: 5,
+    });
+  });
+
+  it('extracts assertion from data source', () => {
+    const assertion = {
+      root: {
+        op: 'and' as const,
+        children: [
+          {
+            id: 'test-1',
+            op: 'status_code_check' as const,
+            operator: {cmp: 'equals' as const},
+            value: 200,
+          },
+        ],
+        id: 'root-1',
+      },
+    };
+
+    const detector = UptimeDetectorFixture({
+      dataSources: [
+        {
+          ...UptimeDetectorFixture().dataSources[0],
+          queryObj: {
+            ...UptimeDetectorFixture().dataSources[0].queryObj,
+            assertion,
+          },
+        },
+      ],
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData.assertion).toEqual(assertion);
+  });
+
+  it('sets assertion to null when not present in data source', () => {
+    const detector = UptimeDetectorFixture({
+      dataSources: [
+        {
+          ...UptimeDetectorFixture().dataSources[0],
+          queryObj: {
+            ...UptimeDetectorFixture().dataSources[0].queryObj,
+            assertion: undefined as any,
+          },
+        },
+      ],
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData.assertion).toBe(null);
+  });
+
+  it('uses default values when data source is missing', () => {
+    const detector = UptimeDetectorFixture({
+      dataSources: [],
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData).toMatchObject({
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '',
+      assertion: null,
+    });
+  });
+
+  it('uses default thresholds when config is missing', () => {
+    const detector = UptimeDetectorFixture({
+      config: {} as any,
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData.recoveryThreshold).toBe(UPTIME_DEFAULT_RECOVERY_THRESHOLD);
+    expect(formData.downtimeThreshold).toBe(UPTIME_DEFAULT_DOWNTIME_THRESHOLD);
+  });
+
+  it('converts body to empty string when null', () => {
+    const detector = UptimeDetectorFixture({
+      dataSources: [
+        {
+          ...UptimeDetectorFixture().dataSources[0],
+          queryObj: {
+            ...UptimeDetectorFixture().dataSources[0].queryObj,
+            body: null,
+          },
+        },
+      ],
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData.body).toBe('');
+  });
+
+  it('preserves non-null body', () => {
+    const detector = UptimeDetectorFixture({
+      dataSources: [
+        {
+          ...UptimeDetectorFixture().dataSources[0],
+          queryObj: {
+            ...UptimeDetectorFixture().dataSources[0].queryObj,
+            body: '{"test": "data"}',
+          },
+        },
+      ],
+    });
+
+    const formData = uptimeSavedDetectorToFormData(detector);
+
+    expect(formData.body).toBe('{"test": "data"}');
+  });
+});

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -121,7 +121,7 @@ describe('uptimeFormDataToEndpointPayload', () => {
 
     const payload = uptimeFormDataToEndpointPayload(formData);
 
-    expect(payload.dataSources[0].body).toBe(null);
+    expect(payload.dataSources[0].body).toBeNull();
   });
 
   it('includes non-empty body in payload', () => {
@@ -250,7 +250,7 @@ describe('uptimeSavedDetectorToFormData', () => {
 
     const formData = uptimeSavedDetectorToFormData(detector);
 
-    expect(formData.assertion).toBe(null);
+    expect(formData.assertion).toBeNull();
   });
 
   it('uses default values when data source is missing', () => {

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -96,7 +96,7 @@ describe('uptimeFormDataToEndpointPayload', () => {
 
     const payload = uptimeFormDataToEndpointPayload(formData);
 
-    expect(payload.dataSources[0].assertion).toEqual(assertion);
+    expect(payload.dataSources[0]?.assertion).toEqual(assertion);
   });
 
   it('converts body to null when empty string', () => {
@@ -121,7 +121,7 @@ describe('uptimeFormDataToEndpointPayload', () => {
 
     const payload = uptimeFormDataToEndpointPayload(formData);
 
-    expect(payload.dataSources[0].body).toBeNull();
+    expect(payload.dataSources[0]?.body).toBeNull();
   });
 
   it('includes non-empty body in payload', () => {
@@ -146,7 +146,7 @@ describe('uptimeFormDataToEndpointPayload', () => {
 
     const payload = uptimeFormDataToEndpointPayload(formData);
 
-    expect(payload.dataSources[0].body).toBe('{"key": "value"}');
+    expect(payload.dataSources[0]?.body).toBe('{"key": "value"}');
   });
 
   it('uses default thresholds when not provided', () => {
@@ -180,7 +180,7 @@ describe('uptimeSavedDetectorToFormData', () => {
   it('converts detector to form data', () => {
     const detector = UptimeDetectorFixture({
       name: 'Saved Monitor',
-      owner: {type: 'user', id: '1'},
+      owner: {type: 'user', id: '1', name: 'User 1'},
       projectId: '123',
       config: {
         environment: 'production',
@@ -255,7 +255,7 @@ describe('uptimeSavedDetectorToFormData', () => {
 
   it('uses default values when data source is missing', () => {
     const detector = UptimeDetectorFixture({
-      dataSources: [],
+      dataSources: [] as any,
     });
 
     const formData = uptimeSavedDetectorToFormData(detector);


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds the "Assertions" field to the Monitors Uptime Form, aligning its functionality with the existing Detectors/Insights Uptime Form. This allows users to define verification conditions for uptime checks consistently across both interfaces.

Includes new tests to verify the `assertion` field is correctly sent in API requests and handled during form data conversion.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C04P3P6669X/p1768512863401869?thread_ts=1768512863.401869&cid=C04P3P6669X)

<a href="https://cursor.com/background-agent?bcId=bc-6df5f2b0-2d0d-4170-8658-6cd8fbabc04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6df5f2b0-2d0d-4170-8658-6cd8fbabc04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

