### PR TITLE
ref(sentry-apps): Improve RpcSentryAppError with from_exc factory method

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -99,7 +99,7 @@ class IntegrationPlatformEndpoint(Endpoint):
         """
         Surfaces errors from the region-side Sentry App RPC to the client.
         """
-        response_body = rpc_error.public_dict or {}
+        response_body = rpc_error.get_public_dict()
         status_code = rpc_error.status_code or 500
         response = Response(response_body, status=status_code)
         response.exception = True

--- a/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
+++ b/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.services.region.model import RpcPlatformExternalIssue
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
@@ -21,7 +22,7 @@ class PlatformExternalIssueSerializerResponse(TypedDict):
 class PlatformExternalIssueSerializer(Serializer):
     def serialize(
         self,
-        obj: PlatformExternalIssue,
+        obj: PlatformExternalIssue | RpcPlatformExternalIssue,
         attrs: Mapping[str, Any],
         user: User | AnonymousUser | RpcUser,
         **kwargs: Any,

--- a/src/sentry/sentry_apps/api/serializers/servicehookproject.py
+++ b/src/sentry/sentry_apps/api/serializers/servicehookproject.py
@@ -1,10 +1,11 @@
 from sentry.api.serializers import Serializer, register
 from sentry.sentry_apps.models.servicehook import ServiceHookProject
+from sentry.sentry_apps.services.region.model import RpcServiceHookProject
 
 
 @register(ServiceHookProject)
 class ServiceHookProjectSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj: ServiceHookProject | RpcServiceHookProject, attrs, user, **kwargs):
         return {
             "id": str(obj.id),
             "project_id": str(obj.project_id),

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -60,12 +60,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 project_slug=project_slug,
             ).run()
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
-            error = RpcSentryAppError(
-                message=e.message,
-                webhook_context=e.webhook_context,
-                status_code=e.status_code,
-            )
-            return RpcSelectRequesterResult(error=error)
+            return RpcSelectRequesterResult(error=RpcSentryAppError.from_exc(e))
 
         return RpcSelectRequesterResult(
             choices=list(result.get("choices", [])),
@@ -95,7 +90,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcPlatformExternalIssueResult(
                 error=RpcSentryAppError(
                     message="Could not find the corresponding issue for the given groupId",
-                    webhook_context={},
                     status_code=404,
                 )
             )
@@ -110,13 +104,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 user=user,
             ).run()
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
-            return RpcPlatformExternalIssueResult(
-                error=RpcSentryAppError(
-                    message=e.message,
-                    webhook_context=e.webhook_context,
-                    status_code=e.status_code,
-                )
-            )
+            return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
         return RpcPlatformExternalIssueResult(
             external_issue=RpcPlatformExternalIssue(
@@ -150,7 +138,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcPlatformExternalIssueResult(
                 error=RpcSentryAppError(
                     message="Could not find the corresponding issue for the given issueId",
-                    webhook_context={},
                     status_code=404,
                 )
             )
@@ -164,13 +151,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 identifier=identifier,
             ).run()
         except SentryAppSentryError as e:
-            return RpcPlatformExternalIssueResult(
-                error=RpcSentryAppError(
-                    message=e.message,
-                    webhook_context=e.webhook_context,
-                    status_code=e.status_code,
-                )
-            )
+            return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
         return RpcPlatformExternalIssueResult(
             external_issue=RpcPlatformExternalIssue(
@@ -203,7 +184,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 success=False,
                 error=RpcSentryAppError(
                     message="Could not find the corresponding external issue from given external_issue_id",
-                    webhook_context={},
                     status_code=404,
                 ),
             )
@@ -229,7 +209,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
                     message="Service hook not found for installation",
-                    webhook_context={},
                     status_code=404,
                 )
             )
@@ -260,7 +239,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
                     message="Projects list cannot be empty",
-                    webhook_context={},
                     status_code=400,
                 )
             )
@@ -273,7 +251,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
                     message="One or more project IDs do not belong to the organization",
-                    webhook_context={},
                     status_code=400,
                 )
             )
@@ -286,7 +263,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
                     message="Service hook not found for installation",
-                    webhook_context={},
                     status_code=404,
                 )
             )
@@ -341,7 +317,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 success=False,
                 error=RpcSentryAppError(
                     message="Service hook not found for installation",
-                    webhook_context={},
                     status_code=404,
                 ),
             )
@@ -418,7 +393,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                     success=False,
                     error=RpcSentryAppError(
                         message=f"The field componentType is required and must be one of {COMPONENT_TYPES}",
-                        webhook_context={},
                         status_code=400,
                     ),
                 )
