### PR TITLE
fix(insights): Fix user misery bar chart

### DIFF
--- a/static/app/components/scoreBar.tsx
+++ b/static/app/components/scoreBar.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {SIMILARITY_SCORE_COLORS} from './similarScoreCard';
@@ -55,9 +56,13 @@ const ScoreBar = styled(BaseScoreBar)`
 
   ${p =>
     p.vertical
-      ? `flex-direction: column-reverse;
-    justify-content: flex-end;`
-      : 'min-width: 80px;'};
+      ? css`
+          flex-direction: column-reverse;
+          justify-content: flex-end;
+        `
+      : css`
+          min-width: 80px;
+        `};
 `;
 
 type BarProps = {

--- a/static/app/components/userMisery.tsx
+++ b/static/app/components/userMisery.tsx
@@ -24,7 +24,7 @@ function UserMisery(props: Props) {
   // 0 User Misery while still preserving the actual value for sorting purposes.
   const adjustedMisery = userMisery > 0.05 ? userMisery : 0;
 
-  const palette = new Array(bars).fill(colors[0][0]);
+  const palette = new Array(bars).fill(colors[0]);
   const score = Math.round(adjustedMisery * palette.length);
 
   let title: React.ReactNode;


### PR DESCRIPTION
All colors in the array were [0] which is just the '#' of the hex color

<img width="386" height="136" alt="image" src="https://github.com/user-attachments/assets/56e27407-01c7-498c-86fc-a4f1a2fa1655" />
