### PR TITLE
feat(uptime): Create response captures on check failures

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
+import base64
 import logging
 import random
 import uuid
 from datetime import datetime, timedelta, timezone
+from io import BytesIO
 from uuid import UUID
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_DISALLOWED_BY_ROBOTS,
+    CHECKSTATUS_FAILURE,
     CHECKSTATUS_MISSED_WINDOW,
+    CHECKSTATUS_SUCCESS,
     CheckResult,
 )
 
 from sentry import features
 from sentry.conf.types.kafka_definition import Topic
 from sentry.locks import locks
+from sentry.models.files.file import File
 from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
@@ -23,6 +28,7 @@ from sentry.uptime.autodetect.result_handler import handle_onboarding_result
 from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
 from sentry.uptime.grouptype import UptimePacketValue
 from sentry.uptime.models import (
+    UptimeResponseCapture,
     UptimeSubscription,
     UptimeSubscriptionRegion,
     get_detector,
@@ -33,6 +39,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     check_and_update_regions,
     delete_uptime_subscription,
     disable_uptime_detector,
+    set_response_capture_enabled,
 )
 from sentry.uptime.subscriptions.tasks import (
     send_uptime_config_deletion,
@@ -69,6 +76,78 @@ TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS = 30
 
 # The maximum number of missed checks we backfill, upon noticing a gap in our expected check results
 MAX_SYNTHETIC_MISSED_CHECKS = 100
+
+
+RESPONSE_BODY_SEPARATOR = b"\r\n\r\n---BODY---\r\n\r\n"
+
+
+def format_response_for_storage(
+    headers: list[tuple[str, str]] | None,
+    body: bytes,
+) -> bytes:
+    """
+    Format response headers and body for storage.
+
+    Format: headers (one per line), separator, body
+    Split on RESPONSE_BODY_SEPARATOR to parse.
+    """
+    lines = []
+    if headers:
+        for name, value in headers:
+            lines.append(f"{name}: {value}")
+    header_bytes = "\r\n".join(lines).encode("utf-8")
+    return header_bytes + RESPONSE_BODY_SEPARATOR + body
+
+
+def create_uptime_response_capture(
+    subscription: UptimeSubscription,
+    result: CheckResult,
+) -> UptimeResponseCapture | None:
+    """
+    Create a response capture from a check result if it contains response data.
+
+    Returns the created capture, or None if there's no response data in result
+    """
+    request_info_list = result.get("request_info_list")
+    if not request_info_list:
+        return None
+
+    request_info = request_info_list[-1]
+    response_body_b64 = request_info.get("response_body")
+    if not response_body_b64:
+        return None
+
+    try:
+        response_body = base64.b64decode(response_body_b64)
+    except Exception:
+        logger.exception("Failed to decode response body")
+        return None
+
+    response_headers = request_info.get("response_headers")
+    response_content = format_response_for_storage(
+        headers=response_headers,
+        body=response_body,
+    )
+    file = File.objects.create(
+        name=f"uptime-response-{uuid.uuid4().hex}",
+        type="uptime.response",
+    )
+    file.putfile(BytesIO(response_content))
+    capture = UptimeResponseCapture.objects.create(
+        uptime_subscription=subscription,
+        file_id=file.id,
+        scheduled_check_time_ms=result["scheduled_check_time_ms"],
+    )
+
+    metrics.incr("uptime.response_capture.created", sample_rate=1.0)
+    metrics.distribution(
+        "uptime.response_capture.size",
+        len(response_content),
+        sample_rate=1.0,
+        unit="byte",
+    )
+
+    return capture
 
 
 def get_host_provider_if_valid(subscription: UptimeSubscription) -> str:
@@ -108,18 +187,20 @@ def should_run_region_checks(subscription: UptimeSubscription, result: CheckResu
 
 def try_check_and_update_regions(
     subscription: UptimeSubscription, regions: list[UptimeSubscriptionRegion]
-):
+) -> bool:
     """
-    This method will check if regions have been added or removed from our region configuration,
-    and updates regions associated with this uptime monitor to reflect the new state.
+    Check if regions have been added or removed from our region configuration,
+    and update regions associated with this uptime monitor to reflect the new state.
+
+    Returns True if regions were updated and a config push is needed, False otherwise.
     """
     if not check_and_update_regions(subscription, regions):
-        return
+        return False
 
     # Regardless of whether we added or removed regions, we need to send an updated config to all active
     # regions for this subscription so that they all get an update set of currently active regions.
     subscription.update(status=UptimeSubscription.Status.UPDATING.value)
-    update_remote_uptime_subscription.delay(subscription.id)
+    return True
 
 
 def is_shadow_region_result(result: CheckResult, regions: list[UptimeSubscriptionRegion]) -> bool:
@@ -279,13 +360,28 @@ def process_result_internal(
     result: CheckResult,
     metric_tags: dict[str, str],
     cluster,
+    subscription_regions: list[UptimeSubscriptionRegion],
 ) -> None:
     """
     Core result processing logic shared by main consumer and retry task.
 
     Does NOT include: dedup check, backfill detection, queue check.
-    Contains: metrics, mode handling, EAP production, state updates.
+    Contains: metrics, mode handling, EAP production, state updates,
+    response capture toggle, and region updates.
     """
+    needs_update = False
+
+    if result["status"] == CHECKSTATUS_SUCCESS:
+        needs_update |= set_response_capture_enabled(uptime_subscription, True)
+    elif result["status"] == CHECKSTATUS_FAILURE:
+        needs_update |= set_response_capture_enabled(uptime_subscription, False)
+
+    if should_run_region_checks(uptime_subscription, result):
+        needs_update |= try_check_and_update_regions(uptime_subscription, subscription_regions)
+
+    if needs_update and uptime_subscription.subscription_id:
+        update_remote_uptime_subscription.delay(uptime_subscription.id)
+
     mode_name = UptimeMonitorMode(detector.config["mode"]).name.lower()
 
     # We log the result stats here after the duplicate check so that we
@@ -398,7 +494,19 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             )
 
         try:
