### PR TITLE
ref(preprod): Remove duped permission

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -16,10 +16,7 @@ from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
     PreprodArtifactApiSizeAnalysisComparePostEvent,
 )
-from sentry.preprod.api.bases.preprod_artifact_endpoint import (
-    PreprodArtifactEndpoint,
-    ProjectPreprodArtifactPermission,
-)
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     transform_preprod_artifact_to_build_details,
 )
@@ -46,7 +43,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (ProjectPreprodArtifactPermission,)
 
     def get(
         self,


### PR DESCRIPTION
ProjectPreprodArtifactPermission is set on the base class
PreprodArtifactEndpoint already.

