### PR TITLE
ref(grouping): Reorganize fingerprinting helpers and types

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -17,14 +17,14 @@ from sentry.grouping.enhancer import (
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting.types import FingerprintInfo
-from sentry.grouping.fingerprinting.utils import get_fingerprint_type, is_default_fingerprint_var
-from sentry.grouping.strategies.base import GroupingContext
-from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
-from sentry.grouping.utils import (
-    expand_title_template,
-    hash_from_values,
+from sentry.grouping.fingerprinting.utils import (
+    get_fingerprint_type,
+    is_default_fingerprint_var,
     resolve_fingerprint_values,
 )
+from sentry.grouping.strategies.base import GroupingContext
+from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
+from sentry.grouping.utils import expand_title_template, hash_from_values
 from sentry.grouping.variants import (
     BaseVariant,
     ChecksumVariant,

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -17,12 +17,11 @@ from sentry.grouping.enhancer import (
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting.types import FingerprintInfo
-from sentry.grouping.fingerprinting.utils import is_default_fingerprint_var
+from sentry.grouping.fingerprinting.utils import get_fingerprint_type, is_default_fingerprint_var
 from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
 from sentry.grouping.utils import (
     expand_title_template,
-    get_fingerprint_type,
     hash_from_values,
     resolve_fingerprint_values,
 )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -17,13 +17,13 @@ from sentry.grouping.enhancer import (
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting.types import FingerprintInfo
+from sentry.grouping.fingerprinting.utils import is_default_fingerprint_var
 from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
 from sentry.grouping.utils import (
     expand_title_template,
     get_fingerprint_type,
     hash_from_values,
-    is_default_fingerprint_var,
     resolve_fingerprint_values,
 )
 from sentry.grouping.variants import (

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -18,13 +18,14 @@ from sentry.grouping.enhancer import (
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting.types import FingerprintInfo
 from sentry.grouping.fingerprinting.utils import (
+    expand_title_template,
     get_fingerprint_type,
     is_default_fingerprint_var,
     resolve_fingerprint_values,
 )
 from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
-from sentry.grouping.utils import expand_title_template, hash_from_values
+from sentry.grouping.utils import hash_from_values
 from sentry.grouping.variants import (
     BaseVariant,
     ChecksumVariant,

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -16,6 +16,7 @@ from sentry.grouping.enhancer import (
     get_enhancements_version,
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
+from sentry.grouping.fingerprinting.types import FingerprintRuleJSON
 from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
 from sentry.grouping.utils import (
@@ -42,7 +43,6 @@ from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.fingerprinting import FingerprintingConfig
-    from sentry.grouping.fingerprinting.rules import FingerprintRuleJSON
     from sentry.grouping.strategies.base import StrategyConfiguration
     from sentry.models.project import Project
     from sentry.services.eventstore.models import Event

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import sentry_sdk
 
@@ -16,7 +16,7 @@ from sentry.grouping.enhancer import (
     get_enhancements_version,
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
-from sentry.grouping.fingerprinting.types import FingerprintRuleJSON
+from sentry.grouping.fingerprinting.types import FingerprintInfo
 from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
 from sentry.grouping.utils import (
@@ -48,11 +48,6 @@ if TYPE_CHECKING:
     from sentry.services.eventstore.models import Event
 
 HASH_RE = re.compile(r"^[0-9a-f]{32}$")
-
-
-class FingerprintInfo(TypedDict):
-    client_fingerprint: NotRequired[list[str]]
-    matched_rule: NotRequired[FingerprintRuleJSON]
 
 
 @dataclass

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -10,7 +10,8 @@ from parsimonious.exceptions import ParseError
 
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.grouping.fingerprinting.parser import FingerprintingVisitor, fingerprinting_grammar
-from sentry.grouping.fingerprinting.rules import FingerprintRule, FingerprintRuleMatch
+from sentry.grouping.fingerprinting.rules import FingerprintRule
+from sentry.grouping.fingerprinting.types import FingerprintRuleMatch
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/grouping/fingerprinting/parser.py
+++ b/src/sentry/grouping/fingerprinting/parser.py
@@ -8,11 +8,8 @@ from parsimonious.nodes import Node, NodeVisitor, RegexNode
 
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
-from sentry.grouping.fingerprinting.rules import (
-    FingerprintRule,
-    FingerprintRuleAttributes,
-    FingerprintWithAttributes,
-)
+from sentry.grouping.fingerprinting.rules import FingerprintRule, FingerprintWithAttributes
+from sentry.grouping.fingerprinting.types import FingerprintRuleAttributes
 from sentry.grouping.utils import DEFAULT_FINGERPRINT_VARIABLE, is_default_fingerprint_var
 from sentry.utils.strings import unescape_string
 

--- a/src/sentry/grouping/fingerprinting/parser.py
+++ b/src/sentry/grouping/fingerprinting/parser.py
@@ -8,8 +8,11 @@ from parsimonious.nodes import Node, NodeVisitor, RegexNode
 
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
-from sentry.grouping.fingerprinting.rules import FingerprintRule, FingerprintWithAttributes
-from sentry.grouping.fingerprinting.types import FingerprintRuleAttributes
+from sentry.grouping.fingerprinting.rules import FingerprintRule
+from sentry.grouping.fingerprinting.types import (
+    FingerprintRuleAttributes,
+    FingerprintWithAttributes,
+)
 from sentry.grouping.utils import DEFAULT_FINGERPRINT_VARIABLE, is_default_fingerprint_var
 from sentry.utils.strings import unescape_string
 

--- a/src/sentry/grouping/fingerprinting/parser.py
+++ b/src/sentry/grouping/fingerprinting/parser.py
@@ -13,8 +13,10 @@ from sentry.grouping.fingerprinting.types import (
     FingerprintRuleAttributes,
     FingerprintWithAttributes,
 )
-from sentry.grouping.fingerprinting.utils import DEFAULT_FINGERPRINT_VARIABLE
-from sentry.grouping.utils import is_default_fingerprint_var
+from sentry.grouping.fingerprinting.utils import (
+    DEFAULT_FINGERPRINT_VARIABLE,
+    is_default_fingerprint_var,
+)
 from sentry.utils.strings import unescape_string
 
 logger = logging.getLogger("sentry.events.grouping")

--- a/src/sentry/grouping/fingerprinting/parser.py
+++ b/src/sentry/grouping/fingerprinting/parser.py
@@ -13,7 +13,8 @@ from sentry.grouping.fingerprinting.types import (
     FingerprintRuleAttributes,
     FingerprintWithAttributes,
 )
-from sentry.grouping.utils import DEFAULT_FINGERPRINT_VARIABLE, is_default_fingerprint_var
+from sentry.grouping.fingerprinting.utils import DEFAULT_FINGERPRINT_VARIABLE
+from sentry.grouping.utils import is_default_fingerprint_var
 from sentry.utils.strings import unescape_string
 
 logger = logging.getLogger("sentry.events.grouping")

--- a/src/sentry/grouping/fingerprinting/rules.py
+++ b/src/sentry/grouping/fingerprinting/rules.py
@@ -7,19 +7,12 @@ from typing import NamedTuple, NotRequired, Self, TypedDict
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
 from sentry.grouping.fingerprinting.types import (
     FingerprintRuleAttributes,
+    FingerprintRuleConfig,
     FingerprintWithAttributes,
 )
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger("sentry.events.grouping")
-
-
-class FingerprintRuleConfig(TypedDict):
-    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
-    matchers: list[list[str]]
-    fingerprint: list[str]
-    attributes: NotRequired[FingerprintRuleAttributes]
-    is_builtin: NotRequired[bool]
 
 
 # This is just `FingerprintRuleConfig` with an extra `text` entry and with `attributes` required

--- a/src/sentry/grouping/fingerprinting/rules.py
+++ b/src/sentry/grouping/fingerprinting/rules.py
@@ -2,29 +2,18 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import NamedTuple, NotRequired, Self, TypedDict
+from typing import NamedTuple, Self
 
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
 from sentry.grouping.fingerprinting.types import (
     FingerprintRuleAttributes,
     FingerprintRuleConfig,
+    FingerprintRuleJSON,
     FingerprintWithAttributes,
 )
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger("sentry.events.grouping")
-
-
-# This is just `FingerprintRuleConfig` with an extra `text` entry and with `attributes` required
-# rather than optional. (Unfortunately, you can't overwrite lack of required-ness when subclassing a
-# TypedDict, so we have to create the full type independently.)
-class FingerprintRuleJSON(TypedDict):
-    text: str
-    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
-    matchers: list[list[str]]
-    fingerprint: list[str]
-    attributes: FingerprintRuleAttributes
-    is_builtin: NotRequired[bool]
 
 
 class FingerprintRuleMatch(NamedTuple):

--- a/src/sentry/grouping/fingerprinting/rules.py
+++ b/src/sentry/grouping/fingerprinting/rules.py
@@ -5,15 +5,13 @@ from collections.abc import Sequence
 from typing import NamedTuple, NotRequired, Self, TypedDict
 
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
-from sentry.grouping.fingerprinting.types import FingerprintRuleAttributes
+from sentry.grouping.fingerprinting.types import (
+    FingerprintRuleAttributes,
+    FingerprintWithAttributes,
+)
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger("sentry.events.grouping")
-
-
-class FingerprintWithAttributes(NamedTuple):
-    fingerprint: list[str]
-    attributes: FingerprintRuleAttributes
 
 
 class FingerprintRuleConfig(TypedDict):

--- a/src/sentry/grouping/fingerprinting/rules.py
+++ b/src/sentry/grouping/fingerprinting/rules.py
@@ -5,13 +5,10 @@ from collections.abc import Sequence
 from typing import NamedTuple, NotRequired, Self, TypedDict
 
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
+from sentry.grouping.fingerprinting.types import FingerprintRuleAttributes
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger("sentry.events.grouping")
-
-
-class FingerprintRuleAttributes(TypedDict):
-    title: NotRequired[str]
 
 
 class FingerprintWithAttributes(NamedTuple):

--- a/src/sentry/grouping/fingerprinting/rules.py
+++ b/src/sentry/grouping/fingerprinting/rules.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import NamedTuple, Self
+from typing import Self
 
 from sentry.grouping.fingerprinting.matchers import FingerprintMatcher
 from sentry.grouping.fingerprinting.types import (
@@ -14,12 +14,6 @@ from sentry.grouping.fingerprinting.types import (
 from sentry.grouping.fingerprinting.utils import EventDatastore
 
 logger = logging.getLogger("sentry.events.grouping")
-
-
-class FingerprintRuleMatch(NamedTuple):
-    matched_rule: FingerprintRule
-    fingerprint: list[str]
-    attributes: FingerprintRuleAttributes
 
 
 class FingerprintRule:

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from typing import NotRequired, TypedDict
+from typing import NamedTuple, NotRequired, TypedDict
 
 
 class FingerprintRuleAttributes(TypedDict):
     title: NotRequired[str]
+
+
+class FingerprintWithAttributes(NamedTuple):
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import NamedTuple, NotRequired, TypedDict
+from typing import TYPE_CHECKING, NamedTuple, NotRequired, TypedDict
+
+if TYPE_CHECKING:
+    from sentry.grouping.fingerprinting.rules import FingerprintRule
 
 
 class FingerprintRuleAttributes(TypedDict):
@@ -30,3 +33,9 @@ class FingerprintRuleJSON(TypedDict):
     fingerprint: list[str]
     attributes: FingerprintRuleAttributes
     is_builtin: NotRequired[bool]
+
+
+class FingerprintRuleMatch(NamedTuple):
+    matched_rule: FingerprintRule
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+
+class FingerprintRuleAttributes(TypedDict):
+    title: NotRequired[str]

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -39,3 +39,8 @@ class FingerprintRuleMatch(NamedTuple):
     matched_rule: FingerprintRule
     fingerprint: list[str]
     attributes: FingerprintRuleAttributes
+
+
+class FingerprintInfo(TypedDict):
+    client_fingerprint: NotRequired[list[str]]
+    matched_rule: NotRequired[FingerprintRuleJSON]

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -18,3 +18,15 @@ class FingerprintRuleConfig(TypedDict):
     fingerprint: list[str]
     attributes: NotRequired[FingerprintRuleAttributes]
     is_builtin: NotRequired[bool]
+
+
+# This is just `FingerprintRuleConfig` with an extra `text` entry and with `attributes` required
+# rather than optional. (Unfortunately, you can't overwrite lack of required-ness when subclassing a
+# TypedDict, so we have to create the full type independently.)
+class FingerprintRuleJSON(TypedDict):
+    text: str
+    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
+    matchers: list[list[str]]
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes
+    is_builtin: NotRequired[bool]

--- a/src/sentry/grouping/fingerprinting/types.py
+++ b/src/sentry/grouping/fingerprinting/types.py
@@ -10,3 +10,11 @@ class FingerprintRuleAttributes(TypedDict):
 class FingerprintWithAttributes(NamedTuple):
     fingerprint: list[str]
     attributes: FingerprintRuleAttributes
+
+
+class FingerprintRuleConfig(TypedDict):
+    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
+    matchers: list[list[str]]
+    fingerprint: list[str]
+    attributes: NotRequired[FingerprintRuleAttributes]
+    is_builtin: NotRequired[bool]

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Mapping
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
@@ -174,3 +174,26 @@ def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
 
 def is_default_fingerprint_var(value: str) -> bool:
     return parse_fingerprint_entry_as_variable(value) == "default"
+
+
+def get_fingerprint_type(
+    fingerprint: list[str] | None,
+) -> Literal["default", "hybrid", "custom"] | None:
+    """
+    Examine a fingerprint to determine if it's custom, hybrid, or the default fingerprint.
+
+    Accepts (and then returns) None for convenience, so the fingerprint's existence doesn't have to
+    be separately checked.
+    """
+    if not fingerprint:
+        return None
+
+    return (
+        "default"
+        if len(fingerprint) == 1 and is_default_fingerprint_var(fingerprint[0])
+        else (
+            "hybrid"
+            if any(is_default_fingerprint_var(entry) for entry in fingerprint)
+            else "custom"
+        )
+    )

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -170,3 +170,7 @@ def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
     if match is not None and match.end() == len(entry):
         return match.group(1)
     return None
+
+
+def is_default_fingerprint_var(value: str) -> bool:
+    return parse_fingerprint_entry_as_variable(value) == "default"

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -15,7 +15,7 @@ from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
 logger = logging.getLogger("sentry.events.grouping")
 
-_fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
+FINGERPRINT_VARIABLE_REGEX = re.compile(r"\{\{\s*(\S+)\s*\}\}")
 DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
@@ -168,7 +168,7 @@ def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
     extract the variable name from a variable string of the form "{{ var_name }}"). If the given
     entry isn't the correct form to be a variable, return None.
     """
-    match = _fingerprint_var_re.match(entry)
+    match = FINGERPRINT_VARIABLE_REGEX.match(entry)
     if match is not None and match.end() == len(entry):
         return match.group(1)
     return None
@@ -322,4 +322,4 @@ def expand_title_template(
         # If the variable can't be resolved, return it as is
         return match.group(0)
 
-    return _fingerprint_var_re.sub(_handle_match, template)
+    return FINGERPRINT_VARIABLE_REGEX.sub(_handle_match, template)

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -158,3 +158,15 @@ class EventDatastore:
             {"release": self.event["release"].strip() if self.event.get("release") else None}
         ]
         return self._release
+
+
+def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
+    """
+    Determine if the given fingerprint entry is a variable, and if it is, return its key (that is,
+    extract the variable name from a variable string of the form "{{ var_name }}"). If the given
+    entry isn't the correct form to be a variable, return None.
+    """
+    match = _fingerprint_var_re.match(entry)
+    if match is not None and match.end() == len(entry):
+        return match.group(1)
+    return None

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -5,8 +5,10 @@ import re
 from collections.abc import Mapping
 from typing import Any, Literal, NotRequired, TypedDict
 
+from sentry.db.models.fields.node import NodeData
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
+from sentry.stacktraces.processing import get_crash_frame_from_event_data
 from sentry.utils.event_frames import find_stack_frames
 from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
@@ -197,3 +199,79 @@ def get_fingerprint_type(
             else "custom"
         )
     )
+
+
+def resolve_fingerprint_variable(
+    variable_key: str,
+    event_data: NodeData | Mapping[str, Any],
+    use_legacy_unknown_variable_handling: bool,
+) -> str | None:
+    if variable_key == "transaction":
+        return event_data.get("transaction") or "<no-transaction>"
+
+    elif variable_key == "message":
+        message = (
+            get_path(event_data, "logentry", "formatted")
+            or get_path(event_data, "logentry", "message")
+            or get_path(event_data, "exception", "values", -1, "value")
+        )
+        return message or "<no-message>"
+
+    elif variable_key in ("type", "error.type"):
+        exception_type = get_path(event_data, "exception", "values", -1, "type")
+        return exception_type or "<no-type>"
+
+    elif variable_key in ("value", "error.value"):
+        value = get_path(event_data, "exception", "values", -1, "value")
+        return value or "<no-value>"
+
+    elif variable_key in ("function", "stack.function"):
+        frame = get_crash_frame_from_event_data(event_data)
+        func = frame.get("function") if frame else None
+        return func or "<no-function>"
+
+    elif variable_key in ("path", "stack.abs_path"):
+        frame = get_crash_frame_from_event_data(event_data)
+        abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
+        return abs_path or "<no-abs-path>"
+
+    elif variable_key == "stack.filename":
+        frame = get_crash_frame_from_event_data(event_data)
+        filename = frame.get("filename") or frame.get("abs_path") if frame else None
+        return filename or "<no-filename>"
+
+    elif variable_key in ("module", "stack.module"):
+        frame = get_crash_frame_from_event_data(event_data)
+        module = frame.get("module") if frame else None
+        return module or "<no-module>"
+
+    elif variable_key in ("package", "stack.package"):
+        frame = get_crash_frame_from_event_data(event_data)
+        pkg = frame.get("package") if frame else None
+        if pkg:
+            # If the package is formatted as either a POSIX or Windows path, grab the last segment
+            pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        return pkg or "<no-package>"
+
+    elif variable_key == "level":
+        return event_data.get("level") or "<no-level>"
+
+    elif variable_key == "logger":
+        return event_data.get("logger") or "<no-logger>"
+
+    elif variable_key.startswith("tags."):
+        # Turn "tags.some_tag" into just "some_tag"
+        requested_tag = variable_key[5:]
+        for tag_name, tag_value in event_data.get("tags") or ():
+            if tag_name == requested_tag and tag_value is not None:
+                return tag_value
+        return "<no-value-for-tag-%s>" % requested_tag
+    else:
+        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
+        # can remove `use_legacy_unknown_variable_handling` and just return the string. (At that
+        # point we can also change the return type of this function to just be `str`.)
+        return (
+            None
+            if use_legacy_unknown_variable_handling
+            else "<unrecognized-variable-%s>" % variable_key
+        )

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any, NotRequired, TypedDict
 
@@ -11,6 +12,8 @@ from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
 logger = logging.getLogger("sentry.events.grouping")
+
+_fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
 
 
 class _MessageInfo(TypedDict):

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -14,6 +14,7 @@ from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 logger = logging.getLogger("sentry.events.grouping")
 
 _fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
+DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
 class _MessageInfo(TypedDict):

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -301,3 +301,25 @@ def resolve_fingerprint_values(
         return resolved_value
 
     return [_resolve_single_entry(entry) for entry in fingerprint]
+
+
+def expand_title_template(
+    template: str, event_data: Mapping[str, Any], use_legacy_unknown_variable_handling: bool = False
+) -> str:
+    def _handle_match(match: re.Match[str]) -> str:
+        variable_key = match.group(1)
+        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
+        # can remove `use_legacy_unknown_variable_handling` and just return the value given by
+        # `resolve_fingerprint_variable`
+        resolved_value = resolve_fingerprint_variable(
+            variable_key, event_data, use_legacy_unknown_variable_handling
+        )
+
+        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
+        # can remove this
+        if resolved_value is not None:
+            return resolved_value
+        # If the variable can't be resolved, return it as is
+        return match.group(0)
+
+    return _fingerprint_var_re.sub(_handle_match, template)

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -8,11 +8,11 @@ from django.utils import timezone
 
 from sentry import options
 from sentry import ratelimits as ratelimiter
+from sentry.grouping.fingerprinting.utils import get_fingerprint_type
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.grouping.ingest.grouphash_metadata import (
     check_grouphashes_for_positive_fingerprint_match,
 )
-from sentry.grouping.utils import get_fingerprint_type
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from hashlib import md5
 from re import Match
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from django.utils.encoding import force_bytes
@@ -12,7 +12,6 @@ from sentry.db.models.fields.node import NodeData
 from sentry.grouping.fingerprinting.utils import (
     DEFAULT_FINGERPRINT_VARIABLE,
     _fingerprint_var_re,
-    is_default_fingerprint_var,
     parse_fingerprint_entry_as_variable,
 )
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -32,29 +31,6 @@ def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingCompon
     for value in values:
         result.update(force_bytes(value, errors="replace"))
     return result.hexdigest()
-
-
-def get_fingerprint_type(
-    fingerprint: list[str] | None,
-) -> Literal["default", "hybrid", "custom"] | None:
-    """
-    Examine a fingerprint to determine if it's custom, hybrid, or the default fingerprint.
-
-    Accepts (and then returns) None for convenience, so the fingerprint's existence doesn't have to
-    be separately checked.
-    """
-    if not fingerprint:
-        return None
-
-    return (
-        "default"
-        if len(fingerprint) == 1 and is_default_fingerprint_var(fingerprint[0])
-        else (
-            "hybrid"
-            if any(is_default_fingerprint_var(entry) for entry in fingerprint)
-            else "custom"
-        )
-    )
 
 
 def bool_from_string(value: str) -> bool | None:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -12,6 +12,7 @@ from sentry.db.models.fields.node import NodeData
 from sentry.grouping.fingerprinting.utils import (
     DEFAULT_FINGERPRINT_VARIABLE,
     _fingerprint_var_re,
+    is_default_fingerprint_var,
     parse_fingerprint_entry_as_variable,
 )
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -19,10 +20,6 @@ from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
-
-
-def is_default_fingerprint_var(value: str) -> bool:
-    return parse_fingerprint_entry_as_variable(value) == "default"
 
 
 def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingComponent]) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -8,13 +8,7 @@ from uuid import UUID
 
 from django.utils.encoding import force_bytes
 
-from sentry.db.models.fields.node import NodeData
-from sentry.grouping.fingerprinting.utils import (
-    DEFAULT_FINGERPRINT_VARIABLE,
-    _fingerprint_var_re,
-    parse_fingerprint_entry_as_variable,
-    resolve_fingerprint_variable,
-)
+from sentry.grouping.fingerprinting.utils import _fingerprint_var_re, resolve_fingerprint_variable
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
@@ -45,32 +39,6 @@ def bool_from_string(value: str) -> bool | None:
             return False
 
     return None
-
-
-def resolve_fingerprint_values(
-    fingerprint: list[str], event_data: NodeData, use_legacy_unknown_variable_handling: bool = False
-) -> list[str]:
-    def _resolve_single_entry(entry: str) -> str:
-        variable_key = parse_fingerprint_entry_as_variable(entry)
-        if variable_key == "default":  # entry is some variation of `{{ default }}`
-            return DEFAULT_FINGERPRINT_VARIABLE
-        if variable_key is None:  # entry isn't a variable
-            return entry
-
-        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove `use_legacy_unknown_variable_handling` and just return the value given by
-        # `resolve_fingerprint_variable`
-        resolved_value = resolve_fingerprint_variable(
-            variable_key, event_data, use_legacy_unknown_variable_handling
-        )
-
-        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove this
-        if resolved_value is None:  # variable wasn't recognized
-            return entry
-        return resolved_value
-
-    return [_resolve_single_entry(entry) for entry in fingerprint]
 
 
 def expand_title_template(

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from hashlib import md5
-from re import Match
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from django.utils.encoding import force_bytes
-
-from sentry.grouping.fingerprinting.utils import _fingerprint_var_re, resolve_fingerprint_variable
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
@@ -39,25 +36,3 @@ def bool_from_string(value: str) -> bool | None:
             return False
 
     return None
-
-
-def expand_title_template(
-    template: str, event_data: Mapping[str, Any], use_legacy_unknown_variable_handling: bool = False
-) -> str:
-    def _handle_match(match: Match[str]) -> str:
-        variable_key = match.group(1)
-        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove `use_legacy_unknown_variable_handling` and just return the value given by
-        # `resolve_fingerprint_variable`
-        resolved_value = resolve_fingerprint_variable(
-            variable_key, event_data, use_legacy_unknown_variable_handling
-        )
-
-        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove this
-        if resolved_value is not None:
-            return resolved_value
-        # If the variable can't be resolved, return it as is
-        return match.group(0)
-
-    return _fingerprint_var_re.sub(_handle_match, template)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -9,15 +9,12 @@ from uuid import UUID
 from django.utils.encoding import force_bytes
 
 from sentry.db.models.fields.node import NodeData
-from sentry.grouping.fingerprinting.utils import _fingerprint_var_re
+from sentry.grouping.fingerprinting.utils import DEFAULT_FINGERPRINT_VARIABLE, _fingerprint_var_re
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
 from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
-
-
-DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
 def parse_fingerprint_entry_as_variable(entry: str) -> str | None:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from collections.abc import Iterable, Mapping
 from hashlib import md5
 from re import Match
@@ -10,6 +9,7 @@ from uuid import UUID
 from django.utils.encoding import force_bytes
 
 from sentry.db.models.fields.node import NodeData
+from sentry.grouping.fingerprinting.utils import _fingerprint_var_re
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
 from sentry.utils.safe import get_path
 
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
 
 
-_fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
 DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -9,24 +9,16 @@ from uuid import UUID
 from django.utils.encoding import force_bytes
 
 from sentry.db.models.fields.node import NodeData
-from sentry.grouping.fingerprinting.utils import DEFAULT_FINGERPRINT_VARIABLE, _fingerprint_var_re
+from sentry.grouping.fingerprinting.utils import (
+    DEFAULT_FINGERPRINT_VARIABLE,
+    _fingerprint_var_re,
+    parse_fingerprint_entry_as_variable,
+)
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
 from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
-
-
-def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
-    """
-    Determine if the given fingerprint entry is a variable, and if it is, return its key (that is,
-    extract the variable name from a variable string of the form "{{ var_name }}"). If the given
-    entry isn't the correct form to be a variable, return None.
-    """
-    match = _fingerprint_var_re.match(entry)
-    if match is not None and match.end() == len(entry):
-        return match.group(1)
-    return None
 
 
 def is_default_fingerprint_var(value: str) -> bool:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -13,9 +13,8 @@ from sentry.grouping.fingerprinting.utils import (
     DEFAULT_FINGERPRINT_VARIABLE,
     _fingerprint_var_re,
     parse_fingerprint_entry_as_variable,
+    resolve_fingerprint_variable,
 )
-from sentry.stacktraces.processing import get_crash_frame_from_event_data
-from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
@@ -46,82 +45,6 @@ def bool_from_string(value: str) -> bool | None:
             return False
 
     return None
-
-
-def resolve_fingerprint_variable(
-    variable_key: str,
-    event_data: NodeData | Mapping[str, Any],
-    use_legacy_unknown_variable_handling: bool,
-) -> str | None:
-    if variable_key == "transaction":
-        return event_data.get("transaction") or "<no-transaction>"
-
-    elif variable_key == "message":
-        message = (
-            get_path(event_data, "logentry", "formatted")
-            or get_path(event_data, "logentry", "message")
-            or get_path(event_data, "exception", "values", -1, "value")
-        )
-        return message or "<no-message>"
-
-    elif variable_key in ("type", "error.type"):
-        exception_type = get_path(event_data, "exception", "values", -1, "type")
-        return exception_type or "<no-type>"
-
-    elif variable_key in ("value", "error.value"):
-        value = get_path(event_data, "exception", "values", -1, "value")
-        return value or "<no-value>"
-
-    elif variable_key in ("function", "stack.function"):
-        frame = get_crash_frame_from_event_data(event_data)
-        func = frame.get("function") if frame else None
-        return func or "<no-function>"
-
-    elif variable_key in ("path", "stack.abs_path"):
-        frame = get_crash_frame_from_event_data(event_data)
-        abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
-        return abs_path or "<no-abs-path>"
-
-    elif variable_key == "stack.filename":
-        frame = get_crash_frame_from_event_data(event_data)
-        filename = frame.get("filename") or frame.get("abs_path") if frame else None
-        return filename or "<no-filename>"
-
-    elif variable_key in ("module", "stack.module"):
-        frame = get_crash_frame_from_event_data(event_data)
-        module = frame.get("module") if frame else None
-        return module or "<no-module>"
-
-    elif variable_key in ("package", "stack.package"):
-        frame = get_crash_frame_from_event_data(event_data)
-        pkg = frame.get("package") if frame else None
-        if pkg:
-            # If the package is formatted as either a POSIX or Windows path, grab the last segment
-            pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-        return pkg or "<no-package>"
-
-    elif variable_key == "level":
-        return event_data.get("level") or "<no-level>"
-
-    elif variable_key == "logger":
-        return event_data.get("logger") or "<no-logger>"
-
-    elif variable_key.startswith("tags."):
-        # Turn "tags.some_tag" into just "some_tag"
-        requested_tag = variable_key[5:]
-        for tag_name, tag_value in event_data.get("tags") or ():
-            if tag_name == requested_tag and tag_value is not None:
-                return tag_value
-        return "<no-value-for-tag-%s>" % requested_tag
-    else:
-        # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove `use_legacy_unknown_variable_handling` and just return the string. (At that
-        # point we can also change the return type of this function to just be `str`.)
-        return (
-            None
-            if use_legacy_unknown_variable_handling
-            else "<unrecognized-variable-%s>" % variable_key
-        )
 
 
 def resolve_fingerprint_values(

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 
 from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.fingerprinting.rules import FingerprintRule
+from sentry.grouping.fingerprinting.types import FingerprintInfo
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 
 if TYPE_CHECKING:
-    from sentry.grouping.api import FingerprintInfo
     from sentry.grouping.strategies.base import StrategyConfiguration
 
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.fingerprinting.rules import FingerprintRule
 from sentry.grouping.fingerprinting.types import FingerprintInfo
-from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
+from sentry.grouping.fingerprinting.utils import is_default_fingerprint_var
+from sentry.grouping.utils import hash_from_values
 
 if TYPE_CHECKING:
     from sentry.grouping.strategies.base import StrategyConfiguration

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -22,11 +22,11 @@ from sentry.grouping.api import (
 from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.enhancer import EnhancementsConfig
 from sentry.grouping.fingerprinting import FingerprintingConfig
+from sentry.grouping.fingerprinting.utils import expand_title_template
 from sentry.grouping.strategies.configurations import (
     GROUPING_CONFIG_CLASSES,
     register_grouping_config,
 )
-from sentry.grouping.utils import expand_title_template
 from sentry.grouping.variants import BaseVariant
 from sentry.models.project import Project
 from sentry.services import eventstore

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -13,7 +13,7 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
-from sentry.grouping.utils import resolve_fingerprint_values
+from sentry.grouping.fingerprinting.utils import resolve_fingerprint_values
 from sentry.grouping.variants import BaseVariant
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
-from sentry.grouping.fingerprinting.rules import FingerprintRuleJSON
+from sentry.grouping.fingerprinting.types import FingerprintRuleJSON
 from sentry.grouping.variants import BaseVariant, CustomFingerprintVariant, expose_fingerprint_dict
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all


### PR DESCRIPTION
This is a small refactor of our fingerprinting code, moving things around both for organizational purposes and to prevent circular imports which would otherwise be caused by an upcoming PR. Specifically, it moves all of the various types we use into a separate `types` file, and moves all of the fingerprinting-related helpers from the general grouping `utils` module to the fingerprint `utils` module.