### PR TITLE
ref(alerts): Migrate `AlertsContainer` and children views off of `deprecatedRouteProps`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1474,7 +1474,6 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -1488,7 +1487,6 @@ function buildRoutes(): RouteObject[] {
                 () =>
                   import('sentry/views/alerts/workflowEngineRedirectWrappers/alertEdit')
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1550,7 +1548,6 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -1566,7 +1563,6 @@ function buildRoutes(): RouteObject[] {
                     'sentry/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit'
                   )
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1578,7 +1574,6 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-          deprecatedRouteProps: true,
           children: [
             {
               path: ':ruleId/',
@@ -1588,7 +1583,6 @@ function buildRoutes(): RouteObject[] {
                     'sentry/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit'
                   )
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1600,12 +1594,10 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-          deprecatedRouteProps: true,
           children: [
             {
               path: ':monitorSlug/',
               component: make(() => import('sentry/views/alerts/edit')),
-              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1623,15 +1615,12 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/alerts/wizard')),
-          deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: 'new/',
       component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -1644,7 +1633,6 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/alerts/workflowEngineRedirectWrappers/alertCreate')
           ),
-          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1662,17 +1650,14 @@ function buildRoutes(): RouteObject[] {
             'sentry/views/alerts/workflowEngineRedirectWrappers/alertBuilderProjectProvider'
           )
       ),
-      deprecatedRouteProps: true,
       children: [
         {
           path: 'new/',
           component: make(() => import('sentry/views/alerts/create')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'wizard/',
           component: make(() => import('sentry/views/alerts/wizard')),
-          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1684,13 +1669,11 @@ function buildRoutes(): RouteObject[] {
         component: withDomainRequired(make(() => import('sentry/views/alerts'))),
         customerDomainOnlyRoute: true,
         children: alertChildRoutes(true),
-        deprecatedRouteProps: true,
       },
       {
         path: '/organizations/:orgId/alerts/',
         component: withDomainRedirect(make(() => import('sentry/views/alerts'))),
         children: alertChildRoutes(false),
-        deprecatedRouteProps: true,
       },
     ],
   };
@@ -2694,7 +2677,6 @@ function buildRoutes(): RouteObject[] {
       path: 'alerts/',
       component: make(() => import('sentry/views/alerts')),
       children: alertChildRoutes(true),
-      deprecatedRouteProps: true,
     },
     traceView,
   ];

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -50,18 +50,15 @@ export default function Create() {
   const router = useRouter();
   const {project, members} = useAlertBuilderOutlet();
   const hasMetricAlerts = organization.features.includes('incidents');
-  const {
-    aggregate,
-    dataset,
-    createFromDuplicate,
-    duplicateRuleId,
-    createFromDiscover,
-    query,
-    createFromWizard,
-  } = location?.query ?? {};
-  const eventTypes = location?.query?.eventTypes
-    ? (decodeScalar(location.query.eventTypes) as EventTypes)
-    : undefined;
+
+  const aggregate = decodeScalar(location.query.aggregate);
+  const dataset = decodeScalar(location.query.dataset) as Dataset | undefined;
+  const createFromDuplicate = decodeScalar(location.query.createFromDuplicate);
+  const duplicateRuleId = decodeScalar(location.query.duplicateRuleId);
+  const createFromDiscover = decodeScalar(location.query.createFromDiscover);
+  const query = decodeScalar(location.query.query);
+  const createFromWizard = decodeScalar(location.query.createFromWizard);
+  const eventTypes = decodeScalar(location.query.eventTypes) as EventTypes | undefined;
 
   const alertType = params.alertType || AlertRuleType.METRIC;
 
@@ -117,10 +114,10 @@ export default function Create() {
   useRouteAnalyticsEventNames('new_alert_rule.viewed', 'New Alert Rule: Viewed');
 
   const wizardTemplate: WizardRuleTemplate = {
-    aggregate: (aggregate as string | undefined) ?? DEFAULT_WIZARD_TEMPLATE.aggregate,
-    dataset: (dataset as Dataset | undefined) ?? DEFAULT_WIZARD_TEMPLATE.dataset,
+    aggregate: aggregate ?? DEFAULT_WIZARD_TEMPLATE.aggregate,
+    dataset: dataset ?? DEFAULT_WIZARD_TEMPLATE.dataset,
     eventTypes: eventTypes ?? DEFAULT_WIZARD_TEMPLATE.eventTypes,
-    query: (query as string | undefined) ?? DEFAULT_WIZARD_TEMPLATE.query,
+    query: query ?? DEFAULT_WIZARD_TEMPLATE.query,
   };
   const eventView = createFromDiscover ? EventView.fromLocation(location) : undefined;
 

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -16,6 +16,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useRouter from 'sentry/utils/useRouter';
+import {useRoutes} from 'sentry/utils/useRoutes';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import {useAlertBuilderOutlet} from 'sentry/views/alerts/builder/projectProvider';
@@ -48,6 +49,7 @@ export default function Create() {
   const location = useLocation();
   const params = useParams<RouteParams>();
   const router = useRouter();
+  const routes = useRoutes();
   const {project, members} = useAlertBuilderOutlet();
   const hasMetricAlerts = organization.features.includes('incidents');
 
@@ -182,7 +184,7 @@ export default function Create() {
                 location={location}
                 params={params}
                 router={router}
-                routes={[]}
+                routes={routes}
                 route={{}}
                 routeParams={params}
                 project={project}
@@ -197,7 +199,7 @@ export default function Create() {
                   location={location}
                   params={params}
                   router={router}
-                  routes={[]}
+                  routes={routes}
                   route={{}}
                   routeParams={params}
                   project={project}
@@ -211,7 +213,7 @@ export default function Create() {
                   location={location}
                   params={params}
                   router={router}
-                  routes={[]}
+                  routes={routes}
                   route={{}}
                   routeParams={params}
                   organization={organization}

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -10,6 +10,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useRouter from 'sentry/utils/useRouter';
+import {useRoutes} from 'sentry/utils/useRoutes';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import {useAlertBuilderOutlet} from 'sentry/views/alerts/builder/projectProvider';
@@ -30,6 +31,7 @@ export default function ProjectAlertsEditor() {
   const location = useLocation();
   const params = useParams<RouteParams>();
   const router = useRouter();
+  const routes = useRoutes();
   const {project, members} = useAlertBuilderOutlet();
 
   const [title, setTitle] = useState('');
@@ -85,7 +87,7 @@ export default function ProjectAlertsEditor() {
                 location={location}
                 params={params}
                 router={router}
-                routes={[]}
+                routes={routes}
                 route={{}}
                 routeParams={params}
                 project={project}
@@ -99,7 +101,7 @@ export default function ProjectAlertsEditor() {
                 location={location}
                 params={params}
                 router={router}
-                routes={[]}
+                routes={routes}
                 route={{}}
                 routeParams={params}
                 organization={organization}
@@ -113,7 +115,7 @@ export default function ProjectAlertsEditor() {
                 location={location}
                 params={params}
                 router={router}
-                routes={[]}
+                routes={routes}
                 route={{}}
                 routeParams={params}
                 organization={organization}

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -4,14 +4,15 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Member, Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import useRouter from 'sentry/utils/useRouter';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
+import {useAlertBuilderOutlet} from 'sentry/views/alerts/builder/projectProvider';
 
 import {CronRulesEdit} from './rules/crons/edit';
 import IssueEditor from './rules/issue';
@@ -24,15 +25,12 @@ type RouteParams = {
   ruleId: string;
 };
 
-type Props = RouteComponentProps<RouteParams> & {
-  members: Member[] | undefined;
-  organization: Organization;
-  project: Project;
-};
-
-function ProjectAlertsEditor(props: Props) {
-  const {members, organization, project} = props;
+export default function ProjectAlertsEditor() {
+  const organization = useOrganization();
   const location = useLocation();
+  const params = useParams<RouteParams>();
+  const router = useRouter();
+  const {project, members} = useAlertBuilderOutlet();
 
   const [title, setTitle] = useState('');
 
@@ -84,7 +82,12 @@ function ProjectAlertsEditor(props: Props) {
           <Fragment>
             {alertType === CombinedAlertType.ISSUE && (
               <IssueEditor
-                {...props}
+                location={location}
+                params={params}
+                router={router}
+                routes={[]}
+                route={{}}
+                routeParams={params}
                 project={project}
                 onChangeTitle={setTitle}
                 userTeamIds={teams.map(({id}) => id)}
@@ -93,7 +96,13 @@ function ProjectAlertsEditor(props: Props) {
             )}
             {alertType === CombinedAlertType.METRIC && (
               <MetricRulesEdit
-                {...props}
+                location={location}
+                params={params}
+                router={router}
+                routes={[]}
+                route={{}}
+                routeParams={params}
+                organization={organization}
                 project={project}
                 onChangeTitle={setTitle}
                 userTeamIds={teams.map(({id}) => id)}
@@ -101,13 +110,23 @@ function ProjectAlertsEditor(props: Props) {
             )}
             {alertType === CombinedAlertType.UPTIME && (
               <UptimeRulesEdit
-                {...props}
+                location={location}
+                params={params}
+                router={router}
+                routes={[]}
+                route={{}}
+                routeParams={params}
+                organization={organization}
                 onChangeTitle={setTitle}
                 userTeamIds={teams.map(({id}) => id)}
               />
             )}
             {alertType === CombinedAlertType.CRONS && (
-              <CronRulesEdit {...props} project={project} onChangeTitle={setTitle} />
+              <CronRulesEdit
+                organization={organization}
+                project={project}
+                onChangeTitle={setTitle}
+              />
             )}
           </Fragment>
         )}
@@ -115,5 +134,3 @@ function ProjectAlertsEditor(props: Props) {
     </Fragment>
   );
 }
-
-export default ProjectAlertsEditor;

--- a/static/app/views/alerts/index.tsx
+++ b/static/app/views/alerts/index.tsx
@@ -1,23 +1,12 @@
-import {cloneElement, isValidElement} from 'react';
+import {Outlet} from 'react-router-dom';
 
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import Redirect from 'sentry/components/redirect';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
-type Props = {
-  children: React.ReactNode;
-};
-
-function AlertsContainer({children}: Props) {
+export default function AlertsContainer() {
   const organization = useOrganization();
-
-  const content =
-    children && isValidElement(children)
-      ? cloneElement<any>(children, {
-          organization,
-        })
-      : children;
 
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/alerts/',
@@ -28,7 +17,9 @@ function AlertsContainer({children}: Props) {
     return <Redirect to={redirectPath} />;
   }
 
-  return <NoProjectMessage organization={organization}>{content}</NoProjectMessage>;
+  return (
+    <NoProjectMessage organization={organization}>
+      <Outlet />
+    </NoProjectMessage>
+  );
 }
-
-export default AlertsContainer;

--- a/static/app/views/alerts/list/incidents/index.spec.tsx
+++ b/static/app/views/alerts/list/incidents/index.spec.tsx
@@ -18,7 +18,6 @@ import selectEvent from 'sentry-test/selectEvent';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
-import AlertsContainer from 'sentry/views/alerts';
 import IncidentsList from 'sentry/views/alerts/list/incidents';
 
 describe('IncidentsList', () => {
@@ -34,14 +33,7 @@ describe('IncidentsList', () => {
       features: ['incidents'],
       ...orgOverride,
     });
-
-    const {router} = render(
-      <AlertsContainer>
-        <IncidentsList />
-      </AlertsContainer>,
-      {organization}
-    );
-
+    const {router} = render(<IncidentsList />, {organization});
     return {router};
   };
 

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -19,6 +19,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import withApi from 'sentry/utils/withApi';
+import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {
@@ -309,4 +310,4 @@ class MetricAlertDetails extends Component<Props, State> {
   }
 }
 
-export default withApi(withProjects(MetricAlertDetails));
+export default withApi(withOrganization(withProjects(MetricAlertDetails)));

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -19,15 +19,16 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    const {router} = render(
-      <AlertWizard organization={organization} projectId={project.slug} />,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {pathname: '/organizations/org-slug/alerts/wizard/'},
+    const {router} = render(<AlertWizard />, {
+      organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
         },
-      }
-    );
+      },
+    });
 
     await userEvent.click(screen.getByText('Crash Free Session Rate'));
     await userEvent.click(screen.getByText('Set Conditions'));
@@ -54,8 +55,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     expect(screen.getByText('Errors')).toBeInTheDocument();
@@ -75,8 +83,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     expect(screen.getByText('Errors')).toBeInTheDocument();
@@ -90,8 +105,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     expect(screen.getByText('Uptime Monitor')).toBeInTheDocument();
@@ -109,8 +131,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     await userEvent.click(screen.getByText('Throughput'));
@@ -131,8 +160,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     expect(screen.queryByText('Logs')).not.toBeInTheDocument();
@@ -149,8 +185,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     expect(screen.getAllByText('Logs')).toHaveLength(2);
@@ -167,8 +210,15 @@ describe('AlertWizard', () => {
       access: ['org:write', 'alerts:write'],
     });
 
-    render(<AlertWizard organization={organization} projectId={project.slug} />, {
+    render(<AlertWizard />, {
       organization,
+      outletContext: {project, members: []},
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/wizard/',
+          query: {project: project.slug},
+        },
+      },
     });
 
     await userEvent.click(screen.getByText('Throughput'));

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -8,6 +8,12 @@ import AlertWizard from 'sentry/views/alerts/wizard/index';
 
 describe('AlertWizard', () => {
   const project = ProjectFixture();
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/alerts/wizard/',
+      query: {project: project.slug},
+    },
+  };
 
   beforeEach(() => {
     ConfigStore.init();
@@ -22,12 +28,7 @@ describe('AlertWizard', () => {
     const {router} = render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     await userEvent.click(screen.getByText('Crash Free Session Rate'));
@@ -58,12 +59,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     expect(screen.getByText('Errors')).toBeInTheDocument();
@@ -86,12 +82,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     expect(screen.getByText('Errors')).toBeInTheDocument();
@@ -108,12 +99,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     expect(screen.getByText('Uptime Monitor')).toBeInTheDocument();
@@ -134,12 +120,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     await userEvent.click(screen.getByText('Throughput'));
@@ -163,12 +144,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     expect(screen.queryByText('Logs')).not.toBeInTheDocument();
@@ -188,12 +164,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     expect(screen.getAllByText('Logs')).toHaveLength(2);
@@ -213,12 +184,7 @@ describe('AlertWizard', () => {
     render(<AlertWizard />, {
       organization,
       outletContext: {project, members: []},
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/alerts/wizard/',
-          query: {project: project.slug},
-        },
-      },
+      initialRouterConfig,
     });
 
     await userEvent.click(screen.getByText('Throughput'));


### PR DESCRIPTION
[notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7](https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7)