### PR TITLE
feat: Add flamegraph for metric kit hangs

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -161,6 +161,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
+    # Enable flamegraph visualization for MetricKit hang diagnostic stack traces
+    manager.add("organizations:metrickit-flamegraph", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -161,9 +161,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
+    manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable flamegraph visualization for MetricKit hang diagnostic stack traces
     manager.add("organizations:metrickit-flamegraph", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enables higher limit for alert rules

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/index.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/index.ts
@@ -1,0 +1,2 @@
+export {StacktraceFlamegraph} from './stacktraceFlamegraph';
+export {hasFlamegraphData} from './utils';

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
@@ -1,0 +1,135 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {FlamegraphPreview} from 'sentry/components/profiling/flamegraph/flamegraphPreview';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Frame} from 'sentry/types/event';
+import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
+import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
+import {SampledProfile} from 'sentry/utils/profiling/profile/sampledProfile';
+
+import {
+  buildFrameTree,
+  createStacktraceFrameIndex,
+  treeToSampledProfileData,
+} from './utils';
+
+interface StacktraceFlamegraphProps {
+  frames: Frame[];
+}
+
+export function StacktraceFlamegraph({frames}: StacktraceFlamegraphProps) {
+  const flamegraph = useMemo(() => {
+    // Build tree from frames using parent_frame_index
+    const roots = buildFrameTree(frames);
+
+    // Convert tree to samples/weights format
+    const {samples, weights} = treeToSampledProfileData(roots);
+
+    // If no samples, return empty flamegraph
+    if (samples.length === 0) {
+      return Flamegraph.Empty();
+    }
+
+    // Create frame index for profiling
+    const frameIndex = createStacktraceFrameIndex(frames);
+
+    // Calculate total weight for duration
+    const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+
+    // Create sampled profile data
+    const sampledProfileData: Profiling.SampledProfile = {
+      type: 'sampled',
+      name: 'Stacktrace',
+      unit: 'count',
+      threadID: 0,
+      startValue: 0,
+      endValue: totalWeight,
+      samples,
+      weights,
+    };
+
+    // Create profile from sampled data
+    const profile = SampledProfile.FromProfile(sampledProfileData, frameIndex, {
+      type: 'flamegraph',
+    });
+
+    // Create flamegraph model with left-heavy sorting
+    return new Flamegraph(profile, {
+      inverted: false,
+      sort: 'left heavy',
+    });
+  }, [frames]);
+
+  // Calculate duration for preview
+  const duration = flamegraph.configSpace.width || 1;
+
+  return (
+    <FlamegraphThemeProvider>
+      <FlamegraphWrapper>
+        <FlamegraphLegend />
+        <FlamegraphContainer>
+          <FlamegraphPreview
+            flamegraph={flamegraph}
+            relativeStartTimestamp={0}
+            relativeStopTimestamp={duration}
+          />
+        </FlamegraphContainer>
+      </FlamegraphWrapper>
+    </FlamegraphThemeProvider>
+  );
+}
+
+function FlamegraphLegend() {
+  const theme = useFlamegraphTheme();
+  const applicationFrameColor = colorComponentsToRGBA(
+    theme.COLORS.FRAME_APPLICATION_COLOR
+  );
+  const systemFrameColor = colorComponentsToRGBA(theme.COLORS.FRAME_SYSTEM_COLOR);
+
+  return (
+    <Flex gap="lg">
+      <LegendItem>
+        <LegendMarker color={applicationFrameColor} />
+        {t('Application Function')}
+      </LegendItem>
+      <LegendItem>
+        <LegendMarker color={systemFrameColor} />
+        {t('System Function')}
+      </LegendItem>
+    </Flex>
+  );
+}
+
+const FlamegraphWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const FlamegraphContainer = styled('div')`
+  height: 300px;
+  position: relative;
+`;
+
+const LegendItem = styled('span')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(0.5)};
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
+`;
+
+const LegendMarker = styled('span')<{color: string}>`
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 1px;
+  background-color: ${p => p.color};
+`;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
@@ -71,7 +71,7 @@ export function StacktraceFlamegraph({frames}: StacktraceFlamegraphProps) {
 
   return (
     <FlamegraphThemeProvider>
-      <FlamegraphWrapper>
+      <Flex direction="column" gap="md">
         <FlamegraphLegend />
         <FlamegraphContainer>
           <FlamegraphPreview
@@ -80,7 +80,7 @@ export function StacktraceFlamegraph({frames}: StacktraceFlamegraphProps) {
             relativeStopTimestamp={duration}
           />
         </FlamegraphContainer>
-      </FlamegraphWrapper>
+      </Flex>
     </FlamegraphThemeProvider>
   );
 }
@@ -105,12 +105,6 @@ function FlamegraphLegend() {
     </Flex>
   );
 }
-
-const FlamegraphWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-`;
 
 const FlamegraphContainer = styled('div')`
   height: 300px;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
@@ -2,10 +2,10 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {FlamegraphPreview} from 'sentry/components/profiling/flamegraph/flamegraphPreview';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Frame} from 'sentry/types/event';
 import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
@@ -94,14 +94,18 @@ function FlamegraphLegend() {
 
   return (
     <Flex gap="lg">
-      <LegendItem>
+      <Flex align="center" gap="xs">
         <LegendMarker color={applicationFrameColor} />
-        {t('Application Function')}
-      </LegendItem>
-      <LegendItem>
+        <Text size="sm" variant="muted">
+          {t('Application Function')}
+        </Text>
+      </Flex>
+      <Flex align="center" gap="xs">
         <LegendMarker color={systemFrameColor} />
-        {t('System Function')}
-      </LegendItem>
+        <Text size="sm" variant="muted">
+          {t('System Function')}
+        </Text>
+      </Flex>
     </Flex>
   );
 }
@@ -109,15 +113,6 @@ function FlamegraphLegend() {
 const FlamegraphContainer = styled('div')`
   height: 300px;
   position: relative;
