### PR TITLE
perf(integrations): Fix N+1 queries in organization code mappings

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -178,7 +178,9 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
 
         # Always filter by projects the user can access
         projects = self.get_projects(request, organization)
-        queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects)
+        queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects).select_related(
+            "project", "repository"
+        )
 
         if integration_id:
             # get_organization_integration will raise a 404 if no org_integration is found


### PR DESCRIPTION
Add select_related for project and repository since the serializer accesses project.slug and repository.id/name for each result.

n+1 issue
https://sentry.sentry.io/issues/6764987634/
