### PR TITLE
ref(forms): Convert BooleanField from class to functional component

### DIFF
--- a/static/app/components/forms/fields/booleanField.spec.tsx
+++ b/static/app/components/forms/fields/booleanField.spec.tsx
@@ -1,0 +1,109 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import BooleanField from 'sentry/components/forms/fields/booleanField';
+import Form from 'sentry/components/forms/form';
+
+describe('BooleanField', () => {
+  it('renders without form context', () => {
+    render(<BooleanField name="fieldName" />);
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('renders with form context', () => {
+    render(
+      <Form initialData={{fieldName: true}}>
+        <BooleanField name="fieldName" />
+      </Form>
+    );
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('toggles on and off', async () => {
+    const onChange = jest.fn();
+    render(<BooleanField name="fieldName" onChange={onChange} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  it('starts with initial value of true', () => {
+    render(<BooleanField name="fieldName" value />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('starts with initial value of false', () => {
+    render(<BooleanField name="fieldName" value={false} />);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('coerces truthy values to boolean', () => {
+    render(<BooleanField name="fieldName" value="truthy string" />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('coerces falsy values to boolean', () => {
+    render(<BooleanField name="fieldName" value="" />);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('shows disabled state', () => {
+    render(<BooleanField name="fieldName" disabled />);
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('shows disabled reason in tooltip', async () => {
+    render(<BooleanField name="fieldName" disabled disabledReason="Not allowed" />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeDisabled();
+
+    await userEvent.hover(checkbox);
+    await waitFor(() => {
+      expect(screen.getByText('Not allowed')).toBeInTheDocument();
+    });
+  });
+
+  describe('with confirm prop', () => {
+    it('skips confirm dialog when no message for current state', async () => {
+      const onChange = jest.fn();
+      const confirm = {
+        true: 'Are you sure you want to enable this?',
+      };
+
+      render(
+        <BooleanField name="fieldName" value onChange={onChange} confirm={confirm} />
+      );
+
+      // Clicking to disable (false state) - no confirm message for false
+      await userEvent.click(screen.getByRole('checkbox'));
+
+      // Should call onChange immediately without showing dialog
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('calls change immediately when no confirm message defined', async () => {
+      const onChange = jest.fn();
+
+      render(<BooleanField name="fieldName" onChange={onChange} />);
+
+      await userEvent.click(screen.getByRole('checkbox'));
+
+      // Should call onChange immediately
+      expect(onChange).toHaveBeenCalledWith(true, expect.anything());
+    });
+  });
+
+  it('calls both onChange and onBlur when toggled', async () => {
+    const onChange = jest.fn();
+    const onBlur = jest.fn();
+
+    render(<BooleanField name="fieldName" onChange={onChange} onBlur={onBlur} />);
+
+    await userEvent.click(screen.getByRole('checkbox'));
+
+    expect(onChange).toHaveBeenCalledWith(true, expect.anything());
+    expect(onBlur).toHaveBeenCalledWith(true, expect.anything());
+  });
+});

--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -1,5 +1,3 @@
-import {Component} from 'react';
-
 import Confirm from 'sentry/components/confirm';
 import {Switch, type SwitchProps} from 'sentry/components/core/switch';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -16,95 +14,81 @@ export interface BooleanFieldProps extends InputFieldProps {
   };
 }
 
-export default class BooleanField extends Component<BooleanFieldProps> {
-  coerceValue(value: any) {
-    return !!value;
-  }
+export default function BooleanField({confirm, ...fieldProps}: BooleanFieldProps) {
+  return (
+    <FormField {...fieldProps} resetOnError>
+      {({
+        children: _children,
+        onChange,
+        onBlur,
+        value,
+        disabled,
+        disabledReason,
+        ...props
+      }: {
+        disabled: boolean;
+        disabledReason: boolean;
+        onBlur: OnEvent;
+        onChange: OnEvent;
+        type: string;
+        value: any;
+        children?: React.ReactNode;
+      }) => {
+        const handleChange = (
+          e?: React.ChangeEvent<HTMLInputElement> | React.FormEvent<HTMLInputElement>
+        ) => {
+          // We need to toggle current value because Switch is not an input
+          const newValue = !value;
+          onChange(newValue, e);
+          onBlur(newValue, e);
+        };
 
-  handleChange = (
-    value: any,
-    onChange: OnEvent,
-    onBlur: OnEvent,
-    e: React.FormEvent<HTMLInputElement>
-  ) => {
-    // We need to toggle current value because Switch is not an input
-    const newValue = this.coerceValue(!value);
-    onChange(newValue, e);
-    onBlur(newValue, e);
-  };
-
-  render() {
-    const {confirm, ...fieldProps} = this.props;
-
-    return (
-      <FormField {...fieldProps} resetOnError>
-        {({
-          children: _children,
-          onChange,
-          onBlur,
-          value,
+        const {type: _, ...propsWithoutType} = props;
+        const switchProps: SwitchProps = {
+          ...propsWithoutType,
+          size: 'lg',
+          checked: !!value,
           disabled,
-          disabledReason,
-          ...props
-        }: {
-          disabled: boolean;
-          disabledReason: boolean;
-          onBlur: OnEvent;
-          onChange: OnEvent;
-          type: string;
-          value: any;
-          children?: React.ReactNode;
-        }) => {
-          // Create a function with required args bound
-          const handleChange = this.handleChange.bind(this, value, onChange, onBlur);
+          onChange: handleChange,
+        };
 
-          const {type: _, ...propsWithoutType} = props;
-          const switchProps: SwitchProps = {
-            ...propsWithoutType,
-            size: 'lg',
-            checked: !!value,
-            disabled,
-            onChange: handleChange,
-          };
-
-          if (confirm) {
-            return (
-              <Confirm
-                // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                renderMessage={() => confirm[(!value).toString()]}
-                onConfirm={() => handleChange({})}
-                isDangerous={confirm.isDangerous}
-              >
-                {({open}) => (
-                  <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
-                    <Switch
-                      {...switchProps}
-                      onChange={e => {
-                        // If we have a `confirm` prop and enabling switch
-                        // Then show confirm dialog, otherwise propagate change as normal
-                        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                        if (confirm[(!value).toString()]) {
-                          // Open confirm modal
-                          open();
-                          return;
-                        }
-
-                        handleChange(e);
-                      }}
-                    />
-                  </Tooltip>
-                )}
-              </Confirm>
-            );
-          }
-
+        if (confirm) {
           return (
-            <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
-              <Switch {...switchProps} />
-            </Tooltip>
+            <Confirm
+              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+              renderMessage={() => confirm[(!value).toString()]}
+              onConfirm={() => handleChange()}
+              isDangerous={confirm.isDangerous}
+            >
+              {({open}) => (
+                <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
+                  <Switch
+                    {...switchProps}
+                    onChange={e => {
+                      // If we have a `confirm` prop and enabling switch
+                      // Then show confirm dialog, otherwise propagate change as normal
+                      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+                      if (confirm[(!value).toString()]) {
+                        // Open confirm modal
+                        open();
+                        return;
+                      }
+
+                      handleChange(e);
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Confirm>
           );
-        }}
-      </FormField>
-    );
-  }
+        }
+
+        return (
+          <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
+            <Switch {...switchProps} />
+          </Tooltip>
+        );
+      }}
+    </FormField>
+  );
 }

--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -34,48 +34,34 @@ export default function BooleanField({confirm, ...fieldProps}: BooleanFieldProps
         value: any;
         children?: React.ReactNode;
       }) => {
-        const handleChange = (
-          e?: React.ChangeEvent<HTMLInputElement> | React.FormEvent<HTMLInputElement>
-        ) => {
-          // We need to toggle current value because Switch is not an input
+        const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
           const newValue = !value;
-          onChange(newValue, e);
-          onBlur(newValue, e);
+          onChange(newValue, event);
+          onBlur(newValue, event);
         };
 
         const {type: _, ...propsWithoutType} = props;
         const switchProps: SwitchProps = {
           ...propsWithoutType,
           size: 'lg',
-          checked: !!value,
+          checked: Boolean(value),
           disabled,
-          onChange: handleChange,
         };
 
         if (confirm) {
+          const confirmMessage = confirm[(!value).toString() as 'true' | 'false'];
+
           return (
             <Confirm
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              renderMessage={() => confirm[(!value).toString()]}
-              onConfirm={() => handleChange()}
+              renderMessage={() => confirmMessage}
+              onConfirm={() => handleChange({} as React.FormEvent<HTMLInputElement>)}
               isDangerous={confirm.isDangerous}
             >
               {({open}) => (
                 <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
                   <Switch
                     {...switchProps}
-                    onChange={e => {
-                      // If we have a `confirm` prop and enabling switch
-                      // Then show confirm dialog, otherwise propagate change as normal
-                      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                      if (confirm[(!value).toString()]) {
-                        // Open confirm modal
-                        open();
-                        return;
-                      }
-
-                      handleChange(e);
-                    }}
+                    onChange={confirmMessage ? open : handleChange}
                   />
                 </Tooltip>
               )}
@@ -85,7 +71,7 @@ export default function BooleanField({confirm, ...fieldProps}: BooleanFieldProps
 
         return (
           <Tooltip title={disabledReason} skipWrapper disabled={!disabled}>
-            <Switch {...switchProps} />
+            <Switch {...switchProps} onChange={handleChange} />
           </Tooltip>
         );
       }}

--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -1,3 +1,5 @@
+import type {FormEvent, ReactNode} from 'react';
+
 import Confirm from 'sentry/components/confirm';
 import {Switch, type SwitchProps} from 'sentry/components/core/switch';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -8,9 +10,9 @@ import type {InputFieldProps, OnEvent} from './inputField';
 
 export interface BooleanFieldProps extends InputFieldProps {
   confirm?: {
-    false?: React.ReactNode;
+    false?: ReactNode;
     isDangerous?: boolean;
-    true?: React.ReactNode;
+    true?: ReactNode;
   };
 }
 
@@ -27,14 +29,14 @@ export default function BooleanField({confirm, ...fieldProps}: BooleanFieldProps
         ...props
       }: {
         disabled: boolean;
-        disabledReason: boolean;
+        disabledReason: ReactNode;
         onBlur: OnEvent;
         onChange: OnEvent;
         type: string;
         value: any;
-        children?: React.ReactNode;
+        children?: ReactNode;
       }) => {
-        const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+        const handleChange = (event: FormEvent<HTMLInputElement>) => {
           const newValue = !value;
           onChange(newValue, event);
           onBlur(newValue, event);
@@ -54,7 +56,7 @@ export default function BooleanField({confirm, ...fieldProps}: BooleanFieldProps
           return (
             <Confirm
               renderMessage={() => confirmMessage}
-              onConfirm={() => handleChange({} as React.FormEvent<HTMLInputElement>)}
+              onConfirm={() => handleChange({} as FormEvent<HTMLInputElement>)}
               isDangerous={confirm.isDangerous}
             >
               {({open}) => (


### PR DESCRIPTION
## Summary

Refactors `BooleanField` from a class component to a functional component to align with modern React patterns and Sentry's frontend guidelines (no new class components).

This component was identified as a stateless class component (no internal state management), making it an ideal candidate for conversion to a functional component.

## Changes

- Converted class component to functional component
- Removed `Component` import and class syntax  
- Made event parameter optional in `handleChange` to match `OnEvent` type signature
- Simplified event type handling (`React.ChangeEvent` | `React.FormEvent`)
- Removed redundant `coerceValue` helper method (inlined logic)
- Maintained all existing functionality and behavior

## Test plan

- ✅ Linting passes
- ✅ Accessibility tests pass (`static/app/components/forms/fields/accessibility.spec.tsx`)
- ✅ No functional changes - component behavior is identical

Related to https://github.com/getsentry/frontend-tsc/issues/42