### PR TITLE
fix(seer): Update showNewSeer conditions to count the `code-review-beta` cohort as legacy orgs

### DIFF
--- a/static/app/utils/seer/showNewSeer.spec.ts
+++ b/static/app/utils/seer/showNewSeer.spec.ts
@@ -1,0 +1,95 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
+
+describe('showNewSeer', () => {
+  describe('new seat-based Seer plan', () => {
+    it('returns true when seat-based-seer-enabled is present', () => {
+      const organization = OrganizationFixture({
+        features: ['seat-based-seer-enabled'],
+      });
+
+      expect(showNewSeer(organization)).toBe(true);
+    });
+  });
+
+  describe('old Seer plan (seer-added)', () => {
+    it('returns false when seer-added is present', () => {
+      const organization = OrganizationFixture({
+        features: ['seer-added'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+
+    it('returns false even with launch flags when seer-added is present', () => {
+      const organization = OrganizationFixture({
+        features: ['seer-added', 'seer-user-billing', 'seer-user-billing-launch'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+  });
+
+  describe('code-review-beta trial', () => {
+    it('returns false when code-review-beta is present', () => {
+      const organization = OrganizationFixture({
+        features: ['code-review-beta'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+
+    it('returns false even with launch flags when code-review-beta is present', () => {
+      const organization = OrganizationFixture({
+        features: ['code-review-beta', 'seer-user-billing', 'seer-user-billing-launch'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+  });
+
+  describe('seer-user-billing-launch flag', () => {
+    it('returns true when both seer-user-billing and seer-user-billing-launch are present', () => {
+      const organization = OrganizationFixture({
+        features: ['seer-user-billing', 'seer-user-billing-launch'],
+      });
+
+      expect(showNewSeer(organization)).toBe(true);
+    });
+
+    it('returns false when only seer-user-billing is present', () => {
+      const organization = OrganizationFixture({
+        features: ['seer-user-billing'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+
+    it('returns false when only seer-user-billing-launch is present', () => {
+      const organization = OrganizationFixture({
+        features: ['seer-user-billing-launch'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+  });
+
+  describe('no relevant features', () => {
+    it('returns false when no Seer-related features are present', () => {
+      const organization = OrganizationFixture({
+        features: [],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+
+    it('returns false with unrelated features', () => {
+      const organization = OrganizationFixture({
+        features: ['some-other-feature', 'another-feature'],
+      });
+
+      expect(showNewSeer(organization)).toBe(false);
+    });
+  });
+});

--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -15,8 +15,11 @@ export default function showNewSeer(organization: Organization) {
     return true;
   }
 
-  // Old seer plan
-  if (organization.features.includes('seer-added')) {
+  // Old seer plan or code-review-beta orgs
+  if (
+    organization.features.includes('seer-added') ||
+    organization.features.includes('code-review-beta')
+  ) {
     return false;
   }
 

--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -4,7 +4,7 @@ import type {Organization} from 'sentry/types/organization';
  * This hook determines if we should show the new Seer settings/onboarding or not.
  *
  * This is based on the following factors:
- *  - The organization is on the new Seer, seat-based plan
+ *  - The organization is on the new Seer, seat-based plan. This supersedes all other checks.
  *  - The organization is on the old Seer plan
  *  - The organization is on the code-review-beta trial
  *  - If the new Seer billing is released


### PR DESCRIPTION
`showNewSeer()` is meant to check the `code-review-beta` flag. Now it does.