### PR TITLE
fix(dashboards): Properly read type and unit from response for spans

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -5,11 +5,16 @@ import {WidgetFixture} from 'sentry-fixture/widget';
 import {waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {Client} from 'sentry/api';
-import type {Organization} from 'sentry/types/organization';
+import type {
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+  Organization,
+} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {WidgetType, type WidgetQuery} from 'sentry/views/dashboards/types';
 
 describe('SpansConfig', () => {
   let organization: Organization;
@@ -63,5 +68,99 @@ describe('SpansConfig', () => {
         })
       );
     });
+  });
+
+  it('surfaces types and units correctly for multi-series (grouped) responses with a single aggregate', () => {
+    // Meta is copied for all series in the response
+    const commonMockedMeta: EventsStats['meta'] = {
+      units: {'count(span.duration)': 'millisecond'},
+      fields: {'count(span.duration)': 'integer'},
+      isMetricsData: false,
+      tips: {},
+    };
+    // Multi-series response with multiple grouped series
+    const multiSeriesData: MultiSeriesEventsStats = {
+      'GET /api/users': {
+        order: 0,
+        data: [[1234567890, [{count: 100}]]],
+        meta: commonMockedMeta,
+      },
+      'POST /api/data': {
+        order: 1,
+        data: [[1234567890, [{count: 250}]]],
+        meta: commonMockedMeta,
+      },
+    };
+
+    const widgetQuery: WidgetQuery = {
+      name: '',
+      fields: [],
+      columns: ['transaction'], // Grouped by transaction
+      fieldAliases: [],
+      aggregates: ['count(span.duration)'],
+      conditions: '',
+      orderby: '-count(span.duration)',
+    };
+
+    const resultTypes = SpansConfig.getSeriesResultType!(multiSeriesData, widgetQuery);
+    expect(resultTypes['GET /api/users']).toBe('integer');
+    expect(resultTypes['POST /api/data']).toBe('integer');
+
+    const resultUnits = SpansConfig.getSeriesResultUnit!(multiSeriesData, widgetQuery);
+    expect(resultUnits['GET /api/users']).toBe('millisecond');
+    expect(resultUnits['POST /api/data']).toBe('millisecond');
+  });
+
+  it('surfaces types and units correctly for multi-series (grouped) responses with a multiple aggregates', () => {
+    // Meta is copied for all series in the response
+    const commonMockedMeta: EventsStats['meta'] = {
+      units: {'count(span.duration)': null, 'p50(span.duration)': 'millisecond'},
+      fields: {'count(span.duration)': 'integer', 'p50(span.duration)': 'duration'},
+      isMetricsData: false,
+      tips: {},
+    };
+    // Multi-series response with multiple aggregates and grouped series
+    const multiSeriesData: GroupedMultiSeriesEventsStats = {
+      'GET /api/users': {
+        order: 0,
+        'count(span.duration)': {
+          data: [[1234567890, [{count: 100}]]],
+          meta: commonMockedMeta,
+        },
+        'p50(span.duration)': {
+          data: [[1234567890, [{count: 100}]]],
+          meta: commonMockedMeta,
+        },
+      },
+      'POST /api/data': {
+        order: 1,
+        'count(span.duration)': {
+          data: [[1234567890, [{count: 250}]]],
+          meta: commonMockedMeta,
+        },
+        'p50(span.duration)': {
+          data: [[1234567890, [{count: 100}]]],
+          meta: commonMockedMeta,
+        },
+      },
+    };
+
+    const widgetQuery: WidgetQuery = {
+      name: '',
+      fields: [],
+      columns: ['transaction'], // Grouped by transaction
+      fieldAliases: [],
+      aggregates: ['count(span.duration)', 'p50(span.duration)'],
+      conditions: '',
+      orderby: '-count(span.duration)',
+    };
+
+    const resultTypes = SpansConfig.getSeriesResultType!(multiSeriesData, widgetQuery);
+    expect(resultTypes['count(span.duration)']).toBe('integer');
+    expect(resultTypes['p50(span.duration)']).toBe('duration');
+
+    const resultUnits = SpansConfig.getSeriesResultUnit!(multiSeriesData, widgetQuery);
+    expect(resultUnits['count(span.duration)']).toBeNull();
+    expect(resultUnits['p50(span.duration)']).toBe('millisecond');
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -61,7 +61,10 @@ import {combineBaseFieldsWithTags} from 'sentry/views/dashboards/datasetConfig/u
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
-import {isMultiSeriesEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
+import {
+  isGroupedMultiSeriesEventsStats,
+  isMultiSeriesEventsStats,
+} from 'sentry/views/dashboards/utils/isEventsStats';
 import {transformEventsResponseToSeries} from 'sentry/views/dashboards/utils/transformEventsResponseToSeries';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
 import {isPerformanceScoreBreakdownChart} from 'sentry/views/dashboards/widgetBuilder/utils/isPerformanceScoreBreakdownChart';
@@ -177,6 +180,74 @@ function useSpansSearchBarDataProvider(props: SearchBarDataProviderProps): Searc
   };
 }
 
+/**
+ * Generic helper to extract metadata (units or types) from events-stats series data.
+ * Handles both MultiSeriesEventsStats and GroupedMultiSeriesEventsStats responses.
+ */
+function extractSeriesMetadata<T>({
+  data,
+  getFieldMetaValue,
+  getMetaField,
+  widgetQuery,
+}: {
+  data: EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats;
+  getFieldMetaValue: (
+    meta: NonNullable<NonNullable<WidgetQuery['fieldMeta']>[number]>
+  ) => T;
+  getMetaField: (seriesMeta: NonNullable<EventsStats['meta']>, aggregate: string) => T;
+  widgetQuery: WidgetQuery;
+}): Record<string, T> {
+  const result: Record<string, T> = {};
+
+  // Initialize from fieldMeta if available
+  widgetQuery.fieldMeta?.forEach((meta, index) => {
+    if (meta && widgetQuery.fields) {
+      result[widgetQuery.fields[index]!] = getFieldMetaValue(meta);
+    }
+  });
+
+  if (isMultiSeriesEventsStats(data)) {
+    // If there's only one aggregate and multiple groupings, series names are group names
+    // In this case, we can use the first meta value for all series
+    const firstMeta = widgetQuery.fieldMeta?.find(meta => meta !== null);
+    const isSingleAggregateMultiGroup =
+      firstMeta &&
+      widgetQuery.aggregates?.length === 1 &&
+      widgetQuery.columns?.length > 0;
+
+    if (isSingleAggregateMultiGroup) {
+      // Use hardcoded config for all series
+      Object.keys(data).forEach(seriesName => {
+        result[seriesName] = getFieldMetaValue(firstMeta);
+      });
+    } else {
+      Object.keys(data).forEach(seriesName => {
+        const seriesData = data[seriesName];
+        if (!seriesData?.meta) {
+          return;
+        }
+        widgetQuery.aggregates?.forEach(aggregate => {
+          // Multi-series can be keyed by aggregate or series name depending on aggregate count
+          const key = widgetQuery.aggregates?.length > 1 ? aggregate : seriesName;
+          result[key] = getMetaField(seriesData.meta!, aggregate);
+        });
+      });
+    }
+  } else if (isGroupedMultiSeriesEventsStats(data)) {
+    Object.keys(data).forEach(groupName => {
+      widgetQuery.aggregates?.forEach(aggregate => {
+        const seriesData = data[groupName]![aggregate] as EventsStats;
+        if (!seriesData?.meta) {
+          return;
+        }
+        result[aggregate] = getMetaField(seriesData.meta, aggregate);
+      });
+    });
+  }
+
+  return result;
+}
+
 export const SpansConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats,
   TableData | EventsTableData
@@ -247,55 +318,21 @@ export const SpansConfig: DatasetConfig<
     return getFieldRenderer(field, meta, false, widget, dashboardFilters);
   },
   getSeriesResultUnit: (data, widgetQuery) => {
-    const resultUnits: Record<string, DataUnit> = {};
-    widgetQuery.fieldMeta?.forEach((meta, index) => {
-      if (meta && widgetQuery.fields) {
-        resultUnits[widgetQuery.fields[index]!] = meta.valueUnit;
-      }
+    return extractSeriesMetadata({
+      data,
+      widgetQuery,
+      getFieldMetaValue: meta => meta.valueUnit,
+      getMetaField: (seriesMeta, aggregate) => seriesMeta.units[aggregate] as DataUnit,
     });
-    const isMultiSeriesStats = isMultiSeriesEventsStats(data);
-
-    // if there's only one aggregate and more then one group by the series names are the name of the group, not the aggregate name
-    // But we can just assume the units is for all the series
-    // TODO: This doesn't work with multiple aggregates
-    const firstMeta = widgetQuery.fieldMeta?.find(meta => meta !== null);
-    if (
-      isMultiSeriesStats &&
-      firstMeta &&
-      widgetQuery.aggregates?.length === 1 &&
-      widgetQuery.columns?.length > 0
-    ) {
-      Object.keys(data).forEach(seriesName => {
-        resultUnits[seriesName] = firstMeta.valueUnit;
-      });
-    }
-    return resultUnits;
   },
   getSeriesResultType: (data, widgetQuery) => {
-    const resultTypes: Record<string, AggregationOutputType> = {};
-    widgetQuery.fieldMeta?.forEach((meta, index) => {
-      if (meta && widgetQuery.fields) {
-        resultTypes[widgetQuery.fields[index]!] = meta.valueType as AggregationOutputType;
-      }
+    return extractSeriesMetadata({
+      data,
+      widgetQuery,
+      getFieldMetaValue: meta => meta.valueType as AggregationOutputType,
+      getMetaField: (seriesMeta, aggregate) =>
+        seriesMeta.fields[aggregate] as AggregationOutputType,
     });
-
-    const isMultiSeriesStats = isMultiSeriesEventsStats(data);
-
-    // if there's only one aggregate and more then one group by the series names are the name of the group, not the aggregate name
-    // But we can just assume the units is for all the series
-    // TODO: This doesn't work with multiple aggregates
-    const firstMeta = widgetQuery.fieldMeta?.find(meta => meta !== null);
-    if (
-      isMultiSeriesStats &&
-      firstMeta &&
-      widgetQuery.aggregates?.length === 1 &&
-      widgetQuery.columns?.length > 0
-    ) {
-      Object.keys(data).forEach(seriesName => {
-        resultTypes[seriesName] = firstMeta.valueType as AggregationOutputType;
-      });
-    }
-    return resultTypes;
   },
 };
 


### PR DESCRIPTION
Spans widgets with groupings had issues rendering with the proper units (see DAIN-485)

Covers multiseries and grouped multiseries responses from events-stats when the widget doesn't have any hardcoded types. A generic helper was added to minimize the duplication because traversing into the units and types was essentially the same.