### PR TITLE
feat(crons-detector-thresholds): Expanding bucket intervals and fixing tooltip 

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Tooltip} from 'sentry/components/core/tooltip';
+import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
 import {tn} from 'sentry/locale';
 
@@ -42,6 +42,12 @@ interface CheckInTimelineProps<Status extends string>
    * Defaults to 'check-ins'
    */
   makeUnit?: (count: number) => React.ReactNode;
+
+  /**
+   * Extra props to pass to the Tooltip component,
+   * Title is determined by the CheckInTooltip component
+   */
+  tooltipProps?: Omit<TooltipProps, 'title'>;
 }
 
 export function CheckInTimeline<Status extends string>({
@@ -53,6 +59,7 @@ export function CheckInTimeline<Status extends string>({
   className,
   style,
   makeUnit = count => tn('check-in', 'check-ins', count),
+  tooltipProps,
 }: CheckInTimelineProps<Status>) {
   const jobTicks = mergeBuckets(
     statusPrecedent,
@@ -76,6 +83,7 @@ export function CheckInTimeline<Status extends string>({
             skipWrapper
             key={startTs}
             makeUnit={makeUnit}
+            {...tooltipProps}
           >
             <JobTick
               style={{left, width}}

--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -47,7 +47,7 @@ interface CheckInTimelineProps<Status extends string>
    * Extra props to pass to the Tooltip component,
    * Title is determined by the CheckInTooltip component
    */
-  tooltipProps?: Omit<TooltipProps, 'title'>;
+  tooltipProps?: Omit<TooltipProps, 'title' | 'skipWrapper'>;
 }
 
 export function CheckInTimeline<Status extends string>({

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
@@ -163,25 +163,4 @@ describe('getConfigFromTimeRange', () => {
       timezone,
     });
   });
-
-  it('shifts the time window forward when underscan would fall before epoch', () => {
-    // Start at the Unix epoch so that any underscan pushes the start < 0.
-    const start = new Date(0);
-    const end = new Date(60_000);
-    const config = getConfigFromTimeRange(start, end, 101, timezone);
-
-    // Underscan start is clamped to "one second after epoch" (1000ms).
-    expect(config.start.getTime()).toBe(1000);
-
-    // The entire window is shifted forward by a constant delta, preserving duration.
-    const shiftMs = config.periodStart.getTime() - start.getTime();
-    expect(shiftMs).toBeGreaterThan(0);
-    expect(config.periodStart.getTime()).toBe(start.getTime() + shiftMs);
-    expect(config.end.getTime()).toBe(end.getTime() + shiftMs);
-
-    // The duration of the window is preserved.
-    expect(config.end.getTime() - config.periodStart.getTime()).toBe(
-      end.getTime() - start.getTime()
-    );
-  });
 });

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
@@ -163,4 +163,25 @@ describe('getConfigFromTimeRange', () => {
       timezone,
     });
   });
+
+  it('shifts the time window forward when underscan would fall before epoch', () => {
+    // Start at the Unix epoch so that any underscan pushes the start < 0.
+    const start = new Date(0);
+    const end = new Date(60_000);
+    const config = getConfigFromTimeRange(start, end, 101, timezone);
+
+    // Underscan start is clamped to "one second after epoch" (1000ms).
+    expect(config.start.getTime()).toBe(1000);
+
+    // The entire window is shifted forward by a constant delta, preserving duration.
+    const shiftMs = config.periodStart.getTime() - start.getTime();
+    expect(shiftMs).toBeGreaterThan(0);
+    expect(config.periodStart.getTime()).toBe(start.getTime() + shiftMs);
+    expect(config.end.getTime()).toBe(end.getTime() + shiftMs);
+
+    // The duration of the window is preserved.
+    expect(config.end.getTime() - config.periodStart.getTime()).toBe(
+      end.getTime() - start.getTime()
+    );
+  });
 });

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
@@ -40,8 +40,11 @@ const CLAMPED_MINUTE_RANGES = [
   60 * 12,
 ] as const;
 
-const ONE_HOUR_SECS = 60 * 60;
 const ONE_MINUTE_SECS = 60;
