### PR TITLE
fix(preprod): use get_or_create to avoid duplicate comparison IntegrityError

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -200,17 +200,20 @@ def compare_preprod_artifact_size_analysis(
         for comp in comparisons:
             head_metric = comp["head_metric"]
             base_metric = comp["base_metric"]
-            comparison = PreprodArtifactSizeComparison.objects.create(
+            comparison, created = PreprodArtifactSizeComparison.objects.get_or_create(
                 head_size_analysis=head_metric,
                 base_size_analysis=base_metric,
                 organization_id=org_id,
-                state=PreprodArtifactSizeComparison.State.PENDING,
+                defaults={"state": PreprodArtifactSizeComparison.State.PENDING},
             )
-            comparison.save()
 
             logger.info(
                 "preprod.size_analysis.compare.running_comparison",
-                extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+                extra={
+                    "head_metric_id": head_metric.id,
+                    "base_metric_id": base_metric.id,
+                    "comparison_created": created,
+                },
             )
             _run_size_analysis_comparison(org_id, head_metric, base_metric)
 


### PR DESCRIPTION
Fixes SENTRY-5AZ7

When concurrent task executions try to create the same PreprodArtifactSizeComparison record, an IntegrityError is raised due to the unique constraint on (organization_id, head_size_analysis_id, base_size_analysis_id).

This changes create() to get_or_create() so that if the record already exists, it's returned instead of throwing an error. The downstream _run_size_analysis_comparison function already handles existing comparisons in PROCESSING/SUCCESS/FAILED states.

