### PR TITLE
Add logging for abnormally long EVALSHA in spans buffer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3098,6 +3098,13 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Latency threshold in milliseconds for logging slow EVALSHA pipeline operations
+register(
+    "spans.buffer.evalsha-latency-threshold",
+    type=Int,
+    default=100,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Segments consumer
 register(

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -12,6 +12,12 @@ ARGS:
 - set_timeout -- int
 - *span_id -- str[]
 
+RETURNS:
+- redirect_depth -- int
+- set_key -- str
+- has_root_span -- bool
+- latency_ms -- number (milliseconds elapsed during script execution)
+
 ]]--
 
 local project_and_trace = KEYS[1]
@@ -23,6 +29,10 @@ local set_timeout = tonumber(ARGV[4])
 local max_segment_bytes = tonumber(ARGV[5])
 local byte_count = tonumber(ARGV[6])
 local NUM_ARGS = 6
+
+-- Capture start time for latency measurement
+local start_time = redis.call("TIME")
+local start_time_ms = tonumber(start_time[1]) * 1000 + tonumber(start_time[2]) / 1000
 
 local set_span_id = parent_span_id
 local redirect_depth = 0
@@ -109,4 +119,9 @@ redis.call("expire", ingested_byte_count_key, set_timeout)
 
 redis.call("expire", set_key, set_timeout)
 
-return {redirect_depth, set_key, has_root_span}
+-- Capture end time and calculate latency in milliseconds
+local end_time = redis.call("TIME")
+local end_time_ms = tonumber(end_time[1]) * 1000 + tonumber(end_time[2]) / 1000
+local latency_ms = end_time_ms - start_time_ms
+
+return {redirect_depth, set_key, has_root_span, latency_ms}

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -81,6 +81,7 @@ from sentry import options
 from sentry.constants import DataCategory
 from sentry.models.project import Project
 from sentry.processing.backpressure.memory import ServiceMemory, iter_cluster_memory_usage
+from sentry.spans.buffer_logger import BufferLogger
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.utils import metrics, redis
 from sentry.utils.outcomes import Outcome, track_outcome
@@ -166,6 +167,7 @@ class SpansBuffer:
         self._current_compression_level = None
         self._zstd_compressor: zstandard.ZstdCompressor | None = None
         self._zstd_decompressor = zstandard.ZstdDecompressor()
+        self._buffer_logger = BufferLogger()
 
     @cached_property
     def client(self) -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -250,7 +252,10 @@ class SpansBuffer:
             assert len(result_meta) == len(results)
 
             for (project_and_trace, parent_span_id), result in zip(result_meta, results):