+const ONE_HOUR_SECS = ONE_MINUTE_SECS * 60;
+const ONE_DAY_SECS = ONE_HOUR_SECS * 24;
+const ONE_MONTH_SECS = ONE_DAY_SECS * 30;
+const ONE_YEAR_SECS = ONE_MONTH_SECS * 12;
 
 /**
  * Acceptable bucket intervals
@@ -50,17 +53,35 @@ const BUCKET_INTERVALS = [
   15,
   30,
   ONE_MINUTE_SECS,
+  // Minute intervals
   ONE_MINUTE_SECS * 2,
   ONE_MINUTE_SECS * 5,
   ONE_MINUTE_SECS * 10,
   ONE_MINUTE_SECS * 15,
   ONE_MINUTE_SECS * 30,
+  // Hour intervals
   ONE_HOUR_SECS,
   ONE_HOUR_SECS * 2,
   ONE_HOUR_SECS * 3,
   ONE_HOUR_SECS * 4,
   ONE_HOUR_SECS * 12,
-  ONE_HOUR_SECS * 24,
+  // Day intervals
+  ONE_DAY_SECS,
+  ONE_DAY_SECS * 2,
+  ONE_DAY_SECS * 3,
+  ONE_DAY_SECS * 7,
+  ONE_DAY_SECS * 14,
+  // Month intervals
+  ONE_MONTH_SECS,
+  ONE_MONTH_SECS * 2,
+  ONE_MONTH_SECS * 3,
+  ONE_MONTH_SECS * 6,
+  ONE_MONTH_SECS * 12,
+  // Year intervals
+  ONE_YEAR_SECS,
+  ONE_YEAR_SECS * 2,
+  ONE_YEAR_SECS * 3,
+  ONE_YEAR_SECS * 5,
 ] as const;
 
 /**
@@ -210,9 +231,21 @@ export function getConfigFromTimeRange(
   // buckets evenly). Calculations coorelating the container position should be
   // relative to the periodStart, which will be aligned at the pixel value of
   // the underscanWidth.
-  const underscanStart = moment(start)
+  const underscanStartRaw = moment(start)
     .subtract(rollupConfig.underscanBuckets * rollupConfig.interval, 'seconds')
     .toDate();
+  // In extreme cases (very large intervals and/or large underscan), the computed
+  // underscan start can fall before the unix epoch. If that happens, shift the
+  // entire time window forward by the same delta so the window width stays the
+  // same while staying within valid unix timestamps.
+  const minEpochMs = 1000; // 1s after epoch (0 is falsy in some enabled checks)
+  const shiftMs =
+    underscanStartRaw.getTime() < minEpochMs
+      ? minEpochMs - underscanStartRaw.getTime()
+      : 0;
+  const underscanStart = new Date(underscanStartRaw.getTime() + shiftMs);
+  const periodStart = new Date(start.getTime() + shiftMs);
+  const periodEnd = new Date(end.getTime() + shiftMs);
 
   // Display only the time (no date) when the start and end times are the same day
   const timeOnly =
@@ -242,8 +275,8 @@ export function getConfigFromTimeRange(
 
     return {
       start: underscanStart,
-      periodStart: start,
-      end,
+      periodStart,
+      end: periodEnd,
       elapsedMinutes,
       timelineWidth,
       rollupConfig,
@@ -259,8 +292,8 @@ export function getConfigFromTimeRange(
 
   return {
     start: underscanStart,
-    periodStart: start,
-    end,
+    periodStart,
+    end: periodEnd,
     elapsedMinutes,
     timelineWidth,
     rollupConfig,

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
@@ -25,7 +25,7 @@ const TIMELABEL_WIDTH_TIME = 100;
 /**
  * One second after epoch
  */
