### PR TITLE
fix(crons): Handle None threshold values in schedule sample window endpoint

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
@@ -89,8 +89,8 @@ class OrganizationMonitorScheduleSampleBucketsEndpoint(OrganizationEndpoint):
 
         config = validator.validated_data
 
-        failure_threshold = config.get("failure_issue_threshold", MIN_THRESHOLD)
-        recovery_threshold = config.get("recovery_threshold", MIN_THRESHOLD)
+        failure_threshold = config.get("failure_issue_threshold") or MIN_THRESHOLD
+        recovery_threshold = config.get("recovery_threshold") or MIN_THRESHOLD
 
         schedule_type = config.get("schedule_type")
         schedule = config.get("schedule")

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_window.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_window.py
@@ -54,8 +54,8 @@ class OrganizationMonitorScheduleSampleWindowEndpoint(OrganizationEndpoint):
             return self.respond(validator.errors, status=400)
 
         config = validator.validated_data
-        failure_threshold = config.get("failure_issue_threshold", MIN_THRESHOLD)
-        recovery_threshold = config.get("recovery_threshold", MIN_THRESHOLD)
+        failure_threshold = config.get("failure_issue_threshold") or MIN_THRESHOLD
+        recovery_threshold = config.get("recovery_threshold") or MIN_THRESHOLD
 
         num_ticks = _get_num_ticks(
             failure_threshold=failure_threshold,


### PR DESCRIPTION
fix(crons): Handle None threshold values in schedule sample window endpoint

Empty query params for failure_issue_threshold and recovery_threshold
were causing a TypeError because EmptyIntegerField converts "" to None,
but dict.get(key, default) only uses the default when the key is missing,
not when it's explicitly None.

The fix uses `config.get(key) or MIN_THRESHOLD` instead. Using `or` is
safe here because the validator's min_value=1 constraint ensures valid
integers are always >= 1 (truthy), so only None values trigger the fallback.

Fixes SENTRY-5GX7