### PR TITLE
perf(issues): Fix N+1 query on repository in get_sorted_code_mapping_configs

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -378,8 +378,12 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
     # sure that we are still ordering by `id` because we want to make sure
     # the ordering is deterministic
     # codepath mappings must have an associated integration for stacktrace linking.
-    configs = RepositoryProjectPathConfig.objects.filter(
-        project=project, organization_integration_id__isnull=False
+    configs = (
+        RepositoryProjectPathConfig.objects.filter(
+            project=project, organization_integration_id__isnull=False
+        )
+        .select_related("repository")
+        .order_by("id")
     )
 
     sorted_configs: list[RepositoryProjectPathConfig] = []


### PR DESCRIPTION
Add select_related("repository") to the RepositoryProjectPathConfig query. 

- GroupAutofixEndpoint._get_legacy - iterates over code mappings and accesses mapping.repository.external_id
- ProjectSeerPreferencesEndpoint.get - calls get_autofix_repos_from_project_code_mappings (seer/autofix/utils.py:319) which accesses code_mapping.repository.name, .provider, .external_id
- ProjectStacktraceLinkEndpoint.get - calls get_stacktrace_config (integrations/utils/stacktrace_link.py:112) which accesses config.repository in the loop and passes it to get_link for install.get_stacktrace_link()
- process_commit_context task - calls find_commit_context_for_event_all_frames → _generate_integration_to_files_mapping (integrations/utils/commit_context.py:255) which accesses code_mapping.repository

n+1 issues  
https://sentry.sentry.io/issues/6218481153/
https://sentry.sentry.io/issues/6866977334/
https://sentry.sentry.io/issues/6834551736/