### PR TITLE
chore(aci): create default detectors in tests

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -559,7 +559,7 @@ class Factories:
         organization=None,
         teams=None,
         fire_project_created=False,
-        create_default_detectors=False,
+        create_default_detectors=True,
         **kwargs,
     ) -> Project:
         from sentry.receivers.project_detectors import disable_default_detector_creation

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -51,40 +51,38 @@ class OrganizationDetectorIndexGetTest(BaseDetectorTestCase):
     def test_list_monitor_incident_detectors(self):
         response = self.get_success_response(self.organization.slug)
 
-        detector_data = response.data[0]
+        detector_data = response.data[2]
 
-        assert response.data == [
-            {
-                "id": str(self.detector.id),
-                "projectId": str(self.project.id),
-                "name": "Original Detector",
-                "description": None,
-                "type": MonitorIncidentType.slug,
-                "workflowIds": [],
-                "owner": None,
-                "createdBy": None,
-                "dateCreated": detector_data["dateCreated"],
-                "dateUpdated": detector_data["dateUpdated"],
-                "dataSources": [
-                    {
-                        "id": detector_data["dataSources"][0]["id"],
-                        "organizationId": str(self.organization.id),
-                        "type": DATA_SOURCE_CRON_MONITOR,
-                        "sourceId": str(self.monitor.id),
-                        "queryObj": serialize(
-                            self.monitor, user=self.user, serializer=MonitorSerializer()
-                        ),
-                    }
-                ],
-                "conditionGroup": detector_data["conditionGroup"],
-                "config": {},
-                "enabled": True,
-                "alertRuleId": None,
-                "ruleId": None,
-                "latestGroup": None,
-                "openIssues": 0,
-            }
-        ]
+        assert detector_data == {
+            "id": str(self.detector.id),
+            "projectId": str(self.project.id),
+            "name": "Original Detector",
+            "description": None,
+            "type": MonitorIncidentType.slug,
+            "workflowIds": [],
+            "owner": None,
+            "createdBy": None,
+            "dateCreated": detector_data["dateCreated"],
+            "dateUpdated": detector_data["dateUpdated"],
+            "dataSources": [
+                {
+                    "id": detector_data["dataSources"][0]["id"],
+                    "organizationId": str(self.organization.id),
+                    "type": DATA_SOURCE_CRON_MONITOR,
+                    "sourceId": str(self.monitor.id),
+                    "queryObj": serialize(
+                        self.monitor, user=self.user, serializer=MonitorSerializer()
+                    ),
+                }
+            ],
+            "conditionGroup": detector_data["conditionGroup"],
+            "config": {},
+            "enabled": True,
+            "alertRuleId": None,
+            "ruleId": None,
+            "latestGroup": None,
+            "openIssues": 0,
+        }
 
 
 @region_silo_test

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -442,8 +442,8 @@ class OrganizationDetectorIndexGetFilterTest(UptimeDetectorBaseTest):
         assert str(active_detector.id) in returned_ids
         assert str(onboarding_detector.id) not in returned_ids
 
-        # Verify the count is correct (3 = base detector + manual + active)
-        assert len(response.data) == 3
+        # Verify the count is correct (5 = base detector + manual + active + default [issue stream + error])
+        assert len(response.data) == 5
 
     def test_filters_onboarding_detectors_with_query(self):
         """Test that AUTO_DETECTED_ONBOARDING detectors are filtered even when using query filters."""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_count.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_count.py
@@ -27,13 +27,6 @@ class OrganizationDetectorCountTest(APITestCase):
             enabled=True,
             config={"detection_type": AlertRuleDetectionType.STATIC.value},
         )
-        self.create_detector(
-            project=self.project,
-            name="Active Detector 2",
-            type=ErrorGroupType.slug,
-            enabled=True,
-            config={},
-        )
 
         # Create inactive detector
         self.create_detector(
@@ -51,10 +44,11 @@ class OrganizationDetectorCountTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
 
+        # includes 2 default detectors (error and issue stream)
         assert response.data == {
-            "active": 2,
+            "active": 3,
             "deactive": 1,
-            "total": 3,
+            "total": 4,
         }
 
     def test_filtered_by_type(self) -> None:
@@ -135,9 +129,10 @@ class OrganizationDetectorCountTest(APITestCase):
         )
 
         # Test with no project access
