### PR TITLE
AI agent shared issue markdown

### DIFF
--- a/src/sentry/issues/endpoints/shared_group_details.py
+++ b/src/sentry/issues/endpoints/shared_group_details.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.http import HttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -9,6 +10,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environment_func
 from sentry.api.serializers import SharedGroupSerializer, serialize
+from sentry.issues.endpoints.shared_group_markdown import format_shared_issue_as_markdown
 from sentry.models.group import Group
 
 
@@ -20,12 +22,43 @@ class SharedGroupDetailsEndpoint(Endpoint):
     }
     permission_classes = ()
 
+    def _is_markdown_requested(self, request: Request) -> bool:
+        """
+        Determine if the client is requesting markdown format.
+
+        Checks:
+        1. Accept header contains text/markdown or text/plain
+        2. User-Agent indicates an AI agent (cursor, claude, chatgpt, etc.)
+        """
+        # Check Accept header
+        accept_header = request.META.get("HTTP_ACCEPT", "")
+        if "text/markdown" in accept_header.lower() or "text/plain" in accept_header.lower():
+            return True
+
+        # Check User-Agent for common AI agents
+        user_agent = request.META.get("HTTP_USER_AGENT", "").lower()
+        ai_agent_patterns = [
+            "cursor",
+            "claude",
+            "chatgpt",
+            "gpt-",
+            "openai",
+            "anthropic",
+            "copilot",
+            "github-copilot",
+            "ai-agent",
+        ]
+        if any(pattern in user_agent for pattern in ai_agent_patterns):
+            return True
+
+        return False
+
     def get(
         self,
         request: Request,
         organization_id_or_slug: int | str | None = None,
         share_id: str | None = None,
-    ) -> Response:
+    ) -> Response | HttpResponse:
         """
         Retrieve an aggregate
 
@@ -65,4 +98,10 @@ class SharedGroupDetailsEndpoint(Endpoint):
                 environment_func=get_environment_func(request, group.project.organization_id)
             ),
         )
+
+        # Return markdown if requested by AI agent
+        if self._is_markdown_requested(request):
+            markdown_content = format_shared_issue_as_markdown(context)
+            return HttpResponse(markdown_content, content_type="text/markdown; charset=utf-8")
+
         return Response(context)

--- a/src/sentry/issues/endpoints/shared_group_markdown.py
+++ b/src/sentry/issues/endpoints/shared_group_markdown.py
@@ -205,9 +205,7 @@ def _format_request_entry(data: dict[str, Any], lines: list[str]) -> None:
     if headers and isinstance(headers, dict):
         # Only show some common useful headers
         useful_headers = ["user-agent", "referer", "content-type"]
-        filtered_headers = {
-            k: v for k, v in headers.items() if k.lower() in useful_headers
-        }
+        filtered_headers = {k: v for k, v in headers.items() if k.lower() in useful_headers}
         if filtered_headers:
             lines.append("\n**Headers:**")
             for key, value in filtered_headers.items():

--- a/src/sentry/issues/endpoints/shared_group_markdown.py
+++ b/src/sentry/issues/endpoints/shared_group_markdown.py
@@ -1,0 +1,214 @@
+"""
+Markdown formatter for shared issues.
+
+This module provides utilities to render shared issues in markdown format
+for AI agents and other consumers that prefer markdown over JSON.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def format_shared_issue_as_markdown(data: dict[str, Any]) -> str:
+    """
+    Format a shared issue data dictionary as markdown.
+
+    Args:
+        data: Serialized shared issue data from SharedGroupSerializer
+
+    Returns:
+        Markdown formatted string representation of the issue
+    """
+    lines = []
+
+    # Title and basic info
+    title = data.get("title", "Untitled Issue")
+    short_id = data.get("shortId", "")
+    lines.append(f"# {title}")
+    if short_id:
+        lines.append(f"\n**Issue ID:** {short_id}")
+
+    permalink = data.get("permalink")
+    if permalink:
+        lines.append(f"**Link:** {permalink}")
+
+    # Issue metadata
+    lines.append("\n## Issue Details")
+
+    issue_category = data.get("issueCategory", "")
+    if issue_category:
+        lines.append(f"- **Category:** {issue_category}")
+
+    is_unhandled = data.get("isUnhandled")
+    if is_unhandled is not None:
+        lines.append(f"- **Unhandled:** {is_unhandled}")
+
+    culprit = data.get("culprit")
+    if culprit:
+        lines.append(f"- **Culprit:** `{culprit}`")
+
+    # Project information
+    project = data.get("project", {})
+    if project:
+        lines.append("\n## Project")
+        project_name = project.get("name", "")
+        project_slug = project.get("slug", "")
+        if project_name:
+            lines.append(f"- **Name:** {project_name}")
+        if project_slug:
+            lines.append(f"- **Slug:** {project_slug}")
+
+        org = project.get("organization", {})
+        if org:
+            org_name = org.get("name", "")
+            org_slug = org.get("slug", "")
+            if org_name:
+                lines.append(f"- **Organization:** {org_name}")
+            if org_slug:
+                lines.append(f"  - **Slug:** {org_slug}")
+
+    # Latest event information
+    latest_event = data.get("latestEvent", {})
+    if latest_event:
+        lines.append("\n## Latest Event")
+
+        event_id = latest_event.get("eventID") or latest_event.get("id")
+        if event_id:
+            lines.append(f"- **Event ID:** `{event_id}`")
+
+        platform = latest_event.get("platform")
+        if platform:
+            lines.append(f"- **Platform:** {platform}")
+
+        date_created = latest_event.get("dateCreated")
+        if date_created:
+            lines.append(f"- **Date:** {date_created}")
+
+        message = latest_event.get("message")
+        if message:
+            lines.append(f"\n**Message:**\n```\n{message}\n```")
+
+        # Event entries (stack traces, exception, etc.)
+        entries = latest_event.get("entries", [])
+        if entries:
+            lines.append("\n### Event Details")
+            for entry in entries:
+                entry_type = entry.get("type", "")
+                entry_data = entry.get("data", {})
+
+                if entry_type == "exception":
+                    _format_exception_entry(entry_data, lines)
+                elif entry_type == "message":
+                    _format_message_entry(entry_data, lines)
+                elif entry_type == "stacktrace":
+                    _format_stacktrace_entry(entry_data, lines)
+                elif entry_type == "request":
+                    _format_request_entry(entry_data, lines)
+
+    return "\n".join(lines)
+
+
+def _format_exception_entry(data: dict[str, Any], lines: list[str]) -> None:
+    """Format an exception entry."""
+    values = data.get("values", [])
+    if not values:
+        return
+
+    lines.append("\n#### Exception")
+    for idx, exc in enumerate(values):
+        exc_type = exc.get("type", "Unknown")
+        exc_value = exc.get("value", "")
+        mechanism = exc.get("mechanism", {})
+
+        if len(values) > 1:
+            lines.append(f"\n**Exception {idx + 1}:** {exc_type}")
+        else:
+            lines.append(f"\n**Type:** {exc_type}")
+
+        if exc_value:
+            lines.append(f"**Value:** {exc_value}")
+
+        if mechanism:
+            mechanism_type = mechanism.get("type")
+            if mechanism_type:
+                lines.append(f"**Mechanism:** {mechanism_type}")
+
+        # Stack trace for this exception
+        stacktrace = exc.get("stacktrace")
+        if stacktrace:
+            _format_stacktrace_data(stacktrace, lines)
+
+
+def _format_stacktrace_entry(data: dict[str, Any], lines: list[str]) -> None:
+    """Format a stacktrace entry."""
+    lines.append("\n#### Stack Trace")
+    _format_stacktrace_data(data, lines)
+
+
+def _format_stacktrace_data(stacktrace: dict[str, Any], lines: list[str]) -> None:
+    """Format stacktrace data."""
+    frames = stacktrace.get("frames", [])
+    if not frames:
+        return
+
+    lines.append("\n```")
+    # Show frames in reverse order (most recent first)
+    for frame in reversed(frames[-10:]):  # Only show last 10 frames to keep it concise
+        filename = frame.get("filename") or frame.get("absPath", "unknown")
+        function = frame.get("function", "unknown")
+        lineno = frame.get("lineNo")
+        context_line = frame.get("context")
+
+        location = f"{filename}:{lineno}" if lineno else filename
+        lines.append(f"  at {function} ({location})")
+
+        # Show context line if available
+        if context_line:
+            lines.append(f"    > {context_line.strip()}")
+
+    if len(frames) > 10:
+        lines.append(f"  ... ({len(frames) - 10} more frames)")
+
+    lines.append("```")
+
+
+def _format_message_entry(data: dict[str, Any], lines: list[str]) -> None:
+    """Format a message entry."""
+    formatted = data.get("formatted")
+    if formatted:
+        lines.append(f"\n**Message:**\n```\n{formatted}\n```")
+
+
+def _format_request_entry(data: dict[str, Any], lines: list[str]) -> None:
+    """Format a request entry."""
+    lines.append("\n#### Request Information")
+
+    url = data.get("url")
+    if url:
+        lines.append(f"- **URL:** {url}")
+
+    method = data.get("method")
+    if method:
+        lines.append(f"- **Method:** {method}")
+
+    query_string = data.get("queryString")
+    if query_string:
+        if isinstance(query_string, str):
+            lines.append(f"- **Query String:** {query_string}")
+        elif isinstance(query_string, list):
+            qs_str = "&".join([f"{k}={v}" for k, v in query_string])
+            if qs_str:
+                lines.append(f"- **Query String:** {qs_str}")
+
+    headers = data.get("headers")
+    if headers and isinstance(headers, dict):
+        # Only show some common useful headers
+        useful_headers = ["user-agent", "referer", "content-type"]
+        filtered_headers = {
+            k: v for k, v in headers.items() if k.lower() in useful_headers
+        }
+        if filtered_headers:
+            lines.append("\n**Headers:**")
+            for key, value in filtered_headers.items():
+                lines.append(f"- `{key}`: {value}")

