### PR TITLE
ref(spans): Add logging to SpanFlusher startup

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -195,6 +195,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
     def _create_process_for_shards(self, process_index: int, shards: list[int]):
         self.process_healthy_since[process_index].value = 0
 
+        logger.info("Creating flusher process %s for shards %s", process_index, shards)
+
         # Create a buffer for these specific shards
         shard_buffer = SpansBuffer(shards, slice_id=self.slice_id)
 
@@ -227,6 +229,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         )
 
         process.start()
+        pid = getattr(process, "pid", None)
+        logger.info("Flusher process %s started (pid=%s) for shards %s", process_index, pid, shards)
         self.processes[process_index] = process
         self.buffers[process_index] = shard_buffer
 
@@ -247,6 +251,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         healthy_since,
         produce_to_pipe: Callable[[KafkaPayload], None] | None,
     ) -> None:
+        logger.info("Flusher process main started for shards %s", shards)
+
         # TODO: remove once span buffer is live in all regions
         scope = sentry_sdk.get_isolation_scope()
         scope.level = "warning"
@@ -255,6 +261,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         sentry_sdk.set_tag("sentry_spans_buffer_component", "flusher")
         sentry_sdk.set_tag("sentry_spans_buffer_shards", shard_tag)
 
+        logger.info("Flusher process started for shards %s", shard_tag)
+
         try:
             producer_futures = []
 
@@ -262,15 +270,21 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                 produce = produce_to_pipe
                 producer_manager = None
             else:
+                logger.info("Flusher creating Kafka producer for shards %s", shard_tag)
                 producer_manager = MultiProducer(Topic.BUFFERED_SEGMENTS)
+                logger.info("Flusher Kafka producer created for shards %s", shard_tag)
 
                 def produce(payload: KafkaPayload) -> None:
                     producer_futures.append(producer_manager.produce(payload))
 
+            first_iteration = True
             while not stopped.value:
                 system_now = int(time.time())
                 now = system_now + current_drift.value
                 flushed_segments = buffer.flush_segments(now=now)
+
+                if first_iteration:
+                    logger.info("Flusher first flush_segments completed for shards %s", shard_tag)
 
                 # Check backpressure flag set by buffer
                 if buffer.any_shard_at_limit:
@@ -281,6 +295,10 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
 
                 # Update healthy_since for all shards handled by this process
                 healthy_since.value = system_now
+
+                if first_iteration:
+                    logger.info("Flusher process healthy for shards %s", shard_tag)
+                    first_iteration = False
 
                 if not flushed_segments:
                     time.sleep(1)


### PR DESCRIPTION
Refs STREAM-567

Add logging to debug flusher subprocess startup timeout. We want to find out where the subprocess is stuck, so we log:
- When flusher process creation begins
- When process is spawned (with PID)
These are logged within the subprocess so I think they will not show up in the Sentry issue to debug, I would have to get the GCP logs around the same timestamp that the issue would occur.
- Entry to main()
- Before/after Kafka producer creation
- After first Redis flush_segments() call
- When process reports healthy

