### PR TITLE
ref(routes): Remove usage of `deprecatedRouteProps` for `appRoutes`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -3076,14 +3076,15 @@ function buildRoutes(): RouteObject[] {
   };
 
   const appRoutes: SentryRouteObject = {
-    component: ({children}: {children: React.ReactNode}) => {
+    component: () => {
       return (
         <ProvideAriaRouter>
-          <ScrapsProviders>{children}</ScrapsProviders>
+          <ScrapsProviders>
+            <Outlet />
+          </ScrapsProviders>
         </ProvideAriaRouter>
       );
     },
-    deprecatedRouteProps: true,
     children: [
       experimentalSpaRoutes,
       {


### PR DESCRIPTION
https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7