-const MINIMUM_UNIX_TIMESTAMP_SECONDS = 1000;
+const MINIMUM_UNIX_TIMESTAMP_MS = 1000;
 
 /**
  * Acceptable minute durations between time labels. These will be used to
@@ -81,7 +81,6 @@ const BUCKET_INTERVALS = [
   ONE_MONTH_SECS * 2,
   ONE_MONTH_SECS * 3,
   ONE_MONTH_SECS * 6,
-  ONE_MONTH_SECS * 12,
   // Year intervals
   ONE_YEAR_SECS,
   ONE_YEAR_SECS * 2,
@@ -246,8 +245,8 @@ export function getConfigFromTimeRange(
   // entire time window forward by the same delta so the window width stays the
   // same while staying within valid unix timestamps.
   const shiftMs =
-    underscanStartRaw.getTime() < MINIMUM_UNIX_TIMESTAMP_SECONDS
-      ? MINIMUM_UNIX_TIMESTAMP_SECONDS - underscanStartRaw.getTime()
+    underscanStartRaw.getTime() < MINIMUM_UNIX_TIMESTAMP_MS
+      ? MINIMUM_UNIX_TIMESTAMP_MS - underscanStartRaw.getTime()
       : 0;
 
   const underscanStart = new Date(underscanStartRaw.getTime() + shiftMs);
@@ -256,7 +255,7 @@ export function getConfigFromTimeRange(
 
   // Display only the time (no date) when the start and end times are the same day
   const timeOnly =
-    elapsedMinutes <= ONE_HOUR_SECS * 24 && start.getDate() === end.getDate();
+    elapsedMinutes <= ONE_HOUR_SECS * 24 && periodStart.getDate() === periodEnd.getDate();
 
   // When one pixel represents less than at least one minute we also want to
   // display second values on our labels.

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
@@ -23,11 +23,6 @@ const TIMELABEL_WIDTH_DATE = 110;
 const TIMELABEL_WIDTH_TIME = 100;
 
 /**
- * One second after epoch
- */
-const MINIMUM_UNIX_TIMESTAMP_MS = 1000;
-
-/**
  * Acceptable minute durations between time labels. These will be used to
  * computed the timeMarkerInterval of the TimeWindow when the start and end
  * times fit into these buckets.
@@ -236,26 +231,13 @@ export function getConfigFromTimeRange(
   // buckets evenly). Calculations coorelating the container position should be
   // relative to the periodStart, which will be aligned at the pixel value of
   // the underscanWidth.
-  const underscanStartRaw = moment(start)
+  const underscanStart = moment(start)
     .subtract(rollupConfig.underscanBuckets * rollupConfig.interval, 'seconds')
     .toDate();
 
-  // In extreme cases (very large intervals and/or large underscan), the computed
-  // underscan start can fall before the unix epoch. If that happens, shift the
-  // entire time window forward by the same delta so the window width stays the
-  // same while staying within valid unix timestamps.
-  const shiftMs =
-    underscanStartRaw.getTime() < MINIMUM_UNIX_TIMESTAMP_MS
-      ? MINIMUM_UNIX_TIMESTAMP_MS - underscanStartRaw.getTime()
-      : 0;
-
-  const underscanStart = new Date(underscanStartRaw.getTime() + shiftMs);
-  const periodStart = new Date(start.getTime() + shiftMs);
-  const periodEnd = new Date(end.getTime() + shiftMs);
-
   // Display only the time (no date) when the start and end times are the same day
   const timeOnly =
-    elapsedMinutes <= ONE_HOUR_SECS * 24 && periodStart.getDate() === periodEnd.getDate();
+    elapsedMinutes <= ONE_HOUR_SECS * 24 && start.getDate() === end.getDate();
 
   // When one pixel represents less than at least one minute we also want to
   // display second values on our labels.
@@ -281,8 +263,8 @@ export function getConfigFromTimeRange(
 
     return {
       start: underscanStart,
-      periodStart,
-      end: periodEnd,
+      periodStart: start,
+      end,
       elapsedMinutes,
       timelineWidth,
       rollupConfig,
@@ -298,8 +280,8 @@ export function getConfigFromTimeRange(
 
   return {
     start: underscanStart,
-    periodStart,
-    end: periodEnd,
+    periodStart: start,
+    end,
     elapsedMinutes,
     timelineWidth,
     rollupConfig,

--- a/static/app/views/detectors/components/forms/common/schedulePreview.spec.tsx
+++ b/static/app/views/detectors/components/forms/common/schedulePreview.spec.tsx
@@ -79,9 +79,10 @@ describe('SchedulePreview', () => {
     );
 
     expect(
-      await screen.findByText(/No schedule preview available\./i)
+      await screen.findByText(
+        /No preview available\. The provided schedule is invalid, or the thresholds are incompatible with it\./i
+      )
     ).toBeInTheDocument();
-    expect(screen.getByText(/schedule: Invalid schedule/i)).toBeInTheDocument();
   });
 
   it('shows a generic error on non-400 errors', async () => {

--- a/static/app/views/detectors/components/forms/common/schedulePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/schedulePreview.tsx
@@ -75,7 +75,9 @@ export function SchedulePreview({statusToText, ...detectorFields}: SchedulePrevi
 
     const message = badRequestError ? (
       <Alert variant="warning">
-        {t('No schedule preview available. %s', getErrorMessage(badRequestError))}
+        {t(
+          'No preview available. The provided schedule is invalid, or the thresholds are incompatible with it.'
+        )}
       </Alert>
     ) : (
       <LoadingError message={t('Failed to load schedule preview')} />
@@ -200,15 +202,6 @@ function ContentWrapper({
 
 function getBucketStatus(stats: Record<string, number> | undefined) {
   return stats ? statusPrecedent.find(status => (stats[status] ?? 0) > 0) : undefined;
-}
-
-function getErrorMessage(error: RequestError) {
-  return Object.entries(error.responseJSON ?? {})
-    .map(
-      ([key, value]) =>
-        `${key}: ${Array.isArray(value) ? value.join(', ') : String(value)}`
-    )
-    .join(', ');
 }
 
 const OpenPeriodBar = styled('div')`

--- a/static/app/views/detectors/components/forms/common/schedulePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/schedulePreview.tsx
@@ -113,6 +113,7 @@ export function SchedulePreview({statusToText, ...detectorFields}: SchedulePrevi
               statusLabel={statusToText}
               statusStyle={tickStyle}
               statusPrecedent={statusPrecedent}
+              tooltipProps={{maxWidth: 500}}
             />
           </Container>
         </Fragment>


### PR DESCRIPTION
- Doesn't impact any use of the checkintimeline component. We choose the highest granularity as the candidate. 
- Tooltip fallsback to 225px when maxwidth isn't passed. Not enough for our usecase: [link](https://github.com/getsentry/sentry/blob/master/static/app/components/core/tooltip/tooltip.tsx#L117) 
