### PR TITLE
chore: fix typos in comments and messages

### DIFF
--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -274,7 +274,7 @@ class Span:
         parts = s.rsplit(":", 1)
         if len(parts) != 2:
             raise ValueError(
-                "span must consist of of a span op and a valid 16 character hex delimited by a colon (:)"
+                "span must consist of a span op and a valid 16 character hex delimited by a colon (:)"
             )
         if not is_span_id(parts[1]):
             raise ValueError(INVALID_SPAN_ID.format("spanGroup"))

--- a/static/app/actionCreators/release.tsx
+++ b/static/app/actionCreators/release.tsx
@@ -31,9 +31,7 @@ export function archiveRelease(api: Client, params: ParamsGet) {
       addSuccessMessage(t('Release was successfully archived.'));
     })
     .catch(error => {
-      addErrorMessage(
-        error.responseJSON?.detail ?? t('Release could not be archived.')
-      );
+      addErrorMessage(error.responseJSON?.detail ?? t('Release could not be archived.'));
       throw error;
     });
 }
@@ -56,9 +54,7 @@ export function restoreRelease(api: Client, params: ParamsGet) {
       addSuccessMessage(t('Release was successfully restored.'));
     })
     .catch(error => {
-      addErrorMessage(
-        error.responseJSON?.detail ?? t('Release could not be restored.')
-      );
+      addErrorMessage(error.responseJSON?.detail ?? t('Release could not be restored.'));
       throw error;
     });
 }

--- a/static/app/actionCreators/release.tsx
+++ b/static/app/actionCreators/release.tsx
@@ -32,7 +32,7 @@ export function archiveRelease(api: Client, params: ParamsGet) {
     })
     .catch(error => {
       addErrorMessage(
-        error.responseJSON?.detail ?? t('Release could not be be archived.')
+        error.responseJSON?.detail ?? t('Release could not be archived.')
       );
       throw error;
     });