+        # Only picks up project default detectors
         response = self.get_success_response(self.organization.slug, qs_params={"project": []})
         assert response.data == {
-            "active": 0,
+            "active": 2,
             "deactive": 0,
-            "total": 0,
+            "total": 2,
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1249,6 +1249,76 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.type == UptimeDomainCheckFailure.slug
 
+    def test_owner_team_not_member_denied(self) -> None:
+        """
+        Test that members cannot assign a team they are not a member of as owner.
+        This is a regression test for an IDOR vulnerability.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
+        response = self.get_error_response(
+            self.organization.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"owner": ["You do not have permission to assign this owner"]}
+
+    def test_owner_team_member_allowed(self) -> None:
+        """
+        Test that members CAN assign a team they are a member of as owner.
+        """
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
+        data = {**self.valid_data, "owner": f"team:{self.team.id}"}
+        response = self.get_success_response(
+            self.organization.slug,
+            **data,
+            status_code=201,
+        )
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.owner_team_id == self.team.id
+
+    def test_owner_team_admin_can_assign_any_team(self) -> None:
+        """
+        Test that users with team:admin scope CAN assign any team as owner.
+        """
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=admin_user,
+            organization=self.organization,
+            role="admin",
+            teams=[self.team],
+        )
+        self.login_as(admin_user)
+
+        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
+        response = self.get_success_response(
+            self.organization.slug,
+            **data,
+            status_code=201,
+        )
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.owner_team_id == other_team.id
+
 
 @region_silo_test
 @with_feature("organizations:incidents")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -43,6 +43,7 @@ from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class OrganizationDetectorIndexBaseTest(APITestCase):
@@ -58,6 +59,12 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,
         )
+        self.error_detector = self.create_detector(
+            type=ErrorGroupType.slug, project=self.project, name="Error Monitor"
+        )
+        self.issue_stream_detector = self.create_detector(
+            type=IssueStreamGroupType.slug, project=self.project, name="Issue Stream"
+        )
 
 
 @region_silo_test
@@ -72,7 +79,9 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         response = self.get_success_response(
             self.organization.slug, qs_params={"project": self.project.id}
         )
-        assert response.data == serialize([detector, detector_2])
+        assert response.data == serialize(
+            [self.error_detector, self.issue_stream_detector, detector, detector_2]
+        )
 
         # Verify openIssues field is present in serialized response
         for detector_data in response.data:
@@ -82,7 +91,7 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         # Verify X-Hits header is present and correct
         assert "X-Hits" in response
         hits = int(response["X-Hits"])
-        assert hits == 2
+        assert hits == 4
 
     def test_uptime_detector(self) -> None:
         subscription = self.create_uptime_subscription()
@@ -109,13 +118,17 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         response = self.get_success_response(
             self.organization.slug, qs_params={"project": self.project.id}
         )
-        assert response.data[0]["dataSources"][0]["queryObj"] == serialize(subscription)
+        assert response.data[2]["dataSources"][0]["queryObj"] == serialize(subscription)
 
-    def test_empty_result(self) -> None:
+    def test_default_detector_result(self) -> None:
+        """
+        Test that the only results are the default detectors for a project
+        """
         response = self.get_success_response(
             self.organization.slug, qs_params={"project": self.project.id}
         )
-        assert len(response.data) == 0
+        assert len(response.data) == 2
+        assert response.data == serialize([self.error_detector, self.issue_stream_detector])
 
     def test_project_unspecified(self) -> None:
         d1 = self.create_detector(
@@ -129,7 +142,13 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         response = self.get_success_response(
             self.organization.slug,
         )
-        assert {d["name"] for d in response.data} == {d1.name, d2.name}
+
+        assert {d["name"] for d in response.data} == {
+            d1.name,
+            d2.name,
+            self.error_detector.name,
+            self.issue_stream_detector.name,
+        }
 
     def test_invalid_project(self) -> None:
         self.create_detector(project=self.project, name="A Test Detector", type=MetricIssue.slug)
@@ -192,11 +211,17 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug, qs_params={"project": self.project.id, "sortBy": "-name"}
         )
         assert [d["name"] for d in response.data] == [
+            self.issue_stream_detector.name,
+            self.error_detector.name,
             detector_2.name,
             detector.name,
         ]
 
     def test_sort_by_connected_workflows(self) -> None:
+        # delete the project default detectors as they cause flaky sorting results
+        self.error_detector.delete()
+        self.issue_stream_detector.delete()
+
         workflow = self.create_workflow(
             organization_id=self.organization.id,
         )
@@ -269,6 +294,8 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             detector_2.name,
             detector_3.name,
             detector_1.name,
+            self.error_detector.name,
+            self.issue_stream_detector.name,
             detector_4.name,  # No groups, should be last
         ]
 
@@ -277,6 +304,8 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug, qs_params={"project": self.project.id, "sortBy": "latestGroup"}
         )
         assert [d["name"] for d in response2.data] == [
+            self.error_detector.name,
+            self.issue_stream_detector.name,
             detector_4.name,  # No groups, should be first
             detector_1.name,
             detector_3.name,
@@ -284,6 +313,10 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         ]
 
     def test_sort_by_open_issues(self) -> None:
+        # delete the project default detectors as they cause flaky sorting results
+        self.error_detector.delete()
+        self.issue_stream_detector.delete()
+
         detector_1 = self.create_detector(
             project=self.project, name="Detector 1", type=MetricIssue.slug
         )
@@ -390,7 +423,10 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug,
             qs_params={"project": self.project.id, "query": "!type:metric_issue"},
         )
-        assert {d["name"] for d in response3.data} == {detector2.name}
+        assert {d["name"] for d in response3.data} == {
+            detector2.name,
+            self.issue_stream_detector.name,
+        }
 
     def test_query_by_type_alias(self) -> None:
         """
@@ -573,7 +609,11 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug,
             qs_params={"project": self.project.id, "query": "assignee:none"},
         )
