### PR TITLE
feat(ai-insights): support new otel spec

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -115,7 +115,6 @@ function findToolCallsBetween(
  * Extracts text content from a message that may use the new parts format or old content format.
  */
 function extractTextFromMessage(msg: RequestMessage): string | null {
-  // Try new parts format first
   if (msg.parts && Array.isArray(msg.parts)) {
     const textParts = msg.parts
       .filter(p => p.type === 'text')
@@ -126,7 +125,6 @@ function extractTextFromMessage(msg: RequestMessage): string | null {
     }
   }
 
-  // Fall back to old content format
   if (msg.content) {
     return typeof msg.content === 'string' ? msg.content : (msg.content[0]?.text ?? null);
   }
@@ -135,12 +133,10 @@ function extractTextFromMessage(msg: RequestMessage): string | null {
 }
 
 function parseUserContent(node: AITraceSpanNode): string | null {
-  // 1. Check new format first (gen_ai.input.messages)
   const inputMessages = node.attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES] as
     | string
     | undefined;
 
-  // 2. Fall back to current format (gen_ai.request.messages)
   const requestMessages =
     inputMessages ??
     (node.attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES] as string | undefined);
@@ -164,7 +160,6 @@ function parseUserContent(node: AITraceSpanNode): string | null {
 }
 
 function parseAssistantContent(node: AITraceSpanNode): string | null {
-  // 1. Check new format first (gen_ai.output.messages)
   const outputMessages = node.attributes?.[SpanFields.GEN_AI_OUTPUT_MESSAGES] as
     | string
     | undefined;
@@ -172,7 +167,6 @@ function parseAssistantContent(node: AITraceSpanNode): string | null {
   if (outputMessages) {
     try {
       const messagesArray: RequestMessage[] = JSON.parse(outputMessages);
-      // Find the last assistant message
       const assistantMessage = messagesArray.findLast(
         msg => msg.role === 'assistant' && (msg.content || msg.parts)
       );
@@ -183,11 +177,10 @@ function parseAssistantContent(node: AITraceSpanNode): string | null {
         }
       }
     } catch {
-      // If parsing fails, fall through to legacy attributes
+      // Parsing failed, fall through to legacy attributes
     }
   }
 
-  // 2. Fall back to current format
   return (
     (node.attributes?.[SpanFields.GEN_AI_RESPONSE_TEXT] as string | undefined) ||
     (node.attributes?.[SpanFields.GEN_AI_RESPONSE_OBJECT] as string | undefined) ||

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -116,6 +116,10 @@ export enum SpanFields {
   GEN_AI_OPERATION_TYPE = 'gen_ai.operation.type',
   GEN_AI_OPERATION_NAME = 'gen_ai.operation.name',
   GEN_AI_CONVERSATION_ID = 'gen_ai.conversation.id',
+  GEN_AI_INPUT_MESSAGES = 'gen_ai.input.messages',
+  GEN_AI_OUTPUT_MESSAGES = 'gen_ai.output.messages',
+  GEN_AI_SYSTEM_INSTRUCTIONS = 'gen_ai.system_instructions',
+  GEN_AI_TOOL_DEFINITIONS = 'gen_ai.tool.definitions',
   MCP_CLIENT_NAME = 'mcp.client.name',
   MCP_TRANSPORT = 'mcp.transport',
   MCP_TOOL_NAME = 'mcp.tool.name',
@@ -263,6 +267,10 @@ export type SpanStringFields =
   | SpanFields.GEN_AI_AGENT_NAME
   | SpanFields.GEN_AI_REQUEST_MODEL
   | SpanFields.GEN_AI_REQUEST_MESSAGES
+  | SpanFields.GEN_AI_INPUT_MESSAGES
+  | SpanFields.GEN_AI_OUTPUT_MESSAGES
+  | SpanFields.GEN_AI_SYSTEM_INSTRUCTIONS
+  | SpanFields.GEN_AI_TOOL_DEFINITIONS
   | SpanFields.GEN_AI_RESPONSE_TEXT
   | SpanFields.GEN_AI_RESPONSE_OBJECT
   | SpanFields.GEN_AI_RESPONSE_MODEL

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -41,7 +41,6 @@ function tryParseJson(value: string) {
 function getAIToolDefinitions(
   attributes: Record<string, string | number | boolean>
 ): any[] | null {
-  // 1. Check new format first (gen_ai.tool.definitions)
   const toolDefinitions = attributes['gen_ai.tool.definitions'];
   if (toolDefinitions) {
     const parsed = tryParseJson(toolDefinitions.toString());
@@ -50,7 +49,6 @@ function getAIToolDefinitions(
     }
   }
 
-  // 2. Fall back to current format (gen_ai.request.available_tools)
   const availableTools = attributes['gen_ai.request.available_tools'];
   if (availableTools) {
     const parsed = tryParseJson(availableTools.toString());

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -34,6 +34,34 @@ function tryParseJson(value: string) {
   }
 }
 
+/**
+ * Gets AI tool definitions, checking attributes in priority order.
+ * Priority: gen_ai.tool.definitions > gen_ai.request.available_tools
+ */
+function getAIToolDefinitions(
+  attributes: Record<string, string | number | boolean>
+): any[] | null {
+  // 1. Check new format first (gen_ai.tool.definitions)
+  const toolDefinitions = attributes['gen_ai.tool.definitions'];
+  if (toolDefinitions) {
+    const parsed = tryParseJson(toolDefinitions.toString());
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  }
+
+  // 2. Fall back to current format (gen_ai.request.available_tools)
+  const availableTools = attributes['gen_ai.request.available_tools'];
+  if (availableTools) {
+    const parsed = tryParseJson(availableTools.toString());
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
 export function getHighlightedSpanAttributes({
   op,
   spanId,
@@ -170,14 +198,8 @@ function getAISpanAttributes({
     });
   }
 
-  const availableTools = attributes['gen_ai.request.available_tools'];
-  const toolsArray = tryParseJson(availableTools?.toString() || '');
-  if (
-    toolsArray &&
-    Array.isArray(toolsArray) &&
-    toolsArray.length > 0 &&
-    getIsAiAgentSpan(genAiOpType)
-  ) {
+  const toolsArray = getAIToolDefinitions(attributes);
+  if (toolsArray && toolsArray.length > 0 && getIsAiAgentSpan(genAiOpType)) {
     highlightedAttributes.push({
       name: t('Available Tools'),
       value: <HighlightedTools availableTools={toolsArray} spanId={spanId} />,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -204,7 +204,6 @@ function getAIInputMessages(
     attributes
   );
 
-  // 1. Check new format first (gen_ai.input.messages)
   const inputMessages = getTraceNodeAttribute(
     'gen_ai.input.messages',
     node,
@@ -217,7 +216,6 @@ function getAIInputMessages(
     return prependSystemInstructions(transformed, systemInstructions?.toString());
   }
 
-  // 2. Check current format (gen_ai.request.messages)
   const requestMessages = getTraceNodeAttribute(
     'gen_ai.request.messages',
     node,
@@ -231,7 +229,6 @@ function getAIInputMessages(
     );
   }
 
-  // 3. Check legacy format (ai.input_messages)
   const legacyInputMessages = getTraceNodeAttribute(
     'ai.input_messages',
     node,
@@ -245,7 +242,6 @@ function getAIInputMessages(
     }
   }
 
-  // 4. Check oldest legacy format (ai.prompt)
   const prompt = getTraceNodeAttribute('ai.prompt', node, event, attributes);
   if (prompt) {
     const transformed = transformPrompt(prompt.toString());
@@ -254,7 +250,6 @@ function getAIInputMessages(
     }
   }
 
-  // If we only have system instructions, create a messages array with just that
   if (systemInstructions) {
     return JSON.stringify([{role: 'system', content: systemInstructions.toString()}]);
   }
@@ -279,12 +274,10 @@ function prependSystemInstructions(
       return messagesJson;
     }
 
-    // Check if there's already a system message at the start
     if (messages.length > 0 && messages[0].role === 'system') {
       return messagesJson;
     }
 
-    // Prepend the system instructions
     return JSON.stringify([{role: 'system', content: systemInstructions}, ...messages]);
   } catch {
     return messagesJson;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -158,7 +158,7 @@ function transformPartsMessages(messages: string): string | undefined {
       // Concatenate all text parts
       const textContent = msg.parts
         .filter((p: any) => p.type === 'text')
-        .map((p: any) => p.content)
+        .map((p: any) => p.content || p.text)
         .filter(Boolean)
         .join('\n');
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -95,7 +95,7 @@ function extractFromOutputMessages(outputMessages: string): AIOutputData {
       );
     }
   } catch {
-    // If parsing fails, return empty result
+    // Parsing failed, return empty result
   }
 
   return result;
@@ -110,7 +110,6 @@ function getAIOutputData(
   attributes?: TraceItemResponseAttribute[],
   event?: EventTransaction
 ): AIOutputData {
-  // 1. Check new format first (gen_ai.output.messages)
   const outputMessages = getTraceNodeAttribute(
     'gen_ai.output.messages',
     node,
@@ -119,13 +118,11 @@ function getAIOutputData(
   );
   if (outputMessages) {
     const extracted = extractFromOutputMessages(outputMessages.toString());
-    // If we extracted anything from the new format, use it
     if (extracted.responseText || extracted.responseObject || extracted.toolCalls) {
       return extracted;
     }
   }
 
-  // 2. Fall back to current format
   const responseText = getTraceNodeAttribute(
     'gen_ai.response.text',
     node,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -59,9 +59,13 @@ function extractFromOutputMessages(outputMessages: string): AIOutputData {
     const objectParts: any[] = [];
 
     for (const msg of parsed) {
+      if (msg.role !== 'assistant') {
+        continue;
+      }
+
       if (!msg.parts || !Array.isArray(msg.parts)) {
         // Old format - extract content directly
-        if (msg.content && msg.role === 'assistant') {
+        if (msg.content) {
           if (typeof msg.content === 'string') {
             textParts.push(msg.content);
           } else if (typeof msg.content === 'object') {
@@ -73,8 +77,8 @@ function extractFromOutputMessages(outputMessages: string): AIOutputData {
 
       // New parts-based format
       for (const part of msg.parts) {
-        if (part.type === 'text' && part.content) {
-          textParts.push(part.content);
+        if (part.type === 'text' && (part.content || part.text)) {
+          textParts.push(part.content || part.text);
         } else if (part.type === 'tool_call') {
           toolCallParts.push(part);
         } else if (part.type === 'object') {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -31,12 +31,134 @@ function renderAIResponse(text: string) {
   );
 }
 
+interface AIOutputData {
+  responseObject: string | null;
+  responseText: string | null;
+  toolCalls: string | null;
+}
+
+/**
+ * Extracts content from the new parts-based format.
+ * Handles text parts, tool calls, and structured objects.
+ */
+function extractFromOutputMessages(outputMessages: string): AIOutputData {
+  const result: AIOutputData = {
+    responseText: null,
+    responseObject: null,
+    toolCalls: null,
+  };
+
+  try {
+    const parsed = JSON.parse(outputMessages);
+    if (!Array.isArray(parsed)) {
+      return result;
+    }
+
+    const textParts: string[] = [];
+    const toolCallParts: any[] = [];
+    const objectParts: any[] = [];
+
+    for (const msg of parsed) {
+      if (!msg.parts || !Array.isArray(msg.parts)) {
+        // Old format - extract content directly
+        if (msg.content && msg.role === 'assistant') {
+          if (typeof msg.content === 'string') {
+            textParts.push(msg.content);
+          } else if (typeof msg.content === 'object') {
+            objectParts.push(msg.content);
+          }
+        }
+        continue;
+      }
+
+      // New parts-based format
+      for (const part of msg.parts) {
+        if (part.type === 'text' && part.content) {
+          textParts.push(part.content);
+        } else if (part.type === 'tool_call') {
+          toolCallParts.push(part);
+        } else if (part.type === 'object') {
+          objectParts.push(part);
+        }
+      }
+    }
+
+    if (textParts.length > 0) {
+      result.responseText = textParts.join('\n');
+    }
+    if (toolCallParts.length > 0) {
+      result.toolCalls = JSON.stringify(toolCallParts);
+    }
+    if (objectParts.length > 0) {
+      result.responseObject = JSON.stringify(
+        objectParts.length === 1 ? objectParts[0] : objectParts
+      );
+    }
+  } catch {
+    // If parsing fails, return empty result
+  }
+
+  return result;
+}
+
+/**
+ * Gets AI output content, checking attributes in priority order.
+ * Priority: gen_ai.output.messages > gen_ai.response.text/object
+ */
+function getAIOutputData(
+  node: EapSpanNode | SpanNode | TransactionNode,
+  attributes?: TraceItemResponseAttribute[],
+  event?: EventTransaction
+): AIOutputData {
+  // 1. Check new format first (gen_ai.output.messages)
+  const outputMessages = getTraceNodeAttribute(
+    'gen_ai.output.messages',
+    node,
+    event,
+    attributes
+  );
+  if (outputMessages) {
+    const extracted = extractFromOutputMessages(outputMessages.toString());
+    // If we extracted anything from the new format, use it
+    if (extracted.responseText || extracted.responseObject || extracted.toolCalls) {
+      return extracted;
+    }
+  }
+
+  // 2. Fall back to current format
+  const responseText = getTraceNodeAttribute(
+    'gen_ai.response.text',
+    node,
+    event,
+    attributes
+  );
+  const responseObject = getTraceNodeAttribute(
+    'gen_ai.response.object',
+    node,
+    event,
+    attributes
+  );
+  const toolCalls = getTraceNodeAttribute(
+    'gen_ai.response.tool_calls',
+    node,
+    event,
+    attributes
+  );
+
+  return {
+    responseText: responseText?.toString() ?? null,
+    responseObject: responseObject?.toString() ?? null,
+    toolCalls: toolCalls?.toString() ?? null,
+  };
+}
+
 export function hasAIOutputAttribute(
   node: EapSpanNode | SpanNode | TransactionNode,
   attributes?: TraceItemResponseAttribute[],
   event?: EventTransaction
 ) {
   return (
+    getTraceNodeAttribute('gen_ai.output.messages', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.text', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.object', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.tool_calls', node, event, attributes) ||
@@ -57,25 +179,12 @@ export function AIOutputSection({
     return null;
   }
 
-  const responseText = getTraceNodeAttribute(
-    'gen_ai.response.text',
+  const {responseText, responseObject, toolCalls} = getAIOutputData(
     node,
-    event,
-    attributes
-  );
-  const toolCalls = getTraceNodeAttribute(
-    'gen_ai.response.tool_calls',
-    node,
-    event,
-    attributes
+    attributes,
+    event
   );
   const toolOutput = getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes);
-  const responseObject = getTraceNodeAttribute(
-    'gen_ai.response.object',
-    node,
-    event,
-    attributes
-  );
 
   if (!responseText && !responseObject && !toolCalls && !toolOutput) {
     return null;
@@ -92,7 +201,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
-          {renderAIResponse(responseText.toString())}
+          {renderAIResponse(responseText)}
         </Fragment>
       )}
       {responseObject && (
@@ -100,7 +209,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          {renderAIResponse(responseObject.toString())}
+          {renderAIResponse(responseObject)}
         </Fragment>
       )}
       {toolCalls && (


### PR DESCRIPTION
Part of [TET-1731: Update to latest otel spec](https://linear.app/getsentry/issue/TET-1731/update-to-latest-otel-spec)

Makes sure that the frontend promotes the new OTEL attributes
- `gen_ai.input.messages`
- `gen_ai.output.messages`
- `gen_ai.system_instructions`
- `gen_ai.tool_definitions`
while also keeping support for existing attributes