### PR TITLE
fix(preprod): Fix settings api bug for status checks

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -81,6 +81,10 @@ export type Project = {
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: {version: string} | null;
   options?: Record<string, boolean | string>;
+  preprodDistributionEnabledQuery?: string | null;
+  preprodSizeEnabledQuery?: string | null;
+  preprodSizeStatusChecksEnabled?: boolean;
+  preprodSizeStatusChecksRules?: unknown[];
   securityToken?: string;
   securityTokenHeader?: string;
   seerScannerAutomation?: boolean;

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -47,28 +47,51 @@ function parseRules(raw: unknown): StatusCheckRule[] {
 export function useStatusCheckRules(project: Project) {
   const updateProject = useUpdateProject(project);
 
-  const enabled = project.options?.[ENABLED_KEY] !== false;
-  const rulesJson = project.options?.[RULES_KEY];
+  const enabled =
+    project.preprodSizeStatusChecksEnabled ?? project.options?.[ENABLED_KEY] ?? true;
+
+  const rulesRaw = project.preprodSizeStatusChecksRules ?? project.options?.[RULES_KEY];
   const rules: StatusCheckRule[] = useMemo(() => {
-    if (typeof rulesJson !== 'string') {
+    if (Array.isArray(rulesRaw)) {
+      return parseRules(rulesRaw);
+    }
+    if (typeof rulesRaw !== 'string') {
       return [];
     }
     try {
-      return parseRules(JSON.parse(rulesJson));
+      return parseRules(JSON.parse(rulesRaw));
     } catch {
       return [];
     }
-  }, [rulesJson]);
+  }, [rulesRaw]);
 
   const config = {enabled, rules};
 
-  const updateConfig = useCallback(
-    (newOptions: Record<string, string | boolean>, successMessage?: string) => {
+  const setEnabled = useCallback(
+    (value: boolean) => {
       addLoadingMessage(t('Saving...'));
       updateProject.mutate(
+        {preprodSizeStatusChecksEnabled: value},
         {
-          options: newOptions,
-        },
+          onSuccess: () => {
+            addSuccessMessage(
+              value ? t('Status checks enabled.') : t('Status checks disabled.')
+            );
+          },
+          onError: () => {
+            addErrorMessage(t('Failed to save changes. Please try again.'));
+          },
+        }
+      );
+    },
+    [updateProject]
+  );
+
+  const saveRules = useCallback(
+    (newRules: StatusCheckRule[], successMessage?: string) => {
+      addLoadingMessage(t('Saving...'));
+      updateProject.mutate(
+        {preprodSizeStatusChecksRules: newRules as unknown[]},
         {
           onSuccess: () => {
             if (successMessage) {
@@ -82,23 +105,6 @@ export function useStatusCheckRules(project: Project) {
       );
     },
     [updateProject]
-  );
-
-  const setEnabled = useCallback(
-    (value: boolean) => {
-      updateConfig(
-        {[ENABLED_KEY]: value},
-        value ? t('Status checks enabled.') : t('Status checks disabled.')
-      );
-    },
-    [updateConfig]
-  );
-
-  const saveRules = useCallback(
-    (newRules: StatusCheckRule[], successMessage?: string) => {
-      updateConfig({[RULES_KEY]: JSON.stringify(newRules)}, successMessage);
-    },
-    [updateConfig]
   );
 
   const addRule = useCallback(

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -47,8 +47,9 @@ function parseRules(raw: unknown): StatusCheckRule[] {
 export function useStatusCheckRules(project: Project) {
   const updateProject = useUpdateProject(project);
 
+  // Check top-level field first (optimistic update), fallback to options (server response)
   const enabled =
-    project.preprodSizeStatusChecksEnabled ?? project.options?.[ENABLED_KEY] ?? true;
+    project.preprodSizeStatusChecksEnabled ?? project.options?.[ENABLED_KEY] !== false;
 
   const rulesRaw = project.preprodSizeStatusChecksRules ?? project.options?.[RULES_KEY];
   const rules: StatusCheckRule[] = useMemo(() => {


### PR DESCRIPTION
The frontend was sending data wrapped in an options object:
{"options": {"sentry:preprod_size_status_checks_enabled": false}}

The options field only exists in ProjectAdminSerializer which requires project:write or project:admin scope. Users with only project:read were getting 403 errors.

Changed to send top-level camelCase fields that match ProjectMemberSerializer:
{"preprodSizeStatusChecksEnabled": false}