-        assert {d["name"] for d in response.data} == {unassigned_detector.name}
+        assert {d["name"] for d in response.data} == {
+            unassigned_detector.name,
+            self.error_detector.name,
+            self.issue_stream_detector.name,
+        }
 
     def test_query_by_assignee_multiple_values(self) -> None:
         user = self.create_user(email="user1@example.com")
@@ -628,7 +668,11 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug,
             qs_params={"project": self.project.id, "query": f"!assignee:{user.email}"},
         )
-        assert {d["name"] for d in response.data} == {included_detector.name}
+        assert {d["name"] for d in response.data} == {
+            included_detector.name,
+            self.error_detector.name,
+            self.issue_stream_detector.name,
+        }
 
     def test_query_by_assignee_invalid_user(self) -> None:
         self.create_detector(
@@ -664,7 +708,11 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             qs_params={"project": new_project.id},
             status_code=200,
         )
-        assert {d["name"] for d in response.data} == {detector.name}
+        assert {d["name"] for d in response.data} == {
+            detector.name,
+            self.error_detector.name,
+            self.issue_stream_detector.name,
+        }
 
     def test_query_by_id_owner_user(self) -> None:
         self.detector = self.create_detector(
@@ -1201,76 +1249,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.type == UptimeDomainCheckFailure.slug
 
-    def test_owner_team_not_member_denied(self) -> None:
-        """
-        Test that members cannot assign a team they are not a member of as owner.
-        This is a regression test for an IDOR vulnerability.
-        """
-        other_team = self.create_team(organization=self.organization, name="other-team")
-
-        user_with_team = self.create_user(is_superuser=False)
-        self.create_member(
-            user=user_with_team,
-            organization=self.organization,
-            role="member",
-            teams=[self.team],
-        )
-        self.login_as(user_with_team)
-
-        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
-        response = self.get_error_response(
-            self.organization.slug,
-            **data,
-            status_code=400,
-        )
-        assert response.data == {"owner": ["You do not have permission to assign this owner"]}
-
-    def test_owner_team_member_allowed(self) -> None:
-        """
-        Test that members CAN assign a team they are a member of as owner.
-        """
-        user_with_team = self.create_user(is_superuser=False)
-        self.create_member(
-            user=user_with_team,
-            organization=self.organization,
-            role="member",
-            teams=[self.team],
-        )
-        self.login_as(user_with_team)
-
-        data = {**self.valid_data, "owner": f"team:{self.team.id}"}
-        response = self.get_success_response(
-            self.organization.slug,
-            **data,
-            status_code=201,
-        )
-        detector = Detector.objects.get(id=response.data["id"])
-        assert detector.owner_team_id == self.team.id
-
-    def test_owner_team_admin_can_assign_any_team(self) -> None:
-        """
-        Test that users with team:admin scope CAN assign any team as owner.
-        """
-        other_team = self.create_team(organization=self.organization, name="other-team")
-
-        admin_user = self.create_user(is_superuser=False)
-        self.create_member(
-            user=admin_user,
-            organization=self.organization,
-            role="admin",
-            teams=[self.team],
-        )
-        self.login_as(admin_user)
-
-        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
-        response = self.get_success_response(
-            self.organization.slug,
-            **data,
-            status_code=201,
-        )
-        detector = Detector.objects.get(id=response.data["id"])
-        assert detector.owner_team_id == other_team.id
-
 
 @region_silo_test
 @with_feature("organizations:incidents")
@@ -1708,51 +1686,15 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
         # Other detectors should be unaffected
         self.assert_unaffected_detectors([self.detector_two, self.detector_three])
 
-    def test_delete_detectors_by_project_success(self) -> None:
-        # Create detector in another project
-        other_project = self.create_project(organization=self.organization)
-        detector_other_project = self.create_detector(
-            project_id=other_project.id, name="Other Project Detector", type=MetricIssue.slug
+    def test_cannot_delete_system_created_detector(self) -> None:
+        self.get_error_response(
+            self.organization.slug, qs_params={"project": str(self.project.id)}, status_code=403
         )
 
-        with outbox_runner():
-            self.get_success_response(
-                self.organization.slug,
-                qs_params={"project": str(self.project.id)},
-                status_code=204,
-            )
-
-        # Ensure the detectors in the target project are scheduled for deletion
-        self.detector.refresh_from_db()
-        self.detector_two.refresh_from_db()
-        self.detector_three.refresh_from_db()
-        assert self.detector.status == ObjectStatus.PENDING_DELETION
-        assert self.detector_two.status == ObjectStatus.PENDING_DELETION
-        assert self.detector_three.status == ObjectStatus.PENDING_DELETION
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=self.detector.id,
+        assert self.error_detector.status != ObjectStatus.PENDING_DELETION
+        assert not RegionScheduledDeletion.objects.filter(
+            model_name="Detector", object_id=self.error_detector.id
         ).exists()
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=self.detector_two.id,
-        ).exists()
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=self.detector_three.id,
-        ).exists()
-
-        # Delete the detectors
-        with self.tasks():
-            run_scheduled_deletions()
-
-        # Ensure detectors are removed
-        assert not Detector.objects.filter(id=self.detector.id).exists()
-        assert not Detector.objects.filter(id=self.detector_two.id).exists()
-        assert not Detector.objects.filter(id=self.detector_three.id).exists()
-
-        # Detector in other project should be unaffected
-        self.assert_unaffected_detectors([detector_other_project])
 
     def test_delete_no_matching_detectors(self) -> None:
         # Test deleting detectors with non-existent ID

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -653,7 +653,6 @@ class TestEnsureDefaultDetectors(TestCase):
             mock_lock.assert_not_called()
 
     def test_ensure_default_detector__lock_fails(self) -> None:
