### PR TITLE
fix(prompts): Remove redundant organization_id from GET query params

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -112,7 +112,10 @@ export const makePromptsCheckQueryKey = ({
   organization,
   projectId,
 }: PromptCheckParams): ApiQueryKey => {
-  const url = `/organizations/${organization.slug}/prompts-activity/`;
+  // Use optional chaining because query keys are generated even when the query
+  // is disabled. Some callers use `organization!` with `enabled: false` when
+  // organization may be null (e.g., stacktraceBanners.tsx with allowNull: true).
+  const url = `/organizations/${organization?.slug}/prompts-activity/`;
   return [url, {query: {feature, project_id: projectId}}];
 };
 

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -49,6 +49,12 @@ type PromptCheckParams = {
   projectId?: string;
 };
 
+type PromptCheckHookParams = {
+  feature: string | string[];
+  organization: OrganizationSummary | null;
+  projectId?: string;
+};
+
 /**
  * Raw response data from the endpoint
  */
@@ -111,16 +117,13 @@ export const makePromptsCheckQueryKey = ({
   feature,
   organization,
   projectId,
-}: PromptCheckParams): ApiQueryKey => {
-  // Use optional chaining because query keys are generated even when the query
-  // is disabled. Some callers use `organization!` with `enabled: false` when
-  // organization may be null (e.g., stacktraceBanners.tsx with allowNull: true).
+}: PromptCheckHookParams): ApiQueryKey => {
   const url = `/organizations/${organization?.slug}/prompts-activity/`;
   return [url, {query: {feature, project_id: projectId}}];
 };
 
 export function usePromptsCheck(
-  {feature, organization, projectId}: PromptCheckParams,
+  {feature, organization, projectId}: PromptCheckHookParams,
   {enabled = true, ...options}: Partial<UseApiQueryOptions<PromptResponse>> = {}
 ) {
   return useApiQuery<PromptResponse>(
@@ -146,7 +149,7 @@ export function usePrompts({
   isDismissed = promptIsDismissed,
 }: {
   features: string[];
-  organization: Organization;
+  organization: Organization | null;
   daysToSnooze?: number;
   isDismissed?: (prompt: PromptData, daysToSnooze?: number) => boolean;
   options?: Partial<UseApiQueryOptions<PromptResponse>>;
@@ -288,7 +291,7 @@ export function usePrompt({
   options,
 }: {
   feature: string;
-  organization: Organization;
+  organization: Organization | null;
   daysToSnooze?: number;
   options?: Partial<UseApiQueryOptions<PromptResponse>>;
   projectId?: string;

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -88,12 +88,14 @@ export async function promptsCheck(
   api: Client,
   params: PromptCheckParams
 ): Promise<PromptData> {
+  if (!params.organization) {
+    throw new Error('promptsCheck requires an organization');
+  }
   const query = {
     feature: params.feature,
-    organization_id: params.organization?.id,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
-  const url = `/organizations/${params.organization?.slug}/prompts-activity/`;
+  const url = `/organizations/${params.organization.slug}/prompts-activity/`;
   const response: PromptResponse = await api.requestPromise(url, {
     query,
   });
@@ -114,10 +116,7 @@ export const makePromptsCheckQueryKey = ({
   projectId,
 }: PromptCheckParams): ApiQueryKey => {
   const url = `/organizations/${organization?.slug}/prompts-activity/`;
-  return [
-    url,
-    {query: {feature, organization_id: organization?.id, project_id: projectId}},
-  ];
+  return [url, {query: {feature, project_id: projectId}}];
 };
 
 export function usePromptsCheck(
@@ -422,7 +421,6 @@ export async function batchedPromptsCheck<T extends readonly string[]>(
 ): Promise<Record<T[number], PromptData>> {
   const query = {
     feature: features,
-    organization_id: params.organization.id,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
   const url = `/organizations/${params.organization.slug}/prompts-activity/`;

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -42,7 +42,7 @@ type PromptCheckParams = {
    * The prompt feature name
    */
   feature: string | string[];
-  organization: OrganizationSummary | null;
+  organization: OrganizationSummary;
   /**
    * The numeric project ID as a string
    */
@@ -88,9 +88,6 @@ export async function promptsCheck(
   api: Client,
   params: PromptCheckParams
 ): Promise<PromptData> {
-  if (!params.organization) {
-    throw new Error('promptsCheck requires an organization');
-  }
   const query = {
     feature: params.feature,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
@@ -115,7 +112,7 @@ export const makePromptsCheckQueryKey = ({
   organization,
   projectId,
 }: PromptCheckParams): ApiQueryKey => {
-  const url = `/organizations/${organization?.slug}/prompts-activity/`;
+  const url = `/organizations/${organization.slug}/prompts-activity/`;
   return [url, {query: {feature, project_id: projectId}}];
 };
 
@@ -146,7 +143,7 @@ export function usePrompts({
   isDismissed = promptIsDismissed,
 }: {
   features: string[];
-  organization: Organization | null;
+  organization: Organization;
   daysToSnooze?: number;
   isDismissed?: (prompt: PromptData, daysToSnooze?: number) => boolean;
   options?: Partial<UseApiQueryOptions<PromptResponse>>;
@@ -288,7 +285,7 @@ export function usePrompt({
   options,
 }: {
   feature: string;
-  organization: Organization | null;
+  organization: Organization;
   daysToSnooze?: number;
   options?: Partial<UseApiQueryOptions<PromptResponse>>;
   projectId?: string;

--- a/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.spec.tsx
@@ -92,7 +92,6 @@ describe('StacktraceBanners', () => {
       expect.objectContaining({
         query: {
           feature: 'stacktrace_link',
-          organization_id: org.id,
           project_id: project.id,
         },
       })

--- a/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.tsx
@@ -45,7 +45,7 @@ export function StacktraceBanners({stacktrace, event}: StacktraceBannersProps) {
   );
 
   const {isLoading, isError, isPromptDismissed, dismissPrompt} = usePrompt({
-    organization: organization!,
+    organization,
     feature: integrationPromptKey,
     projectId: project?.id,
     options: {enabled},


### PR DESCRIPTION
Removes the redundant `organization_id` query parameter from the frontend prompts API calls. The GET endpoint now uses the organization from the URL path (after the fix in #104990), making this parameter ignored but harmless.

Changes:
- Remove `organization_id` from `promptsCheck()`, `makePromptsCheckQueryKey()`, and `batchedPromptsCheck()`
- Add explicit error handling in `promptsCheck()` when organization is null (previously would create an invalid URL `/organizations/undefined/...`)

Follow-up to #104990.