### PR TITLE
fix(code-review): Add easy flippable code review beta freeze

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -698,9 +698,9 @@ register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "seer.code-review.direct-to-seer-enabled-gh-orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-# When True, the code review beta is still open and orgs can opt in to it
+# When True, the code review beta signup is still open and orgs can opt in to it
 register(
-    "seer.code-review.is-beta-open",
+    "seer.code-review.is-beta-signup-open",
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -698,6 +698,12 @@ register("github.webhook.pr", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "seer.code-review.direct-to-seer-enabled-gh-orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+# When True, the code review beta is still open and orgs can opt in to it
+register(
+    "seer.code-review.is-beta-open",
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -205,7 +205,7 @@ class CodeReviewRepoSettingsEndpoint(Endpoint):
         if repo_settings is None:
             organization = Organization.objects.filter(id=sentry_org_id).first()
 
-            if options.get("seer.code-review.is-beta-open"):
+            if options.get("seer.code-review.is-beta-signup-open"):
                 if organization and (
                     features.has("organizations:code-review-beta", organization)
                     or bool(

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 
-from sentry import features
+from sentry import features, options
 from sentry.constants import ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT, HIDE_AI_FEATURES_DEFAULT
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -124,12 +124,14 @@ class CodeReviewPreflightService:
         return features.has("organizations:seat-based-seer-enabled", self.organization)
 
     def _is_code_review_beta_org(self) -> bool:
-        # TODO: Remove the has_legacy_opt_in check once the beta list is frozen
         has_beta_flag = features.has("organizations:code-review-beta", self.organization)
         has_legacy_opt_in = self.organization.get_option(
             "sentry:enable_pr_review_test_generation", False
         )
-        return has_beta_flag or bool(has_legacy_opt_in)
+        if options.get("seer.code-review.is-beta-open"):
+            return has_beta_flag or bool(has_legacy_opt_in)
+
+        return has_beta_flag
 
     def _is_legacy_usage_based_seer_plan_org(self) -> bool:
         return features.has("organizations:seer-added", self.organization)

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -128,7 +128,7 @@ class CodeReviewPreflightService:
         has_legacy_opt_in = self.organization.get_option(
             "sentry:enable_pr_review_test_generation", False
         )
-        if options.get("seer.code-review.is-beta-open"):
+        if options.get("seer.code-review.is-beta-signup-open"):
             return has_beta_flag or bool(has_legacy_opt_in)
 
         return has_beta_flag

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -581,7 +581,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
         ["test-secret"],
     )
-    def test_returns_enabled_with_default_triggers_when_pr_review_test_generation_enabled_and_beta_open(
+    def test_returns_enabled_with_default_triggers_when_pr_review_test_generation_enabled_and_beta_signup_open(
         self,
     ):
         org = self.create_organization()
@@ -595,7 +595,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         }
         auth = self._auth_header_for_get(url, params, "test-secret")
 
-        with self.options({"seer.code-review.is-beta-open": True}):
+        with self.options({"seer.code-review.is-beta-signup-open": True}):
             resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
 
         assert resp.status_code == 200
@@ -608,7 +608,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
         ["test-secret"],
     )
-    def test_returns_disabled_when_beta_closed_and_only_legacy_opt_in(self):
+    def test_returns_disabled_when_beta_signup_closed_and_only_legacy_opt_in(self):
         org = self.create_organization()
         org.update_option("sentry:enable_pr_review_test_generation", True)
 
@@ -620,7 +620,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         }
         auth = self._auth_header_for_get(url, params, "test-secret")
 
-        with self.options({"seer.code-review.is-beta-open": False}):
+        with self.options({"seer.code-review.is-beta-signup-open": False}):
             resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
 
         assert resp.status_code == 200
@@ -633,8 +633,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
         ["test-secret"],
     )
-    def test_returns_enabled_when_beta_closed_but_has_beta_flag(self):
-        """With beta closed, beta flag still grants access."""
+    def test_returns_enabled_when_beta_signup_closed_and_in_static_code_revoew_beta_list(self):
         org = self.create_organization()
         org.update_option("sentry:enable_pr_review_test_generation", True)
 
@@ -647,7 +646,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         auth = self._auth_header_for_get(url, params, "test-secret")
 
         with (
-            self.options({"seer.code-review.is-beta-open": False}),
+            self.options({"seer.code-review.is-beta-signup-open": False}),
             self.feature({"organizations:code-review-beta": org}),
         ):
             resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -124,7 +124,7 @@ class TestCodeReviewPreflightService(TestCase):
         """With beta closed, legacy opt-in alone does NOT grant access."""
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
-        with self.options({"seer.code-review.is-beta-open": False}):
+        with self.options({"seer.code-review.is-beta-signup-open": False}):
             service = self._create_service()
             result = service.check()
 
@@ -143,7 +143,7 @@ class TestCodeReviewPreflightService(TestCase):
         )
 
         with (
-            self.options({"seer.code-review.is-beta-open": False}),
+            self.options({"seer.code-review.is-beta-signup-open": False}),
             patch(
                 "sentry.seer.code_review.billing.quotas.backend.check_seer_quota",
                 return_value=True,

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -99,8 +99,7 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.denial_reason is None
 
     @with_feature("organizations:gen-ai-features")
-    def test_allowed_when_org_is_legacy_opt_in_without_beta_flag(self) -> None:
-        """With beta open (default), legacy opt-in alone grants access."""
+    def test_allowed_when_org_is_legacy_opt_in_without_beta_flag_and_beta_signup_open(self) -> None:
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
         OrganizationContributors.objects.create(
@@ -109,9 +108,12 @@ class TestCodeReviewPreflightService(TestCase):
             external_identifier=self.external_identifier,
         )
 
-        with patch(
-            "sentry.seer.code_review.billing.quotas.backend.check_seer_quota",
-            return_value=True,
+        with (
+            patch(
+                "sentry.seer.code_review.billing.quotas.backend.check_seer_quota",
+                return_value=True,
+            ),
+            self.options({"seer.code-review.is-beta-signup-open": True}),
         ):
             service = self._create_service()
             result = service.check()
@@ -120,8 +122,7 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.denial_reason is None
 
     @with_feature("organizations:gen-ai-features")
-    def test_denied_when_beta_closed_and_only_legacy_opt_in(self) -> None:
-        """With beta closed, legacy opt-in alone does NOT grant access."""
+    def test_denied_when_beta_signup_closed_and_only_legacy_opt_in(self) -> None:
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
         with self.options({"seer.code-review.is-beta-signup-open": False}):
@@ -132,8 +133,7 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.denial_reason == PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
 
     @with_feature(["organizations:gen-ai-features", "organizations:code-review-beta"])
-    def test_allowed_when_beta_closed_but_has_beta_flag(self) -> None:
-        """With beta closed, beta flag still grants access."""
+    def test_allowed_when_beta_signup_closed_but_has_beta_flag(self) -> None:
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
         OrganizationContributors.objects.create(


### PR DESCRIPTION
Plug into a flag we can flip at the moment when the code review beta list is frozen