### PR TITLE
perf(groups): Fix N+1 query on Project in qualified_short_id

### DIFF
--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -122,14 +122,11 @@ class DiscoverProcessor:
         if "issue" in self.header_fields:
             issue_ids = {result["issue.id"] for result in new_result_list}
             assert self.snuba_params.organization is not None
-            issues = {
-                i.id: i.qualified_short_id
-                for i in Group.objects.filter(
-                    id__in=issue_ids,
-                    project__in=self.snuba_params.project_ids,
-                    project__organization_id=self.snuba_params.organization.id,
-                )
-            }
+            issues = Group.objects.get_issues_mapping(
+                issue_ids,
+                self.snuba_params.project_ids,
+                self.snuba_params.organization,
+            )
             for result in new_result_list:
                 if "issue.id" in result:
                     result["issue"] = issues.get(result["issue.id"], "unknown")

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -604,7 +604,7 @@ class GroupManager(BaseManager["Group"]):
                 id__in=group_ids,
                 project_id__in=project_ids,
                 project__organization=organization,
-            )
+            ).select_related("project")
         }
 
 

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -216,7 +216,10 @@ def fetch_associated_groups(
             group_id_data[event["group_id"]].add(event[trace_id_event_name])
 
         group_ids = group_id_data.keys()
-        for group in Group.objects.filter(project_id=project_id, id__in=group_ids):
+        groups_queryset = Group.objects.filter(
+            project_id=project_id, id__in=group_ids
+        ).select_related("project")
+        for group in groups_queryset:
             for trace_id in group_id_data[group.id]:
                 trace_groups[trace_id].append({"id": group.id, "shortId": group.qualified_short_id})
 


### PR DESCRIPTION
The `qualified_short_id` property on Group accesses `self.project.slug` to construct the short ID (e.g., "PROJECT-ABC"). Without prefetching the project relation, each access triggers a separate database query.

This affected several code paths:
- `get_issues_mapping()` used by OrganizationEventsEndpoint when the "issue" field is requested
- Data export discover processor when exporting issues
- Monitors trace groups lookup

Add `select_related("project")` to these queries so the project is fetched in a single JOIN rather than N separate queries.

n+1 issue
https://sentry.sentry.io/issues/6583294196/