@@ -431,7 +405,6 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 success=False,
                 error=RpcSentryAppError(
                     message="The tsdbField must be one of: sentry_app_viewed, sentry_app_component_interacted",
-                    webhook_context={},
                     status_code=400,
                 ),
             )

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -4,6 +4,7 @@ from typing import Any
 from sentry import deletions, tsdb
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.projects.services.project.serial import serialize_project
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
@@ -108,8 +109,8 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
 
         return RpcPlatformExternalIssueResult(
             external_issue=RpcPlatformExternalIssue(
-                id=str(external_issue.id),
-                issue_id=str(external_issue.group_id),
+                id=external_issue.id,
+                group_id=external_issue.group_id,
                 service_type=external_issue.service_type,
                 display_name=external_issue.display_name,
                 web_url=external_issue.web_url,
@@ -155,8 +156,8 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
 
         return RpcPlatformExternalIssueResult(
             external_issue=RpcPlatformExternalIssue(
-                id=str(external_issue.id),
-                issue_id=str(external_issue.group_id),
+                id=external_issue.id,
+                group_id=external_issue.group_id,
                 service_type=external_issue.service_type,
                 display_name=external_issue.display_name,
                 web_url=external_issue.web_url,
@@ -216,8 +217,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id).order_by(
             "project_id"
         )
-
+        projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
         return RpcServiceHookProjectsResult(
+            projects=[serialize_project(p) for p in projects],
             service_hook_projects=[
                 RpcServiceHookProject(id=hp.id, project_id=hp.project_id) for hp in hook_projects
             ],
@@ -292,8 +294,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id).order_by(
             "project_id"
         )
-
+        projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
         return RpcServiceHookProjectsResult(
+            projects=[serialize_project(p) for p in projects],
             service_hook_projects=[
                 RpcServiceHookProject(id=hp.id, project_id=hp.project_id) for hp in hook_projects
             ],

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -22,6 +22,7 @@ class RpcSentryAppError(RpcModel):
     status_code: int = 400
     message: str = ""
     public_dict: SentryAppPublicErrorBody | None = None
+    public_context: dict[str, Any] | None = None
     webhook_context: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
@@ -33,6 +34,19 @@ class RpcSentryAppError(RpcModel):
             public_dict=exception.to_public_dict(),
             webhook_context=exception.webhook_context,
         )
+
+    def get_public_dict(self) -> SentryAppPublicErrorBody:
+        """
+        Conceptually matches SentryAppBaseError.to_public_dict(), allows endpoints to
+        correctly create error responses without the raw Exception.
+        """
+        if self.public_dict:
+            return self.public_dict
+
+        public_dict: SentryAppPublicErrorBody = {"detail": self.message}
+        if self.public_context:
+            public_dict["context"] = self.public_context
+        return public_dict
 
 
 class RpcSelectRequesterResult(RpcModel):

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -3,8 +3,6 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from __future__ import annotations
-
 from typing import Any
 
 from pydantic.fields import Field
@@ -27,7 +25,7 @@ class RpcSentryAppError(RpcModel):
     webhook_context: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
-    def from_exc(cls, exception: SentryAppBaseError) -> RpcSentryAppError:
+    def from_exc(cls, exception: SentryAppBaseError) -> "RpcSentryAppError":
         return RpcSentryAppError(
             error_type=exception.error_type,
             status_code=exception.status_code,

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic.fields import Field
 
 from sentry.hybridcloud.rpc import RpcModel
+from sentry.projects.services.project.model import RpcProject
 from sentry.sentry_apps.utils.errors import (
     SentryAppBaseError,
     SentryAppErrorType,
@@ -56,8 +57,8 @@ class RpcSelectRequesterResult(RpcModel):
 
 
 class RpcPlatformExternalIssue(RpcModel):
-    id: str
-    issue_id: str
+    id: int
+    group_id: int
     service_type: str
     display_name: str
     web_url: str
@@ -79,6 +80,7 @@ class RpcServiceHookProject(RpcModel):
 
 
 class RpcServiceHookProjectsResult(RpcModel):
+    projects: list[RpcProject] = Field(default_factory=list)
     service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
     error: RpcSentryAppError | None = None
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -121,7 +121,7 @@ class TestSentryAppRegionService(TestCase):
 
         assert result.error is None
         assert result.external_issue is not None
-        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.group_id == self.group.id
         assert result.external_issue.web_url == "https://example.com/project/issue-id"
         assert result.external_issue.display_name == "Projectname#issue-1"
 
@@ -168,7 +168,7 @@ class TestSentryAppRegionService(TestCase):
 
         assert result.error is None
         assert result.external_issue is not None
-        assert result.external_issue.issue_id == str(self.group.id)
+        assert result.external_issue.group_id == self.group.id
         assert result.external_issue.web_url == "https://example.com/project/issue-1"
         assert result.external_issue.display_name == "ProjectName#issue-1"
 


### PR DESCRIPTION
Add `RpcSentryAppError.from_exc()` factory method and `respond_rpc_sentry_app_error()` endpoint helper. Previously we were swallowing `public_context` when converting exceptions to RPC errors.

Part of the sentry app installation endpoint migration stack.