### PR TITLE
fix(insights): queries module system selector should match table

### DIFF
--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -2,6 +2,7 @@ import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {BASE_FILTERS} from 'sentry/views/insights/database/settings';
 import {
   DATABASE_SYSTEM_TO_LABEL,
   SupportedDatabaseSystem,
@@ -16,7 +17,7 @@ export function useSystemSelectorOptions() {
 
   const {data, isPending, isError} = useSpans(
     {
-      search: MutableSearch.fromQueryObject({'span.op': 'db'}),
+      search: MutableSearch.fromQueryObject(BASE_FILTERS),
 
       fields: [SpanFields.SPAN_SYSTEM, 'count()'],
       sorts: [{field: 'count()', kind: 'desc'}],


### PR DESCRIPTION
The underlying query that is used to find possible db systems should match the the underlying query that is used to get the main data on the page. This is so there isn't a discrepancy between the possible db selector options and the rest of the data on the page (for example, you never have results in the table, but missing db selector options for those results)

fixes https://github.com/getsentry/sentry/issues/104512