-        project = self.create_project(create_default_detectors=False)
         with patch("sentry.workflow_engine.processors.detector.locks.get") as mock_lock:
             mock_lock.return_value.blocking_acquire.side_effect = UnableToAcquireLock
             with pytest.raises(UnableToAcquireLockApiError):

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -138,7 +138,7 @@ class IssueAlertMigratorTest(TestCase):
         assert not AlertRuleDetector.objects.filter(rule_id=issue_alert.id).exists()
 
         assert Workflow.objects.all().count() == 0
-        assert Detector.objects.all().count() == 0
+        assert Detector.objects.all().count() == 2
         assert DataConditionGroup.objects.all().count() == 0
         assert DataCondition.objects.all().count() == 0
         assert Action.objects.all().count() == 0
@@ -643,15 +643,17 @@ class TestEnsureDefaultDetectors(TestCase):
 
     def test_ensure_default_detector__already_exists(self) -> None:
         project = self.create_project()
-        detectors = ensure_default_detectors(project)
+        detectors = Detector.objects.filter(project=project)
         with patch("sentry.workflow_engine.processors.detector.locks.get") as mock_lock:
             default_detectors = ensure_default_detectors(project)
-            assert default_detectors[0].id == detectors[0].id
-            assert default_detectors[1].id == detectors[1].id
+            assert {default_detectors[0].id, default_detectors[1].id} == {
+                detectors.id for detectors in detectors
+            }
             # No lock if it already exists.
             mock_lock.assert_not_called()
 
     def test_ensure_default_detector__lock_fails(self) -> None:
