### PR TITLE
feat(uptime): Include response capture in incident evidence

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -52,6 +52,7 @@ from sentry.uptime.utils import (
     build_backlog_task_scheduled_key,
     build_last_interval_change_timestamp_key,
     build_last_update_key,
+    generate_scheduled_check_times_ms,
     get_cluster,
 )
 from sentry.utils import json, metrics
@@ -343,7 +344,12 @@ def create_backfill_misses(
 
         synthetic_metric_tags = metric_tags.copy()
         synthetic_metric_tags["status"] = CHECKSTATUS_MISSED_WINDOW
-        for i in range(0, num_missed_checks):
+        missed_times = generate_scheduled_check_times_ms(
+            last_update_ms + subscription_interval_ms,
+            subscription_interval_ms,
+            num_missed_checks,
+        )
+        for scheduled_time_ms in missed_times:
             missed_result: CheckResult = {
                 "guid": uuid.uuid4().hex,
                 "subscription_id": result["subscription_id"],
@@ -355,7 +361,7 @@ def create_backfill_misses(
                 "trace_id": uuid.uuid4().hex,
                 "span_id": uuid.uuid4().hex,
                 "region": result["region"],
-                "scheduled_check_time_ms": last_update_ms + ((i + 1) * subscription_interval_ms),
+                "scheduled_check_time_ms": scheduled_time_ms,
                 "actual_check_time_ms": result["actual_check_time_ms"],
                 "duration_ms": 0,
                 "request_info": None,

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -39,3 +39,28 @@ def build_backlog_schedule_lock_key(subscription_id: str) -> str:
 
 def get_cluster() -> RedisCluster | StrictRedis:
     return redis.redis_clusters.get(settings.SENTRY_UPTIME_DETECTOR_CLUSTER)
+
+
+def generate_scheduled_check_times_ms(
+    base_time_ms: int,
+    interval_ms: int,
+    count: int,
+    forward: bool = True,
+) -> list[int]:
+    """
+    Generate a sequence of scheduled check times.
+
+    Args:
+        base_time_ms: The reference scheduled check time in milliseconds
+        interval_ms: The interval between checks in milliseconds
+        count: Number of times to generate
+        forward: If True, generate times forward from base (inclusive).
+                 If False, generate times backward ending at base (inclusive).
+
+    Returns:
+        List of scheduled check times in milliseconds, in ascending order.
+
+    """
+    start = 0 if forward else -(count - 1)
+    end = count if forward else 1
+    return [base_time_ms + (i * interval_ms) for i in range(start, end)]

--- a/tests/sentry/uptime/test_utils.py
+++ b/tests/sentry/uptime/test_utils.py
@@ -1,4 +1,31 @@
-from sentry.uptime.utils import build_backlog_key, build_backlog_task_scheduled_key
+from sentry.uptime.utils import (
+    build_backlog_key,
+    build_backlog_task_scheduled_key,
+    generate_scheduled_check_times_ms,
+)
+
+
+class TestGenerateScheduledCheckTimesMs:
+    def test_forward_single(self):
+        assert generate_scheduled_check_times_ms(1000, 60000, 1) == [1000]
+
+    def test_forward_multiple(self):
+        assert generate_scheduled_check_times_ms(1000, 60000, 3) == [1000, 61000, 121000]
+
+    def test_backward_single(self):
+        assert generate_scheduled_check_times_ms(1000, 60000, 1, forward=False) == [1000]
+
+    def test_backward_multiple(self):
+        assert generate_scheduled_check_times_ms(121000, 60000, 3, forward=False) == [
+            1000,
+            61000,
+            121000,
+        ]
+
+    def test_forward_is_default(self):
+        assert generate_scheduled_check_times_ms(
+            1000, 60000, 3
+        ) == generate_scheduled_check_times_ms(1000, 60000, 3, forward=True)
 
 
 class TestBuildBacklogKey:


### PR DESCRIPTION
When an uptime incident is created, look up the most recent response capture from the failure sequence and include its ID in the occurrence evidence_data. This allows the API/UI to retrieve and display the captured response.

Also adds generate_scheduled_check_times_ms utility for extrapolating scheduled check times forward or backward from a base time.

## Project Context

This is part of the Uptime Response Capture feature - storing HTTP response data (body + headers) when downtime incidents are created to help users debug failures.

PRs in this series:
1. sentry-kafka-schemas: Schema changes
2. uptime-checker: Response capture config and logic
3. sentry: Storage model (UptimeResponseCapture)
4. sentry: Config production and toggle helper
5. sentry: Consumer capture creation
6. sentry: Incident integration <-- this PR
7. sentry: API and UI

<!-- Describe your PR here. -->