### PR TITLE
fix(dashboards): Check query ID before moving out of loading state

### DIFF
--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -442,13 +442,13 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
         await fetchTableData(fetchID);
       }
     } catch (err: any) {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
         setErrorMessage(
           err?.responseJSON?.detail || err?.message || t('An unknown error occurred.')
         );
       }
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
         setLoading(false);
       }
     }


### PR DESCRIPTION
Two requests can clobber each other when another request is fired before the previous one finishes. This checks that the current query ID we've generated is currently being processed, ignoring past requests for state changes (i.e. we don't change loading -> `false` if it's not the most current request)

Fixes EXP-712