-                redirect_depth, set_key, has_root_span = result
+                redirect_depth, set_key, has_root_span, evalsha_latency_ms = result
+
+                # Log individual EVALSHA latency for this trace
+                self._buffer_logger.log(project_and_trace, evalsha_latency_ms)
 
                 shard = self.assigned_shards[
                     int(project_and_trace.split(":")[1], 16) % len(self.assigned_shards)

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -1,10 +1,3 @@
-"""
-BufferLogger tracks and logs slow Redis pipeline operations in the spans buffer.
-
-It maintains a count of project/trace combinations that exceed a configurable
-latency threshold and periodically logs the most frequently occurring slow operations.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -24,54 +17,54 @@ class BufferLogger:
     Tracks slow EVALSHA operations and logs the most problematic
     project/trace combinations.
 
-    This logger keeps a bounded map (max 100 entries) of project_and_trace keys
+    This logger keeps a bounded map (max 1000 entries) of project_and_trace keys
     to their occurrence counts and maximum latencies. When the configured latency
     threshold is exceeded, affected keys are recorded. Every 5 seconds, the top 50
     entries by count are logged at INFO level, then the tracked data is cleared.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._data: dict[str, tuple[int, float]] = {}
-        self._last_log_time = None
+        self._last_log_time: float | None = None
 
     def log(self, project_and_trace: str, latency_ms: int) -> None:
         """
         Record a single EVALSHA operation and periodically log the top offenders.
         """
-        if len(self._data) >= MAX_ENTRIES:
-            return
+        if len(self._data) < MAX_ENTRIES:
+            threshold = options.get("spans.buffer.evalsha-latency-threshold")
 
-        threshold = options.get("spans.buffer.evalsha-latency-threshold")
+            if latency_ms <= threshold:
+                return
 
-        if latency_ms <= threshold:
-            return
+            if not self._last_log_time:
+                self._last_log_time = time.time()
 
-        if not self._last_log_time:
-            self._last_log_time = time.time()
+            if project_and_trace in self._data:
+                count, max_latency = self._data[project_and_trace]
+                self._data[project_and_trace] = (count + 1, max(max_latency, latency_ms))
+            else:
+                self._data[project_and_trace] = (1, latency_ms)
 
-        # Update count and max latency for this project_and_trace
-        if project_and_trace in self._data:
-            count, max_latency = self._data[project_and_trace]
-            self._data[project_and_trace] = (count + 1, max(max_latency, latency_ms))
-        else:
-            self._data[project_and_trace] = (1, latency_ms)
-
-        if time.time() - self._last_log_time >= LOGGING_INTERVAL:
+        if time.time() - (self._last_log_time or 0.0) >= LOGGING_INTERVAL:
             if len(self._data) > LOGGING_ENTRIES:
                 sorted_items = sorted(self._data.items(), key=lambda x: x[1][0], reverse=True)
             else:
                 sorted_items = list(self._data.items())
 
-            entries_str = [
-                f"{key}:{count}:{max_latency}" for key, (count, max_latency) in sorted_items
-            ]
+            if len(sorted_items) > 0:
+                entries_str = [
+                    f"{key}:{count}:{max_latency}"
+                    for key, (count, max_latency) in sorted_items[:50]
+                ]
 
-            logger.info(
-                "spans.buffer.slow_evalsha_operations",
-                extra={
-                    "top_slow_operations": entries_str,
-                    "num_tracked_keys": len(self._data),
-                },
-            )
+                logger.info(
+                    "spans.buffer.slow_evalsha_operations",
+                    extra={
+                        "top_slow_operations": entries_str,
+                        "num_tracked_keys": len(self._data),
+                        "pruned_list": len(self._data) == MAX_ENTRIES,
+                    },
+                )
             self._data.clear()
             self._last_log_time = None

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -1,0 +1,77 @@
+"""
+BufferLogger tracks and logs slow Redis pipeline operations in the spans buffer.
+
+It maintains a count of project/trace combinations that exceed a configurable
+latency threshold and periodically logs the most frequently occurring slow operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from sentry import options
+
+logger = logging.getLogger(__name__)
+
+MAX_ENTRIES = 1000
+LOGGING_ENTRIES = 50
+LOGGING_INTERVAL = 5  # seconds
+
+
+class BufferLogger:
+    """
+    Tracks slow EVALSHA operations and logs the most problematic
+    project/trace combinations.
+
+    This logger keeps a bounded map (max 100 entries) of project_and_trace keys
+    to their occurrence counts and maximum latencies. When the configured latency
+    threshold is exceeded, affected keys are recorded. Every 5 seconds, the top 50
+    entries by count are logged at INFO level, then the tracked data is cleared.
+    """
+
+    def __init__(self):
+        self._data: dict[str, tuple[int, float]] = {}
+        self._last_log_time = None
+
+    def log(self, project_and_trace: str, latency_ms: int) -> None:
+        """
+        Record a single EVALSHA operation and periodically log the top offenders.
+        """
+        if len(self._data) >= MAX_ENTRIES:
+            return
+
+        threshold = options.get("spans.buffer.evalsha-latency-threshold")
+
+        if latency_ms <= threshold:
+            return
+
+        if not self._last_log_time:
+            self._last_log_time = time.time()
+
+        # Update count and max latency for this project_and_trace
+        if project_and_trace in self._data:
+            count, max_latency = self._data[project_and_trace]
+            self._data[project_and_trace] = (count + 1, max(max_latency, latency_ms))
+        else:
+            self._data[project_and_trace] = (1, latency_ms)
+
+        if time.time() - self._last_log_time >= LOGGING_INTERVAL:
+            if len(self._data) > LOGGING_ENTRIES:
+                sorted_items = sorted(self._data.items(), key=lambda x: x[1][0], reverse=True)
+            else:
+                sorted_items = list(self._data.items())
+
+            entries_str = [
+                f"{key}:{count}:{max_latency}" for key, (count, max_latency) in sorted_items
+            ]
+
+            logger.info(
+                "spans.buffer.slow_evalsha_operations",
+                extra={
+                    "top_slow_operations": entries_str,
+                    "num_tracked_keys": len(self._data),
+                },
+            )
+            self._data.clear()
+            self._last_log_time = None

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -22,6 +22,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.backpressure-seconds": 10,
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.compression.level": 0,
+    "spans.buffer.evalsha-latency-threshold": 100,
 }
 
 

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -2,277 +2,144 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
-
 from sentry.spans.buffer_logger import BufferLogger
 from sentry.testutils.helpers.options import override_options
 
 
 class TestBufferLogger:
-    """Tests for BufferLogger class that tracks slow pipeline operations."""
-
-    def test_does_not_log_below_threshold(self):
-        """Test that operations below threshold are not recorded."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-            keys = [("123:abc", "span1"), ("456:def", "span2")]
-
-            # Latency below threshold should not be recorded
-            logger.log(keys, latency_ms=50)
-
-            assert len(logger._counts) == 0
-
-    def test_logs_above_threshold(self):
-        """Test that operations above threshold are recorded."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-            keys = [("123:abc", "span1"), ("456:def", "span2")]
-
-            # Latency above threshold should be recorded
-            logger.log(keys, latency_ms=150)
-
-            assert len(logger._counts) == 2
-            assert logger._counts["123:abc"] == 1
-            assert logger._counts["456:def"] == 1
-
-    def test_increments_existing_counts(self):
-        """Test that counts are incremented for repeated slow operations."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-            keys = [("123:abc", "span1")]
-
-            # Log the same key multiple times
-            logger.log(keys, latency_ms=150)
-            logger.log(keys, latency_ms=200)
-            logger.log(keys, latency_ms=175)
-
-            assert logger._counts["123:abc"] == 3
-
-    def test_prunes_to_max_entries(self):
-        """Test that map is pruned to keep only top 100 entries by count."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-
-            # Add 101 unique entries with varying counts
-            for i in range(101):
-                # First 50 entries get count of 10, next 51 get count of 1
-                count = 10 if i < 50 else 1
-                for _ in range(count):
-                    logger.log([(f"{i}:trace{i}", "span")], latency_ms=150)
-
-            # Should have been pruned to 100 entries
-            assert len(logger._counts) == 100
-
-            # The top 50 entries (with count 10) should be preserved
-            for i in range(50):
-                assert f"{i}:trace{i}" in logger._counts
-                assert logger._counts[f"{i}:trace{i}"] == 10
-
-            # Some of the lower count entries should have been dropped
-            low_count_entries = [key for key in logger._counts if logger._counts[key] == 1]
-            assert len(low_count_entries) == 50
-
-    def test_prune_to_top_n(self):
-        """Test the _prune_to_top_n method directly."""
-        logger = BufferLogger()
-        logger._counts = {
-            "high1": 10,
-            "high2": 9,
-            "high3": 8,
-            "mid1": 5,
-            "mid2": 4,
-            "low1": 1,
-            "low2": 2,
-        }
-
-        logger._prune_to_top_n(5)
-
-        assert len(logger._counts) == 5
-        assert "high1" in logger._counts
-        assert "high2" in logger._counts
-        assert "high3" in logger._counts
-        assert "mid1" in logger._counts
-        assert "mid2" in logger._counts
-        assert "low1" not in logger._counts
-        assert "low2" not in logger._counts
-
-    def test_prune_to_top_n_no_op_when_below_limit(self):
-        """Test that pruning is a no-op when entries are below limit."""
-        logger = BufferLogger()
-        logger._counts = {"key1": 5, "key2": 3}
-
-        logger._prune_to_top_n(10)
-
-        assert len(logger._counts) == 2
-        assert logger._counts["key1"] == 5
-        assert logger._counts["key2"] == 3
 
     @mock.patch("sentry.spans.buffer_logger.logger")
     @mock.patch("sentry.spans.buffer_logger.time")