@@ -57,7 +57,7 @@ export function restoreRelease(api: Client, params: ParamsGet) {
     })
     .catch(error => {
       addErrorMessage(
-        error.responseJSON?.detail ?? t('Release could not be be restored.')
+        error.responseJSON?.detail ?? t('Release could not be restored.')
       );
       throw error;
     });

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -627,7 +627,7 @@ describe('AssigneeSelectorDropdown', () => {
     expect(await screen.findByText('commit data')).toBeInTheDocument();
 
     await openMenu();
-    // User 4, Git Hub, would have normally been cut off by the the size limit since it is
+    // User 4, Git Hub, would have normally been cut off by the size limit since it is
     // alphabetically last, but it should still be shown because it is a suggested assignee
     const options = await screen.findAllByRole('option');
     expect(options).toHaveLength(2);

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -106,7 +106,7 @@ export interface DeprecatedDropdownMenuProps {
  * - For an action menu (where there's no selection state, clicking on a menu
  * item will trigger an action): use `DropdownMenuControl`.
  *
- * - For for other menus/overlays: use a combination of `Overlay` and the
+ * - For other menus/overlays: use a combination of `Overlay` and the
  * `useOverlay` hook.
  * https://storybook.sentry.dev/?path=/story/components-buttons-dropdowns-overlay--overlay
  *

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -192,7 +192,7 @@ export function getKnownStructuredData(
 
 /**
  * Returns the type of a given context, after coercing from its type and alias.
- * - 'type' refers the the `type` key on it's data blob. This is usually overridden by the SDK for known types, but not always.
+ * - 'type' refers to the `type` key on it's data blob. This is usually overridden by the SDK for known types, but not always.
  * - 'alias' refers to the key on event.contexts. This can be set by the user, but we have to depend on it for some contexts.
  */
 export function getContextType({alias, type}: {alias: string; type?: string}): string {

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1523,7 +1523,7 @@ function ReleaseHasUploadedArtifactsChecklistItem({
         </p>
         <p>
           {tct(
-            'Read the [link:Sentry Source Maps Documentation] to learn how to to upload your build artifacts to Sentry.',
+            'Read the [link:Sentry Source Maps Documentation] to learn how to upload your build artifacts to Sentry.',
             {
               link: defined(sourceMapsDocLinks.legacyUploadingMethods) ? (
                 <ExternalLinkWithIcon href={sourceMapsDocLinks.legacyUploadingMethods} />

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -162,7 +162,7 @@ export interface TableType {
   columnLabels: Record<PropertyKey, React.ReactNode>;
   type: 'table';
   /**
-   * The confirmation message before a a row is deleted
+   * The confirmation message before a row is deleted
    */
   confirmDeleteMessage?: string;
   // TODO(TS): Should we have addButtonText and allowEmpty here as well?

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -40,7 +40,7 @@ function ListLink({
   const active =
     isActive?.(target, index) ??
     // XXX(epurkhiser): This is carry over from the react-router 3 days.
-    // There's probably a a better way to detect active
+    // There's probably a better way to detect active
     location.pathname === (typeof target === 'string' ? target : target.pathname);
 
   return (

--- a/static/app/plugins/defaultPlugin.tsx
+++ b/static/app/plugins/defaultPlugin.tsx
@@ -2,7 +2,7 @@ import BasePlugin from 'sentry/plugins/basePlugin';
 
 class DefaultPlugin extends BasePlugin {
   static displayName = 'DefaultPlugin';
-  // should never be be called since this is a non-issue plugin
+  // should never be called since this is a non-issue plugin
   renderGroupActions() {
     return null;
   }

--- a/static/app/plugins/sessionstack/index.tsx
+++ b/static/app/plugins/sessionstack/index.tsx
@@ -4,7 +4,7 @@ import Settings from './components/settings';
 
 class SessionStackPlugin extends BasePlugin {
   displayName = 'SessionStack';
-  // should never be be called since this is a non-issue plugin
+  // should never be called since this is a non-issue plugin
   renderGroupActions() {
     return null;
   }

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -12,7 +12,7 @@ type Options = {
 
   location?: Location;
   /**
-   * The number of routes to to pop off of `routes
+   * The number of routes to pop off of `routes
    * Must be < 0
    *
    * There's no ts type for negative numbers so we are arbitrarily specifying -1-9

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -86,7 +86,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
     def test_no_cron_monitor_rules(self) -> None:
         """
         Tests that the shadow cron monitor rules are NOT returned as part of
-        the the list of alert rules.
+        the list of alert rules.
         """
         self.create_alert_rule()
         cron_rule = Rule.objects.create(

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -308,7 +308,7 @@ def test_preallocation_end_to_end(default_project) -> None:
     assert redis.llen(redis_key) == calculate_cached_id_block_size(2) - 1
     assert redis.lpop(redis_key) == "3"
 
-    # see the the database value is still the same since we didn't refill
+    # see the database value is still the same since we didn't refill
     assert Counter.objects.get(
         project_id=default_project.id
     ).value == 1 + calculate_cached_id_block_size(1)

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -1125,7 +1125,7 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
         assert response.data == {
             "span": [
                 ErrorDetail(
-                    "span must consist of of a span op and a valid 16 character hex delimited by a colon (:)",
+                    "span must consist of a span op and a valid 16 character hex delimited by a colon (:)",
                     code="invalid",
                 )
             ]
@@ -1736,7 +1736,7 @@ class OrganizationEventsSpansStatsEndpointTest(OrganizationEventsSpansEndpointTe
         assert response.data == {
             "span": [
                 ErrorDetail(
-                    "span must consist of of a span op and a valid 16 character hex delimited by a colon (:)",
+                    "span must consist of a span op and a valid 16 character hex delimited by a colon (:)",
                     code="invalid",
                 )
             ]


### PR DESCRIPTION
Fix typos in comments and messages:
- `of of` → `of` (x2)
- `the the` → `the` (x3)
- `be be` → `be` (x4)
- `to to` → `to` (x2)
- `a a` → `a` (x2)
- `For for` → `For`