### PR TITLE
feat(search agent): Visualize Steps in UI

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -1,0 +1,634 @@
+import {useLayoutEffect, useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {type AriaComboBoxProps} from '@react-aria/combobox';
+import {mergeRefs} from '@react-aria/utils';
+import {Item} from '@react-stately/collections';
+import {useComboBoxState} from '@react-stately/combobox';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/core/button';
+import {Input} from 'sentry/components/core/input';
+import {Text} from 'sentry/components/core/text';
+import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
+import {AskSeerProgressBlocks} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks';
+import {AskSeerSearchHeader} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerSearchHeader';
+import {AskSeerSearchListBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox';
+import {AskSeerSearchPopover} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover';
+import QueryTokens from 'sentry/components/searchQueryBuilder/askSeerCombobox/queryTokens';
+import type {
+  AskSeerSearchItems,
+  QueryTokensProps,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {useAskSeerPolling} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling';
+import {
+  formatQueryToNaturalLanguage,
+  generateQueryTokensString,
+  isNoneOfTheseItem,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
+import {IconClose, IconMegaphone, IconSearch} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {UseMutationOptions} from 'sentry/utils/queryClient';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import useOrganization from 'sentry/utils/useOrganization';
+import useOverlay from 'sentry/utils/useOverlay';
+
+// The menu size can change from things like loading states, long options,
+// or custom menus like a date picker. This hook ensures that the overlay
+// is updated in response to these changes.
+function useUpdateOverlayPositionOnContentChange({
+  contentRef,
+  updateOverlayPosition,
+  isOpen,
+}: {
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  updateOverlayPosition: (() => void) | null;
+}) {
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  // Keep a ref to the updateOverlayPosition function so that we can
+  // access the latest value in the resize observer callback.
+  const updateOverlayPositionRef = useRef(updateOverlayPosition);
+  if (updateOverlayPositionRef.current !== updateOverlayPosition) {
+    updateOverlayPositionRef.current = updateOverlayPosition;
+  }
+
+  useLayoutEffect(() => {
+    resizeObserverRef.current = new ResizeObserver(() => {
+      if (!updateOverlayPositionRef.current) {
+        return;
+      }
+      updateOverlayPositionRef.current?.();
+    });
+
+    return () => {
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!contentRef.current || !resizeObserverRef.current || !isOpen) {
+      return () => {};
+    }
+
+    resizeObserverRef.current?.observe(contentRef.current);
+
+    return () => {
+      resizeObserverRef.current?.disconnect();
+    };
+  }, [contentRef, isOpen, updateOverlayPosition]);
+}
+
+interface AskSeerPollingComboBoxProps<T extends QueryTokensProps>
+  extends Omit<AriaComboBoxProps<unknown>, 'children'> {
+  /**
+   * The source of the analytics event, must be a dot-separated identifier like "trace.
+   * explorer" or "issue.list"
+   * @example 'trace.explorer'
+   */
+  analyticsSource: string;
+  applySeerSearchQuery: (item: T) => void;
+  /**
+   * The owner of the feedback form, must be an underscore-separated identifier like
+   * "trace_explorer_ai_query" or "issue_list_ai_query"
+   *
+   * @example 'trace_explorer_ai_query'
+   */
+  feedbackSource: string;
+  initialQuery: string;
+  projectIds: number[];
+  strategy: string;
+  /**
+   * Fallback mutation options to use if the polling endpoint fails.
+   * If provided, the component will fall back to AskSeerComboBox on start failure.
+   */
+  fallbackMutationOptions?: UseMutationOptions<any, Error, string>;
+  /**
+   * Transform the final response from the polling API to the expected format.
+   * This allows customization of how the response is converted to query items.
+   */
+  transformResponse?: (response: T) => T[];
+}
+
+export function AskSeerPollingComboBox<T extends QueryTokensProps>({
+  initialQuery,
+  feedbackSource,
+  analyticsSource,
+  projectIds,
+  strategy,
+  transformResponse,
+  fallbackMutationOptions,
+  ...props
+}: AskSeerPollingComboBoxProps<T>) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listBoxRef = useRef<HTMLUListElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLInputElement>(null);
+  const isInitialRender = useRef(true);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const organization = useOrganization();
+
+  const [searchQuery, setSearchQuery] = useState(() =>
+    formatQueryToNaturalLanguage(initialQuery)
+  );
+
+  const openForm = useFeedbackForm();
+
+  const {
+    setDisplayAskSeer,
+    setDisplayAskSeerFeedback,
+    askSeerNLQueryRef,
+    autoSubmitSeer,
+    setAutoSubmitSeer,
+    enableAISearch,
+  } = useSearchQueryBuilder();
+
+  const {
+    submitQuery,
+    isPending,
+    isPolling,
+    isError,
+    finalResponse,
+    unsupportedReason,
+    currentStep,
+    completedSteps,
+    reset,
+    startFailed,
+  } = useAskSeerPolling<T>({
+    projectIds,
+    strategy,
+    onError: error => {
+      addErrorMessage(t('Failed to process AI query: %(error)s', {error: error.message}));
+    },
+  });
+
+  // Transform the final response into query items
+  const queries = useMemo(() => {
+    if (!finalResponse) {
+      return [];
+    }
+    if (transformResponse) {
+      return transformResponse(finalResponse);
+    }
+    // Default: wrap single response in array
+    return [finalResponse];
+  }, [finalResponse, transformResponse]);
+
+  const handleNoneOfTheseClick = () => {
+    if (openForm) {
+      openForm({
+        messagePlaceholder: t('Why were these queries incorrect?'),
+        tags: {
+          ['feedback.source']: feedbackSource,
+          ['feedback.owner']: 'ml-ai',
+          ['feedback.natural_language_query']: searchQuery,
+          ['feedback.raw_result']: JSON.stringify(queries).replace(/\n/g, ''),
+          ['feedback.num_queries_returned']: queries.length ?? 0,
+        },
+      });
+    } else {
+      addErrorMessage(t('Unable to open feedback form'));
+    }
+  };
+
+  const items: Array<AskSeerSearchItems<T>> = useMemo(() => {
+    if (queries.length > 0) {
+      const results: Array<AskSeerSearchItems<T>> = queries.map((query, index) => ({
+        ...query,
+        key: `${index}-${query.query}`,
+      }));
+
+      results.push({
+        key: 'none-of-these',
+        label: t('None of these'),
+      });
+
+      return results;
+    }
+
+    return [];
+  }, [queries]);
+
+  const state = useComboBoxState({
+    ...props,
+    items,
+    defaultItems: [],
+    selectedKey: null,
+    allowsCustomValue: true,
+    allowsEmptyCollection: true,
+    shouldCloseOnBlur: false,
+    inputValue: searchQuery,
+    onInputChange: setSearchQuery,
+    defaultFilter: () => true,
+    onSelectionChange(key) {
+      if (typeof key !== 'string') return;
+
+      if (key === 'none-of-these') {
+        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+          organization,
+          natural_language_query: searchQuery,
+          num_queries_returned: queries.length ?? 0,
+        });
+        handleNoneOfTheseClick();
+        return;
+      }
+
+      const item = items.find(i => i.key === key);
+      if (!item || isNoneOfTheseItem(item)) {
+        addErrorMessage(t('Failed to find AI query to apply'));
+        return;
+      }
+
+      askSeerNLQueryRef.current = searchQuery.trim();
+      props.applySeerSearchQuery(item);
+      setDisplayAskSeerFeedback(true);
+      setDisplayAskSeer(false);
+      reset();
+      state.close();
+    },
+    children: item => {
+      if (isNoneOfTheseItem(item)) {
+        return (
+          <Item key={item.key} textValue={item.label} data-is-none-of-these>
+            <Text variant="muted">{item.label}</Text>
+          </Item>
+        );
+      }
+
+      const readableQuery = generateQueryTokensString(item);
+
+      return (
+        <Item
+          key={item.key}
+          textValue={readableQuery}
+          aria-label={`Query parameters: ${readableQuery}`}
+        >
+          <QueryTokens
+            sort={item?.sort}
+            query={item?.query}
+            groupBys={item?.groupBys}
+            statsPeriod={item?.statsPeriod}
+            start={item?.start}
+            end={item?.end}
+            visualizations={item?.visualizations}
+          />
+        </Item>
+      );
+    },
+  });
+
+  const {inputProps, listBoxProps} = useSearchTokenCombobox(
+    {
+      ...props,
+      inputRef,
+      buttonRef,
+      listBoxRef,
+      popoverRef,
+      'aria-label': t('Ask Seer with Natural Language'),
+      onFocus: () => {
+        state.open();
+      },
+      onBlur: () => {
+        state.close();
+      },
+      onKeyDown: e => {
+        switch (e.key) {
+          case 'Escape':
+            if (!state.isOpen) {
+              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+                organization,
+                action: 'closed',
+              });
+              setDisplayAskSeerFeedback(false);
+              setDisplayAskSeer(false);
+            }
+
+            reset();
+            state.close();
+            return;
+          case 'Enter':
+            if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
+              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+                organization,
+                natural_language_query: searchQuery,
+                num_queries_returned: queries.length ?? 0,
+              });
+              handleNoneOfTheseClick();
+              state.open();
+              return;
+            }
+
+            if (state.isOpen && state.selectionManager.focusedKey) {
+              const item = items.find(i => i.key === state.selectionManager.focusedKey);
+              if (!item || isNoneOfTheseItem(item)) {
+                addErrorMessage(t('Failed to find AI query to apply'));
+                return;
+              }
+
+              askSeerNLQueryRef.current = searchQuery.trim();
+              props.applySeerSearchQuery(item);
+              setDisplayAskSeerFeedback(true);
+              setDisplayAskSeer(false);
+              reset();
+              state.close();
+              return;
+            }
+
+            if (
+              state.isOpen &&
+              searchQuery.trim() !== null &&
+              searchQuery.trim() !== ''
+            ) {
+              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+                organization,
+                natural_language_query: searchQuery.trim(),
+              });
+              askSeerNLQueryRef.current = searchQuery.trim();
+              submitQuery(searchQuery.trim());
+              state.open();
+              return;
+            }
+
+            state.open();
+            return;
+          default:
+            return;
+        }
+      },
+    },
+    state
+  );
+
+  const {
+    overlayProps,
+    triggerProps,
+    update: updateOverlayPosition,
+  } = useOverlay({
+    type: 'listbox',
+    isOpen: state.isOpen,
+    position: 'bottom-start',
+    offset: 2,
+    shouldCloseOnBlur: true,
+    shouldApplyMinWidth: false,
+    isKeyboardDismissDisabled: true,
+    preventOverflowOptions: {boundary: document.body},
+    flipOptions: {
+      // We don't want the menu to ever flip to the other side of the input
+      fallbackPlacements: [],
+    },
+    shouldCloseOnInteractOutside: el => {
+      if (popoverRef.current?.contains(el) || containerRef.current?.contains(el)) {
+        return false;
+      }
+      return true;
+    },
+    onInteractOutside: () => {
+      state.close();
+    },
+  });
+
+  useUpdateOverlayPositionOnContentChange({
+    contentRef: popoverRef,
+    updateOverlayPosition,
+    isOpen: state.isOpen,
+  });
+
+  useLayoutEffect(() => {
+    if (!state.isOpen && inputRef.current && isInitialRender.current) {
+      isInitialRender.current = false;
+      inputRef.current?.focus();
+      state.open();
+    }
+  }, [state]);
+
+  useLayoutEffect(() => {
+    if (autoSubmitSeer && searchQuery.trim()) {
+      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+        organization,
+        natural_language_query: searchQuery.trim(),
+      });
+      submitQuery(searchQuery.trim());
+      setAutoSubmitSeer(false);
+    }
+  }, [
+    analyticsSource,
+    autoSubmitSeer,
+    organization,
+    searchQuery,
+    setAutoSubmitSeer,
+    submitQuery,
+  ]);
+
+  const onMouseLeave = () => {
+    state.selectionManager.setFocusedKey(null);
+  };
+
+  if (!enableAISearch) {
+    return null;
+  }
+
+  // Fall back to mutation-based AskSeerComboBox if start failed and fallback options provided
+  if (startFailed && fallbackMutationOptions) {
+    return (
+      <AskSeerComboBox
+        initialQuery={initialQuery}
+        askSeerMutationOptions={fallbackMutationOptions}
+        applySeerSearchQuery={props.applySeerSearchQuery}
+        analyticsSource={analyticsSource}
+        feedbackSource={feedbackSource}
+      />
+    );
+  }
+
+  const showLoading = isPending || isPolling;
+  const hasResults = queries.length > 0;
+
+  return (
+    <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
+      <PositionedSearchIconContainer>
+        <SearchIcon size="sm" />
+      </PositionedSearchIconContainer>
+      <InputWrapper>
+        <InvisibleInput
+          {...inputProps}
+          autoComplete="off"
+          onClick={() => state.open()}
+          placeholder={t('Ask Seer with Natural Language')}
+          ref={mergeRefs(inputRef, triggerProps.ref as React.Ref<HTMLInputElement>)}
+        />
+      </InputWrapper>
+      <ButtonsWrapper>
+        <Button
+          size="xs"
+          icon={<IconClose />}
+          onFocus={() => !state.isOpen && state.open()}
+          onClick={() => {
+            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+              organization,
+              action: 'closed',
+            });
+            setDisplayAskSeerFeedback(false);
+            setDisplayAskSeer(false);
+            reset();
+          }}
+          aria-label={t('Close Seer Search')}
+          borderless
+        />
+      </ButtonsWrapper>
+      {state.isOpen ? (
+        <AskSeerSearchPopover
+          isNonModal
+          state={state}
+          triggerRef={inputRef}
+          popoverRef={popoverRef}
+          containerRef={containerRef}
+          overlayProps={overlayProps}
+        >
+          {showLoading ? (
+            <SeerContent>
+              <AskSeerSearchHeader title={t("I'm on it...")} loading />
+              <AskSeerProgressBlocks
+                completedSteps={completedSteps}
+                currentStep={currentStep}
+              />
+            </SeerContent>
+          ) : isError ? (
+            <SeerContent>
+              <AskSeerSearchHeader
+                title={t('An error occurred while fetching Seer queries')}
+              />
+            </SeerContent>
+          ) : hasResults ? (
+            <SeerContent onMouseLeave={onMouseLeave}>
+              <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
+              <AskSeerSearchListBox
+                {...listBoxProps}
+                listBoxRef={listBoxRef}
+                state={state}
+              />
+            </SeerContent>
+          ) : unsupportedReason ? (
+            <SeerContent>
+              <AskSeerSearchHeader
+                title={unsupportedReason || 'This query is not supported'}
+              />
+            </SeerContent>
+          ) : (
+            <SeerContent onMouseLeave={onMouseLeave}>
+              <AskSeerSearchHeader title={t("Describe what you're looking for.")} />
+            </SeerContent>
+          )}
+          <SeerFooter>
+            {openForm && (
+              <Button
+                size="xs"
+                icon={<IconMegaphone />}
+                onClick={() =>
+                  openForm({
+                    messagePlaceholder: t('How can we make Seer search better for you?'),
+                    tags: {
+                      ['feedback.source']: feedbackSource,
+                      ['feedback.owner']: 'ml-ai',
+                    },
+                  })
+                }
+              >
+                {t('Give Feedback')}
+              </Button>
+            )}
+          </SeerFooter>
+        </AskSeerSearchPopover>
+      ) : null}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled(Input.withComponent('div'))<{isDropdownOpen: boolean}>`
+  min-height: ${p => p.theme.form.md.minHeight};
+  padding: 0;
+  height: auto;
+  width: 100%;
+  position: relative;
+  font-size: ${p => p.theme.fontSize.md};
+  cursor: text;
+
+  border-bottom-left-radius: ${p => (p.isDropdownOpen ? '0' : p.theme.radius.md)};
+  border-bottom-right-radius: ${p => (p.isDropdownOpen ? '0' : p.theme.radius.md)};
+`;
+
+const PositionedSearchIconContainer = styled('div')`
+  position: absolute;
+  left: ${p => p.theme.space.lg};
+  top: ${p => p.theme.space.sm};
+`;
+
+const SearchIcon = styled(IconSearch)`
+  color: ${p => p.theme.tokens.content.secondary};
+  height: 22px;
+`;
+
+const InputWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const InvisibleInput = styled('input')`
+  position: absolute;
+  inset: 0;
+  resize: none;
+  outline: none;
+  border: 0;
+  width: 100%;
+  height: ${p => p.theme.form.md.height};
+  line-height: 25px;
+  margin-bottom: -1px;
+  background: transparent;
+
+  padding-top: ${p => p.theme.space.sm};
+  padding-bottom: ${p => p.theme.space.sm};
+  padding-left: ${p => p.theme.space['3xl']};
+  padding-right: ${p => p.theme.space.sm};
+
+  &::selection {
+    background: rgba(0, 0, 0, 0.2);
+  }
+
+  :placeholder-shown {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [disabled] {
+    color: ${p => p.theme.tokens.content.disabled};
+  }
+`;
+
+const ButtonsWrapper = styled('div')`
+  position: absolute;
+  right: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const SeerFooter = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  padding: ${p => p.theme.space.md};
+  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  background-color: ${p => p.theme.tokens.background.primary};
+`;
+
+const SeerContent = styled('div')`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
@@ -1,0 +1,285 @@
+import styled from '@emotion/styled';
+
+import {Text} from 'sentry/components/core/text';
+import {space} from 'sentry/styles/space';
+
+import type {AskSeerStep} from './types';
+
+/**
+ * Normalize a step key by extracting just the first unique key.
+ * Handles comma-separated keys from parallel tool calls (e.g., "get_field_values,get_field_values").
+ */
+function normalizeStepKey(step: AskSeerStep): string {
+  if (!step.key.includes(',')) {
+    return step.key;
+  }
+  // Take the first key from comma-separated parallel calls
+  const firstKey = step.key.split(',')[0]?.trim();
+  return firstKey || step.key;
+}
+
+interface StepLabel {
+  completed: string;
+  loading: string;
+}
+
+/**
+ * Human-readable labels for step keys.
+ * Maps the agent's step keys to user-friendly descriptions.
+ * Array format allows for variation when steps repeat.
+ */
+const STEP_LABELS: Record<string, StepLabel[]> = {
+  fetch_tag_values: [
+    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
+    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
+    {loading: 'Checking additional tags...', completed: 'Found more tags'},
+  ],
+  get_field_values: [
+    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
+    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
+    {loading: 'Checking additional tags...', completed: 'Found more tags'},
+  ],
+  get_tag_values: [
+    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
+    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
+    {loading: 'Checking additional tags...', completed: 'Found more tags'},
+  ],
+  get_errors_field_values: [
+    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
+    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
+    {loading: 'Checking additional tags...', completed: 'Found more tags'},
+  ],
+  test_query: [
+    {loading: 'Testing your query...', completed: 'Tested query'},
+    {loading: 'Trying another approach...', completed: 'Tried another approach'},
+    {loading: 'Running one more test...', completed: 'Ran another test'},
+  ],
+  run_query: [
+    {loading: 'Running your query...', completed: 'Ran query'},
+    {loading: 'Running it again...', completed: 'Ran again'},
+    {loading: 'One more time...', completed: 'Tried once more'},
+  ],
+  analyze_results: [
+    {loading: 'Analyzing what I found...', completed: 'Analyzed results'},
+    {loading: 'Taking a closer look...', completed: 'Looked closer'},
+    {loading: 'Examining the details...', completed: 'Examined details'},
+  ],
+  refine_query: [
+    {loading: 'Fine-tuning the query...', completed: 'Refined query'},
+    {loading: 'Making some adjustments...', completed: 'Made adjustments'},
+    {loading: 'Tweaking a few things...', completed: 'Tweaked query'},
+  ],
+  search_issues: [
+    {loading: 'Looking through your issues...', completed: 'Searched issues'},
+    {loading: 'Checking more issues...', completed: 'Checked more issues'},
+  ],
+  search_spans: [
+    {loading: 'Exploring your traces...', completed: 'Explored traces'},
+    {loading: 'Looking at more traces...', completed: 'Found more traces'},
+  ],
+  search_logs: [
+    {loading: 'Digging through your logs...', completed: 'Searched logs'},
+    {loading: 'Checking more logs...', completed: 'Checked more logs'},
+  ],
+  generate_query: [
+    {loading: 'Crafting a query for you...', completed: 'Generated query'},
+    {loading: 'Building another option...', completed: 'Built another option'},
+  ],
+  validate_query: [
+    {loading: 'Validating your query...', completed: 'Validated your query'},
+    {loading: 'Double-checking everything...', completed: 'Double-checked results'},
+  ],
+  thinking: [
+    {loading: 'Thinking...', completed: 'Thought about it'},
+    {loading: 'Hmm, let me think...', completed: 'Considered options'},
+    {loading: 'Working through this...', completed: 'Worked through it'},
+  ],
+};
+
+/**
+ * Convert a step key to a grammatically correct phrase.
+ * e.g., "get_field_values" -> "Getting field values"
+ *       "search_spans" -> "Searching spans"
+ */
+function formatStepKey(key: string, isLoading: boolean): string {
+  const words = key.split('_');
+  const verb = words[0];
+  if (!verb) {
+    return key;
+  }
+
+  const rest = words.slice(1).join(' ');
+
+  if (isLoading) {
+    // Convert verb to -ing form
+    let ingVerb = verb;
+    if (verb.endsWith('e') && !verb.endsWith('ee')) {
+      ingVerb = verb.slice(0, -1) + 'ing';
+    } else if (verb.match(/[aeiou][^aeiou]$/)) {
+      // Double consonant for short vowel + consonant (e.g., run -> running)
+      ingVerb = verb + verb.slice(-1) + 'ing';
+    } else {
+      ingVerb = verb + 'ing';
+    }
+    // Capitalize first letter
+    ingVerb = ingVerb.charAt(0).toUpperCase() + ingVerb.slice(1);
+    return rest ? `${ingVerb} ${rest}...` : `${ingVerb}...`;
+  }
+
+  // For completed state, capitalize first letter
+  const capitalized = verb.charAt(0).toUpperCase() + verb.slice(1);
+  return rest ? `${capitalized} ${rest}` : capitalized;
+}
+
+/**
+ * Format a step for display.
+ * @param step - The step to format
+ * @param isLoading - Whether the step is currently in progress
+ * @param occurrence - Which occurrence of this step (0-indexed)
+ */
+function formatStep(step: AskSeerStep, isLoading: boolean, occurrence: number): string {
+  const key = normalizeStepKey(step);
+  const labelVariants = STEP_LABELS[key];
+  if (labelVariants && labelVariants.length > 0) {
+    // Use modulo to cycle through variants if we have more occurrences than variants
+    const variantIndex = Math.min(occurrence, labelVariants.length - 1);
+    const labels = labelVariants[variantIndex];
+    if (labels) {
+      return isLoading ? labels.loading : labels.completed;
+    }
+  }
+  // Default formatting for unknown steps
+  return formatStepKey(key, isLoading);
+}
+
+interface AskSeerProgressBlocksProps {
+  completedSteps: AskSeerStep[];
+  currentStep: AskSeerStep | null;
+}
+
+/**
+ * Count occurrences of each step key up to (and including) the given index.
+ * Uses normalized keys to handle comma-separated parallel calls.
+ */
+function countOccurrences(
+  steps: AskSeerStep[],
+  targetKey: string,
+  upToIndex: number
+): number {
+  let count = 0;
+  for (let i = 0; i <= upToIndex && i < steps.length; i++) {
+    const step = steps[i];
+    if (step && normalizeStepKey(step) === targetKey) {
+      count++;
+    }
+  }
+  return count - 1; // 0-indexed occurrence
+}
+
+/**
+ * Deduplicate consecutive steps with the same key (parallel tool calls).
+ * Returns a list of unique steps, collapsing consecutive duplicates.
+ * Uses normalized keys to handle comma-separated parallel calls.
+ */
+function dedupeConsecutiveSteps(steps: AskSeerStep[]): AskSeerStep[] {
+  const result: AskSeerStep[] = [];
+  for (const step of steps) {
+    const lastStep = result[result.length - 1];
+    const currentKey = normalizeStepKey(step);
+    const lastKey = lastStep ? normalizeStepKey(lastStep) : null;
+    if (lastKey !== currentKey) {
+      result.push(step);
+    }
+  }
+  return result;
+}
+
+/**
+ * Component to display progress steps from the search agent.
+ * Shows completed and in-progress steps.
+ */
+export function AskSeerProgressBlocks({
+  completedSteps,
+  currentStep,
+}: AskSeerProgressBlocksProps) {
+  // Dedupe consecutive steps (parallel tool calls show as single step)
+  const dedupedSteps = dedupeConsecutiveSteps(completedSteps);
+
+  // Don't render if no steps to show
+  if (dedupedSteps.length === 0 && !currentStep) {
+    return null;
+  }
+
+  // Don't show current step if it's the same as the last completed step
+  const lastCompletedStep = dedupedSteps[dedupedSteps.length - 1];
+  const currentStepKey = currentStep ? normalizeStepKey(currentStep) : null;
+  const lastCompletedKey = lastCompletedStep ? normalizeStepKey(lastCompletedStep) : null;
+  const showCurrentStep = currentStep && currentStepKey !== lastCompletedKey;
+
+  // Count how many times the current step's key has appeared in deduped completed steps
+  const currentStepOccurrence =
+    currentStep && showCurrentStep && currentStepKey
+      ? dedupedSteps.filter(s => normalizeStepKey(s) === currentStepKey).length
+      : 0;
+
+  return (
+    <ProgressContainer>
+      {dedupedSteps.map((step, idx) => {
+        const normalizedKey = normalizeStepKey(step);
+        const occurrence = countOccurrences(dedupedSteps, normalizedKey, idx);
+        return (
+          <ProgressItem key={`${normalizedKey}-${idx}`}>
+            <CompletedDot />
+            <Text variant="muted">{formatStep(step, false, occurrence)}</Text>
+          </ProgressItem>
+        );
+      })}
+      {showCurrentStep && (
+        <ProgressItem>
+          <LoadingDot />
+          <Text>{formatStep(currentStep, true, currentStepOccurrence)}</Text>
+        </ProgressItem>
+      )}
+    </ProgressContainer>
+  );
+}
+
+const ProgressContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.75)};
+  padding: ${space(1.5)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const ProgressItem = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const CompletedDot = styled('div')`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${p => p.theme.tokens.content.success};
+`;
+
+const LoadingDot = styled('div')`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${p => p.theme.tokens.content.promotion};
+  animation: blink 1s infinite;
+
+  @keyframes blink {
+    0%,
+    50% {
+      opacity: 1;
+    }
+    51%,
+    100% {
+      opacity: 0.3;
+    }
+  }
+`;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Text} from 'sentry/components/core/text';
 
 import type {AskSeerStep} from './types';
@@ -218,17 +220,17 @@ export function AskSeerProgressBlocks({
         const normalizedKey = normalizeStepKey(step);
         const occurrence = countOccurrences(dedupedSteps, normalizedKey, idx);
         return (
-          <ProgressItem key={`${normalizedKey}-${idx}`}>
+          <Flex key={`${normalizedKey}-${idx}`} align="center" gap="sm">
             <CompletedDot />
             <Text variant="muted">{formatStep(step, false, occurrence)}</Text>
-          </ProgressItem>
+          </Flex>
         );
       })}
       {showCurrentStep && (
-        <ProgressItem>
+        <Flex align="center" gap="sm">
           <LoadingDot />
           <Text>{formatStep(currentStep, true, currentStepOccurrence)}</Text>
-        </ProgressItem>
+        </Flex>
       )}
     </ProgressContainer>
   );
@@ -240,12 +242,6 @@ const ProgressContainer = styled('div')`
   gap: 6px;
   padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-`;
-
-const ProgressItem = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
 `;
 
 const CompletedDot = styled('div')`

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerProgressBlocks.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import {Text} from 'sentry/components/core/text';
-import {space} from 'sentry/styles/space';
 
 import type {AskSeerStep} from './types';
 
@@ -23,32 +22,23 @@ interface StepLabel {
   loading: string;
 }
 
+// Shared labels for tag/field investigation steps
+const TAG_INVESTIGATION_LABELS: StepLabel[] = [
+  {loading: 'Investigating your tags...', completed: 'Investigated tags'},
+  {loading: 'Looking at more tags...', completed: 'Checked more tags'},
+  {loading: 'Checking additional tags...', completed: 'Found more tags'},
+];
+
 /**
  * Human-readable labels for step keys.
  * Maps the agent's step keys to user-friendly descriptions.
  * Array format allows for variation when steps repeat.
  */
 const STEP_LABELS: Record<string, StepLabel[]> = {
-  fetch_tag_values: [
-    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
-    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
-    {loading: 'Checking additional tags...', completed: 'Found more tags'},
-  ],
-  get_field_values: [
-    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
-    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
-    {loading: 'Checking additional tags...', completed: 'Found more tags'},
-  ],
-  get_tag_values: [
-    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
-    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
-    {loading: 'Checking additional tags...', completed: 'Found more tags'},
-  ],
-  get_errors_field_values: [
-    {loading: 'Investigating your tags...', completed: 'Investigated tags'},
-    {loading: 'Looking at more tags...', completed: 'Checked more tags'},
-    {loading: 'Checking additional tags...', completed: 'Found more tags'},
-  ],
+  fetch_tag_values: TAG_INVESTIGATION_LABELS,
+  get_field_values: TAG_INVESTIGATION_LABELS,
+  get_tag_values: TAG_INVESTIGATION_LABELS,
+  get_errors_field_values: TAG_INVESTIGATION_LABELS,
   test_query: [
     {loading: 'Testing your query...', completed: 'Tested query'},
     {loading: 'Trying another approach...', completed: 'Tried another approach'},
@@ -247,15 +237,15 @@ export function AskSeerProgressBlocks({
 const ProgressContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(0.75)};
-  padding: ${space(1.5)} ${space(2)};
+  gap: 6px;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
 const ProgressItem = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.sm};
 `;
 
 const CompletedDot = styled('div')`

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -31,3 +31,43 @@ export interface AskSeerSearchQuery extends QueryTokensProps {
   statsPeriod: string;
   visualizations: Array<{chartType: ChartType; yAxes: string[]}>;
 }
+
+/**
+ * Represents a step in the search agent execution.
+ */
+export interface AskSeerStep {
+  key: string;
+}
+
+/**
+ * Response from the /search-agent/start/ endpoint.
+ */
+export interface AskSeerStartResponse {
+  run_id: number;
+}
+
+/**
+ * Session data returned from the /search-agent/state/ endpoint.
+ */
+export interface AskSeerSession<T extends QueryTokensProps> {
+  completed_steps: AskSeerStep[];
+  created_at: string;
+  current_step: AskSeerStep | null;
+  natural_language_query: string;
+  org_id: number;
+  org_slug: string;
+  run_id: number;
+  status: 'processing' | 'completed' | 'error';
+  strategy: string;
+  updated_at: string;
+  final_query?: string | null;
+  final_response?: T | null;
+  unsupported_reason?: string | null;
+}
+
+/**
+ * Full response from the /search-agent/state/ endpoint.
+ */
+export interface AskSeerPollingResponse<T extends QueryTokensProps> {
+  session: AskSeerSession<T> | null;
+}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -1,0 +1,226 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import type {
+  AskSeerPollingResponse,
+  AskSeerStartResponse,
+  QueryTokensProps,
+} from './types';
+
+const POLL_INTERVAL = 500; // Poll every 500ms, matching Seer Explorer
+
+/**
+ * Generate the query key for polling the search agent state.
+ */
+export const makeAskSeerQueryKey = (
+  orgSlug: string,
+  runId?: number
+): ApiQueryKey | null => {
+  if (!runId) {
+    return null;
+  }
+  return [`/organizations/${orgSlug}/search-agent/state/${runId}/`, {}];
+};
+
+/**
+ * Determine if we should be polling for updates.
+ */
+const isPolling = <T extends QueryTokensProps>(
+  sessionData: AskSeerPollingResponse<T>['session'],
+  waitingForResponse: boolean
+): boolean => {
+  if (!sessionData && !waitingForResponse) {
+    return false;
+  }
+
+  if (!sessionData) {
+    return waitingForResponse;
+  }
+
+  // Poll while status is processing or there's a current step in progress
+  return sessionData.status === 'processing' || sessionData.current_step !== null;
+};
+
+const makeInitialAskSeerData = <
+  T extends QueryTokensProps,
+>(): AskSeerPollingResponse<T> => ({
+  session: null,
+});
+
+interface UseAskSeerPollingOptions<T extends QueryTokensProps> {
+  projectIds: number[];
+  strategy: string;
+  onError?: (error: Error) => void;
+  onSuccess?: (result: T) => void;
+}
+
+/**
+ * Hook for managing async search agent polling.
+ *
+ * This hook follows the same pattern as useSeerExplorer:
+ * 1. POST to /search-agent/start/ to start the agent and get a run_id
+ * 2. Poll /search-agent/state/{run_id}/ for status and results
+ * 3. Stop polling when status is completed or error
+ */
+export function useAskSeerPolling<T extends QueryTokensProps>(
+  options: UseAskSeerPollingOptions<T>
+) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
+  const orgSlug = organization.slug;
+
+  const [runId, setRunId] = useState<number | null>(null);
+  const [waitingForResponse, setWaitingForResponse] = useState(false);
+  const [startFailed, setStartFailed] = useState(false);
+
+  const queryKey = makeAskSeerQueryKey(orgSlug, runId ?? undefined);
+
+  // Poll for state
+  const {data: apiData, isPending} = useApiQuery<AskSeerPollingResponse<T>>(
+    queryKey ?? ['__disabled__', {}],
+    {
+      staleTime: 0,
+      retry: false,
+      enabled: !!runId && !!orgSlug,
+      refetchInterval: query => {
+        const sessionData = query.state.data?.[0]?.session ?? null;
+        if (isPolling(sessionData, waitingForResponse)) {
+          return POLL_INTERVAL;
+        }
+        return false;
+      },
+    } as UseApiQueryOptions<AskSeerPollingResponse<T>, RequestError>
+  );
+
+  const sessionData = apiData?.session ?? null;
+
+  // Start a new search
+  const submitQuery = useCallback(
+    async (query: string) => {
+      setWaitingForResponse(true);
+
+      try {
+        const response = (await api.requestPromise(
+          `/organizations/${orgSlug}/search-agent/start/`,
+          {
+            method: 'POST',
+            data: {
+              natural_language_query: query,
+              project_ids: options.projectIds,
+              strategy: options.strategy,
+            },
+          }
+        )) as AskSeerStartResponse;
+
+        setRunId(response.run_id);
+
+        // Invalidate to start polling
+        const newQueryKey = makeAskSeerQueryKey(orgSlug, response.run_id);
+        if (newQueryKey) {
+          queryClient.invalidateQueries({
+            queryKey: newQueryKey,
+          });
+        }
+      } catch (error) {
+        setWaitingForResponse(false);
+        setStartFailed(true);
+        addErrorMessage((error as Error)?.message ?? 'Failed to start AI search');
+        options.onError?.(error as Error);
+      }
+    },
+    [api, orgSlug, options, queryClient]
+  );
+
+  // Handle completion callback
+  useEffect(() => {
+    if (waitingForResponse && sessionData) {
+      const isStillProcessing =
+        sessionData.status === 'processing' || sessionData.current_step !== null;
+      if (!isStillProcessing) {
+        setWaitingForResponse(false);
+        if (sessionData.status === 'completed' && sessionData.final_response) {
+          options.onSuccess?.(sessionData.final_response);
+        }
+      }
+    }
+  }, [waitingForResponse, sessionData, options]);
+
+  // Reset function
+  const reset = useCallback(() => {
+    setRunId(null);
+    setWaitingForResponse(false);
+    setStartFailed(false);
+    if (queryKey) {
+      setApiQueryData<AskSeerPollingResponse<T>>(
+        queryClient,
+        queryKey,
+        makeInitialAskSeerData()
+      );
+    }
+  }, [queryClient, queryKey]);
+
+  // Only show pending state after user has submitted a query
+  const isActuallyPending = waitingForResponse || (!!runId && isPending);
+
+  return {
+    /**
+     * Current session state, or null if no run exists.
+     */
+    sessionData,
+    /**
+     * Whether we're waiting for a response (initial load or polling).
+     */
+    isPending: isActuallyPending,
+    /**
+     * Whether polling is active.
+     */
+    isPolling: isPolling(sessionData, waitingForResponse),
+    /**
+     * Whether the request errored.
+     */
+    isError: sessionData?.status === 'error',
+    /**
+     * Whether the start request failed (use fallback).
+     */
+    startFailed,
+    /**
+     * The final response (available when status is completed).
+     */
+    finalResponse: sessionData?.final_response ?? null,
+    /**
+     * The final query string (available when status is completed).
+     */
+    finalQuery: sessionData?.final_query ?? null,
+    /**
+     * Unsupported reason if the query couldn't be translated.
+     */
+    unsupportedReason: sessionData?.unsupported_reason,
+    /**
+     * Current step being processed (if any).
+     */
+    currentStep: sessionData?.current_step ?? null,
+    /**
+     * Completed steps.
+     */
+    completedSteps: sessionData?.completed_steps ?? [],
+    /**
+     * Submit a natural language query to start the search agent.
+     */
+    submitQuery,
+    /**
+     * Reset the state to start fresh.
+     */
+    reset,
+    /**
+     * Current run ID.
+     */
+    runId,
+  };
+}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -18,10 +18,7 @@ const POLL_INTERVAL = 500; // Poll every 500ms, matching Seer Explorer
 /**
  * Generate the query key for polling the search agent state.
  */
-export const makeAskSeerQueryKey = (
-  orgSlug: string,
-  runId?: number
-): ApiQueryKey | null => {
+const makeAskSeerQueryKey = (orgSlug: string, runId?: number): ApiQueryKey | null => {
   if (!runId) {
     return null;
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -40,6 +40,11 @@ function formatToken(token: string): string {
       const negation = isNegated ? 'not ' : '';
       const description = desc ? `${negation}${desc}` : negation ? 'not' : '';
 
+      // Special case: avoid "is is unresolved" for fields like "is:unresolved"
+      if (cleanKey.toLowerCase() === 'is') {
+        return `is ${negation}${cleanVal}`.replace(/\s+/g, ' ').trim();
+      }
+
       return `${cleanKey} is ${description} ${cleanVal}`.replace(/\s+/g, ' ').trim();
     }
   }

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from 'react';
 
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
+import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {Token} from 'sentry/components/searchSyntax/parser';
@@ -263,8 +264,70 @@ export function LogsTabSeerComboBox() {
     !organization?.hideAiFeatures &&
     organization.features.includes('gen-ai-features');
 
+  const usePollingEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
+  // Get selected project IDs for the polling variant
+  const selectedProjectIds = useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
+  }, [pageFilters.selection.projects, projects]);
+
+  // Transform the final_response from Seer to match the expected format
+  const transformResponse = useCallback(
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const seerResponse = response as unknown as {
+        responses?: Array<{
+          end: string | null;
+          group_by: string[];
+          mode: string;
+          query: string;
+          sort: string;
+          start: string | null;
+          stats_period: string;
+        }>;
+      };
+
+      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
+        return seerResponse.responses.map(r => ({
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'samples',
+        }));
+      }
+
+      return [response];
+    },
+    []
+  );
+
   if (!areAiFeaturesAllowed) {
     return null;
+  }
+
+  if (usePollingEndpoint) {
+    return (
+      <AskSeerPollingComboBox<AskSeerSearchQuery>
+        initialQuery={initialSeerQuery}
+        projectIds={selectedProjectIds}
+        strategy="Logs"
+        applySeerSearchQuery={applySeerSearchQuery}
+        transformResponse={transformResponse}
+        analyticsSource="logs"
+        feedbackSource="logs_ai_query"
+        fallbackMutationOptions={logsTabAskSeerMutationOptions}
+      />
+    );
   }
 
   return (

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -140,7 +140,7 @@ export function SpansTabSeerComboBox() {
             visualizations:
               r?.visualization?.map(v => ({
                 chartType: v?.chart_type,
-                yAxes: v?.y_axes,
+                yAxes: v?.y_axes ?? [],
               })) ?? [],
             query: r?.query ?? '',
             sort: r?.sort ?? '',
@@ -170,7 +170,7 @@ export function SpansTabSeerComboBox() {
           visualizations:
             q?.visualization?.map((v: any) => ({
               chartType: v?.chart_type,
-              yAxes: v?.y_axes,
+              yAxes: v?.y_axes ?? [],
             })) ?? [],
           query: q?.query,
           sort: q?.sort ?? '',
@@ -314,7 +314,7 @@ export function SpansTabSeerComboBox() {
           visualizations:
             r?.visualization?.map(v => ({
               chartType: v?.chart_type,
-              yAxes: v?.y_axes,
+              yAxes: v?.y_axes ?? [],
             })) ?? [],
           query: r?.query ?? '',
           sort: r?.sort ?? '',


### PR DESCRIPTION
- Visualize steps by polling backend for Search Agent in the search bars!
- Support for Issues, Traces, Logs, and Errors (Discover tab)
- Falls back to standard translation if fails

Example from Issues. All of the other ones are the same/similar:

https://github.com/user-attachments/assets/7b7a9fc4-c489-4c00-8f27-b5b9421f55a8

