### PR TITLE
chore: temporarily run task every hour

### DIFF
--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -26,7 +26,7 @@ LAST_RUN_CACHE_KEY = "seer:explorer_index:last_run"
 LAST_RUN_CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours
 
 EXPLORER_INDEX_PROJECTS_PER_BATCH = 100
-EXPLORER_INDEX_RUN_FREQUENCY = timedelta(hours=24)
+EXPLORER_INDEX_RUN_FREQUENCY = timedelta(minutes=50)
 # Use a larger prime number to spread indexing tasks throughout the day
 EXPLORER_INDEX_DISPATCH_STEP = timedelta(seconds=127)
 


### PR DESCRIPTION
Debugging continues...
Logs show that this task was run in the
last 24 hours, so it got past that check.
Temporarily increasing the frequency to
get past this in the next run.


This is currently only enabled in s4s, so
the frequent runs shouldn't be a problem.