### PR TITLE
feat(uptime): Add capture_response_on_failure to config production

### DIFF
--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -145,6 +145,7 @@ def uptime_subscription_to_check_config(
         "request_method": subscription.method,
         "request_headers": subscription.headers,
         "trace_sampling": subscription.trace_sampling,
+        "capture_response_on_failure": subscription.capture_response_on_failure,
         "active_regions": [r.region_slug for r in subscription.regions.filter(mode=region_mode)],
         "region_schedule_mode": UptimeRegionScheduleMode.ROUND_ROBIN.value,
     }

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -110,6 +110,11 @@ class CheckConfig(TypedDict, total=False):
     The runtime assertion to execute, or null.
     """
 
+    capture_response_on_failure: bool
+    """
+    Whether to capture response body and headers on check failures.
+    """
+
 
 class IncidentStatus(IntEnum):
     """

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -325,6 +325,7 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_method": "GET",
             "request_headers": [],
             "trace_sampling": False,
+            "capture_response_on_failure": True,
             "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
@@ -354,6 +355,7 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_headers": headers,
             "request_body": body,
             "trace_sampling": True,
+            "capture_response_on_failure": True,
             "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
@@ -371,7 +373,28 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_method": "GET",
             "request_headers": [],
             "trace_sampling": False,
+            "capture_response_on_failure": True,
             "active_regions": [],
+            "region_schedule_mode": "round_robin",
+        }
+
+    def test_capture_response_disabled(self) -> None:
+        sub = self.create_uptime_subscription(region_slugs=["default"])
+        sub.update(capture_response_on_failure=False)
+
+        subscription_id = uuid4().hex
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        ) == {
+            "subscription_id": subscription_id,
+            "url": sub.url,
+            "interval_seconds": sub.interval_seconds,
+            "timeout_ms": sub.timeout_ms,
+            "request_method": "GET",
+            "request_headers": [],
+            "trace_sampling": False,
+            "capture_response_on_failure": False,
+            "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
 


### PR DESCRIPTION
Includes the capture_response_on_failure field when producing configs to the uptime checker, and adds a helper function to toggle the value.

## Project Context

This is part of the Uptime Response Capture feature - storing HTTP response data (body + headers) when downtime incidents are created to help users debug failures.

PRs in this series:
1. sentry-kafka-schemas: Schema changes
2. uptime-checker: Response capture config and logic
3. sentry: Storage model and capture_response_on_failure field
4. sentry: Config production and toggle helper (this PR)
5. sentry: Consumer capture creation
6. sentry: Incident integration
7. sentry: API and UI
