### PR TITLE
chore(explorer): move panel

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -102,6 +102,7 @@ function ExplorerPanel() {
     switchToRun,
     sessionRunId: runId ?? undefined,
     sessionBlocks: sessionData?.blocks,
+    onUnminimize: useCallback(() => setIsMinimized(false), []),
   });
 
   // Extract repo_pr_states from session
@@ -561,6 +562,8 @@ function ExplorerPanel() {
       isOpen={isVisible}
       isMinimized={isMinimized}
       panelSize={panelSize}
+      blocks={blocks}
+      isPolling={isPolling}
       onUnminimize={handleUnminimize}
     >
       <TopBar

--- a/static/app/views/seerExplorer/openSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/openSeerExplorer.tsx
@@ -117,6 +117,10 @@ interface UseExternalOpenOptions {
   sessionRunId: number | undefined;
   startNewSession: () => void;
   switchToRun: (runId: number) => void;
+  /**
+   * Callback to un-minimize the panel when it's already open but minimized.
+   */
+  onUnminimize?: () => void;
 }
 
 /**
@@ -130,6 +134,7 @@ export function useExternalOpen({
   switchToRun,
   sessionRunId,
   sessionBlocks,
+  onUnminimize,
 }: UseExternalOpenOptions) {
   const pendingOptionsRef = useRef<OpenSeerExplorerOptions | null>(null);
   const onRunCreatedRef = useRef<((runId: number) => void) | null>(null);
@@ -171,7 +176,8 @@ export function useExternalOpen({
       pendingOptionsRef.current = options;
 
       if (isVisible) {
-        // Panel is already open - process immediately since visibility won't change
+        // Panel is already open - un-minimize and process immediately
+        onUnminimize?.();
         const storedOptions = pendingOptionsRef.current;
         pendingOptionsRef.current = null;
         processPendingOptions(storedOptions);
@@ -185,7 +191,7 @@ export function useExternalOpen({
     return () => {
       document.removeEventListener(SEER_EXPLORER_OPEN_EVENT, handleOpenEvent);
     };
-  }, [isVisible, processPendingOptions]);
+  }, [isVisible, onUnminimize, processPendingOptions]);
 
   // Handle pending options when the panel becomes visible
   useEffect(() => {

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -36,7 +36,7 @@ function getStatusText(blocks: Block[]): string {
 
     // Check for tool calls
     const toolStrings = getToolsStringFromBlock(block);
-    if (toolStrings.length > 0 && !block.loading) {
+    if (toolStrings.length > 0) {
       return toolStrings[toolStrings.length - 1] || t('Analyzing...');
     }
   }

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -83,10 +83,8 @@ function PanelContainers({
             transformOrigin: 'bottom right',
           }}
           transition={{
-            type: 'spring',
-            stiffness: 400,
-            damping: 30,
-            mass: 1,
+            duration: 0.2,
+            ease: [0.4, 0, 0.2, 1],
           }}
         >
           <PanelContent ref={ref} data-seer-explorer-root="">


### PR DESCRIPTION
Based on design team's designs, move's explorer panel to the right. Floating action button from designs will be added in a follow up.

<img width="1235" height="832" alt="Screenshot 2026-01-15 at 3 04 37 PM" src="https://github.com/user-attachments/assets/881524e8-3ea7-49b7-b5d9-784b31c6576a" />
<img width="1239" height="804" alt="Screenshot 2026-01-15 at 3 04 48 PM" src="https://github.com/user-attachments/assets/40340125-30ad-4db2-b7e5-8f87eebfc6c3" />
<img width="1212" height="790" alt="Screenshot 2026-01-15 at 3 04 57 PM" src="https://github.com/user-attachments/assets/27681214-220f-4b6a-966b-4df4c4468c8c" />