--- a/tests/sentry/issues/endpoints/test_shared_group_details.py
+++ b/tests/sentry/issues/endpoints/test_shared_group_details.py
@@ -109,3 +109,121 @@ class SharedGroupDetailsTest(APITestCase):
 
             assert response.status_code == 200, response.content
             assert response.data["permalink"]
+
+    def test_markdown_with_accept_header(self) -> None:
+        """Test that markdown is returned when Accept: text/markdown header is sent."""
+        self.login_as(user=self.user)
+
+        min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(
+            data={
+                "timestamp": min_ago,
+                "message": "Test error message",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "ValueError",
+                            "value": "Test exception value",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "filename": "test.py",
+                                        "function": "test_function",
+                                        "lineNo": 42,
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+        group = event.group
+
+        GroupShare.objects.create(project_id=group.project_id, group=group)
+        share_id = group.get_share_id()
+        assert share_id is not None
+
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, HTTP_ACCEPT="text/markdown")
+
+            assert response.status_code == 200, response.content
+            assert response["Content-Type"] == "text/markdown; charset=utf-8"
+
+            # Verify markdown content includes key information
+            content = response.content.decode("utf-8")
+            assert "# " in content  # Title
+            assert "## Issue Details" in content
+            assert group.qualified_short_id in content
+            assert self.project.slug in content
+            assert self.organization.slug in content
+
+    def test_markdown_with_cursor_user_agent(self) -> None:
+        """Test that markdown is returned when User-Agent indicates Cursor AI agent."""
+        self.login_as(user=self.user)
+
+        min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(data={"timestamp": min_ago}, project_id=self.project.id)
+        assert event.group is not None
+        group = event.group
+
+        GroupShare.objects.create(project_id=group.project_id, group=group)
+        share_id = group.get_share_id()
+        assert share_id is not None
+
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, HTTP_USER_AGENT="cursor-ai/1.0")
+
+            assert response.status_code == 200, response.content
+            assert response["Content-Type"] == "text/markdown; charset=utf-8"
+
+            content = response.content.decode("utf-8")
+            assert "# " in content
+            assert group.qualified_short_id in content
+
+    def test_markdown_with_claude_user_agent(self) -> None:
+        """Test that markdown is returned when User-Agent indicates Claude AI agent."""
+        self.login_as(user=self.user)
+
+        min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(data={"timestamp": min_ago}, project_id=self.project.id)
+        assert event.group is not None
+        group = event.group
+
+        GroupShare.objects.create(project_id=group.project_id, group=group)
+        share_id = group.get_share_id()
+        assert share_id is not None
+
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, HTTP_USER_AGENT="Claude/1.0")
+
+            assert response.status_code == 200, response.content
+            assert response["Content-Type"] == "text/markdown; charset=utf-8"
+
+    def test_json_without_markdown_headers(self) -> None:
+        """Test that JSON is still returned when neither Accept header nor AI User-Agent is present."""
+        self.login_as(user=self.user)
+
+        min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(data={"timestamp": min_ago}, project_id=self.project.id)
+        assert event.group is not None
+        group = event.group
+
+        GroupShare.objects.create(project_id=group.project_id, group=group)
+        share_id = group.get_share_id()
+        assert share_id is not None
+
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            # Regular request without special headers
+            response = self.client.get(path, format="json")
+
+            assert response.status_code == 200, response.content
+            # Should be JSON response
+            assert hasattr(response, "data")
+            assert response.data["id"] == str(group.id)

