### PR TITLE
ref(cells): Use isCellScoped for user customers endpoint

### DIFF
--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -22,6 +22,7 @@ function UserCustomers({userId}: Props) {
       panelTitle="Organization Membership"
       path={`/_admin/users/${userId}/`}
       endpoint={`/users/${userId}/customers/`}
+      isCellScoped
       hasSearch={false}
       sortOptions={undefined}
       filters={undefined}

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -19,7 +19,7 @@ describe('User Details', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/users/${mockUser.id}/customers/`,
+      url: `/_admin/cells/us/users/${mockUser.id}/customers/`,
       body: [{}],
     });
 


### PR DESCRIPTION
Migrates the user customers endpoint to use the cell-scoped variant by
enabling the isCellScoped prop on CustomerGrid.

Old endpoint: /api/0/users/{user_id}/customers/
New endpoint: /api/0/_admin/cells/{cell_id}/users/{user_id}/customers/

The ResultGrid component now automatically handles the URL transformation
and region routing.