-    def test_periodic_logging_triggers_after_interval(self, mock_time, mock_logger):
-        """Test that logging occurs after the configured interval."""
+    def test_logs_only_above_threshold_with_repeating_traces(self, mock_time, mock_logger):
         with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            # Mock time to control when logging should trigger
-            # Each log() call makes exactly 1 call to time.time()
             mock_time.time.side_effect = [
-                1000.0,  # Initial time in __init__
-                1000.0,  # First log call - check current time
-                1006.0,  # Second log call - check current time (> 5s elapsed, triggers logging)
+                1000.0,
+                1000.0,
+                1000.0,
+                1000.0,
+                1006.0,
             ]
 
-            logger = BufferLogger()
-            keys = [("123:abc", "span1")]
+            buffer_logger = BufferLogger()
 
-            # First log - should not trigger periodic logging
-            logger.log(keys, latency_ms=150)
-            assert mock_logger.info.call_count == 0
+            # Log below threshold - should not be recorded, no time calls
+            buffer_logger.log("project1:trace1", latency_ms=50)
+            assert len(buffer_logger._data) == 0
 
-            # Second log after 6 seconds - should trigger periodic logging
-            logger.log(keys, latency_ms=150)
+            # Log above threshold - should be recorded (calls time.time() twice)
+            buffer_logger.log("project1:trace1", latency_ms=150)
+            assert buffer_logger._data["project1:trace1"] == (1, 150)
+
+            buffer_logger.log("project1:trace1", latency_ms=200)
+            assert buffer_logger._data["project1:trace1"] == (2, 200)
+
+            buffer_logger.log("project2:trace2", latency_ms=120)
+            assert buffer_logger._data["project2:trace2"] == (1, 120)
+
+            buffer_logger.log("project1:trace1", latency_ms=180)
+
+            # Verify logging was called
             assert mock_logger.info.call_count == 1
 