-`;
-
-const LegendItem = styled('span')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: ${space(0.5)};
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.sm};
 `;
 
 const LegendMarker = styled('span')<{color: string}>`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -128,17 +128,19 @@ export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
   const weights: number[] = [];
   const visited = new Set<number>();
 
-  function collectSamples(node: StacktraceTreeNode, currentPath: number[]) {
+  const currentPath: number[] = [];
+
+  function collectSamples(node: StacktraceTreeNode) {
     if (visited.has(node.frameIndex)) {
       return;
     }
     visited.add(node.frameIndex);
-    const pathWithNode = [...currentPath, node.frameIndex];
+    currentPath.push(node.frameIndex);
     const inclusiveCount = node.frame.sampleCount ?? 0;
 
     if (node.children.length === 0) {
       if (inclusiveCount > 0) {
-        samples.push(pathWithNode);
+        samples.push(currentPath.slice());
         weights.push(inclusiveCount);
       }
     } else {
@@ -150,18 +152,19 @@ export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
       const selfCount = inclusiveCount - childrenCount;
 
       if (selfCount > 0) {
-        samples.push(pathWithNode);
+        samples.push(currentPath.slice());
         weights.push(selfCount);
       }
 
       for (const child of node.children) {
-        collectSamples(child, pathWithNode);
+        collectSamples(child);
       }
     }
+    currentPath.pop();
   }
 
   for (const root of roots) {
-    collectSamples(root, []);
+    collectSamples(root);
   }
 
   return {samples, weights};

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -1,0 +1,143 @@
+import type {Frame as StacktraceFrame} from 'sentry/types/event';
+import {Frame as ProfilingFrame} from 'sentry/utils/profiling/frame';
+
+export interface StacktraceTreeNode {
+  children: StacktraceTreeNode[];
+  depth: number;
+  frame: StacktraceFrame;
+  frameIndex: number;
+  parent: StacktraceTreeNode | null;
+}
+
+/**
+ * Builds a tree structure from a flat array of frames using the parentIndex field
+ * to establish parent-child relationships. parentIndex contains the index of the
+ * parent frame, or -1 for root frames.
+ */
+export function buildFrameTree(frames: StacktraceFrame[]): StacktraceTreeNode[] {
+  // Create nodes for each frame
+  const nodes: Map<number, StacktraceTreeNode> = new Map();
+
+  frames.forEach((frame, index) => {
+    nodes.set(index, {
+      frame,
+      frameIndex: index,
+      children: [],
+      parent: null,
+      depth: 0,
+    });
+  });
+
+  // Build parent-child relationships
+  const roots: StacktraceTreeNode[] = [];
+
+  frames.forEach((frame, index) => {
+    const node = nodes.get(index)!;
+    // parentIndex contains the parent frame index. -1 means root frame.
+    const parentIndex = frame.parentIndex;
+
+    if (
+      parentIndex !== null &&
+      parentIndex !== undefined &&
+      parentIndex !== -1 &&
+      nodes.has(parentIndex) &&
+      parentIndex !== index // Prevent self-reference
+    ) {
+      const parent = nodes.get(parentIndex)!;
+      node.parent = parent;
+      parent.children.push(node);
+    } else {
+      // No valid parent (parentIndex is -1 or invalid) - this is a root node
+      roots.push(node);
+    }
+  });
+
+  // Calculate depths via DFS
+  function calculateDepth(node: StacktraceTreeNode, depth: number) {
+    node.depth = depth;
+    node.children.forEach(child => calculateDepth(child, depth + 1));
+  }
+
+  roots.forEach(root => calculateDepth(root, 0));
+
+  return roots;
+}
+
+/**
+ * Checks if the stacktrace frames contain flamegraph data.
+ * Flamegraph data is present when frames have parentIndex values set.
+ */
+export function hasFlamegraphData(frames: StacktraceFrame[] | undefined): boolean {
+  if (!frames || frames.length === 0) {
+    return false;
+  }
+
+  // Flamegraph data is present when parentIndex is set (not null/undefined).
+  return frames.some(
+    frame => frame.parentIndex !== null && frame.parentIndex !== undefined
+  );
+}
+
+type FrameIndex = Record<string | number, ProfilingFrame>;
+
+/**
+ * Converts stacktrace frames to profiling Frame objects and creates a frame index.
+ */
+export function createStacktraceFrameIndex(frames: StacktraceFrame[]): FrameIndex {
+  const index: FrameIndex = {};
+
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i]!;
+    index[i] = new ProfilingFrame(
+      {
+        key: i,
+        is_application: frame.inApp ?? false,
+        file: frame.filename ?? undefined,
+        path: frame.absPath ?? undefined,
+        module: frame.module ?? undefined,
+        package: frame.package ?? undefined,
+        name: frame.function ?? frame.filename ?? '<unknown>',
+      },
+      'mobile'
+    );
+  }
+
+  return index;
+}
+
+/**
+ * Converts the stacktrace tree structure to samples and weights format
+ * suitable for creating a SampledProfile.
+ *
+ * Each unique path from root to leaf becomes a sample.
+ * The sample is represented as an array of frame indices from root to leaf.
+ * The weight for each sample comes from the leaf frame's sampleCount field.
+ */
+export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
+  samples: number[][];
+  weights: number[];
+} {
+  const samples: number[][] = [];
+  const weights: number[] = [];
+
+  function collectSamples(node: StacktraceTreeNode, currentPath: number[]) {
+    const pathWithNode = [...currentPath, node.frameIndex];
+
+    if (node.children.length === 0) {
+      // This is a leaf node - add the path as a sample
+      samples.push(pathWithNode);
+      weights.push(node.frame.sampleCount ?? 1);
+    } else {
+      // Continue traversing children
+      for (const child of node.children) {
+        collectSamples(child, pathWithNode);
+      }
+    }
+  }
+
+  for (const root of roots) {
+    collectSamples(root, []);
+  }
+
+  return {samples, weights};
+}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -1,7 +1,7 @@
 import type {Frame as StacktraceFrame} from 'sentry/types/event';
 import {Frame as ProfilingFrame} from 'sentry/utils/profiling/frame';
 
-export interface StacktraceTreeNode {
+interface StacktraceTreeNode {
   children: StacktraceTreeNode[];
   depth: number;
   frame: StacktraceFrame;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -127,9 +127,10 @@ export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
     const inclusiveCount = node.frame.sampleCount ?? 0;
 
     if (node.children.length === 0) {
-      // Leaf node - emit a sample with its weight
-      samples.push(pathWithNode);
-      weights.push(inclusiveCount);
+      if (inclusiveCount > 0) {
+        samples.push(pathWithNode);
+        weights.push(inclusiveCount);
+      }
     } else {
       // Self weight = inclusive count minus children's inclusive counts
       const childrenCount = node.children.reduce(

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -52,8 +52,13 @@ export function buildFrameTree(frames: StacktraceFrame[]): StacktraceTreeNode[] 
     }
   });
 
-  // Calculate depths via DFS
+  // Calculate depths via DFS, tracking visited nodes to avoid cycles
+  const visited = new Set<number>();
   function calculateDepth(node: StacktraceTreeNode, depth: number) {
+    if (visited.has(node.frameIndex)) {
+      return;
+    }
+    visited.add(node.frameIndex);
     node.depth = depth;
     node.children.forEach(child => calculateDepth(child, depth + 1));
   }
@@ -121,8 +126,13 @@ export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
 } {
   const samples: number[][] = [];
   const weights: number[] = [];
+  const visited = new Set<number>();
 
   function collectSamples(node: StacktraceTreeNode, currentPath: number[]) {
+    if (visited.has(node.frameIndex)) {
+      return;
+    }
+    visited.add(node.frameIndex);
     const pathWithNode = [...currentPath, node.frameIndex];
     const inclusiveCount = node.frame.sampleCount ?? 0;
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/utils.ts
@@ -16,7 +16,7 @@ export interface StacktraceTreeNode {
  */
 export function buildFrameTree(frames: StacktraceFrame[]): StacktraceTreeNode[] {
   // Create nodes for each frame
-  const nodes: Map<number, StacktraceTreeNode> = new Map();
+  const nodes = new Map<number, StacktraceTreeNode>();
 
   frames.forEach((frame, index) => {
     nodes.set(index, {
@@ -109,9 +109,11 @@ export function createStacktraceFrameIndex(frames: StacktraceFrame[]): FrameInde
  * Converts the stacktrace tree structure to samples and weights format
  * suitable for creating a SampledProfile.
  *
- * Each unique path from root to leaf becomes a sample.
- * The sample is represented as an array of frame indices from root to leaf.
- * The weight for each sample comes from the leaf frame's sampleCount field.
+ * Each unique path from root to a sampled frame becomes a sample.
+ * The sample is represented as an array of frame indices from root to that frame.
+ * Non-leaf frames with a sampleCount emit a self-sample in addition to
+ * recursing into children, capturing samples where that frame was at the
+ * top of the stack.
  */
 export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
   samples: number[][];
@@ -122,13 +124,25 @@ export function treeToSampledProfileData(roots: StacktraceTreeNode[]): {
 
   function collectSamples(node: StacktraceTreeNode, currentPath: number[]) {
     const pathWithNode = [...currentPath, node.frameIndex];
+    const inclusiveCount = node.frame.sampleCount ?? 0;
 
     if (node.children.length === 0) {
-      // This is a leaf node - add the path as a sample
+      // Leaf node - emit a sample with its weight
       samples.push(pathWithNode);
-      weights.push(node.frame.sampleCount ?? 1);
+      weights.push(inclusiveCount);
     } else {
-      // Continue traversing children
+      // Self weight = inclusive count minus children's inclusive counts
+      const childrenCount = node.children.reduce(
+        (sum, child) => sum + (child.frame.sampleCount ?? 0),
+        0
+      );
+      const selfCount = inclusiveCount - childrenCount;
+
+      if (selfCount > 0) {
+        samples.push(pathWithNode);
+        weights.push(selfCount);
+      }
+
       for (const child of node.children) {
         collectSamples(child, pathWithNode);
       }

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -411,7 +411,7 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformKey): Frame[
   const frames: Frame[] = [];
 
   while (node && !node.isRoot) {
-    const frame = {
+    const frame: Frame = {
       absPath: node.frame.path ?? null,
       colNo: node.frame.column ?? null,
       context: [],
@@ -422,8 +422,10 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformKey): Frame[
       lineNo: node.frame.line ?? null,
       module: node.frame.module ?? null,
       package: node.frame.package ?? null,
+      parentIndex: null,
       platform,
       rawFunction: null,
+      sampleCount: null,
       symbol: node.frame.symbol ?? null,
       symbolAddr: node.frame.symbolAddr ?? null,
       symbolicatorStatus: node.frame.symbolicatorStatus,

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -178,8 +178,10 @@ export type Frame = {
   lineNo: number | null;
   module: string | null;
   package: string | null;
+  parentIndex: number | null;
   platform: PlatformKey | null;
   rawFunction: string | null;
+  sampleCount: number | null;
   symbol: string | null;
   symbolAddr: string | null;
   trust: any | null;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -178,10 +178,8 @@ export type Frame = {
   lineNo: number | null;
   module: string | null;
   package: string | null;
-  parentIndex: number | null;
   platform: PlatformKey | null;
   rawFunction: string | null;
-  sampleCount: number | null;
   symbol: string | null;
   symbolAddr: string | null;
   trust: any | null;
@@ -193,6 +191,8 @@ export type Frame = {
   mapUrl?: string | null;
   minGroupingLevel?: number;
   origAbsPath?: string | null;
+  parentIndex?: number | null;
+  sampleCount?: number | null;
   sourceLink?: string | null;
   symbolicatorStatus?: SymbolicatorStatus;
 };

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -74,6 +74,7 @@ import {isJavascriptPlatform, isMobilePlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {MetricIssuesSection} from 'sentry/views/issueDetails/metricIssues/metricIssuesSection';
+import {MetricKitHangProfileSection} from 'sentry/views/issueDetails/metricKitHangProfileSection';
 import {ProfilePreviewSection} from 'sentry/views/issueDetails/profilePreviewSection';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
@@ -112,6 +113,9 @@ export function EventDetailsContent({
   const hasReplay = Boolean(getReplayIdFromEvent(event));
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
+  const isMetricKitHang =
+    mechanism === 'mx_hang_diagnostic' &&
+    organization.features.includes('metrickit-flamegraph');
   const groupingCurrentLevel = group?.metadata?.current_level;
 
   const hasActionableItems = actionableItemsEnabled({
@@ -235,61 +239,65 @@ export function EventDetailsContent({
           <Message event={event} data={eventEntries[EntryType.MESSAGE].data} />
         </EntryErrorBoundary>
       )}
-      {/* Wrapping all stacktrace components since multiple could appear */}
-      <ClassNames>
-        {({css}) => (
-          <GuideAnchor
-            target="stacktrace"
-            position="top"
-            disabled={
-              !(
-                defined(eventEntries[EntryType.EXCEPTION]) ||
-                defined(eventEntries[EntryType.STACKTRACE]) ||
-                defined(eventEntries[EntryType.THREADS]) ||
-                hasStreamlinedUI
-              )
-            }
-            // Prevent the container span from shrinking the content
-            containerClassName={css`
-              display: block !important;
-            `}
-          >
-            {defined(eventEntries[EntryType.EXCEPTION]) && (
-              <EntryErrorBoundary type={EntryType.EXCEPTION}>
-                <Exception
-                  event={event}
-                  data={eventEntries[EntryType.EXCEPTION].data}
-                  projectSlug={project.slug}
-                  group={group}
-                  groupingCurrentLevel={groupingCurrentLevel}
-                />
-              </EntryErrorBoundary>
-            )}
-            {issueTypeConfig.stacktrace.enabled &&
-              defined(eventEntries[EntryType.STACKTRACE]) && (
-                <EntryErrorBoundary type={EntryType.STACKTRACE}>
-                  <StackTrace
+      {isMetricKitHang ? (
+        <MetricKitHangProfileSection event={event} />
+      ) : (
+        /* Wrapping all stacktrace components since multiple could appear */
+        <ClassNames>
+          {({css}) => (
+            <GuideAnchor
+              target="stacktrace"
+              position="top"
+              disabled={
+                !(
+                  defined(eventEntries[EntryType.EXCEPTION]) ||
+                  defined(eventEntries[EntryType.STACKTRACE]) ||
+                  defined(eventEntries[EntryType.THREADS]) ||
+                  hasStreamlinedUI
+                )
+              }
+              // Prevent the container span from shrinking the content
+              containerClassName={css`
+                display: block !important;
+              `}
+            >
+              {defined(eventEntries[EntryType.EXCEPTION]) && (
+                <EntryErrorBoundary type={EntryType.EXCEPTION}>
+                  <Exception
                     event={event}
-                    data={eventEntries[EntryType.STACKTRACE].data}
-                    projectSlug={projectSlug}
+                    data={eventEntries[EntryType.EXCEPTION].data}
+                    projectSlug={project.slug}
+                    group={group}
                     groupingCurrentLevel={groupingCurrentLevel}
                   />
                 </EntryErrorBoundary>
               )}
-            {defined(eventEntries[EntryType.THREADS]) && (
-              <EntryErrorBoundary type={EntryType.THREADS}>
-                <Threads
-                  event={event}
-                  data={eventEntries[EntryType.THREADS].data}
-                  projectSlug={project.slug}
-                  groupingCurrentLevel={groupingCurrentLevel}
-                  group={group}
-                />
-              </EntryErrorBoundary>
-            )}
-          </GuideAnchor>
-        )}
-      </ClassNames>
+              {issueTypeConfig.stacktrace.enabled &&
+                defined(eventEntries[EntryType.STACKTRACE]) && (
+                  <EntryErrorBoundary type={EntryType.STACKTRACE}>
+                    <StackTrace
+                      event={event}
+                      data={eventEntries[EntryType.STACKTRACE].data}
+                      projectSlug={projectSlug}
+                      groupingCurrentLevel={groupingCurrentLevel}
+                    />
+                  </EntryErrorBoundary>
+                )}
+              {defined(eventEntries[EntryType.THREADS]) && (
+                <EntryErrorBoundary type={EntryType.THREADS}>
+                  <Threads
+                    event={event}
+                    data={eventEntries[EntryType.THREADS].data}
+                    projectSlug={project.slug}
+                    groupingCurrentLevel={groupingCurrentLevel}
+                    group={group}
+                  />
+                </EntryErrorBoundary>
+              )}
+            </GuideAnchor>
+          )}
+        </ClassNames>
+      )}
       {hasStreamlinedUI && (
         <ScreenshotDataSection event={event} projectSlug={project.slug} />
       )}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -116,10 +116,12 @@ export function EventDetailsContent({
   const hasReplay = Boolean(getReplayIdFromEvent(event));
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
-  const isMetricKitHang =
+  const hangProfileData =
     mechanism === 'mx_hang_diagnostic' &&
-    organization.features.includes('metrickit-flamegraph') &&
-    getHangProfileData(event) !== null;
+    organization.features.includes('metrickit-flamegraph')
+      ? getHangProfileData(event)
+      : null;
+  const isMetricKitHang = hangProfileData !== null;
   const groupingCurrentLevel = group?.metadata?.current_level;
 
   const hasActionableItems = actionableItemsEnabled({
@@ -244,7 +246,7 @@ export function EventDetailsContent({
         </EntryErrorBoundary>
       )}
       {isMetricKitHang ? (
-        <MetricKitHangProfileSection event={event} />
+        <MetricKitHangProfileSection data={hangProfileData} />
       ) : (
         /* Wrapping all stacktrace components since multiple could appear */
         <ClassNames>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -74,7 +74,10 @@ import {isJavascriptPlatform, isMobilePlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {MetricIssuesSection} from 'sentry/views/issueDetails/metricIssues/metricIssuesSection';
-import {MetricKitHangProfileSection} from 'sentry/views/issueDetails/metricKitHangProfileSection';
+import {
+  getHangProfileData,
+  MetricKitHangProfileSection,
+} from 'sentry/views/issueDetails/metricKitHangProfileSection';
 import {ProfilePreviewSection} from 'sentry/views/issueDetails/profilePreviewSection';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
@@ -115,7 +118,8 @@ export function EventDetailsContent({
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
   const isMetricKitHang =
     mechanism === 'mx_hang_diagnostic' &&
-    organization.features.includes('metrickit-flamegraph');
+    organization.features.includes('metrickit-flamegraph') &&
+    getHangProfileData(event) !== null;
   const groupingCurrentLevel = group?.metadata?.current_level;
 
   const hasActionableItems = actionableItemsEnabled({

--- a/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
@@ -44,7 +44,9 @@ function makeExceptionEntry({
                 sampleCount: withFlamegraphData ? 5 : undefined,
               },
             ],
+            framesOmitted: null,
             hasSystemFrames: false,
+            registers: null,
           },
           rawStacktrace: null,
           mechanism: null,
@@ -74,7 +76,7 @@ describe('MetricKitHangProfileSection', () => {
   it('does not render when frames do not have parentIndex', () => {
     const event = EventFixture({
       entries: [makeExceptionEntry({withFlamegraphData: false})],
-    } as any);
+    });
 
     const {container} = render(<MetricKitHangProfileSection event={event} />, {
       organization,
@@ -86,7 +88,7 @@ describe('MetricKitHangProfileSection', () => {
   it('renders Hang Profile title and flamegraph when event has flamegraph data', () => {
     const event = EventFixture({
       entries: [makeExceptionEntry()],
-    } as any);
+    });
 
     render(<MetricKitHangProfileSection event={event} />, {organization});
 
@@ -97,7 +99,7 @@ describe('MetricKitHangProfileSection', () => {
   it('displays exception value text above flamegraph', () => {
     const event = EventFixture({
       entries: [makeExceptionEntry({value: 'MXHangDiagnostic hangDuration:2.5 s'})],
-    } as any);
+    });
 
     render(<MetricKitHangProfileSection event={event} />, {organization});
 
@@ -119,11 +121,13 @@ describe('MetricKitHangProfileSection', () => {
                 sampleCount: 10,
               },
             ],
+            framesOmitted: null,
             hasSystemFrames: false,
+            registers: null,
           },
         },
       ],
-    } as any);
+    });
 
     render(<MetricKitHangProfileSection event={event} />, {organization});
 
@@ -136,7 +140,7 @@ describe('MetricKitHangProfileSection', () => {
   it('shows tooltip explaining the hang profile', () => {
     const event = EventFixture({
       entries: [makeExceptionEntry()],
-    } as any);
+    });
 
     render(<MetricKitHangProfileSection event={event} />, {organization});
 
@@ -155,6 +159,7 @@ describe('MetricKitHangProfileSection', () => {
                 current: true,
                 crashed: false,
                 name: 'main',
+                rawStacktrace: null,
                 stacktrace: {
                   frames: [
                     {
@@ -165,14 +170,16 @@ describe('MetricKitHangProfileSection', () => {
                       sampleCount: 10,
                     },
                   ],
+                  framesOmitted: null,
                   hasSystemFrames: false,
+                  registers: null,
                 },
               },
             ],
           },
         },
       ],
-    } as any);
+    });
 
     render(<MetricKitHangProfileSection event={event} />, {organization});
 

--- a/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
@@ -1,0 +1,182 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {EntryType} from 'sentry/types/event';
+import {MetricKitHangProfileSection} from 'sentry/views/issueDetails/metricKitHangProfileSection';
+
+jest.mock(
+  'sentry/components/events/interfaces/crashContent/stackTrace/flamegraph',
+  () => ({
+    ...jest.requireActual(
+      'sentry/components/events/interfaces/crashContent/stackTrace/flamegraph'
+    ),
+    StacktraceFlamegraph: jest.fn(() => <div data-test-id="flamegraph-preview" />),
+  })
+);
+
+function makeExceptionEntry({
+  value = 'MXHangDiagnostic hangDuration:2.5 s',
+  withFlamegraphData = true,
+}: {value?: string; withFlamegraphData?: boolean} = {}) {
+  return {
+    type: EntryType.EXCEPTION as const,
+    data: {
+      values: [
+        {
+          type: 'MXHangDiagnostic',
+          value,
+          stacktrace: {
+            frames: [
+              {
+                function: 'main',
+                filename: 'main.m',
+                inApp: true,
+                parentIndex: withFlamegraphData ? -1 : undefined,
+                sampleCount: withFlamegraphData ? 10 : undefined,
+              },
+              {
+                function: 'doWork',
+                filename: 'worker.m',
+                inApp: true,
+                parentIndex: withFlamegraphData ? 0 : undefined,
+                sampleCount: withFlamegraphData ? 5 : undefined,
+              },
+            ],
+            hasSystemFrames: false,
+          },
+          rawStacktrace: null,
+          mechanism: null,
+          module: null,
+          threadId: null,
+        },
+      ],
+      hasSystemFrames: false,
+      excOmitted: null,
+    },
+  };
+}
+
+describe('MetricKitHangProfileSection', () => {
+  const organization = OrganizationFixture();
+
+  it('does not render when event has no entries', () => {
+    const event = EventFixture({entries: []});
+
+    const {container} = render(<MetricKitHangProfileSection event={event} />, {
+      organization,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when frames do not have parentIndex', () => {
+    const event = EventFixture({
+      entries: [makeExceptionEntry({withFlamegraphData: false})],
+    } as any);
+
+    const {container} = render(<MetricKitHangProfileSection event={event} />, {
+      organization,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders Hang Profile title and flamegraph when event has flamegraph data', () => {
+    const event = EventFixture({
+      entries: [makeExceptionEntry()],
+    } as any);
+
+    render(<MetricKitHangProfileSection event={event} />, {organization});
+
+    expect(screen.getByText('Hang Profile')).toBeInTheDocument();
+    expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
+  });
+
+  it('displays exception value text above flamegraph', () => {
+    const event = EventFixture({
+      entries: [makeExceptionEntry({value: 'MXHangDiagnostic hangDuration:2.5 s'})],
+    } as any);
+
+    render(<MetricKitHangProfileSection event={event} />, {organization});
+
+    expect(screen.getByText('MXHangDiagnostic hangDuration:2.5 s')).toBeInTheDocument();
+  });
+
+  it('does not display exception value text when value is empty', () => {
+    const event = EventFixture({
+      entries: [
+        {
+          type: EntryType.STACKTRACE as const,
+          data: {
+            frames: [
+              {
+                function: 'main',
+                filename: 'main.m',
+                inApp: true,
+                parentIndex: -1,
+                sampleCount: 10,
+              },
+            ],
+            hasSystemFrames: false,
+          },
+        },
+      ],
+    } as any);
+
+    render(<MetricKitHangProfileSection event={event} />, {organization});
+
+    expect(screen.getByText('Hang Profile')).toBeInTheDocument();
+    expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
+    // No pre element with exception value should be rendered
+    expect(screen.queryByText('MXHangDiagnostic')).not.toBeInTheDocument();
+  });
+
+  it('shows tooltip explaining the hang profile', () => {
+    const event = EventFixture({
+      entries: [makeExceptionEntry()],
+    } as any);
+
+    render(<MetricKitHangProfileSection event={event} />, {organization});
+
+    expect(screen.getByTestId('more-information')).toBeInTheDocument();
+  });
+
+  it('extracts flamegraph data from threads entry', () => {
+    const event = EventFixture({
+      entries: [
+        {
+          type: EntryType.THREADS as const,
+          data: {
+            values: [
+              {
+                id: 0,
+                current: true,
+                crashed: false,
+                name: 'main',
+                stacktrace: {
+                  frames: [
+                    {
+                      function: 'main',
+                      filename: 'main.m',
+                      inApp: true,
+                      parentIndex: -1,
+                      sampleCount: 10,
+                    },
+                  ],
+                  hasSystemFrames: false,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as any);
+
+    render(<MetricKitHangProfileSection event={event} />, {organization});
+
+    expect(screen.getByText('Hang Profile')).toBeInTheDocument();
+    expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
@@ -1,10 +1,12 @@
-import {EventFixture} from 'sentry-fixture/event';
+import {FrameFixture} from 'sentry-fixture/frame';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {EntryType} from 'sentry/types/event';
-import {MetricKitHangProfileSection} from 'sentry/views/issueDetails/metricKitHangProfileSection';
+import {
+  MetricKitHangProfileSection,
+  type HangProfileData,
+} from 'sentry/views/issueDetails/metricKitHangProfileSection';
 
 jest.mock(
   'sentry/components/events/interfaces/crashContent/stackTrace/flamegraph',
@@ -16,174 +18,66 @@ jest.mock(
   })
 );
 
-function makeExceptionEntry({
-  value = 'MXHangDiagnostic hangDuration:2.5 s',
-  withFlamegraphData = true,
-}: {value?: string; withFlamegraphData?: boolean} = {}) {
+function makeHangProfileData(overrides: Partial<HangProfileData> = {}): HangProfileData {
   return {
-    type: EntryType.EXCEPTION as const,
-    data: {
-      values: [
-        {
-          type: 'MXHangDiagnostic',
-          value,
-          stacktrace: {
-            frames: [
-              {
-                function: 'main',
-                filename: 'main.m',
-                inApp: true,
-                parentIndex: withFlamegraphData ? -1 : undefined,
-                sampleCount: withFlamegraphData ? 10 : undefined,
-              },
-              {
-                function: 'doWork',
-                filename: 'worker.m',
-                inApp: true,
-                parentIndex: withFlamegraphData ? 0 : undefined,
-                sampleCount: withFlamegraphData ? 5 : undefined,
-              },
-            ],
-            framesOmitted: null,
-            hasSystemFrames: false,
-            registers: null,
-          },
-          rawStacktrace: null,
-          mechanism: null,
-          module: null,
-          threadId: null,
-        },
-      ],
-      hasSystemFrames: false,
-      excOmitted: null,
-    },
+    exceptionValue: 'MXHangDiagnostic hangDuration:2.5 s',
+    frames: [
+      FrameFixture({
+        function: 'main',
+        filename: 'main.m',
+        inApp: true,
+        parentIndex: -1,
+        sampleCount: 10,
+      }),
+      FrameFixture({
+        function: 'doWork',
+        filename: 'worker.m',
+        inApp: true,
+        parentIndex: 0,
+        sampleCount: 5,
+      }),
+    ],
+    ...overrides,
   };
 }
 
 describe('MetricKitHangProfileSection', () => {
   const organization = OrganizationFixture();
 
-  it('does not render when event has no entries', () => {
-    const event = EventFixture({entries: []});
+  it('renders Hang Profile title and flamegraph', () => {
+    const data = makeHangProfileData();
 
-    const {container} = render(<MetricKitHangProfileSection event={event} />, {
-      organization,
-    });
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('does not render when frames do not have parentIndex', () => {
-    const event = EventFixture({
-      entries: [makeExceptionEntry({withFlamegraphData: false})],
-    });
-
-    const {container} = render(<MetricKitHangProfileSection event={event} />, {
-      organization,
-    });
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders Hang Profile title and flamegraph when event has flamegraph data', () => {
-    const event = EventFixture({
-      entries: [makeExceptionEntry()],
-    });
-
-    render(<MetricKitHangProfileSection event={event} />, {organization});
+    render(<MetricKitHangProfileSection data={data} />, {organization});
 
     expect(screen.getByText('Hang Profile')).toBeInTheDocument();
     expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
   });
 
   it('displays exception value text above flamegraph', () => {
-    const event = EventFixture({
-      entries: [makeExceptionEntry({value: 'MXHangDiagnostic hangDuration:2.5 s'})],
+    const data = makeHangProfileData({
+      exceptionValue: 'MXHangDiagnostic hangDuration:2.5 s',
     });
 
-    render(<MetricKitHangProfileSection event={event} />, {organization});
+    render(<MetricKitHangProfileSection data={data} />, {organization});
 
     expect(screen.getByText('MXHangDiagnostic hangDuration:2.5 s')).toBeInTheDocument();
   });
 
   it('does not display exception value text when value is empty', () => {
-    const event = EventFixture({
-      entries: [
-        {
-          type: EntryType.STACKTRACE as const,
-          data: {
-            frames: [
-              {
-                function: 'main',
-                filename: 'main.m',
-                inApp: true,
-                parentIndex: -1,
-                sampleCount: 10,
-              },
-            ],
-            framesOmitted: null,
-            hasSystemFrames: false,
-            registers: null,
-          },
-        },
-      ],
-    });
+    const data = makeHangProfileData({exceptionValue: ''});
 
-    render(<MetricKitHangProfileSection event={event} />, {organization});
+    render(<MetricKitHangProfileSection data={data} />, {organization});
 
     expect(screen.getByText('Hang Profile')).toBeInTheDocument();
     expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
-    // No pre element with exception value should be rendered
     expect(screen.queryByText('MXHangDiagnostic')).not.toBeInTheDocument();
   });
 
   it('shows tooltip explaining the hang profile', () => {
-    const event = EventFixture({
-      entries: [makeExceptionEntry()],
-    });
+    const data = makeHangProfileData();
 
-    render(<MetricKitHangProfileSection event={event} />, {organization});
+    render(<MetricKitHangProfileSection data={data} />, {organization});
 
     expect(screen.getByTestId('more-information')).toBeInTheDocument();
-  });
-
-  it('extracts flamegraph data from threads entry', () => {
-    const event = EventFixture({
-      entries: [
-        {
-          type: EntryType.THREADS as const,
-          data: {
-            values: [
-              {
-                id: 0,
-                current: true,
-                crashed: false,
-                name: 'main',
-                rawStacktrace: null,
-                stacktrace: {
-                  frames: [
-                    {
-                      function: 'main',
-                      filename: 'main.m',
-                      inApp: true,
-                      parentIndex: -1,
-                      sampleCount: 10,
-                    },
-                  ],
-                  framesOmitted: null,
-                  hasSystemFrames: false,
-                  registers: null,
-                },
-              },
-            ],
-          },
-        },
-      ],
-    });
-
-    render(<MetricKitHangProfileSection event={event} />, {organization});
-
-    expect(screen.getByText('Hang Profile')).toBeInTheDocument();
-    expect(screen.getByTestId('flamegraph-preview')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/metricKitHangProfileSection.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.tsx
@@ -23,7 +23,7 @@ interface HangProfileData {
  * Extracts frames with flamegraph data and the associated exception info
  * from the event's exception entry.
  */
-function getHangProfileData(event: Event): HangProfileData | null {
+export function getHangProfileData(event: Event): HangProfileData | null {
   for (const entry of event.entries) {
     if (entry.type === EntryType.EXCEPTION) {
       for (const value of entry.data.values ?? []) {

--- a/static/app/views/issueDetails/metricKitHangProfileSection.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.tsx
@@ -1,0 +1,99 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {
+  hasFlamegraphData,
+  StacktraceFlamegraph,
+} from 'sentry/components/events/interfaces/crashContent/stackTrace/flamegraph';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event, Frame} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+
+interface HangProfileData {
+  exceptionValue: string;
+  frames: Frame[];
+}
+
+/**
+ * Extracts frames with flamegraph data and the associated exception info
+ * from the event's exception entry.
+ */
+function getHangProfileData(event: Event): HangProfileData | null {
+  for (const entry of event.entries) {
+    if (entry.type === EntryType.EXCEPTION) {
+      for (const value of entry.data.values ?? []) {
+        if (hasFlamegraphData(value.stacktrace?.frames)) {
+          return {
+            frames: value.stacktrace!.frames!,
+            exceptionValue: value.value,
+          };
+        }
+      }
+    }
+
+    if (entry.type === EntryType.STACKTRACE) {
+      if (hasFlamegraphData(entry.data.frames)) {
+        return {
+          frames: entry.data.frames!,
+          exceptionValue: '',
+        };
+      }
+    }
+
+    if (entry.type === EntryType.THREADS) {
+      for (const thread of entry.data.values ?? []) {
+        if (hasFlamegraphData(thread.stacktrace?.frames)) {
+          return {
+            frames: thread.stacktrace!.frames!,
+            exceptionValue: '',
+          };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function MetricKitHangProfileSection({event}: {event: Event}) {
+  const data = useMemo(() => getHangProfileData(event), [event]);
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <ErrorBoundary mini>
+      <InterimSection
+        type={SectionKey.STACKTRACE_FLAMEGRAPH}
+        title={
+          <span>
+            {t('Hang Profile')}
+            &nbsp;
+            <QuestionTooltip
+              position="bottom"
+              size="sm"
+              title={t('This profile was reported by MetricKit during the app hang.')}
+            />
+          </span>
+        }
+      >
+        {data.exceptionValue && <StyledPre>{data.exceptionValue}</StyledPre>}
+        <StacktraceFlamegraph frames={data.frames} />
+      </InterimSection>
+    </ErrorBoundary>
+  );
+}
+
+const StyledPre = styled('pre')`
+  padding: 0;
+  margin: 0 0 ${space(1)} 0;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  background-color: inherit;
+`;

--- a/static/app/views/issueDetails/metricKitHangProfileSection.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -14,7 +13,7 @@ import {EntryType} from 'sentry/types/event';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
-interface HangProfileData {
+export interface HangProfileData {
   exceptionValue: string;
   frames: Frame[];
 }
@@ -60,13 +59,7 @@ export function getHangProfileData(event: Event): HangProfileData | null {
   return null;
 }
 
-export function MetricKitHangProfileSection({event}: {event: Event}) {
-  const data = useMemo(() => getHangProfileData(event), [event]);
-
-  if (!data) {
-    return null;
-  }
-
+export function MetricKitHangProfileSection({data}: {data: HangProfileData}) {
   return (
     <ErrorBoundary mini>
       <InterimSection

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -101,6 +101,7 @@ export const enum SectionKey {
   INSTRUMENTATION_FIX = 'instrumentation-fix',
 
   PROFILE_PREVIEW = 'profile-preview',
+  STACKTRACE_FLAMEGRAPH = 'stacktrace-flamegraph',
 }
 
 /**


### PR DESCRIPTION
Uses "parent_index" and "sample_count" on stack traces so the full flamegraph can be visualized for metric kit app hangs. This is the iOS follow up to https://github.com/getsentry/sentry/pull/103256

MetricKit delivers app hang after the hang has ended so we can't use an actual sentry profile for this like we do on Android.

<img width="1444" height="459" alt="Screenshot 2026-03-05 at 5 53 44 PM" src="https://github.com/user-attachments/assets/e9047e5c-ce9e-4615-98f2-915a04f251b9" />
