### PR TITLE
fix(prevent): Improve redirects to pages that exist wrt the Prevent main nav button

### DIFF
--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -34,7 +34,6 @@ import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew/whats
 import {NavTourElement, StackedNavigationTour} from 'sentry/views/nav/tour/tour';
 import {NavLayout, PrimaryNavGroup} from 'sentry/views/nav/types';
 import {UserDropdown} from 'sentry/views/nav/userDropdown';
-import {makePreventPathname} from 'sentry/views/prevent/pathnames';
 import {
   PREVENT_AI_BASE_URL,
   PREVENT_BASE_URL,
@@ -166,7 +165,7 @@ export function PrimaryNavigationItems() {
             <Container position="relative" height="100%">
               {showNewSeer(organization) ? (
                 <SidebarLink
-                  to={makePreventPathname({organization, path: `/${TESTS_BASE_URL}/`})}
+                  to={`/${prefix}/${PREVENT_BASE_URL}/${TESTS_BASE_URL}/`}
                   activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
                   analyticsKey="prevent"
                   group={PrimaryNavGroup.PREVENT}

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -34,7 +34,12 @@ import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew/whats
 import {NavTourElement, StackedNavigationTour} from 'sentry/views/nav/tour/tour';
 import {NavLayout, PrimaryNavGroup} from 'sentry/views/nav/types';
 import {UserDropdown} from 'sentry/views/nav/userDropdown';
-import {PREVENT_AI_BASE_URL, PREVENT_BASE_URL} from 'sentry/views/prevent/settings';
+import {makePreventPathname} from 'sentry/views/prevent/pathnames';
+import {
+  PREVENT_AI_BASE_URL,
+  PREVENT_BASE_URL,
+  TESTS_BASE_URL,
+} from 'sentry/views/prevent/settings';
 
 function SidebarBody({
   children,
@@ -159,15 +164,27 @@ export function PrimaryNavigationItems() {
         <Feature features={['prevent-ai']}>
           {showPreventNav(organization) ? (
             <Container position="relative" height="100%">
-              <SidebarLink
-                to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
-                activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
-                analyticsKey="prevent"
-                group={PrimaryNavGroup.PREVENT}
-                {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
-              >
-                <IconPrevent />
-              </SidebarLink>
+              {showNewSeer(organization) ? (
+                <SidebarLink
+                  to={makePreventPathname({organization, path: `/${TESTS_BASE_URL}/`})}
+                  activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
+                  analyticsKey="prevent"
+                  group={PrimaryNavGroup.PREVENT}
+                  {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
+                >
+                  <IconPrevent />
+                </SidebarLink>
+              ) : (
+                <SidebarLink
+                  to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
+                  activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
+                  analyticsKey="prevent"
+                  group={PrimaryNavGroup.PREVENT}
+                  {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
+                >
+                  <IconPrevent />
+                </SidebarLink>
+              )}
               <BetaBadge type="beta" />
             </Container>
           ) : null}

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -14,7 +14,7 @@ import {
   TOKENS_BASE_URL,
 } from 'sentry/views/prevent/settings';
 
-function PreventSecondaryNav() {
+export default function PreventSecondaryNav() {
   const organization = useOrganization();
   const testsPathname = makePreventPathname({
     organization,
@@ -61,5 +61,3 @@ function PreventSecondaryNav() {
     </Fragment>
   );
 }
-
-export default PreventSecondaryNav;

--- a/static/app/views/prevent/preventAI/wrapper.tsx
+++ b/static/app/views/prevent/preventAI/wrapper.tsx
@@ -18,7 +18,9 @@ export default function PreventAIPageWrapper() {
 
   useEffect(() => {
     if (showNewSeer(organization)) {
-      navigate(normalizeUrl(`/organizations/${organization.slug}/settings/seer/`));
+      navigate(normalizeUrl(`/organizations/${organization.slug}/settings/seer/`), {
+        replace: true,
+      });
     }
   }, [navigate, organization, organization.slug]);
 


### PR DESCRIPTION
This is a followup to https://github.com/getsentry/sentry/pull/105346

In that previous PR i added a redirect to the AI config page, which would kick you out of the Prevent area making the Test Analytics pages inaccessible. This changes the url within the main nav to point to whichever sub-nav items are available. You'll get either:
- code-review page if both code-review and test analytics are enabled
- code-review page if it's the only one enabled.
- test analytics page if that's the only one enabled.

also fixed the `navigate()` call to be a proper redirect, replacing the url instead of appending to history.