### PR TITLE
chore: logging to figure out why tasks not getting created properly

### DIFF
--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -50,10 +50,11 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
 
         with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):
             has_feature = features.has("organizations:seer-explorer-index", project.organization)
-            logger.info("organizations:seer-explorer-index flag not enabled, skipping")
 
         if has_feature:
             yield project.id, project.organization_id
+        else:
+            logger.info("organizations:seer-explorer-index flag not enabled, skipping")
 
 
 @instrumented_task(


### PR DESCRIPTION
The periodic schedule_explorer_index task should be kicking off 
subsequent run_explorer_index_for_projects tasks,
but I don't see them getting [created](https://app.datadoghq.com/s/FH6-Y3/crz-ct3-e23). Adding some logs
to debug what's happening.
