### PR TITLE
feat(preprod): Check quota available in preprod assemble

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -19,6 +19,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
+from sentry.preprod.exceptions import NoPreprodQuota
 from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
@@ -198,21 +199,27 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             if not chunks:
                 return Response({"state": ChunkFileState.NOT_FOUND, "missingChunks": []})
 
-            artifact = create_preprod_artifact(
-                org_id=project.organization_id,
-                project_id=project.id,
-                checksum=checksum,
-                build_configuration_name=data.get("build_configuration"),
-                release_notes=data.get("release_notes"),
-                head_sha=data.get("head_sha"),
-                base_sha=data.get("base_sha"),
-                provider=data.get("provider"),
-                head_repo_name=data.get("head_repo_name"),
-                base_repo_name=data.get("base_repo_name"),
-                head_ref=data.get("head_ref"),
-                base_ref=data.get("base_ref"),
-                pr_number=data.get("pr_number"),
-            )
+            try:
+                artifact = create_preprod_artifact(
+                    org_id=project.organization_id,
+                    project_id=project.id,
+                    checksum=checksum,
+                    build_configuration_name=data.get("build_configuration"),
+                    release_notes=data.get("release_notes"),
+                    head_sha=data.get("head_sha"),
+                    base_sha=data.get("base_sha"),
+                    provider=data.get("provider"),
+                    head_repo_name=data.get("head_repo_name"),
+                    base_repo_name=data.get("base_repo_name"),
+                    head_ref=data.get("head_ref"),
+                    base_ref=data.get("base_ref"),
+                    pr_number=data.get("pr_number"),
+                )
+            except NoPreprodQuota:
+                return Response(
+                    {"detail": "Organization does not have quota for preprod features"},
+                    status=403,
+                )
 
             if artifact is None:
                 return Response(

--- a/src/sentry/preprod/exceptions.py
+++ b/src/sentry/preprod/exceptions.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class NoPreprodQuota(Exception):
+    """Raised when an organization has no quota available for preprod features."""

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from django.db import router, transaction
 from django.utils import timezone
 
-from sentry import features
+from sentry import features, quotas
 from sentry.constants import DataCategory
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
@@ -19,6 +19,7 @@ from sentry.preprod.eap.write import (
     produce_preprod_build_distribution_to_eap,
     produce_preprod_size_metric_to_eap,
 )
+from sentry.preprod.exceptions import NoPreprodQuota
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeComparison,
@@ -197,6 +198,26 @@ def create_preprod_artifact(
         project = Project.objects.get(id=project_id, organization=organization)
         bind_organization_context(organization)
 
+        # Check if organization has quota for either SIZE_ANALYSIS or INSTALLABLE_BUILD
+        has_size_quota = quotas.backend.has_usage_quota(org_id, DataCategory.SIZE_ANALYSIS)
+        has_installable_quota = quotas.backend.has_usage_quota(
+            org_id, DataCategory.INSTALLABLE_BUILD
+        )
+        if not has_size_quota and not has_installable_quota:
+            logger.info(
+                "No quota available for preprod artifact creation",
+                extra={
+                    "project_id": project_id,
+                    "organization_id": org_id,
+                    "checksum": checksum,
+                    "has_size_quota": has_size_quota,
+                    "has_installable_quota": has_installable_quota,
+                },
+            )
+            raise NoPreprodQuota(
+                "Organization does not have quota for preprod features (SIZE_ANALYSIS or INSTALLABLE_BUILD)"
+            )
+
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
             # Create CommitComparison if git information is provided
             commit_comparison = None
@@ -249,7 +270,6 @@ def create_preprod_artifact(
                 extras=extras,
             )
 
-            # TODO(preprod): add gating to only create if has quota
             PreprodArtifactSizeMetrics.objects.get_or_create(
                 preprod_artifact=preprod_artifact,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -270,6 +290,8 @@ def create_preprod_artifact(
 
             return preprod_artifact
 
+    except NoPreprodQuota:
+        raise
     except Exception as e:
         sentry_sdk.capture_exception(e)
         logger.exception(


### PR DESCRIPTION
Check size and/or distribution quota are available in assemble.
If neither is available return an error.

We need at some point to determine which of size and distribution
is requested and which has quota and only allow those parts of the 
processing to go forwards - but assemble should go forward even
if only one is available (to stop e.g. distribution breaking just because
size quota ran out).