-    @mock.patch("sentry.spans.buffer_logger.logger")
-    @mock.patch("sentry.spans.buffer_logger.time")
-    def test_logs_top_50_entries(self, mock_time, mock_logger):
-        """Test that only top 50 entries are logged."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            # Calculate total number of log() calls
-            # 60 entries with counts: 60, 59, 58, ..., 1 = sum(1 to 60) = 1830
-            # Plus 1 final trigger call = 1831 total log() calls
-            # Each log() call makes 1 time.time() call
-            total_log_calls = sum(range(1, 61)) + 1  # 1831
-
-            mock_time.time.side_effect = (
-                [
-                    1000.0,  # Initial time in __init__
-                ]
-                + [1000.0] * (total_log_calls - 1)
-                + [  # All log calls except the last one
-                    1006.0,  # Final trigger call that should trigger logging
-                ]
-            )
-
-            logger = BufferLogger()
-
-            # Add 60 entries with varying counts
-            for i in range(60):
-                count = 60 - i  # Descending counts so entry 0 has highest count
-                for _ in range(count):
-                    logger.log([(f"{i}:trace{i}", "span")], latency_ms=150)
-
-            # Trigger periodic logging
-            logger.log([("trigger:trace", "span")], latency_ms=150)
-
-            # Should have logged
-            assert mock_logger.info.call_count == 1
-
-            # Check the logged data
+            # Verify exact log content
             call_args = mock_logger.info.call_args
             assert call_args[0][0] == "spans.buffer.slow_evalsha_operations"
             extra = call_args[1]["extra"]
 
-            # Should have logged top 50 entries
-            assert extra["top_entries_count"] == 50
-            assert extra["num_tracked_keys"] == 61  # 60 + 1 trigger
+            # Check that logged entries include the correct format
+            entries = extra["top_slow_operations"]
+            assert "project1:trace1:3:200" in entries  # count=3, max_latency=200
+            assert "project2:trace2:1:120" in entries  # count=1, max_latency=120
+            assert extra["num_tracked_keys"] == 2  # only 2 unique keys tracked
 
-            # Verify the format includes entry counts
-            entries_str = extra["top_slow_operations"]
-            assert "0:trace0:60" in entries_str  # Highest count
-            assert "49:trace49:11" in entries_str  # 50th entry
-
-    @mock.patch("sentry.spans.buffer_logger.logger")
-    def test_no_logging_when_empty(self, mock_logger):
-        """Test that nothing is logged when there are no entries."""
-        logger = BufferLogger()
-        logger._log_top_entries()
-
-        assert mock_logger.info.call_count == 0
+            # Verify data was cleared after logging
+            assert len(buffer_logger._data) == 0
+            assert buffer_logger._last_log_time is None
 
     @mock.patch("sentry.spans.buffer_logger.logger")
     @mock.patch("sentry.spans.buffer_logger.time")
-    def test_resets_timer_after_logging(self, mock_time, mock_logger):
-        """Test that the timer is reset after logging."""
+    def test_clears_old_traces_after_logging_period(self, mock_time, mock_logger):
         with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            # Each log() call makes exactly 1 call to time.time()
             mock_time.time.side_effect = [
-                1000.0,  # Initial time in __init__
-                1000.0,  # First log - check current time
-                1006.0,  # Second log - triggers logging (>5s elapsed)
-                1010.0,  # Third log - should not trigger (only 4s since last log at 1006)
-                1012.0,  # Fourth log - should trigger (6s elapsed since 1006)
+                1000.0,
+                1000.0,
+                6000.0,
+                1013.0,
             ]
 
-            logger = BufferLogger()
-            keys = [("123:abc", "span1")]
+            buffer_logger = BufferLogger()
 
-            # First log
-            logger.log(keys, latency_ms=150)
+            buffer_logger.log("old_project1:trace1", latency_ms=151)
+            assert len(buffer_logger._data) == 1
             assert mock_logger.info.call_count == 0
 
-            # Second log - triggers logging
-            logger.log(keys, latency_ms=150)
+            buffer_logger.log("old_project1:trace1", latency_ms=170)
+            assert len(buffer_logger._data) == 0
+
+            # First logging should have occurred
             assert mock_logger.info.call_count == 1
-            assert logger._last_log_time == 1006.0
+            first_call = mock_logger.info.call_args
+            first_entries = first_call[1]["extra"]["top_slow_operations"]
+            assert "old_project1:trace1:2:170" in first_entries
 
-            # Third log - should not trigger (only 4s elapsed)
-            logger.log(keys, latency_ms=150)
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_logs_only_top_50_when_more_than_1000_traces(self, mock_time, mock_logger):
+        """
+        Test that when MAX_ENTRIES (1000) is reached, no more traces are recorded.
+        Also verifies that entries with > LOGGING_ENTRIES (50) are sorted by count.
+        """
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            time_calls = (
+                [1000.0, 1000.0]  # First log: set + check
+                + [1000.0] * 1200  # Logs 2-1000: check only
+                + [1006.0]  # 1000th entry triggers logging
+            )
+            mock_time.time.side_effect = time_calls
+
+            buffer_logger = BufferLogger()
+
+            for i in range(10):
+                buffer_logger.log("high_project:trace", latency_ms=150)
+
+            for i in range(1100):
+                buffer_logger.log(f"high_project{i}:trace{i}", latency_ms=150)
+
+            assert len(buffer_logger._data) == 1000
+
+            mock_time.time.side_effect = [10000.0]
+
+            buffer_logger.log("trigger:trace", latency_ms=150)
+
+            # Verify logging occurred
             assert mock_logger.info.call_count == 1
 
-            # Fourth log - should trigger (6s elapsed)
-            logger.log(keys, latency_ms=150)
-            assert mock_logger.info.call_count == 2
+            # Verify exact log content
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "spans.buffer.slow_evalsha_operations"
+            extra = call_args[1]["extra"]
 
-    def test_handles_empty_keys_iterator(self):
-        """Test that empty keys iterator is handled gracefully."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-            keys = []
+            # Top 50 entries are logged (implementation logs all, not just top 50)
+            entries_list = extra["top_slow_operations"]
+            assert len(entries_list) == 50
 
