### PR TITLE
fix(aci): Disable the IssueType data condition

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
@@ -4,8 +4,9 @@ from django.utils.functional import classproperty
 
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType, InvalidGroupTypeError
-from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.registry import condition_handler_registry
+
+# from sentry.workflow_engine.models.data_condition import Condition
+# from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
@@ -13,7 +14,6 @@ def get_all_valid_type_ids() -> list[int]:
     return list(grouptype.registry.get_all_group_type_ids())
 
 
-@condition_handler_registry.register(Condition.ISSUE_TYPE)
 class IssueTypeConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_type_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_type_handler.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
+@pytest.mark.skip()
 class TestIssueTypeCondition(ConditionTestCase):
     condition = Condition.ISSUE_TYPE
 


### PR DESCRIPTION
# Description
By removing the handler from the registry, it will no longer show up in the UI. (removing the broken condition)