### PR TITLE
ref(routes): Remove `deprecatedRouteProps` from `redirectDeprecatedProjectRoute`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2881,7 +2881,6 @@ function buildRoutes(): RouteObject[] {
           ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
         )
       ),
-      deprecatedRouteProps: true,
     },
   ];
   const legacyOrgRedirects: SentryRouteObject = {

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -160,7 +160,11 @@ const redirectDeprecatedProjectRoute = (generateRedirectRoute: RedirectCallback)
               projectId,
             };
 
-            return <Redirect to={trackRedirect(organizationId, generateRedirectRoute(routeProps))} />;
+            return (
+              <Redirect
+                to={trackRedirect(organizationId, generateRedirectRoute(routeProps))}
+              />
+            );
           }}
         </ProjectDetails>
       </Wrapper>


### PR DESCRIPTION
Convert the legacy project redirect route as part of https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7