-            logger.log(keys, latency_ms=150)
+            # Verify entries are sorted by count (descending) since > LOGGING_ENTRIES
+            # Check that first entries have highest counts
+            assert entries_list[0] == "high_project:trace:10:150"
 
-            assert len(logger._counts) == 0
+            # Verify total tracked keys
+            assert extra["num_tracked_keys"] == 1000
 
-    def test_multiple_keys_in_single_call(self):
-        """Test that multiple keys in a single call are all recorded."""
-        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
-            logger = BufferLogger()
-            keys = [
-                ("123:abc", "span1"),
-                ("456:def", "span2"),
-                ("789:ghi", "span3"),
-            ]
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    def test_no_logging_when_no_data(self, mock_logger):
+        """Test that nothing is logged when _data is empty."""
+        buffer_logger = BufferLogger()
 
-            logger.log(keys, latency_ms=150)
+        # Internal state check - no data
+        assert len(buffer_logger._data) == 0
 
-            assert len(logger._counts) == 3
-            assert logger._counts["123:abc"] == 1
-            assert logger._counts["456:def"] == 1
-            assert logger._counts["789:ghi"] == 1
-
-
-@pytest.mark.parametrize(
-    "threshold,latency,should_record",
-    [
-        (100, 99, False),  # Below threshold - no record
-        (100, 100, False),  # Equal to threshold - no record
-        (100, 101, True),  # Above threshold - record
-        (50, 75, True),  # Above threshold - record
-        (200, 150, False),  # Below threshold - no record
-    ],
-)
-def test_threshold_boundary_conditions(threshold, latency, should_record):
-    """Test various threshold and latency combinations.
-
-    Only records when latency is strictly greater than the threshold.
-    """
-    with override_options({"spans.buffer.evalsha-latency-threshold": threshold}):
-        logger = BufferLogger()
-        keys = [("123:abc", "span1")]
-
-        logger.log(keys, latency_ms=latency)
-
-        if should_record:
-            assert len(logger._counts) == 1
-            assert logger._counts["123:abc"] == 1
-        else:
-            assert len(logger._counts) == 0
+        # Even if we somehow trigger the logging path, it should not log
+        # This is testing the internal behavior, but we can't easily trigger
+        # the logging path without going through log() method
+        # So we just verify initial state
+        assert mock_logger.info.call_count == 0

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from sentry.spans.buffer_logger import BufferLogger
+from sentry.testutils.helpers.options import override_options
+
+
+class TestBufferLogger:
+    """Tests for BufferLogger class that tracks slow pipeline operations."""
+
+    def test_does_not_log_below_threshold(self):
+        """Test that operations below threshold are not recorded."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+            keys = [("123:abc", "span1"), ("456:def", "span2")]
+
+            # Latency below threshold should not be recorded
+            logger.log(keys, latency_ms=50)
+
+            assert len(logger._counts) == 0
+
+    def test_logs_above_threshold(self):
+        """Test that operations above threshold are recorded."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+            keys = [("123:abc", "span1"), ("456:def", "span2")]
+
+            # Latency above threshold should be recorded
+            logger.log(keys, latency_ms=150)
+
+            assert len(logger._counts) == 2
+            assert logger._counts["123:abc"] == 1
+            assert logger._counts["456:def"] == 1
+
+    def test_increments_existing_counts(self):
+        """Test that counts are incremented for repeated slow operations."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+            keys = [("123:abc", "span1")]
+
+            # Log the same key multiple times
+            logger.log(keys, latency_ms=150)
+            logger.log(keys, latency_ms=200)
+            logger.log(keys, latency_ms=175)
+
+            assert logger._counts["123:abc"] == 3
+
+    def test_prunes_to_max_entries(self):
+        """Test that map is pruned to keep only top 100 entries by count."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+
+            # Add 101 unique entries with varying counts
+            for i in range(101):
+                # First 50 entries get count of 10, next 51 get count of 1
+                count = 10 if i < 50 else 1
+                for _ in range(count):
+                    logger.log([(f"{i}:trace{i}", "span")], latency_ms=150)
+
+            # Should have been pruned to 100 entries
+            assert len(logger._counts) == 100
+
+            # The top 50 entries (with count 10) should be preserved
+            for i in range(50):
+                assert f"{i}:trace{i}" in logger._counts
+                assert logger._counts[f"{i}:trace{i}"] == 10
+
+            # Some of the lower count entries should have been dropped
+            low_count_entries = [key for key in logger._counts if logger._counts[key] == 1]
+            assert len(low_count_entries) == 50
+
+    def test_prune_to_top_n(self):
+        """Test the _prune_to_top_n method directly."""
+        logger = BufferLogger()
+        logger._counts = {
+            "high1": 10,
+            "high2": 9,
+            "high3": 8,
+            "mid1": 5,
+            "mid2": 4,
+            "low1": 1,
+            "low2": 2,
+        }
+
+        logger._prune_to_top_n(5)
+
+        assert len(logger._counts) == 5
+        assert "high1" in logger._counts
+        assert "high2" in logger._counts
+        assert "high3" in logger._counts
+        assert "mid1" in logger._counts
+        assert "mid2" in logger._counts
+        assert "low1" not in logger._counts
+        assert "low2" not in logger._counts
+
+    def test_prune_to_top_n_no_op_when_below_limit(self):
+        """Test that pruning is a no-op when entries are below limit."""
+        logger = BufferLogger()
+        logger._counts = {"key1": 5, "key2": 3}
+
+        logger._prune_to_top_n(10)
+
+        assert len(logger._counts) == 2
+        assert logger._counts["key1"] == 5
+        assert logger._counts["key2"] == 3
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_periodic_logging_triggers_after_interval(self, mock_time, mock_logger):
+        """Test that logging occurs after the configured interval."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            # Mock time to control when logging should trigger
+            # Each log() call makes exactly 1 call to time.time()
+            mock_time.time.side_effect = [
+                1000.0,  # Initial time in __init__
+                1000.0,  # First log call - check current time
+                1006.0,  # Second log call - check current time (> 5s elapsed, triggers logging)
+            ]
+
+            logger = BufferLogger()
+            keys = [("123:abc", "span1")]
+
+            # First log - should not trigger periodic logging
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 0
+
+            # Second log after 6 seconds - should trigger periodic logging
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 1
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_logs_top_50_entries(self, mock_time, mock_logger):
+        """Test that only top 50 entries are logged."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            # Calculate total number of log() calls
+            # 60 entries with counts: 60, 59, 58, ..., 1 = sum(1 to 60) = 1830
+            # Plus 1 final trigger call = 1831 total log() calls
+            # Each log() call makes 1 time.time() call
+            total_log_calls = sum(range(1, 61)) + 1  # 1831
+
+            mock_time.time.side_effect = (
+                [
+                    1000.0,  # Initial time in __init__
+                ]
+                + [1000.0] * (total_log_calls - 1)
+                + [  # All log calls except the last one
+                    1006.0,  # Final trigger call that should trigger logging
+                ]
+            )
+
+            logger = BufferLogger()
+
+            # Add 60 entries with varying counts
+            for i in range(60):
+                count = 60 - i  # Descending counts so entry 0 has highest count
+                for _ in range(count):
+                    logger.log([(f"{i}:trace{i}", "span")], latency_ms=150)
+
+            # Trigger periodic logging
+            logger.log([("trigger:trace", "span")], latency_ms=150)
+
+            # Should have logged
+            assert mock_logger.info.call_count == 1
+
+            # Check the logged data
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "spans.buffer.slow_evalsha_operations"
+            extra = call_args[1]["extra"]
+
+            # Should have logged top 50 entries
+            assert extra["top_entries_count"] == 50
+            assert extra["num_tracked_keys"] == 61  # 60 + 1 trigger
+
+            # Verify the format includes entry counts
+            entries_str = extra["top_slow_operations"]
+            assert "0:trace0:60" in entries_str  # Highest count
+            assert "49:trace49:11" in entries_str  # 50th entry
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    def test_no_logging_when_empty(self, mock_logger):
+        """Test that nothing is logged when there are no entries."""
+        logger = BufferLogger()
+        logger._log_top_entries()
+
+        assert mock_logger.info.call_count == 0
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_resets_timer_after_logging(self, mock_time, mock_logger):
+        """Test that the timer is reset after logging."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            # Each log() call makes exactly 1 call to time.time()
+            mock_time.time.side_effect = [
+                1000.0,  # Initial time in __init__
+                1000.0,  # First log - check current time
+                1006.0,  # Second log - triggers logging (>5s elapsed)
+                1010.0,  # Third log - should not trigger (only 4s since last log at 1006)
+                1012.0,  # Fourth log - should trigger (6s elapsed since 1006)
+            ]
+
+            logger = BufferLogger()
+            keys = [("123:abc", "span1")]
+
+            # First log
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 0
+
+            # Second log - triggers logging
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 1
+            assert logger._last_log_time == 1006.0
+
+            # Third log - should not trigger (only 4s elapsed)
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 1
+
+            # Fourth log - should trigger (6s elapsed)
+            logger.log(keys, latency_ms=150)
+            assert mock_logger.info.call_count == 2
+
+    def test_handles_empty_keys_iterator(self):
+        """Test that empty keys iterator is handled gracefully."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+            keys = []
+
+            logger.log(keys, latency_ms=150)
+
+            assert len(logger._counts) == 0
+
+    def test_multiple_keys_in_single_call(self):
+        """Test that multiple keys in a single call are all recorded."""
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            logger = BufferLogger()
+            keys = [
+                ("123:abc", "span1"),
+                ("456:def", "span2"),
+                ("789:ghi", "span3"),
+            ]
+
+            logger.log(keys, latency_ms=150)
+
+            assert len(logger._counts) == 3
+            assert logger._counts["123:abc"] == 1
+            assert logger._counts["456:def"] == 1
+            assert logger._counts["789:ghi"] == 1
+
+
+@pytest.mark.parametrize(
+    "threshold,latency,should_record",
+    [
+        (100, 99, False),  # Below threshold - no record
+        (100, 100, False),  # Equal to threshold - no record
+        (100, 101, True),  # Above threshold - record
+        (50, 75, True),  # Above threshold - record
+        (200, 150, False),  # Below threshold - no record
+    ],
+)
+def test_threshold_boundary_conditions(threshold, latency, should_record):
+    """Test various threshold and latency combinations.
+
+    Only records when latency is strictly greater than the threshold.
+    """
+    with override_options({"spans.buffer.evalsha-latency-threshold": threshold}):
+        logger = BufferLogger()
+        keys = [("123:abc", "span1")]
+
+        logger.log(keys, latency_ms=latency)
+
+        if should_record:
+            assert len(logger._counts) == 1
+            assert logger._counts["123:abc"] == 1
+        else:
+            assert len(logger._counts) == 0


### PR DESCRIPTION
We are observing sustained high latency in the EVALSHA commands in the 
spans buffer. These seem localized on one Redis shard. So chances are
this is caused by a single trace as we use organization id and trace id
to map a key to a slot.

It seems there was no increase in volume of requests but everything running
in the LUA script cannot be broken down. So we need some observability
from the client side. THe goal here is to identify some traces causing slow 
EVALSHA.

1. Return the elapsed time every time we run the LUA script to add a batch
of spans 
2. Introduce BufferLogger that receives the latency for all the calls and decide
  when it is time to log: log the 50 most common trace ids with high latency.
  IT only records at most 1000 spans
