### PR TITLE
chore(preprod): add log when artifact is updated

### DIFF
--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -53,9 +53,9 @@ class PreprodArtifactEndpoint(ProjectEndpoint):
             return args, kwargs
 
         try:
-            head_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-                id=int(head_artifact_id)
-            )
+            head_artifact = PreprodArtifact.objects.select_related(
+                "mobile_app_info", "build_configuration"
+            ).get(id=int(head_artifact_id))
         except (PreprodArtifact.DoesNotExist, ValueError):
             raise HeadPreprodArtifactResourceDoesNotExist
         else:
@@ -69,9 +69,9 @@ class PreprodArtifactEndpoint(ProjectEndpoint):
             return args, kwargs
 
         try:
-            base_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-                id=int(base_artifact_id)
-            )
+            base_artifact = PreprodArtifact.objects.select_related(
+                "mobile_app_info", "build_configuration"
+            ).get(id=int(base_artifact_id))
         except (PreprodArtifact.DoesNotExist, ValueError):
             raise BasePreprodArtifactResourceDoesNotExist
         else:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -358,6 +358,19 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
 
             head_artifact.save(update_fields=updated_fields + ["date_updated"])
 
+            logger.info(
+                "preprod.artifact.processed",
+                extra={
+                    "preprod_artifact_id": head_artifact.id,
+                    "artifact_type": head_artifact.artifact_type,
+                    "app_id": head_artifact.app_id,
+                    "build_configuration": head_artifact.build_configuration.name if head_artifact.build_configuration else None,
+                    "project_id": project.id,
+                    "organization_id": project.organization_id,
+                    "organization_slug": project.organization.slug,
+                },
+            )
+
             create_preprod_status_check_task.apply_async(
                 kwargs={
                     "preprod_artifact_id": artifact_id_int,

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -364,7 +364,11 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                     "preprod_artifact_id": head_artifact.id,
                     "artifact_type": head_artifact.artifact_type,
                     "app_id": head_artifact.app_id,
-                    "build_configuration": head_artifact.build_configuration.name if head_artifact.build_configuration else None,
+                    "build_configuration": (
+                        head_artifact.build_configuration.name
+                        if head_artifact.build_configuration
+                        else None
+                    ),
                     "project_id": project.id,
                     "organization_id": project.organization_id,
                     "organization_slug": project.organization.slug,


### PR DESCRIPTION
We want to build a dashboard with a more detailed breakdown of uploads, like which platform, etc. We currently send a log statement after the artifact model is created but we only get this info after our quick preprocessing step.