### PR TITLE
fix(tracemetrics): Add timestamp to filterable fields

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2584,7 +2584,11 @@ const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
 };
 
 const TRACEMETRIC_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
-  // TODO: Add field definitions for tracemetric fields
+  [FieldKey.TIMESTAMP]: {
+    desc: t('The time the metric was recorded'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
 };
 
 export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -14,6 +14,7 @@ import {getHasTag} from 'sentry/utils/tag';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
 import {useGetTraceItemAttributeValues} from 'sentry/views/explore/hooks/useGetTraceItemAttributeValues';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
+import {TRACEMETRICS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/metrics/constants';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
@@ -274,7 +275,7 @@ function itemTypeToFilterKeySections(itemType: TraceItemDataset) {
     return SPANS_FILTER_KEY_SECTIONS;
   }
   if (itemType === TraceItemDataset.TRACEMETRICS) {
-    return [];
+    return TRACEMETRICS_FILTER_KEY_SECTIONS;
   }
   return LOGS_FILTER_KEY_SECTIONS;
 }

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,4 +1,5 @@
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
 export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
@@ -76,5 +77,11 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
 ];
 
 export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NUMBER];
+
+export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [
+  TraceMetricKnownFieldKey.TIMESTAMP,
+];
+
+export const SENTRY_TRACEMETRIC_NUMBER_TAGS: string[] = [];
 
 export const MAX_CROSS_EVENT_QUERIES = 2;

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -9,6 +9,8 @@ import {
   SENTRY_LOG_STRING_TAGS,
   SENTRY_SPAN_NUMBER_TAGS,
   SENTRY_SPAN_STRING_TAGS,
+  SENTRY_TRACEMETRIC_NUMBER_TAGS,
+  SENTRY_TRACEMETRIC_STRING_TAGS,
 } from 'sentry/views/explore/constants';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -205,12 +207,18 @@ function getDefaultStringAttributes(itemType: TraceItemDataset) {
   if (itemType === TraceItemDataset.SPANS) {
     return SENTRY_SPAN_STRING_TAGS;
   }
+  if (itemType === TraceItemDataset.TRACEMETRICS) {
+    return SENTRY_TRACEMETRIC_STRING_TAGS;
+  }
   return SENTRY_LOG_STRING_TAGS;
 }
 
 function getDefaultNumberAttributes(itemType: TraceItemDataset) {
   if (itemType === TraceItemDataset.SPANS) {
     return SENTRY_SPAN_NUMBER_TAGS;
+  }
+  if (itemType === TraceItemDataset.TRACEMETRICS) {
+    return SENTRY_TRACEMETRIC_NUMBER_TAGS;
   }
   return SENTRY_LOG_NUMBER_TAGS;
 }

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -1,4 +1,10 @@
 import type {SelectOption} from 'sentry/components/core/compactSelect';
+import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
+import {t} from 'sentry/locale';
+import {
+  SENTRY_TRACEMETRIC_NUMBER_TAGS,
+  SENTRY_TRACEMETRIC_STRING_TAGS,
+} from 'sentry/views/explore/constants';
 import {
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
@@ -51,6 +57,17 @@ export const HiddenTraceMetricSearchFields: TraceMetricFieldKey[] = [
 
 export const HiddenTraceMetricGroupByFields: TraceMetricFieldKey[] = [
   ...HiddenTraceMetricSearchFields,
+  TraceMetricKnownFieldKey.TIMESTAMP,
+];
+
+const TRACEMETRICS_FILTERS: FilterKeySection = {
+  value: 'tracemetrics_filters',
+  label: t('Metrics'),
+  children: [...SENTRY_TRACEMETRIC_STRING_TAGS, ...SENTRY_TRACEMETRIC_NUMBER_TAGS],
+};
+
+export const TRACEMETRICS_FILTER_KEY_SECTIONS: FilterKeySection[] = [
+  TRACEMETRICS_FILTERS,
 ];
 
 export const TraceSamplesTableStatColumns: VirtualTableSampleColumnKey[] = [

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -2,11 +2,16 @@ import {useMemo} from 'react';
 
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
   type TraceItemSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {
+  SENTRY_TRACEMETRIC_NUMBER_TAGS,
+  SENTRY_TRACEMETRIC_STRING_TAGS,
+} from 'sentry/views/explore/constants';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -44,19 +49,39 @@ export function Filter({traceMetric}: FilterProps) {
   });
 
   const visibleNumberTags = useMemo(() => {
-    return Object.fromEntries(
-      Object.entries(numberTags ?? {}).filter(
-        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
-      )
-    );
+    const staticNumberTags = SENTRY_TRACEMETRIC_NUMBER_TAGS.reduce((acc, key) => {
+      if (!HiddenTraceMetricSearchFields.includes(key)) {
+        acc[key] = {key, name: key, kind: FieldKind.MEASUREMENT};
+      }
+      return acc;
+    }, {} as TagCollection);
+
+    return {
+      ...staticNumberTags,
+      ...Object.fromEntries(
+        Object.entries(numberTags ?? {}).filter(
+          ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+        )
+      ),
+    };
   }, [numberTags]);
 
   const visibleStringTags = useMemo(() => {
-    return Object.fromEntries(
-      Object.entries(stringTags ?? {}).filter(
-        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
-      )
-    );
+    const staticStringTags = SENTRY_TRACEMETRIC_STRING_TAGS.reduce((acc, key) => {
+      if (!HiddenTraceMetricSearchFields.includes(key)) {
+        acc[key] = {key, name: key, kind: FieldKind.FIELD};
+      }
+      return acc;
+    }, {} as TagCollection);
+
+    return {
+      ...staticStringTags,
+      ...Object.fromEntries(
+        Object.entries(stringTags ?? {}).filter(
+          ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+        )
+      ),
+    };
   }, [stringTags]);
 
   const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps =

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -29,7 +29,7 @@ export enum TraceMetricKnownFieldKey {
   CODE_LINE_NUMBER = 'tags[code.line.number,number]',
   CODE_FUNCTION_NAME = 'code.function.name',
 
-  // SDK attributes https://develop.sentry.dev/sdk/telemetry/logs/#default-attributes
+  // SDK attributes https://develop.sentry.dev/sdk/telemetry/metrics/#default-attributes
   RELEASE = 'release',
   SDK_NAME = 'sdk.name',
   SDK_VERSION = 'sdk.version',


### PR DESCRIPTION
`timestamp` should show up in the filter bars for the metrics explore page and dashboards

Fixes LOGS-523