-            result_json = json.dumps(result)
+            # Strip response body and headers to save Redis memory.
+            # Safe because we've already stored these in UptimeResponseCapture before queuing.
+            result_for_queue = dict(result)
+            if result_for_queue.get("request_info_list"):
+                result_for_queue["request_info_list"] = [
+                    {
+                        k: v
+                        for k, v in info.items()
+                        if k not in ("response_body", "response_headers")
+                    }
+                    for info in result_for_queue["request_info_list"]
+                ]
+            result_json = json.dumps(result_for_queue)
             pipeline = cluster.pipeline()
             pipeline.zadd(backlog_key, {result_json: int(result["scheduled_check_time_ms"])})
             pipeline.expire(backlog_key, 600)
@@ -479,9 +587,6 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             )
             return
 
-        if should_run_region_checks(subscription, result):
-            try_check_and_update_regions(subscription, subscription_regions)
-
         try:
             detector = get_detector(subscription, prefetch_workflow_data=True)
         except Detector.DoesNotExist:
@@ -542,6 +647,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 )
             return
 
+        if result["status"] == CHECKSTATUS_FAILURE:
+            create_uptime_response_capture(subscription, result)
+
         if last_update_ms > 0:
             subscription_interval_ms = subscription.interval_seconds * 1000
             expected_next_ms = last_update_ms + subscription_interval_ms
@@ -556,7 +664,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     detector, subscription, result, last_update_ms, metric_tags, cluster
                 )
 
-        process_result_internal(detector, subscription, result, metric_tags, cluster)
+        process_result_internal(
+            detector, subscription, result, metric_tags, cluster, subscription_regions
+        )
 
 
 class UptimeResultsStrategyFactory(ResultsStrategyFactory[CheckResult, UptimeSubscription]):

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -111,7 +111,7 @@ def create_uptime_response_capture(
     """
     # Check if we already have a capture for this scheduled check time
     # to avoid creating duplicates on retries.
-    scheduled_check_time_ms = result["scheduled_check_time_ms"]
+    scheduled_check_time_ms = int(result["scheduled_check_time_ms"])
     if UptimeResponseCapture.objects.filter(
         uptime_subscription=subscription,
         scheduled_check_time_ms=scheduled_check_time_ms,

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -656,23 +656,15 @@ def check_url_limits(url):
         )
 
 
-def set_response_capture_enabled(subscription: UptimeSubscription, enabled: bool) -> None:
+def set_response_capture_enabled(subscription: UptimeSubscription, enabled: bool) -> bool:
     """
     Toggle response capture for an uptime subscription.
 
-    Updates the capture_response_on_failure flag and pushes the updated config
-    to the uptime checker.
+    Updates the capture_response_on_failure flag in the database.
+    Returns True if a change was made, False otherwise.
     """
     if subscription.capture_response_on_failure == enabled:
-        return
+        return False
 
     subscription.update(capture_response_on_failure=enabled)
-
-    if (
-        subscription.subscription_id
-        and subscription.status == UptimeSubscription.Status.ACTIVE.value
-    ):
-        transaction.on_commit(
-            lambda: update_remote_uptime_subscription.delay(subscription.id),
-            using=router.db_for_write(UptimeSubscription),
-        )
+    return True


### PR DESCRIPTION
Store HTTP response data (headers + body) when uptime check failures occur. This enables users to debug why their endpoints are failing when viewing downtime incidents.

## Project Context

This is part of the Uptime Response Capture feature - storing HTTP response data (body + headers) when downtime incidents are created to help users debug failures.

PRs in this series:
1. sentry-kafka-schemas: Schema changes
2. uptime-checker: Response capture config and logic
3. sentry: Storage model (UptimeResponseCapture)
4. sentry: Config production and toggle helper
5. sentry: Consumer capture creation <-- this PR
6. sentry: Incident integration
7. sentry: API and UI

<!-- Describe your PR here. -->