### PR TITLE
ref(forms): Convert ChoiceMapperField and TableField to functional components

### DIFF
--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import type {DistributedOmit} from 'type-fest';
@@ -219,30 +219,32 @@ function AsyncCompactSelectForIntegrationConfig<Value extends string = string>({
   );
 }
 
-export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps> {
-  static defaultProps = defaultProps;
+function hasValue(value: InputFieldProps['value']) {
+  return defined(value) && !isEmptyObject(value);
+}
 
-  hasValue = (value: InputFieldProps['value']) => defined(value) && !isEmptyObject(value);
-
-  renderField = (props: ChoiceMapperFieldProps) => {
+export default function ChoiceMapperField({
+  addButtonText = defaultProps.addButtonText,
+  perItemMapping = defaultProps.perItemMapping,
+  allowEmpty = defaultProps.allowEmpty,
+  ...props
+}: ChoiceMapperFieldProps) {
+  const renderField = (fieldProps: ChoiceMapperFieldProps) => {
     const {
       onChange,
       onBlur,
-      addButtonText,
       addDropdown,
       mappedColumnLabel,
       columnLabels,
       mappedSelectors,
-      perItemMapping,
       disabled,
-      allowEmpty,
-    } = props;
+    } = fieldProps;
 
     const mappedKeys = Object.keys(columnLabels);
     const emptyValue = mappedKeys.reduce((a, v) => ({...a, [v]: null}), {});
 
-    const valueIsEmpty = this.hasValue(props.value);
-    const value = valueIsEmpty ? props.value : {};
+    const valueIsEmpty = hasValue(fieldProps.value);
+    const value = valueIsEmpty ? fieldProps.value : {};
 
     const saveChanges = (nextValue: ChoiceMapperFieldProps['value']) => {
       onChange?.(nextValue, {});
@@ -417,16 +419,17 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
     );
   };
 
-  render() {
-    return (
-      <FormField
-        {...this.props}
-        inline={({model}: any) => !this.hasValue(model.getValue(this.props.name))}
-      >
-        {this.renderField}
-      </FormField>
-    );
-  }
+  return (
+    <FormField
+      {...props}
+      addButtonText={addButtonText}
+      perItemMapping={perItemMapping}
+      allowEmpty={allowEmpty}
+      inline={({model}: any) => !hasValue(model.getValue(props.name))}
+    >
+      {renderField}
+    </FormField>
+  );
 }
 
 const Control = styled('div')`

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -40,12 +40,6 @@ interface DefaultProps {
   perItemMapping: boolean;
 }
 
-const defaultProps: DefaultProps = {
-  addButtonText: t('Add Item'),
-  perItemMapping: false,
-  allowEmpty: false,
-};
-
 type MappedSelectors = Record<string, Partial<ControlProps>>;
 
 export interface ChoiceMapperProps extends DefaultProps {
@@ -224,9 +218,9 @@ function hasValue(value: InputFieldProps['value']) {
 }
 
 export default function ChoiceMapperField({
-  addButtonText = defaultProps.addButtonText,
-  perItemMapping = defaultProps.perItemMapping,
-  allowEmpty = defaultProps.allowEmpty,
+  addButtonText = t('Add Item'),
+  perItemMapping = false,
+  allowEmpty = false,
   ...props
 }: ChoiceMapperFieldProps) {
   const renderField = (fieldProps: ChoiceMapperFieldProps) => {

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -28,16 +28,16 @@ interface DefaultProps {
   /**
    * Text used for the 'add row' button.
    */
-  addButtonText: NonNullable<React.ReactNode>;
+  addButtonText?: NonNullable<React.ReactNode>;
   /**
    * Automatically save even if fields are empty
    */
-  allowEmpty: boolean;
+  allowEmpty?: boolean;
   /**
    * If using mappedSelectors to specifically map different choice selectors
    * per item specify this as true.
    */
-  perItemMapping: boolean;
+  perItemMapping?: boolean;
 }
 
 type MappedSelectors = Record<string, Partial<ControlProps>>;
@@ -416,9 +416,6 @@ export default function ChoiceMapperField({
   return (
     <FormField
       {...props}
-      addButtonText={addButtonText}
-      perItemMapping={perItemMapping}
-      allowEmpty={allowEmpty}
       inline={({model}: any) => !hasValue(model.getValue(props.name))}
     >
       {renderField}

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -40,28 +40,30 @@ const DEFAULT_PROPS: DefaultProps = {
   allowEmpty: false,
 };
 
-export default class TableField extends Component<InputFieldProps> {
-  static defaultProps = DEFAULT_PROPS;
+function hasValue(value: any) {
+  return defined(value) && !isEmptyObject(value);
+}
 
-  hasValue = (value: any) => defined(value) && !isEmptyObject(value);
-
-  renderField = (props: RenderProps) => {
+export default function TableField({
+  addButtonText = DEFAULT_PROPS.addButtonText,
+  allowEmpty = DEFAULT_PROPS.allowEmpty,
+  ...props
+}: InputFieldProps) {
+  const renderField = (fieldProps: RenderProps) => {
     const {
       onChange,
       onBlur,
-      addButtonText,
       columnLabels,
       columnKeys,
       disabled: rawDisabled,
-      allowEmpty,
       confirmDeleteMessage,
-    } = props;
+    } = fieldProps;
 
     const mappedKeys = columnKeys || [];
     const emptyValue = mappedKeys.reduce((a, v) => ({...a, [v]: null}), {id: ''});
 
-    const valueIsEmpty = this.hasValue(props.value);
-    const value = valueIsEmpty ? (props.value as any[]) : [];
+    const valueIsEmpty = hasValue(fieldProps.value);
+    const value = valueIsEmpty ? (fieldProps.value as any[]) : [];
 
     const saveChanges = (nextValue: Array<Record<PropertyKey, unknown>>) => {
       onChange?.(nextValue, []);
@@ -182,21 +184,21 @@ export default class TableField extends Component<InputFieldProps> {
     );
   };
 
-  render() {
-    // We need formatMessageValue=false since we're saving an object
-    // and there isn't a great way to render the
-    // change within the toast. Just turn off displaying the from/to portion of
-    // the message
-    return (
-      <FormField
-        {...this.props}
-        formatMessageValue={false}
-        inline={({model}: any) => !this.hasValue(model.getValue(this.props.name))}
-      >
-        {this.renderField}
-      </FormField>
-    );
-  }
+  // We need formatMessageValue=false since we're saving an object
+  // and there isn't a great way to render the
+  // change within the toast. Just turn off displaying the from/to portion of
+  // the message
+  return (
+    <FormField
+      {...props}
+      addButtonText={addButtonText}
+      allowEmpty={allowEmpty}
+      formatMessageValue={false}
+      inline={({model}: any) => !hasValue(model.getValue(props.name))}
+    >
+      {renderField}
+    </FormField>
+  );
 }
 
 const HeaderLabel = styled('div')`

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -35,20 +35,15 @@ export interface TableFieldProps extends Omit<InputFieldProps, 'type'> {}
 
 interface RenderProps extends TableFieldProps, DefaultProps, Omit<TableType, 'type'> {}
 
-const DEFAULT_PROPS: DefaultProps = {
-  addButtonText: t('Add Item'),
-  allowEmpty: false,
-};
-
 function hasValue(value: any) {
   return defined(value) && !isEmptyObject(value);
 }
 
 export default function TableField({
-  addButtonText = DEFAULT_PROPS.addButtonText,
-  allowEmpty = DEFAULT_PROPS.allowEmpty,
+  addButtonText = t('Add Item'),
+  allowEmpty = false,
   ...props
-}: InputFieldProps) {
+}: InputFieldProps & DefaultProps) {
   const renderField = (fieldProps: RenderProps) => {
     const {
       onChange,

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -24,11 +24,11 @@ interface DefaultProps {
    * Text used for the 'add' button. An empty string can be used
    * to just render the "+" icon.
    */
-  addButtonText: string;
+  addButtonText?: string;
   /**
    * Automatically save even if fields are empty
    */
-  allowEmpty: boolean;
+  allowEmpty?: boolean;
 }
 
 export interface TableFieldProps extends Omit<InputFieldProps, 'type'> {}
@@ -186,8 +186,6 @@ export default function TableField({
   return (
     <FormField
       {...props}
-      addButtonText={addButtonText}
-      allowEmpty={allowEmpty}
       formatMessageValue={false}
       inline={({model}: any) => !hasValue(model.getValue(props.name))}
     >


### PR DESCRIPTION
## Summary

Refactors `ChoiceMapperField` and `TableField` from class components to functional components to align with modern React patterns and Sentry's frontend guidelines (no new class components).

These components were identified as stateless class components (no internal state management), making them ideal candidates for conversion to functional components.

## Changes

### ChoiceMapperField
- Converted class component to functional component
- Removed `Component` import and class syntax
- Moved static `defaultProps` to default parameter values
- Moved `hasValue` instance method to standalone helper function
- Maintained all existing functionality including async dropdown support

### TableField
- Converted class component to functional component
- Removed `Component` import and class syntax
- Moved static `defaultProps` to default parameter values
- Moved `hasValue` instance method to standalone helper function
- Maintained all existing functionality including row add/remove operations

## Test plan

- ✅ Linting passes for both components
- ✅ All existing tests pass:
  - `choiceMapperField.spec.tsx` - 9 tests passing
  - `tableField.spec.tsx` - 6 tests passing
- ✅ No functional changes - component behavior is identical