--- a/tests/sentry/issues/endpoints/test_shared_group_markdown.py
+++ b/tests/sentry/issues/endpoints/test_shared_group_markdown.py
@@ -145,16 +145,13 @@ class SharedGroupMarkdownFormatterTest(TestCase):
     def test_stacktrace_truncation(self) -> None:
         """Test that long stack traces are truncated to 10 frames."""
         frames = [
-            {"filename": f"file{i}.py", "function": f"func{i}", "lineNo": i}
-            for i in range(20)
+            {"filename": f"file{i}.py", "function": f"func{i}", "lineNo": i} for i in range(20)
         ]
 
         data = {
             "title": "Long Stack Trace",
             "shortId": "TEST-4",
-            "latestEvent": {
-                "entries": [{"type": "stacktrace", "data": {"frames": frames}}]
-            },
+            "latestEvent": {"entries": [{"type": "stacktrace", "data": {"frames": frames}}]},
         }
 
         markdown = format_shared_issue_as_markdown(data)

--- a/tests/sentry/issues/endpoints/test_shared_group_markdown.py
+++ b/tests/sentry/issues/endpoints/test_shared_group_markdown.py
@@ -1,0 +1,213 @@
+from sentry.issues.endpoints.shared_group_markdown import format_shared_issue_as_markdown
+from sentry.testutils.cases import TestCase
+
+
+class SharedGroupMarkdownFormatterTest(TestCase):
+    def test_basic_issue_formatting(self) -> None:
+        """Test basic issue markdown formatting with minimal data."""
+        data = {
+            "id": "123",
+            "title": "Test Issue Title",
+            "shortId": "TEST-1",
+            "permalink": "https://sentry.io/organizations/test-org/issues/123/",
+            "issueCategory": "error",
+            "culprit": "test.function",
+            "project": {
+                "name": "Test Project",
+                "slug": "test-project",
+                "organization": {"name": "Test Org", "slug": "test-org"},
+            },
+            "latestEvent": {
+                "id": "event123",
+                "eventID": "event123",
+                "platform": "python",
+                "message": "Test error message",
+            },
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Verify title
+        assert "# Test Issue Title" in markdown
+
+        # Verify issue ID
+        assert "**Issue ID:** TEST-1" in markdown
+
+        # Verify permalink
+        assert "https://sentry.io/organizations/test-org/issues/123/" in markdown
+
+        # Verify issue details
+        assert "## Issue Details" in markdown
+        assert "**Category:** error" in markdown
+        assert "**Culprit:** `test.function`" in markdown
+
+        # Verify project info
+        assert "## Project" in markdown
+        assert "**Name:** Test Project" in markdown
+        assert "**Slug:** test-project" in markdown
+        assert "**Organization:** Test Org" in markdown
+
+        # Verify event info
+        assert "## Latest Event" in markdown
+        assert "**Event ID:** `event123`" in markdown
+        assert "**Platform:** python" in markdown
+
+    def test_exception_formatting(self) -> None:
+        """Test exception entry formatting in markdown."""
+        data = {
+            "title": "Exception Test",
+            "shortId": "TEST-2",
+            "latestEvent": {
+                "entries": [
+                    {
+                        "type": "exception",
+                        "data": {
+                            "values": [
+                                {
+                                    "type": "ValueError",
+                                    "value": "Invalid value provided",
+                                    "mechanism": {"type": "generic"},
+                                    "stacktrace": {
+                                        "frames": [
+                                            {
+                                                "filename": "app.py",
+                                                "function": "main",
+                                                "lineNo": 10,
+                                                "context": "result = process(data)",
+                                            },
+                                            {
+                                                "filename": "utils.py",
+                                                "function": "process",
+                                                "lineNo": 42,
+                                                "context": "raise ValueError('Invalid value provided')",
+                                            },
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Verify exception formatting
+        assert "#### Exception" in markdown
+        assert "**Type:** ValueError" in markdown
+        assert "**Value:** Invalid value provided" in markdown
+        assert "**Mechanism:** generic" in markdown
+
+        # Verify stack trace
+        assert "at process (utils.py:42)" in markdown
+        assert "at main (app.py:10)" in markdown
+        assert "raise ValueError('Invalid value provided')" in markdown
+
+    def test_request_entry_formatting(self) -> None:
+        """Test request entry formatting in markdown."""
+        data = {
+            "title": "Request Error",
+            "shortId": "TEST-3",
+            "latestEvent": {
+                "entries": [
+                    {
+                        "type": "request",
+                        "data": {
+                            "url": "https://example.com/api/endpoint",
+                            "method": "POST",
+                            "queryString": "param1=value1&param2=value2",
+                            "headers": {
+                                "User-Agent": "Mozilla/5.0",
+                                "Content-Type": "application/json",
+                                "Authorization": "Bearer secret",
+                            },
+                        },
+                    }
+                ]
+            },
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Verify request info
+        assert "#### Request Information" in markdown
+        assert "**URL:** https://example.com/api/endpoint" in markdown
+        assert "**Method:** POST" in markdown
+        assert "**Query String:** param1=value1&param2=value2" in markdown
+
+        # Verify headers (only certain headers should be shown)
+        assert "user-agent" in markdown.lower()
+        assert "content-type" in markdown.lower()
+        # Authorization should not be shown (not in useful_headers list)
+        assert "authorization" not in markdown.lower()
+
+    def test_stacktrace_truncation(self) -> None:
+        """Test that long stack traces are truncated to 10 frames."""
+        frames = [
+            {"filename": f"file{i}.py", "function": f"func{i}", "lineNo": i}
+            for i in range(20)
+        ]
+
+        data = {
+            "title": "Long Stack Trace",
+            "shortId": "TEST-4",
+            "latestEvent": {
+                "entries": [{"type": "stacktrace", "data": {"frames": frames}}]
+            },
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Should show only 10 frames
+        assert "... (10 more frames)" in markdown
+
+    def test_empty_data(self) -> None:
+        """Test that formatter handles empty/minimal data gracefully."""
+        data = {"title": "Minimal Issue"}
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Should at least have the title
+        assert "# Minimal Issue" in markdown
+
+        # Should not crash with missing fields
+        assert isinstance(markdown, str)
+
+    def test_unhandled_flag(self) -> None:
+        """Test that isUnhandled flag is included in markdown."""
+        data = {
+            "title": "Unhandled Error",
+            "shortId": "TEST-5",
+            "isUnhandled": True,
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        assert "**Unhandled:** True" in markdown
+
+    def test_multiple_exceptions(self) -> None:
+        """Test formatting of multiple chained exceptions."""
+        data = {
+            "title": "Chained Exceptions",
+            "shortId": "TEST-6",
+            "latestEvent": {
+                "entries": [
+                    {
+                        "type": "exception",
+                        "data": {
+                            "values": [
+                                {"type": "KeyError", "value": "'missing_key'"},
+                                {"type": "ValueError", "value": "Invalid data"},
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        markdown = format_shared_issue_as_markdown(data)
+
+        # Should show both exceptions
+        assert "**Exception 1:** KeyError" in markdown
+        assert "**Exception 2:** ValueError" in markdown


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds the ability for AI agents to retrieve a markdown representation of shared Sentry issues.

This PR introduces:
-   Logic in `SharedGroupDetailsEndpoint` to detect AI agents based on `Accept` headers (`text/markdown`, `text/plain`) or common AI `User-Agent` patterns.
-   A new markdown formatter (`shared_group_markdown.py`) to convert shared issue data into a structured, human-readable markdown document.
-   When an AI agent is detected, the endpoint now serves the markdown content instead of the default JSON.
-   Comprehensive formatting for issue details, project, latest event, exceptions, truncated stack traces, and request information.

This allows AI agents (e.g., Cursor, Claude, ChatGPT) to more easily consume and understand Sentry shared issue links.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C07P2KGJGG0/p1768608253129149?thread_ts=1768608253.129149&cid=C07P2KGJGG0)

<a href="https://cursor.com/background-agent?bcId=bc-26485e57-c7db-4469-a19d-c6cfdb5c01c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26485e57-c7db-4469-a19d-c6cfdb5c01c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