+        project = self.create_project(create_default_detectors=False)
         with patch("sentry.workflow_engine.processors.detector.locks.get") as mock_lock:
             mock_lock.return_value.blocking_acquire.side_effect = UnableToAcquireLock
             with pytest.raises(UnableToAcquireLockApiError):

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -4,7 +4,6 @@ import pytest
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.incidents.grouptype import MetricIssue
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -91,7 +90,7 @@ class DetectorTest(BaseWorkflowTest):
         """Test successful retrieval of error detector for project, created by default on project creation"""
         error_detector = self.create_detector(
             project=self.project, type=ErrorGroupType.slug, name="Error Detector"
-        )
+        )  # this creates / fetches the single default error detector for the project
         result = Detector.get_error_detector_for_project(self.project.id)
 
         assert result == error_detector
@@ -99,16 +98,9 @@ class DetectorTest(BaseWorkflowTest):
         assert result.project_id == self.project.id
 
     def test_get_error_detector_for_project__not_found(self) -> None:
-        with pytest.raises(Detector.DoesNotExist):
-            Detector.get_error_detector_for_project(self.project.id)
-
-    def test_get_error_detector_for_project__wrong_type(self) -> None:
         self.create_detector(
-            project=self.project,
-            type=MetricIssue.slug,  # Use a different registered type
-            name="Other Detector",
-        )
-
+            project=self.project, type=ErrorGroupType.slug, name="Error Detector"
+        ).delete()  # delete the single default error detector for the project
         with pytest.raises(Detector.DoesNotExist):
             Detector.get_error_detector_for_project(self.project.id)
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1024,32 +1024,8 @@ class TestGetPreferredDetector(TestCase):
 
         assert result == self.detector
 
-    def test_no_detector_id(self) -> None:
-        occurrence = IssueOccurrence(
-            id=uuid.uuid4().hex,
-            project_id=1,
-            event_id="asdf",
-            fingerprint=["asdf"],
-            issue_title="title",
-            subtitle="subtitle",
-            resource_id=None,
-            evidence_data={},
-            evidence_display=[],
-            type=MetricIssue,
-            detection_time=timezone.now(),
-            level="error",
-            culprit="",
-        )
-
-        group_event = GroupEvent.from_event(self.event, self.group)
-        group_event.occurrence = occurrence
-
-        event_data = WorkflowEventData(event=group_event, group=self.group)
-
-        with pytest.raises(Detector.DoesNotExist):
-            get_preferred_detector(event_data)
-
-    def test_errors_on_no_detector(self) -> None:
+    def test_issue_stream_detector_fallback(self) -> None:
+        # falls back to issue stream
         occurrence = IssueOccurrence(
             id=uuid.uuid4().hex,
             project_id=self.project.id,
@@ -1072,8 +1048,8 @@ class TestGetPreferredDetector(TestCase):
 
         event_data = WorkflowEventData(event=group_event, group=self.group)
 
-        with pytest.raises(Detector.DoesNotExist):
-            get_preferred_detector(event_data)
+        detector = get_preferred_detector(event_data)
+        assert detector == Detector.get_issue_stream_detector_for_project(self.project.id)
 
 
 class TestAssociateNewGroupWithDetector(TestCase):


### PR DESCRIPTION
We should update tests to mimic the live behavior, which is that we have default detectors (error and issue stream) created upon project creation.