### PR TITLE
feat(uptime): Add drag-and-drop reordering for assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/modifiers": "7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/babel-plugin": "^11.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/modifiers':
+        specifier: 7.0.0
+        version: 7.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/sortable':
         specifier: ^8.0.0
         version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -1510,6 +1513,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@7.0.0':
+    resolution: {integrity: sha512-BG/ETy3eBjFap7+zIti53f0PCLGDzNXyTmn6fSdrudORf+OH04MxrW4p5+mPu4mgMk9kM41iYONjc3DOUWTcfg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.1.0
+      react: '>=16.8.0'
 
   '@dnd-kit/sortable@8.0.0':
     resolution: {integrity: sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==}
@@ -9991,6 +10000,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@7.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/core': 6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
       tslib: 2.8.1
 
   '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':

--- a/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
@@ -1,0 +1,122 @@
+import {
+  DndContext,
+  PointerSensor,
+  pointerWithin,
+  useDndContext,
+  useDndMonitor,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {restrictToVerticalAxis} from '@dnd-kit/modifiers';
+
+import {Container} from '@sentry/scraps/layout';
+
+import type {LogicalOp, Op} from 'sentry/views/alerts/rules/uptime/types';
+
+import {isAfterOp, moveTo} from './utils';
+
+export function AssertionsDndContext({children}: {children: React.ReactNode}) {
+  const dndSensors = useSensors(useSensor(PointerSensor));
+
+  return (
+    <DndContext
+      sensors={dndSensors}
+      collisionDetection={pointerWithin}
+      modifiers={[restrictToVerticalAxis]}
+    >
+      {children}
+    </DndContext>
+  );
+}
+interface DroppableProps extends React.HTMLAttributes<HTMLDivElement> {
+  disabled: boolean;
+  groupId: string;
+  idIndex: number;
+  op: Op;
+  position: 'before' | 'after' | 'inside';
+}
+
+export function DroppableHitbox(props: DroppableProps) {
+  const {idIndex, op, groupId, position, disabled, ...rest} = props;
+
+  const {active} = useDndContext();
+  const activeOp = active?.data.current as Op | null;
+
+  const dropzoneDisabled =
+    disabled ||
+    // Do not enable drop areas for the actively dragging node
+    activeOp?.id === op.id;
+
+  const {setNodeRef} = useDroppable({
+    id: `${groupId}-${idIndex}-${position}`,
+    data: props,
+    disabled: dropzoneDisabled,
+  });
+
+  const isGroup = op.op === 'and' || op.op === 'or' || op.op === 'not';
+
+  const offsetConfig = {
+    before: {bottom: isGroup ? 'calc(100% - 10px)' : '50%'},
+    after: {top: isGroup ? 'calc(100% - 10px)' : '50%'},
+    inside: {inset: '0px', top: '-10px', left: '-12px'},
+  };
+
+  const offset = offsetConfig[position];
+  const groupHitboxAdjust =
+    isGroup && position === 'after' ? {bottom: '-10px', top: 'calc(100%)'} : {};
+
+  return (
+    <Container
+      ref={setNodeRef}
+      position="absolute"
+      inset="0px"
+      {...offset}
+      {...groupHitboxAdjust}
+      {...rest}
+      style={{pointerEvents: 'none'}}
+    />
+  );
+}
+
+interface DropHandlerProps {
+  onChange: (op: LogicalOp) => void;
+  rootOp: LogicalOp;
+}
+
+/**
+ * Drop hangler for the root assertion container (should only be rendered
+ * once). Monitors the drag-and-drop context as ops are dragged and updates the
+ * tree.
+ */
+export function DropHandler({rootOp, onChange}: DropHandlerProps) {
+  useDndMonitor({
+    onDragOver(event) {
+      const {active, over} = event;
+
+      // the root op should ALWAYS be `and`, but the typing doesn't strictly enforce that
+      if (rootOp.op !== 'and') {
+        return;
+      }
+
+      if (!active?.data.current || !over?.data.current) {
+        return;
+      }
+
+      const activeOp = active.data.current as Op;
+      const overProps = over.data.current as DroppableProps;
+
+      // Do not move to something it's already immediately after
+      if (
+        isAfterOp(rootOp, activeOp.id, overProps.op.id) &&
+        overProps.position === 'after'
+      ) {
+        return;
+      }
+
+      onChange(moveTo(rootOp, activeOp.id, overProps.op.id, overProps.position));
+    },
+  });
+
+  return null;
+}

--- a/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
@@ -85,7 +85,7 @@ interface DropHandlerProps {
 }
 
 /**
- * Drop hangler for the root assertion container (should only be rendered
+ * Drop handler for the root assertion container (should only be rendered
  * once). Monitors the drag-and-drop context as ops are dragged and updates the
  * tree.
  */

--- a/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/dragDrop.tsx
@@ -128,10 +128,16 @@ export function DropHandler({rootOp, onChange}: DropHandlerProps) {
         return;
       }
 
-      // Do not move to something it's already immediately after
+      // Do not move if already in the target position
       if (
-        isAfterOp(rootOp, activeData.id, overData.op.id) &&
-        overData.position === 'after'
+        overData.position === 'after' &&
+        isAfterOp(rootOp, activeData.id, overData.op.id)
+      ) {
+        return;
+      }
+      if (
+        overData.position === 'before' &&
+        isAfterOp(rootOp, overData.op.id, activeData.id)
       ) {
         return;
       }

--- a/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
@@ -5,6 +5,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
 import type {
+  AndOp,
   HeaderCheckOp,
   JsonPathOp,
   LogicalOp,
@@ -12,6 +13,7 @@ import type {
 } from 'sentry/views/alerts/rules/uptime/types';
 
 import {AddOpButton} from './addOpButton';
+import {AssertionsDndContext, DropHandler} from './dragDrop';
 import {AssertionOpGroup} from './opGroup';
 import {AssertionOpHeader} from './opHeader';
 import {AssertionOpJsonPath} from './opJsonPath';
@@ -493,6 +495,103 @@ export default Storybook.story('Uptime Assertions', story => {
           starting point for building assertions.
         </p>
         <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
+        <CodeBlock language="javascript">{JSON.stringify(rootGroup, null, 2)}</CodeBlock>
+      </Fragment>
+    );
+  });
+
+  story('Drag and Drop - Reordering', () => {
+    const [rootGroup, setRootGroup] = useState<AndOp>({
+      id: 'story-dnd-1',
+      op: 'and',
+      children: [
+        {
+          id: 'story-status-dnd-1',
+          op: 'status_code_check',
+          operator: {cmp: 'less_than'},
+          value: 400,
+        },
+        {
+          id: 'story-json-dnd-1',
+          op: 'json_path',
+          value: '$.success',
+        },
+        {
+          id: 'story-header-dnd-1',
+          op: 'header_check',
+          key_op: {cmp: 'equals'},
+          key_operand: {header_op: 'literal', value: 'Content-Type'},
+          value_op: {cmp: 'equals'},
+          value_operand: {header_op: 'literal', value: 'application/json'},
+        },
+      ],
+    });
+
+    return (
+      <Fragment>
+        <p>
+          Assertions can be reordered using drag and drop. Click and drag the{' '}
+          <strong>grip handle</strong> (⠿) next to each assertion label to reorder them.
+          The tree structure updates in real-time as items are dragged.
+        </p>
+        <AssertionsDndContext>
+          <DropHandler rootOp={rootGroup} onChange={setRootGroup} />
+          <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
+        </AssertionsDndContext>
+        <CodeBlock language="javascript">{JSON.stringify(rootGroup, null, 2)}</CodeBlock>
+      </Fragment>
+    );
+  });
+
+  story('Drag and Drop - Between Groups', () => {
+    const [rootGroup, setRootGroup] = useState<AndOp>({
+      id: 'story-dnd-2',
+      op: 'and',
+      children: [
+        {
+          id: 'story-status-dnd-2',
+          op: 'status_code_check',
+          operator: {cmp: 'less_than'},
+          value: 400,
+        },
+        {
+          id: 'story-or-dnd-1',
+          op: 'or',
+          children: [
+            {
+              id: 'story-json-dnd-2',
+              op: 'json_path',
+              value: '$.data.id',
+            },
+            {
+              id: 'story-json-dnd-3',
+              op: 'json_path',
+              value: '$.data.name',
+            },
+          ],
+        },
+        {
+          id: 'story-header-dnd-2',
+          op: 'header_check',
+          key_op: {cmp: 'equals'},
+          key_operand: {header_op: 'literal', value: 'X-Request-Id'},
+          value_op: {cmp: 'always'},
+          value_operand: {header_op: 'none'},
+        },
+      ],
+    });
+
+    return (
+      <Fragment>
+        <p>
+          Assertions can be moved between groups. Drag an assertion from the root level
+          into the nested "Assert Any" group, or drag items out of the group to the root
+          level. You can also drag items into empty groups.
+        </p>
+        <AssertionsDndContext>
+          <DropHandler rootOp={rootGroup} onChange={setRootGroup} />
+          <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
+        </AssertionsDndContext>
         <CodeBlock language="javascript">{JSON.stringify(rootGroup, null, 2)}</CodeBlock>
       </Fragment>
     );

--- a/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
@@ -5,7 +5,6 @@ import {Stack} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
 import type {
-  AndOp,
   HeaderCheckOp,
   JsonPathOp,
   LogicalOp,
@@ -13,7 +12,6 @@ import type {
 } from 'sentry/views/alerts/rules/uptime/types';
 
 import {AddOpButton} from './addOpButton';
-import {AssertionsDndContext, DropHandler} from './dragDrop';
 import {AssertionOpGroup} from './opGroup';
 import {AssertionOpHeader} from './opHeader';
 import {AssertionOpJsonPath} from './opJsonPath';
@@ -501,7 +499,7 @@ export default Storybook.story('Uptime Assertions', story => {
   });
 
   story('Drag and Drop - Reordering', () => {
-    const [rootGroup, setRootGroup] = useState<AndOp>({
+    const [rootGroup, setRootGroup] = useState<LogicalOp>({
       id: 'story-dnd-1',
       op: 'and',
       children: [
@@ -534,17 +532,14 @@ export default Storybook.story('Uptime Assertions', story => {
           <strong>grip handle</strong> (⠿) next to each assertion label to reorder them.
           The tree structure updates in real-time as items are dragged.
         </p>
-        <AssertionsDndContext>
-          <DropHandler rootOp={rootGroup} onChange={setRootGroup} />
-          <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
-        </AssertionsDndContext>
+        <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
         <CodeBlock language="javascript">{JSON.stringify(rootGroup, null, 2)}</CodeBlock>
       </Fragment>
     );
   });
 
   story('Drag and Drop - Between Groups', () => {
-    const [rootGroup, setRootGroup] = useState<AndOp>({
+    const [rootGroup, setRootGroup] = useState<LogicalOp>({
       id: 'story-dnd-2',
       op: 'and',
       children: [
@@ -588,10 +583,7 @@ export default Storybook.story('Uptime Assertions', story => {
           into the nested "Assert Any" group, or drag items out of the group to the root
           level. You can also drag items into empty groups.
         </p>
-        <AssertionsDndContext>
-          <DropHandler rootOp={rootGroup} onChange={setRootGroup} />
-          <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
-        </AssertionsDndContext>
+        <AssertionOpGroup value={rootGroup} onChange={setRootGroup} root />
         <CodeBlock language="javascript">{JSON.stringify(rootGroup, null, 2)}</CodeBlock>
       </Fragment>
     );

--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -16,13 +16,12 @@ interface AnimatedOpProps
   extends MotionProps,
     Omit<React.HTMLAttributes<HTMLDivElement>, keyof MotionProps> {
   children: React.ReactNode;
+  isDragging: boolean;
   op: Op;
   ref: React.Ref<HTMLDivElement>;
 }
 
-export function AnimatedOp({op, ...props}: AnimatedOpProps) {
-  const {isDragging} = useDraggable({id: op.id});
-
+export function AnimatedOp({op, isDragging, ...props}: AnimatedOpProps) {
   useEffect(() => {
     document.body.style.cursor = isDragging ? 'grabbing' : '';
     return () => {
@@ -57,15 +56,16 @@ export function OpContainer({
   inputId,
   op,
 }: OpContainerProps) {
-  const {attributes, setNodeRef, setActivatorNodeRef, listeners} = useDraggable({
-    id: op.id,
-    data: op,
-  });
+  const {attributes, setNodeRef, setActivatorNodeRef, listeners, isDragging} =
+    useDraggable({
+      id: op.id,
+      data: op,
+    });
 
   return (
     <Flex direction="column" gap="sm">
       {flexProps => (
-        <AnimatedOp op={op} ref={setNodeRef} {...flexProps}>
+        <AnimatedOp op={op} isDragging={isDragging} ref={setNodeRef} {...flexProps}>
           <Flex gap="xs" align="center">
             <Text size="sm" bold>
               <label htmlFor={inputId}>{label}</label>

--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -1,47 +1,97 @@
+import {useEffect} from 'react';
+import {useDraggable} from '@dnd-kit/core';
+import {motion, type MotionProps} from 'framer-motion';
+
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {IconDelete} from 'sentry/icons';
+import {IconDelete, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Comparison} from 'sentry/views/alerts/rules/uptime/types';
+import type {Comparison, Op} from 'sentry/views/alerts/rules/uptime/types';
+
+interface AnimatedOpProps
+  extends MotionProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, keyof MotionProps> {
+  children: React.ReactNode;
+  op: Op;
+  ref: React.Ref<HTMLDivElement>;
+}
+
+export function AnimatedOp({op, ...props}: AnimatedOpProps) {
+  const {isDragging} = useDraggable({id: op.id});
+
+  useEffect(() => {
+    document.body.style.cursor = isDragging ? 'grabbing' : '';
+  }, [isDragging]);
+
+  return (
+    <motion.div
+      layout="position"
+      layoutId={op.id}
+      transition={{duration: 0.15}}
+      animate={{opacity: isDragging ? 0.5 : 1}}
+      {...props}
+    />
+  );
+}
 
 interface OpContainerProps {
   children: React.ReactNode;
   label: React.ReactNode;
   onRemove: () => void;
+  op: Op;
   inputId?: string;
   tooltip?: React.ReactNode;
 }
-
 export function OpContainer({
   label,
   children,
   tooltip,
   onRemove,
   inputId,
+  op,
 }: OpContainerProps) {
+  const {attributes, setNodeRef, setActivatorNodeRef, listeners} = useDraggable({
+    id: op.id,
+    data: op,
+  });
+
   return (
-    <Stack gap="sm">
-      <Flex gap="xs" align="center">
-        <Text size="sm" bold>
-          <label htmlFor={inputId}>{label}</label>
-        </Text>
-        {tooltip && <QuestionTooltip size="xs" title={tooltip} isHoverable />}
-      </Flex>
-      <Grid columns="1fr max-content" align="center" gap="sm">
-        {children}
-        <Button
-          size="sm"
-          borderless
-          icon={<IconDelete />}
-          aria-label={t('Remove assertion')}
-          onClick={onRemove}
-        />
-      </Grid>
-    </Stack>
+    <Flex direction="column" gap="sm">
+      {flexProps => (
+        <AnimatedOp op={op} ref={setNodeRef} {...flexProps}>
+          <Flex gap="xs" align="center">
+            <Text size="sm" bold>
+              <label htmlFor={inputId}>{label}</label>
+            </Text>
+            <Button
+              size="zero"
+              borderless
+              icon={<IconGrabbable size="xs" />}
+              aria-label={t('Reorder assertion')}
+              ref={setActivatorNodeRef}
+              style={{cursor: 'grab'}}
+              {...listeners}
+              {...attributes}
+            />
+            {tooltip && <QuestionTooltip size="xs" title={tooltip} isHoverable />}
+          </Flex>
+          <Grid columns="1fr max-content" align="center" gap="sm">
+            {children}
+            <Button
+              size="sm"
+              borderless
+              icon={<IconDelete />}
+              aria-label={t('Remove assertion')}
+              onClick={onRemove}
+            />
+          </Grid>
+        </AnimatedOp>
+      )}
+    </Flex>
   );
 }
 

--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {useDraggable} from '@dnd-kit/core';
 import {motion, type MotionProps} from 'framer-motion';
 
@@ -22,10 +22,20 @@ interface AnimatedOpProps
 }
 
 export function AnimatedOp({op, isDragging, ...props}: AnimatedOpProps) {
+  const wasDraggingRef = useRef(false);
+
   useEffect(() => {
-    document.body.style.cursor = isDragging ? 'grabbing' : '';
-    return () => {
+    if (isDragging) {
+      document.body.style.cursor = 'grabbing';
+      wasDraggingRef.current = true;
+    } else if (wasDraggingRef.current) {
       document.body.style.cursor = '';
+      wasDraggingRef.current = false;
+    }
+    return () => {
+      if (wasDraggingRef.current) {
+        document.body.style.cursor = '';
+      }
     };
   }, [isDragging]);
 

--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -25,6 +25,9 @@ export function AnimatedOp({op, ...props}: AnimatedOpProps) {
 
   useEffect(() => {
     document.body.style.cursor = isDragging ? 'grabbing' : '';
+    return () => {
+      document.body.style.cursor = '';
+    };
   }, [isDragging]);
 
   return (

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Container, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
 import {type SelectOption} from 'sentry/components/core/compactSelect';
 import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
@@ -236,13 +237,16 @@ export function AssertionOpGroup({
       </GroupHeading>
       <Stack gap="md">
         {isEmptyGroup && (
-          <DroppableHitbox
-            op={groupOp}
-            groupId={groupOp.id}
-            idIndex={-1}
-            position="inside"
-            disabled={innerDroppableDisabled}
-          />
+          <Container position="relative">
+            <DroppableHitbox
+              op={groupOp}
+              groupId={groupOp.id}
+              idIndex={-1}
+              position="inside"
+              disabled={innerDroppableDisabled}
+            />
+            <Text size="xs">{t('Empty assertion group')}</Text>
+          </Container>
         )}
         {opList}
         <Container paddingTop="md">
@@ -252,6 +256,8 @@ export function AssertionOpGroup({
               borderless: true,
               size: 'zero',
               icon: <IconAdd size="xs" />,
+              title: t('Add assertion to group'),
+              'aria-label': t('Add assertion to group'),
             }}
             triggerLabel={t('Add Assertion')}
             onAddOp={handleAddOp}

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -54,7 +54,11 @@ export function AssertionOpGroup({
       : value.operand
     : value;
 
-  const [notId] = useState(() => uniqueId());
+  // Generate a stable ID for new negations only (when toggling from non-negated to negated)
+  const [newNotId] = useState(() => uniqueId());
+
+  // Use existing value.id when already negated, or the generated ID for new negations
+  const notId = isNegated ? value.id : newNotId;
 
   const handleAddOp = (newOp: Op) => {
     const newGroupOp: GroupOp = {
@@ -86,7 +90,7 @@ export function AssertionOpGroup({
   };
 
   const handleNegationToggle = (negated: boolean) => {
-    onChange(negated ? {id: notId, op: 'not', operand: groupOp} : groupOp);
+    onChange(negated ? {id: newNotId, op: 'not', operand: groupOp} : groupOp);
   };
 
   // Generate label based on negation and group type

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -190,7 +190,7 @@ export function AssertionOpGroup({
   const isEmptyGroup = groupOp.children.length === 0;
 
   return (
-    <GroupContainer op={groupOp} role="group" ref={setNodeRef}>
+    <GroupContainer op={groupOp} isDragging={isDragging} role="group" ref={setNodeRef}>
       <GroupHeading>
         <CompositeSelect
           size="xs"

--- a/static/app/views/alerts/rules/uptime/assertions/opHeader.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opHeader.spec.tsx
@@ -2,6 +2,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {HeaderCheckOp} from 'sentry/views/alerts/rules/uptime/types';
 
+import {AssertionsDndContext} from './dragDrop';
 import {AssertionOpHeader} from './opHeader';
 
 describe('AssertionOpHeader', () => {
@@ -280,5 +281,27 @@ describe('AssertionOpHeader', () => {
       value_op: {cmp: 'always'},
       value_operand: {header_op: 'none'},
     });
+  });
+
+  it('renders drag handle for reordering', async () => {
+    render(
+      <AssertionsDndContext>
+        <AssertionOpHeader
+          value={{
+            id: 'test-id-1',
+            op,
+            key_op: {cmp: 'equals'},
+            key_operand: {header_op: 'literal', value: 'Content-Type'},
+            value_op: {cmp: 'equals'},
+            value_operand: {header_op: 'literal', value: 'application/json'},
+          }}
+          onChange={mockOnChange}
+          onRemove={mockOnRemove}
+        />
+      </AssertionsDndContext>
+    );
+
+    await screen.findByLabelText('Header');
+    expect(screen.getByRole('button', {name: 'Reorder assertion'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/opHeader.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opHeader.tsx
@@ -232,7 +232,7 @@ export function AssertionOpHeader({value, onChange, onRemove}: AssertionOpHeader
   );
 
   return (
-    <OpContainer label={t('Header')} onRemove={onRemove} inputId={inputId}>
+    <OpContainer label={t('Header')} onRemove={onRemove} inputId={inputId} op={value}>
       <Flex gap="sm" align="center" width="100%">
         {keyInput}
         {showValueInput && valueInput}

--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
@@ -2,6 +2,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {JsonPathOp} from 'sentry/views/alerts/rules/uptime/types';
 
+import {AssertionsDndContext} from './dragDrop';
 import {AssertionOpJsonPath} from './opJsonPath';
 
 describe('AssertionOpJsonPath', () => {
@@ -74,5 +75,19 @@ describe('AssertionOpJsonPath', () => {
     const link = await screen.findByRole('link', {name: 'JSON Path RFC'});
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://www.rfc-editor.org/rfc/rfc9535.html');
+  });
+
+  it('renders drag handle for reordering', () => {
+    render(
+      <AssertionsDndContext>
+        <AssertionOpJsonPath
+          value={{id: 'test-id-1', op, value: '$.data.status'}}
+          onChange={mockOnChange}
+          onRemove={mockOnRemove}
+        />
+      </AssertionsDndContext>
+    );
+
+    expect(screen.getByRole('button', {name: 'Reorder assertion'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
@@ -31,6 +31,7 @@ export function AssertionOpJsonPath({
           link: <ExternalLink href="https://www.rfc-editor.org/rfc/rfc9535.html" />,
         }
       )}
+      op={value}
     >
       <Input
         id={inputId}

--- a/static/app/views/alerts/rules/uptime/assertions/opStatusCode.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opStatusCode.spec.tsx
@@ -4,6 +4,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {StatusCodeOp} from 'sentry/views/alerts/rules/uptime/types';
 
+import {AssertionsDndContext} from './dragDrop';
 import {AssertionOpStatusCode} from './opStatusCode';
 
 describe('AssertionOpStatusCode', () => {
@@ -295,5 +296,20 @@ describe('AssertionOpStatusCode', () => {
       operator: {cmp: 'greater_than'},
       value: 200, // Original value preserved
     });
+  });
+
+  it('renders drag handle for reordering', async () => {
+    render(
+      <AssertionsDndContext>
+        <AssertionOpStatusCode
+          value={{id: 'test-id-1', op, operator: {cmp: 'equals'}, value: 200}}
+          onChange={mockOnChange}
+          onRemove={mockOnRemove}
+        />
+      </AssertionsDndContext>
+    );
+
+    await screen.findByLabelText('Status Code');
+    expect(screen.getByRole('button', {name: 'Reorder assertion'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/opStatusCode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opStatusCode.tsx
@@ -58,7 +58,12 @@ export function AssertionOpStatusCode({
   };
 
   return (
-    <OpContainer label={t('Status Code')} onRemove={onRemove} inputId={inputId}>
+    <OpContainer
+      label={t('Status Code')}
+      onRemove={onRemove}
+      inputId={inputId}
+      op={value}
+    >
       <InputGroup>
         <InputGroup.LeadingItems>
           <CompactSelect

--- a/static/app/views/alerts/rules/uptime/assertions/utils.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.spec.tsx
@@ -1,0 +1,669 @@
+import type {
+  AndOp,
+  NotOp,
+  OrOp,
+  StatusCodeOp,
+} from 'sentry/views/alerts/rules/uptime/types';
+
+import {moveTo} from './utils';
+
+describe('moveTo', () => {
+  it('moves op to after another op in the same parent', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+        {
+          id: 'status-3',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 202,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'status-3', 'after');
+
+    expect(result.children.map(c => c.id)).toEqual(['status-2', 'status-3', 'status-1']);
+  });
+
+  it('moves op to before another op in the same parent', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+        {
+          id: 'status-3',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 202,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-3', 'status-1', 'before');
+
+    expect(result.children.map(c => c.id)).toEqual(['status-3', 'status-1', 'status-2']);
+  });
+
+  it('moves op to before the first element', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+        {
+          id: 'status-3',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 202,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-3', 'status-1', 'before');
+
+    expect(result.children.map(c => c.id)).toEqual(['status-3', 'status-1', 'status-2']);
+  });
+
+  it('moves op to after the last element', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+        {
+          id: 'status-3',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 202,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'status-3', 'after');
+
+    expect(result.children.map(c => c.id)).toEqual(['status-2', 'status-3', 'status-1']);
+  });
+
+  it('moves op from nested group to root level', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-2',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 201,
+            },
+            {
+              id: 'status-3',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 202,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-2', 'status-1', 'after');
+
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-2', 'or-1']);
+    // Verify the nested group still has status-3
+    const orOp = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-3']);
+  });
+
+  it('moves op from root to nested group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-2',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 201,
+            },
+            {
+              id: 'status-3',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 202,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'status-2', 'before');
+
+    expect(result.children.map(c => c.id)).toEqual(['or-1']);
+    // Verify status-1 is now in the nested group
+    const orOp = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-1', 'status-2', 'status-3']);
+  });
+
+  it('moves op within a nested group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-2',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 201,
+            },
+            {
+              id: 'status-3',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 202,
+            },
+            {
+              id: 'status-4',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 203,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-4', 'status-2', 'before');
+
+    const orOp = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-4', 'status-2', 'status-3']);
+  });
+
+  it('returns unchanged tree if source not found', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'nonexistent', 'status-1', 'after');
+
+    expect(result).toBe(rootOp);
+  });
+
+  it('returns unchanged tree if target not found', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'nonexistent', 'after');
+
+    expect(result).toBe(rootOp);
+  });
+
+  it('preserves op data when moving', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'less_than'},
+          value: 400,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'status-2', 'after');
+
+    const movedOp = result.children.find(c => c.id === 'status-1') as StatusCodeOp;
+    expect(movedOp.operator).toEqual({cmp: 'less_than'});
+    expect(movedOp.value).toBe(400);
+  });
+
+  it('handles two ops: move last before first, then back after first', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Move status-2 before status-1
+    const afterFirstMove = moveTo(rootOp, 'status-2', 'status-1', 'before');
+    expect(afterFirstMove.children.map(c => c.id)).toEqual(['status-2', 'status-1']);
+
+    // Move status-2 back after status-1 (should return to original order)
+    const afterSecondMove = moveTo(afterFirstMove, 'status-2', 'status-1', 'after');
+    expect(afterSecondMove.children.map(c => c.id)).toEqual(['status-1', 'status-2']);
+  });
+
+  it('handles multiple consecutive moves', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+        {
+          id: 'status-3',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 202,
+        },
+      ],
+    };
+
+    // Move 3 before 1
+    let result = moveTo(rootOp, 'status-3', 'status-1', 'before');
+    expect(result.children.map(c => c.id)).toEqual(['status-3', 'status-1', 'status-2']);
+
+    // Move 3 after 1
+    result = moveTo(result, 'status-3', 'status-1', 'after');
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-3', 'status-2']);
+
+    // Move 3 after 2
+    result = moveTo(result, 'status-3', 'status-2', 'after');
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-2', 'status-3']);
+  });
+
+  it('does not create duplicate ops when moving rapidly', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Simulate rapid drag events
+    let result = moveTo(rootOp, 'status-2', 'status-1', 'before');
+    result = moveTo(result, 'status-2', 'status-1', 'before');
+    result = moveTo(result, 'status-2', 'status-1', 'after');
+
+    // Should have exactly 2 children, no duplicates
+    expect(result.children).toHaveLength(2);
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-2']);
+  });
+
+  it('handles moving an op to where it already is (no-op move)', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Try to move status-1 before status-2 (it's already before status-2)
+    const result = moveTo(rootOp, 'status-1', 'status-2', 'before');
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-2']);
+    expect(result.children).toHaveLength(2);
+  });
+
+  it('verifies no duplicate IDs after complex moves', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Move back and forth multiple times
+    let result = moveTo(rootOp, 'status-2', 'status-1', 'before');
+    result = moveTo(result, 'status-2', 'status-1', 'after');
+    result = moveTo(result, 'status-1', 'status-2', 'before');
+
+    // Collect all IDs and check for duplicates
+    const ids = result.children.map(c => c.id);
+    const uniqueIds = new Set(ids);
+    expect(ids).toHaveLength(uniqueIds.size);
+    expect(result.children).toHaveLength(2);
+  });
+
+  it('handles moving to same position (status-1 after status-1 should do nothing)', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Try to move status-2 after status-1 (it's already after status-1)
+    const result = moveTo(rootOp, 'status-2', 'status-1', 'after');
+    expect(result.children.map(c => c.id)).toEqual(['status-1', 'status-2']);
+    expect(result.children).toHaveLength(2);
+  });
+
+  it('moves op inside an empty group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'or-1', 'inside');
+
+    // Root should only have the or group now
+    expect(result.children.map(c => c.id)).toEqual(['or-1']);
+    // The or group should now contain status-1
+    const orOp = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-1']);
+  });
+
+  it('moves op inside an empty not group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'not-1',
+          op: 'not',
+          operand: {
+            id: 'or-1',
+            op: 'or',
+            children: [],
+          },
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'or-1', 'inside');
+
+    // Root should only have the not group now
+    expect(result.children.map(c => c.id)).toEqual(['not-1']);
+    // The not's operand (or group) should now contain status-1
+    const notOp = result.children.find(c => c.id === 'not-1') as NotOp;
+    const orOp = notOp.operand as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-1']);
+  });
+
+  it('moves op inside a non-empty group (appends to end)', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-2',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 201,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'or-1', 'inside');
+
+    // Root should only have the or group now
+    expect(result.children.map(c => c.id)).toEqual(['or-1']);
+    // The or group should now contain both ops
+    const orOp = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(orOp.children.map(c => c.id)).toEqual(['status-2', 'status-1']);
+  });
+
+  it('returns unchanged tree if target for inside move is not a group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'status-1',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 200,
+        },
+        {
+          id: 'status-2',
+          op: 'status_code_check',
+          operator: {cmp: 'equals'},
+          value: 201,
+        },
+      ],
+    };
+
+    // Try to move inside a non-group op (should do nothing)
+    const result = moveTo(rootOp, 'status-1', 'status-2', 'inside');
+
+    expect(result).toBe(rootOp);
+  });
+
+  it('moves op from nested group inside another group', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-1',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 200,
+            },
+            {
+              id: 'status-2',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 201,
+            },
+          ],
+        },
+        {
+          id: 'or-2',
+          op: 'or',
+          children: [],
+        },
+      ],
+    };
+
+    const result = moveTo(rootOp, 'status-1', 'or-2', 'inside');
+
+    // or-1 should now have only status-2
+    const or1 = result.children.find(c => c.id === 'or-1') as OrOp;
+    expect(or1.children.map(c => c.id)).toEqual(['status-2']);
+
+    // or-2 should now contain status-1
+    const or2 = result.children.find(c => c.id === 'or-2') as OrOp;
+    expect(or2.children.map(c => c.id)).toEqual(['status-1']);
+  });
+});

--- a/static/app/views/alerts/rules/uptime/assertions/utils.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.spec.tsx
@@ -625,6 +625,50 @@ describe('moveTo', () => {
     expect(result).toBe(rootOp);
   });
 
+  it('returns unchanged tree when moving parent into its own descendant', () => {
+    const rootOp: AndOp = {
+      id: 'and-1',
+      op: 'and',
+      children: [
+        {
+          id: 'or-1',
+          op: 'or',
+          children: [
+            {
+              id: 'status-1',
+              op: 'status_code_check',
+              operator: {cmp: 'equals'},
+              value: 200,
+            },
+            {
+              id: 'and-2',
+              op: 'and',
+              children: [
+                {
+                  id: 'status-2',
+                  op: 'status_code_check',
+                  operator: {cmp: 'equals'},
+                  value: 201,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Try to move or-1 inside its descendant and-2 (should do nothing)
+    const result = moveTo(rootOp, 'or-1', 'and-2', 'inside');
+    expect(result).toBe(rootOp);
+
+    // Also test before/after positions
+    const resultBefore = moveTo(rootOp, 'or-1', 'status-2', 'before');
+    expect(resultBefore).toBe(rootOp);
+
+    const resultAfter = moveTo(rootOp, 'or-1', 'status-2', 'after');
+    expect(resultAfter).toBe(rootOp);
+  });
+
   it('moves op from nested group inside another group', () => {
     const rootOp: AndOp = {
       id: 'and-1',

--- a/static/app/views/alerts/rules/uptime/assertions/utils.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.tsx
@@ -1,0 +1,161 @@
+import type {GroupOp, Op} from 'sentry/views/alerts/rules/uptime/types';
+
+/**
+ * Checks if one op is directly after another op in a container's children array.
+ *
+ * @param containerOp - The op to search within (must be a logical group with children)
+ * @param opId - The ID of the op to check
+ * @param afterOpId - The ID of the op that should come before
+ * @returns true if opId is directly after afterOpId in the container's children, false otherwise
+ */
+export function isAfterOp(containerOp: Op, opId: string, afterOpId: string): boolean {
+  // Only group ops have children where one can be after another
+  if (containerOp.op === 'and' || containerOp.op === 'or') {
+    for (let i = 0; i < containerOp.children.length - 1; i++) {
+      if (containerOp.children[i]?.id === afterOpId) {
+        return containerOp.children[i + 1]?.id === opId;
+      }
+    }
+  }
+
+  // Also check recursively in nested groups
+  if (containerOp.op === 'and' || containerOp.op === 'or') {
+    return containerOp.children.some(child => isAfterOp(child, opId, afterOpId));
+  }
+
+  // Check in not operand
+  if (containerOp.op === 'not') {
+    return isAfterOp(containerOp.operand, opId, afterOpId);
+  }
+
+  return false;
+}
+
+/**
+ * Finds an op by ID in the op tree and returns it along with its parent.
+ *
+ * @param op - The op tree to search in
+ * @param id - The ID of the op to find
+ * @returns An object with the found op and its parent GroupOp, or null if not found
+ */
+function findOpById(op: Op, id: string): {op: Op; parent: GroupOp | null} | null {
+  // Helper function for recursive search
+  const search = (
+    currentOp: Op,
+    parentOp: GroupOp | null
+  ): {op: Op; parent: GroupOp | null} | null => {
+    if (currentOp.id === id) {
+      return {op: currentOp, parent: parentOp};
+    }
+
+    if (currentOp.op === 'and' || currentOp.op === 'or') {
+      for (const child of currentOp.children) {
+        const found = search(child, currentOp);
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    if (currentOp.op === 'not') {
+      // For 'not' ops, check if the operand is a group op to use as parent
+      if (currentOp.operand.op === 'and' || currentOp.operand.op === 'or') {
+        return search(currentOp.operand, currentOp.operand);
+      }
+      return search(currentOp.operand, parentOp);
+    }
+
+    return null;
+  };
+
+  return search(op, null);
+}
+
+/**
+ * Moves an op from its current position to before, after, or inside a target op.
+ *
+ * @param rootOp - The root logical op tree
+ * @param sourceId - The ID of the op to move
+ * @param targetId - The ID of the op to use as reference
+ * @param position - Whether to place the source 'before', 'after', or 'inside' the target
+ * @returns A new root logical op tree with the source moved to the new position
+ */
+export function moveTo(
+  rootOp: GroupOp,
+  sourceId: string,
+  targetId: string,
+  position: 'before' | 'after' | 'inside'
+): GroupOp {
+  // First, find and extract the source op
+  const sourceResult = findOpById(rootOp, sourceId);
+  if (!sourceResult) {
+    return rootOp;
+  }
+
+  const {op: sourceOp} = sourceResult;
+
+  // Find the target to determine where to insert
+  const targetResult = findOpById(rootOp, targetId);
+  if (!targetResult) {
+    return rootOp;
+  }
+
+  // For 'inside' position, target must be a group op and doesn't need a parent
+  if (position === 'inside') {
+    const {op: targetOp} = targetResult;
+    if (targetOp.op !== 'and' && targetOp.op !== 'or') {
+      return rootOp; // Can only move inside group ops
+    }
+  } else {
+    // For 'before' and 'after', target must have a parent
+    if (!targetResult.parent) {
+      return rootOp; // Target not found or has no parent, return unchanged
+    }
+  }
+
+  // Remove the source op from its current location
+  const removeOp = (op: Op): Op => {
+    if (op.op === 'and' || op.op === 'or') {
+      const newChildren = op.children
+        .filter(child => child.id !== sourceId)
+        .map(child => removeOp(child));
+      return {...op, children: newChildren};
+    }
+    if (op.op === 'not') {
+      return {...op, operand: removeOp(op.operand)};
+    }
+    return op;
+  };
+
+  // Insert the source op at the target location
+  const insertOp = (op: Op): Op => {
+    if (op.op === 'and' || op.op === 'or') {
+      // Check if we should insert inside this group
+      if (position === 'inside' && op.id === targetId) {
+        // Append to the end of this group's children
+        return {...op, children: [...op.children, sourceOp]};
+      }
+
+      // Check if target is a direct child for before/after positioning
+      const targetIndex = op.children.findIndex(child => child.id === targetId);
+      if (targetIndex !== -1 && position !== 'inside') {
+        // Found the target in this container
+        const newChildren = [...op.children];
+        const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
+        newChildren.splice(insertIndex, 0, sourceOp);
+        return {...op, children: newChildren};
+      }
+
+      // Target not in this container, recurse into children
+      return {...op, children: op.children.map(child => insertOp(child))};
+    }
+    if (op.op === 'not') {
+      return {...op, operand: insertOp(op.operand)};
+    }
+    return op;
+  };
+
+  // First remove, then insert
+  const withoutSource = removeOp(rootOp);
+  return insertOp(withoutSource) as GroupOp;
+}

--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -10,6 +10,8 @@ import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t, tct} from 'sentry/locale';
 import getDuration from 'sentry/utils/duration/getDuration';
+import useOrganization from 'sentry/utils/useOrganization';
+import {UptimeAssertionsField} from 'sentry/views/alerts/rules/uptime/assertions/field';
 import {HTTPSnippet} from 'sentry/views/alerts/rules/uptime/httpSnippet';
 import {UptimeHeadersField} from 'sentry/views/detectors/components/forms/uptime/detect/uptimeHeadersField';
 import {
@@ -59,6 +61,8 @@ function ConnectedHttpSnippet() {
 }
 
 export function UptimeDetectorFormDetectSection() {
+  const org = useOrganization();
+
   return (
     <Container>
       <Section title={t('Detect')}>
@@ -141,6 +145,16 @@ export function UptimeDetectorFormDetectSection() {
             placeholder='{"key": "value"}'
             flexibleControlStateSize
           />
+          {org.features.includes('uptime-runtime-assertions') && (
+            <UptimeAssertionsField
+              name="assertions"
+              label={t('Assertions')}
+              help={t(
+                'Define conditions that must be met for the check to be considered successful.'
+              )}
+              flexibleControlStateSize
+            />
+          )}
           <BooleanField
             name="traceSampling"
             label={t('Allow Sampling')}

--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -10,8 +10,6 @@ import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t, tct} from 'sentry/locale';
 import getDuration from 'sentry/utils/duration/getDuration';
-import useOrganization from 'sentry/utils/useOrganization';
-import {UptimeAssertionsField} from 'sentry/views/alerts/rules/uptime/assertions/field';
 import {HTTPSnippet} from 'sentry/views/alerts/rules/uptime/httpSnippet';
 import {UptimeHeadersField} from 'sentry/views/detectors/components/forms/uptime/detect/uptimeHeadersField';
 import {
@@ -61,8 +59,6 @@ function ConnectedHttpSnippet() {
 }
 
 export function UptimeDetectorFormDetectSection() {
-  const org = useOrganization();
-
   return (
     <Container>
       <Section title={t('Detect')}>
@@ -145,16 +141,6 @@ export function UptimeDetectorFormDetectSection() {
             placeholder='{"key": "value"}'
             flexibleControlStateSize
           />
-          {org.features.includes('uptime-runtime-assertions') && (
-            <UptimeAssertionsField
-              name="assertion"
-              label={t('Assertions')}
-              help={t(
-                'Define conditions that must be met for the check to be considered successful.'
-              )}
-              flexibleControlStateSize
-            />
-          )}
           <BooleanField
             name="traceSampling"
             label={t('Allow Sampling')}

--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -147,7 +147,7 @@ export function UptimeDetectorFormDetectSection() {
           />
           {org.features.includes('uptime-runtime-assertions') && (
             <UptimeAssertionsField
-              name="assertions"
+              name="assertion"
               label={t('Assertions')}
               help={t(
                 'Define conditions that must be met for the check to be considered successful.'


### PR DESCRIPTION
Implements drag-and-drop functionality for uptime assertion operations, allowing users to reorder assertions and move them between groups.

Still missing tests