### PR TITLE
Update hooks to accepts Props as arguments which work better with renderHook()

### DIFF
--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -590,8 +590,8 @@ export function ContinuousFlamegraph(): ReactElement {
     return new FlamegraphCanvas(memoryChartCanvasRef, vec2.fromValues(0, 0));
   }, [memoryChartCanvasRef]);
 
-  const flamegraphView = useMemoWithPrevious<CanvasView<FlamegraphModel> | null>(
-    previousView => {
+  const flamegraphView = useMemoWithPrevious<CanvasView<FlamegraphModel> | null>({
+    factory: previousView => {
       if (!flamegraphCanvas) {
         return null;
       }
@@ -686,19 +686,18 @@ export function ContinuousFlamegraph(): ReactElement {
     },
 
     // We skip position.view dependency because it will go into an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
+    deps: [
       flamegraph,
       flamegraphCanvas,
       flamegraphTheme,
       profile,
       segment,
       configSpaceQueryParam,
-    ]
-  );
+    ],
+  });
 
-  const uiFramesView = useMemoWithPrevious<CanvasView<UIFrames> | null>(
-    _previousView => {
+  const uiFramesView = useMemoWithPrevious<CanvasView<UIFrames> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !uiFrames) {
         return null;
       }
@@ -724,18 +723,18 @@ export function ContinuousFlamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       flamegraph,
       uiFrames,
       profile,
       configSpaceQueryParam,
-    ]
-  );
+    ],
+  });
 
-  const batteryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const batteryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !batteryChart || !batteryChartCanvas) {
         return null;
       }
@@ -768,7 +767,7 @@ export function ContinuousFlamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       batteryChart,
@@ -776,11 +775,11 @@ export function ContinuousFlamegraph(): ReactElement {
       batteryChartCanvas,
       profile,
       configSpaceQueryParam,
-    ]
-  );
+    ],
+  });
 
-  const cpuChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const cpuChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !CPUChart || !cpuChartCanvas) {
         return null;
       }
@@ -813,7 +812,7 @@ export function ContinuousFlamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       CPUChart,
@@ -821,11 +820,11 @@ export function ContinuousFlamegraph(): ReactElement {
       cpuChartCanvas,
       profile,
       configSpaceQueryParam,
-    ]
-  );
+    ],
+  });
 
-  const memoryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const memoryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !memoryChart || !memoryChartCanvas) {
         return null;
       }
@@ -858,7 +857,7 @@ export function ContinuousFlamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       memoryChart,
@@ -866,11 +865,11 @@ export function ContinuousFlamegraph(): ReactElement {
       memoryChartCanvas,
       profile,
       configSpaceQueryParam,
-    ]
-  );
+    ],
+  });
 
-  const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>(
-    _previousView => {
+  const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>({
+    factory: _previousView => {
       if (!spansCanvas || !spanChart || !flamegraphView) {
         return null;
       }
@@ -899,7 +898,7 @@ export function ContinuousFlamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       spanChart,
       spansCanvas,
       flamegraphView,
@@ -907,8 +906,8 @@ export function ContinuousFlamegraph(): ReactElement {
       profileTimestamp,
       configSpaceQueryParam,
       segment,
-    ]
-  );
+    ],
+  });
 
   // We want to make sure that the views have the same min zoom levels so that
   // if you wheel zoom on one, the other one will also zoom to the same level of detail.

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -570,8 +570,8 @@ function Flamegraph(): ReactElement {
     return new FlamegraphCanvas(memoryChartCanvasRef, vec2.fromValues(0, 0));
   }, [memoryChartCanvasRef]);
 
-  const flamegraphView = useMemoWithPrevious<CanvasView<FlamegraphModel> | null>(
-    previousView => {
+  const flamegraphView = useMemoWithPrevious<CanvasView<FlamegraphModel> | null>({
+    factory: previousView => {
       if (!flamegraphCanvas) {
         return null;
       }
@@ -659,12 +659,12 @@ function Flamegraph(): ReactElement {
     },
 
     // We skip position.view dependency because it will go into an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [flamegraph, flamegraphCanvas, flamegraphTheme, profileOffsetFromTransaction]
-  );
 
-  const uiFramesView = useMemoWithPrevious<CanvasView<UIFrames> | null>(
-    _previousView => {
+    deps: [flamegraph, flamegraphCanvas, flamegraphTheme, profileOffsetFromTransaction],
+  });
+
+  const uiFramesView = useMemoWithPrevious<CanvasView<UIFrames> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !uiFrames) {
         return null;
       }
@@ -690,11 +690,17 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [flamegraphView, flamegraphCanvas, flamegraph, uiFrames, profileOffsetFromTransaction]
-  );
+    deps: [
+      flamegraphView,
+      flamegraphCanvas,
+      flamegraph,
+      uiFrames,
+      profileOffsetFromTransaction,
+    ],
+  });
 
-  const batteryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const batteryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !batteryChart || !batteryChartCanvas) {
         return null;
       }
@@ -727,18 +733,18 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       batteryChart,
       uiFrames.minFrameDuration,
       batteryChartCanvas,
       profileOffsetFromTransaction,
-    ]
-  );
+    ],
+  });
 
-  const cpuChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const cpuChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !CPUChart || !cpuChartCanvas) {
         return null;
       }
@@ -771,18 +777,18 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       CPUChart,
       uiFrames.minFrameDuration,
       cpuChartCanvas,
       profileOffsetFromTransaction,
-    ]
-  );
+    ],
+  });
 
-  const memoryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>(
-    _previousView => {
+  const memoryChartView = useMemoWithPrevious<CanvasView<FlamegraphChartModel> | null>({
+    factory: _previousView => {
       if (!flamegraphView || !flamegraphCanvas || !memoryChart || !memoryChartCanvas) {
         return null;
       }
@@ -815,18 +821,18 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [
+    deps: [
       flamegraphView,
       flamegraphCanvas,
       memoryChart,
       uiFrames.minFrameDuration,
       memoryChartCanvas,
       profileOffsetFromTransaction,
-    ]
-  );
+    ],
+  });
 
-  const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>(
-    _previousView => {
+  const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>({
+    factory: _previousView => {
       if (!spansCanvas || !spanChart || !flamegraphView) {
         return null;
       }
@@ -850,8 +856,8 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [spanChart, spansCanvas, flamegraphView, flamegraphTheme.SIZES]
-  );
+    deps: [spanChart, spansCanvas, flamegraphView, flamegraphTheme.SIZES],
+  });
 
   // We want to make sure that the views have the same min zoom levels so that
   // if you wheel zoom on one, the other one will also zoom to the same level of detail.

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -96,16 +96,16 @@ export function TourContextProvider<T extends TourEnumType>({
     }),
     [onStartTour, onEndTour, onStepChange, requireAllStepsRegistered]
   );
-  const tourContextValue = useTourReducer<T>(
-    {
+  const tourContextValue = useTourReducer<T>({
+    initialState: {
       isCompleted,
       isRegistered: false,
       orderedStepIds,
       currentStepId: null,
       tourKey,
     },
-    options
-  );
+    options,
+  });
   const {endTour, previousStep, nextStep, currentStepId} = tourContextValue;
   const isTourActive = currentStepId !== null;
 

--- a/static/app/components/tours/tourContext.spec.tsx
+++ b/static/app/components/tours/tourContext.spec.tsx
@@ -13,7 +13,9 @@ describe('useTourReducer', () => {
     orderedStepIds: ORDERED_TEST_TOUR,
   };
   function registerAllSteps() {
-    const {result} = renderHook(() => useTourReducer<TestTour>(initialState, {}));
+    const {result} = renderHook(() =>
+      useTourReducer<TestTour>({initialState, options: {}})
+    );
     const {handleStepRegistration} = result.current;
     act(() => {
       ORDERED_TEST_TOUR.forEach(stepId => handleStepRegistration({id: stepId}));
@@ -22,7 +24,9 @@ describe('useTourReducer', () => {
   }
 
   it('handles step registration correctly', () => {
-    const {result} = renderHook(() => useTourReducer<TestTour>(initialState, {}));
+    const {result} = renderHook(() =>
+      useTourReducer<TestTour>({initialState, options: {}})
+    );
     const {handleStepRegistration} = result.current;
     let unregister = () => {};
     // Should be false before any steps are registered

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -168,10 +168,13 @@ function tourReducer<T extends TourEnumType>(
   }
 }
 
-export function useTourReducer<T extends TourEnumType>(
-  initialState: TourState<T>,
-  options: TourOptions<T>
-): TourContextType<T> {
+export function useTourReducer<T extends TourEnumType>({
+  initialState,
+  options,
+}: {
+  initialState: TourState<T>;
+  options: TourOptions<T>;
+}): TourContextType<T> {
   const {orderedStepIds} = initialState;
 
   const [state, dispatch] = useReducer(tourReducer<T>, initialState);

--- a/static/app/utils/demoMode/demoTours.tsx
+++ b/static/app/utils/demoMode/demoTours.tsx
@@ -152,20 +152,20 @@ export function DemoToursProvider({children}: {children: React.ReactNode}) {
     [handleEndTour, handleStepChange]
   );
 
-  const issuesTour = useTourReducer<DemoTourStep>(
-    tourState[DemoTour.ISSUES],
-    getTourOptions(DemoTour.ISSUES)
-  );
+  const issuesTour = useTourReducer<DemoTourStep>({
+    initialState: tourState[DemoTour.ISSUES],
+    options: getTourOptions(DemoTour.ISSUES),
+  });
 
-  const releasesTour = useTourReducer<DemoTourStep>(
-    tourState[DemoTour.RELEASES],
-    getTourOptions(DemoTour.RELEASES)
-  );
+  const releasesTour = useTourReducer<DemoTourStep>({
+    initialState: tourState[DemoTour.RELEASES],
+    options: getTourOptions(DemoTour.RELEASES),
+  });
 
-  const performanceTour = useTourReducer<DemoTourStep>(
-    tourState[DemoTour.PERFORMANCE],
-    getTourOptions(DemoTour.PERFORMANCE)
-  );
+  const performanceTour = useTourReducer<DemoTourStep>({
+    initialState: tourState[DemoTour.PERFORMANCE],
+    options: getTourOptions(DemoTour.PERFORMANCE),
+  });
 
   const tours = useMemo(
     () => ({

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -69,10 +69,10 @@ function getDefaultState(initialState?: DeepPartial<FlamegraphState>): Flamegrap
 export function FlamegraphStateProvider(
   props: FlamegraphStateProviderProps
 ): React.ReactElement {
-  const [state, dispatch, {nextState, previousState}] = useUndoableReducer(
-    flamegraphStateReducer,
-    getDefaultState(props.initialState)
-  );
+  const [state, dispatch, {nextState, previousState}] = useUndoableReducer({
+    reducer: flamegraphStateReducer,
+    initialState: getDefaultState(props.initialState),
+  });
 
   const flamegraphContextValue: FlamegraphStateValue = useMemo(() => {
     return [state, {nextState, previousState}];

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -11,6 +11,18 @@ import {useFetchEventsTimeSeries} from './useFetchEventsTimeSeries';
 
 jest.mock('sentry/utils/usePageFilters');
 
+function useTestableFetchEventsTimeSeries({
+  dataset,
+  options,
+  referrer,
+}: {
+  dataset: Parameters<typeof useFetchEventsTimeSeries>[0];
+  options: Parameters<typeof useFetchEventsTimeSeries>[1];
+  referrer: Parameters<typeof useFetchEventsTimeSeries>[2];
+}) {
+  return useFetchEventsTimeSeries(dataset, options, referrer);
+}
+
 describe('useFetchEventsTimeSeries', () => {
   const organization = OrganizationFixture();
 
@@ -42,15 +54,13 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {
-          yAxis: 'epm()',
-        },
-        REFERRER
-      )
-    );
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {yAxis: 'epm()'},
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
@@ -71,16 +81,16 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {
           yAxis: ['epm()'],
           enabled: false,
         },
-        REFERRER
-      )
-    );
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(true));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -90,16 +100,16 @@ describe('useFetchEventsTimeSeries', () => {
 
   it('requires a referrer', () => {
     expect(() => {
-      renderHookWithProviders(() =>
-        useFetchEventsTimeSeries(
-          DiscoverDatasets.SPANS,
-          {
+      renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+        initialProps: {
+          dataset: DiscoverDatasets.SPANS,
+          options: {
             yAxis: ['epm()'],
             enabled: false,
           },
-          ''
-        )
-      );
+          referrer: '',
+        },
+      });
     }).toThrow();
   });
 
@@ -110,16 +120,16 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {
           yAxis: 'p50(span.duration)',
           query: new MutableSearch('span.op:db*'),
         },
-        REFERRER
-      )
-    );
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
@@ -153,10 +163,10 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {
           yAxis: 'p50(span.duration)',
           interval: '2h',
           pageFilters: {
@@ -170,9 +180,9 @@ describe('useFetchEventsTimeSeries', () => {
             },
           },
         },
-        REFERRER
-      )
-    );
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
@@ -207,10 +217,10 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {
           yAxis: 'p50(span.duration)',
           topEvents: 5,
           groupBy: ['span.category', 'transaction'],
@@ -219,9 +229,9 @@ describe('useFetchEventsTimeSeries', () => {
             kind: 'desc',
           },
         },
-        REFERRER
-      )
-    );
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
@@ -257,13 +267,17 @@ describe('useFetchEventsTimeSeries', () => {
       body: [],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useFetchEventsTimeSeries(
-        DiscoverDatasets.SPANS,
-        {yAxis: 'epm()', logQuery: ['span.op:db*'], metricQuery: ['span.op:db*']},
-        REFERRER
-      )
-    );
+    const {result} = renderHookWithProviders(useTestableFetchEventsTimeSeries, {
+      initialProps: {
+        dataset: DiscoverDatasets.SPANS,
+        options: {
+          yAxis: 'epm()',
+          logQuery: ['span.op:db*'],
+          metricQuery: ['span.op:db*'],
+        },
+        referrer: REFERRER,
+      },
+    });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 

--- a/static/app/utils/useDispatchingReducer.spec.tsx
+++ b/static/app/utils/useDispatchingReducer.spec.tsx
@@ -19,7 +19,7 @@ describe('useDispatchingReducer', () => {
   it('initializes state with initializer', () => {
     const reducer = jest.fn().mockImplementation(s => s);
     const initialState = {type: 'initial'};
-    const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
+    const {result} = renderHook(() => useDispatchingReducer({reducer, initialState}));
 
     expect(result.current[0]).toBe(initialState);
   });
@@ -27,7 +27,11 @@ describe('useDispatchingReducer', () => {
     const reducer = jest.fn().mockImplementation(s => s);
     const initialState = {type: 'initial'};
     const {result} = renderHook(() =>
-      useDispatchingReducer(reducer, undefined, () => initialState)
+      useDispatchingReducer({
+        reducer,
+        initialState: undefined,
+        initializer: () => initialState,
+      })
     );
 
     expect(result.current[0]).toBe(initialState);
@@ -43,7 +47,7 @@ describe('useDispatchingReducer', () => {
     });
     it('calls reducer and updates state', async () => {
       const initialState = {type: 'initial'};
-      const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
+      const {result} = renderHook(() => useDispatchingReducer({reducer, initialState}));
 
       act(() => result.current[1]('action'));
       act(() => {
@@ -57,7 +61,7 @@ describe('useDispatchingReducer', () => {
     });
     it('calls before action with state and action args', () => {
       const initialState = {type: 'initial'};
-      const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
+      const {result} = renderHook(() => useDispatchingReducer({reducer, initialState}));
 
       const beforeAction = jest.fn();
       result.current[2].on('before action', beforeAction);
@@ -72,7 +76,7 @@ describe('useDispatchingReducer', () => {
     });
     it('calls after action with previous, new state and action args', () => {
       const initialState = {type: 'initial'};
-      const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
+      const {result} = renderHook(() => useDispatchingReducer({reducer, initialState}));
 
       const beforeNextState = jest.fn();
       result.current[2].on('before next state', beforeNextState);
@@ -104,7 +108,7 @@ describe('useDispatchingReducer', () => {
           }
         });
       const {result} = renderHook(() =>
-        useDispatchingReducer(action_storing_reducer, initialState)
+        useDispatchingReducer({reducer: action_storing_reducer, initialState})
       );
 
       act(() => {
@@ -140,7 +144,9 @@ describe('useDispatchingReducer', () => {
     });
 
     const initialState = {a: {}, b: {}};
-    const {result} = renderHook(() => useDispatchingReducer(finalReducer, initialState));
+    const {result} = renderHook(() =>
+      useDispatchingReducer({reducer: finalReducer, initialState})
+    );
 
     act(() => {
       result.current[1]('a');
@@ -164,7 +170,7 @@ describe('useDispatchingReducer', () => {
     });
 
     const initialState = {};
-    const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
+    const {result} = renderHook(() => useDispatchingReducer({reducer, initialState}));
 
     result.current[2].on('before action', (_state: any, action: any) => {
       if (action === 'a') {

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -93,11 +93,15 @@ function update<R extends React.Reducer<any, any>>(
   return start;
 }
 
-export function useDispatchingReducer<R extends React.Reducer<any, any>>(
-  reducer: R,
-  initialState: ReducerState<R>,
-  initializer?: (arg: ReducerState<R>) => ReducerState<R>
-): [ReducerState<R>, React.Dispatch<ReducerAction<R>>, DispatchingReducerEmitter<R>] {
+export function useDispatchingReducer<R extends React.Reducer<any, any>>({
+  reducer,
+  initialState,
+  initializer,
+}: {
+  initialState: ReducerState<R>;
+  reducer: R;
+  initializer?: (arg: ReducerState<R>) => ReducerState<R>;
+}): [ReducerState<R>, React.Dispatch<ReducerAction<R>>, DispatchingReducerEmitter<R>] {
   const emitter = useMemo(() => new DispatchingReducerEmitter<R>(), []);
   const [state, setState] = useState(
     initialState ?? (initializer?.(initialState) as ReducerState<R>)

--- a/static/app/utils/useMemoWithPrevious.spec.tsx
+++ b/static/app/utils/useMemoWithPrevious.spec.tsx
@@ -4,11 +4,11 @@ import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 
 describe('useMemoWithPrevious', () => {
   it('calls factory with null', () => {
-    const dep = {};
+    const deps = [{}];
 
     const factory = jest.fn().mockImplementation(() => 'foo');
 
-    const {result} = renderHook(() => useMemoWithPrevious(factory, [dep]));
+    const {result} = renderHook(useMemoWithPrevious, {initialProps: {factory, deps}});
     expect(factory).toHaveBeenCalledWith(null);
     expect(result.current).toBe('foo');
   });
@@ -20,18 +20,14 @@ describe('useMemoWithPrevious', () => {
     const firstDependency: unknown[] = [];
     const secondDependency: unknown[] = [];
 
-    const {rerender, result} = renderHook(
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      ({fact, dep}) => useMemoWithPrevious(fact, [dep]),
-      {
-        initialProps: {
-          fact: factory,
-          dep: firstDependency,
-        },
-      }
-    );
+    const {rerender, result} = renderHook(useMemoWithPrevious, {
+      initialProps: {
+        factory,
+        deps: [firstDependency],
+      },
+    });
 
-    rerender({fact: factory, dep: secondDependency});
+    rerender({factory, deps: [secondDependency]});
 
     expect(result.current).toBe('bar');
     expect(factory.mock.calls[1][0]).toBe('foo');

--- a/static/app/utils/useMemoWithPrevious.ts
+++ b/static/app/utils/useMemoWithPrevious.ts
@@ -3,10 +3,13 @@ import {useState} from 'react';
 import {useEffectAfterFirstRender} from './useEffectAfterFirstRender';
 import usePrevious from './usePrevious';
 
-const useMemoWithPrevious = <T>(
-  factory: (previousInstance: T | null) => T,
-  deps: React.DependencyList
-): T => {
+export function useMemoWithPrevious<T>({
+  deps,
+  factory,
+}: {
+  deps: React.DependencyList;
+  factory: (previousInstance: T | null) => T;
+}): T {
   const [value, setValue] = useState<T>(() => factory(null));
   const previous = usePrevious<T | null>(value);
 
@@ -17,6 +20,4 @@ const useMemoWithPrevious = <T>(
   }, deps);
 
   return value;
-};
-
-export {useMemoWithPrevious};
+}

--- a/static/app/utils/useUndoableReducer.spec.tsx
+++ b/static/app/utils/useUndoableReducer.spec.tsx
@@ -59,13 +59,9 @@ describe('makeUndoableReducer', () => {
           action === 'add' ? state + 1 : state - 1
         );
 
-      const {result} = renderHook(
-        (args: Parameters<typeof useUndoableReducer>) =>
-          useUndoableReducer(args[0], args[1]),
-        {
-          initialProps: [reducer, 100],
-        }
-      );
+      const {result} = renderHook(useUndoableReducer, {
+        initialProps: {reducer, initialState: 100},
+      });
       expect(reducer).not.toHaveBeenCalled();
       expect(result.current[0]).toBe(100);
     });
@@ -77,11 +73,9 @@ describe('makeUndoableReducer', () => {
           action === 'add' ? state + 1 : state - 1
         );
 
-      const {result} = renderHook(
-        (args: Parameters<typeof useUndoableReducer>) =>
-          useUndoableReducer(args[0], args[1]),
-        {initialProps: [reducer, 0]}
-      );
+      const {result} = renderHook(useUndoableReducer, {
+        initialProps: {reducer, initialState: 0},
+      });
       act(() => result.current[1]('add'));
 
       expect(result.current[0]).toBe(1);
@@ -94,11 +88,12 @@ describe('makeUndoableReducer', () => {
     });
 
     it('can undo state', () => {
-      const {result} = renderHook(
-        (args: Parameters<typeof useUndoableReducer>) =>
-          useUndoableReducer(args[0], args[1]),
-        {initialProps: [jest.fn().mockImplementation(s => s + 1), 0]}
-      );
+      const {result} = renderHook(useUndoableReducer, {
+        initialProps: {
+          reducer: jest.fn().mockImplementation(s => s + 1),
+          initialState: 0,
+        },
+      });
 
       act(() => result.current[1](0));
       expect(result.current[0]).toBe(1);
@@ -108,11 +103,12 @@ describe('makeUndoableReducer', () => {
     });
 
     it('can redo state', () => {
-      const {result} = renderHook(
-        (args: Parameters<typeof useUndoableReducer>) =>
-          useUndoableReducer(args[0], args[1]),
-        {initialProps: [jest.fn().mockImplementation(s => s + 1), 0]}
-      );
+      const {result} = renderHook(useUndoableReducer, {
+        initialProps: {
+          reducer: jest.fn().mockImplementation(s => s + 1),
+          initialState: 0,
+        },
+      });
 
       act(() => result.current[1](0)); // 0 + 1
       act(() => result.current[1](1)); // 1 + 1
@@ -134,13 +130,9 @@ describe('makeUndoableReducer', () => {
     const simpleReducer = (state: any, action: any) =>
       action.type === 'add' ? state + 1 : state - 1;
 
-    const {result} = renderHook(
-      (args: Parameters<typeof useUndoableReducer>) =>
-        useUndoableReducer(args[0], args[1]),
-      {
-        initialProps: [simpleReducer, 0],
-      }
-    );
+    const {result} = renderHook(useUndoableReducer, {
+      initialProps: {reducer: simpleReducer, initialState: 0},
+    });
 
     act(() => result.current[1]({type: 'add'}));
     expect(result.current?.[2].previousState).toBe(0);

--- a/static/app/utils/useUndoableReducer.tsx
+++ b/static/app/utils/useUndoableReducer.tsx
@@ -81,7 +81,13 @@ type UndoableReducerState<R extends React.Reducer<ReducerState<R>, ReducerAction
 
 export function useUndoableReducer<
   R extends React.Reducer<ReducerState<R>, ReducerAction<R>>,
->(reducer: R, initialState: ReducerState<R>): UndoableReducerState<R> {
+>({
+  reducer,
+  initialState,
+}: {
+  initialState: ReducerState<R>;
+  reducer: R;
+}): UndoableReducerState<R> {
   const [state, dispatch] = useReducer(makeUndoableReducer(reducer), {
     current: initialState,
     previous: undefined,

--- a/static/app/views/explore/logs/useLogsTimeseries.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.tsx
@@ -75,11 +75,11 @@ export function useLogsTimeseries({
     },
   });
 
-  return useStreamingTimeseriesResult(
+  return useStreamingTimeseriesResult({
     tableData,
-    timeseriesResult.result,
-    timeseriesIngestDelay
-  );
+    timeseriesResult: timeseriesResult.result,
+    timeseriesIngestDelay,
+  });
 }
 
 function useLogsTimeseriesImpl({

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
@@ -456,7 +456,12 @@ describe('useStreamingTimeseriesResult', () => {
     const mockTimeseriesData = getMockSingleAxisTimeseries();
 
     const {result} = renderHook(
-      () => useStreamingTimeseriesResult(mockTableData, mockTimeseriesData, 0n),
+      () =>
+        useStreamingTimeseriesResult({
+          tableData: mockTableData,
+          timeseriesResult: mockTimeseriesData,
+          timeseriesIngestDelay: 0n,
+        }),
       {
         wrapper: createWrapper({autoRefresh: 'enabled', organization: logsOrganization}),
       }
@@ -470,7 +475,12 @@ describe('useStreamingTimeseriesResult', () => {
     const mockTimeseriesData = getMockSingleAxisTimeseries();
 
     const {result} = renderHook(
-      () => useStreamingTimeseriesResult(mockTableData, mockTimeseriesData, 0n),
+      () =>
+        useStreamingTimeseriesResult({
+          tableData: mockTableData,
+          timeseriesResult: mockTimeseriesData,
+          timeseriesIngestDelay: 0n,
+        }),
       {
         wrapper: createWrapper({autoRefresh: 'idle'}),
       }
@@ -484,7 +494,12 @@ describe('useStreamingTimeseriesResult', () => {
     const mockTimeseriesData = getMockMultiAxisTimeseries();
 
     const {result} = renderHook(
-      () => useStreamingTimeseriesResult(mockTableData, mockTimeseriesData, 0n),
+      () =>
+        useStreamingTimeseriesResult({
+          tableData: mockTableData,
+          timeseriesResult: mockTimeseriesData,
+          timeseriesIngestDelay: 0n,
+        }),
       {
         wrapper: createWrapper({autoRefresh: 'idle'}),
       }
@@ -498,7 +513,12 @@ describe('useStreamingTimeseriesResult', () => {
     const mockTimeseriesData = getMockMultiGroupTimeseries();
 
     const {result} = renderHook(
-      () => useStreamingTimeseriesResult(mockTableData, mockTimeseriesData, 0n),
+      () =>
+        useStreamingTimeseriesResult({
+          tableData: mockTableData,
+          timeseriesResult: mockTimeseriesData,
+          timeseriesIngestDelay: 0n,
+        }),
       {
         wrapper: createWrapper({autoRefresh: 'idle'}),
       }
@@ -512,7 +532,12 @@ describe('useStreamingTimeseriesResult', () => {
     const mockTimeseriesData = getMockMultiAxisGroupTimeseries();
 
     const {result} = renderHook(
-      () => useStreamingTimeseriesResult(mockTableData, mockTimeseriesData, 0n),
+      () =>
+        useStreamingTimeseriesResult({
+          tableData: mockTableData,
+          timeseriesResult: mockTimeseriesData,
+          timeseriesIngestDelay: 0n,
+        }),
       {
         wrapper: createWrapper({autoRefresh: 'idle'}),
       }
@@ -527,7 +552,11 @@ describe('useStreamingTimeseriesResult', () => {
 
       const {result, rerender} = renderHook(
         (tableData: UseInfiniteLogsQueryResult) =>
-          useStreamingTimeseriesResult(tableData, mockTimeseriesData, 0n),
+          useStreamingTimeseriesResult({
+            tableData,
+            timeseriesResult: mockTimeseriesData,
+            timeseriesIngestDelay: 0n,
+          }),
         {
           initialProps: createMockTableData([]),
           wrapper: createWrapper({autoRefresh: 'enabled'}),
@@ -601,7 +630,11 @@ describe('useStreamingTimeseriesResult', () => {
 
       const {result, rerender} = renderHook(
         (tableData: UseInfiniteLogsQueryResult) =>
-          useStreamingTimeseriesResult(tableData, mockTimeseriesData, 0n),
+          useStreamingTimeseriesResult({
+            tableData,
+            timeseriesResult: mockTimeseriesData,
+            timeseriesIngestDelay: 0n,
+          }),
         {
           initialProps: createMockTableData([]),
           wrapper: createWrapper({
@@ -839,7 +872,11 @@ describe('useStreamingTimeseriesResult', () => {
 
       const {result, rerender} = renderHook(
         (tableData: UseInfiniteLogsQueryResult) =>
-          useStreamingTimeseriesResult(tableData, mockTimeseriesData, ingestDelayMs),
+          useStreamingTimeseriesResult({
+            tableData,
+            timeseriesResult: mockTimeseriesData,
+            timeseriesIngestDelay: ingestDelayMs,
+          }),
         {
           initialProps: createMockTableData([]),
           wrapper: createWrapper({
@@ -946,7 +983,11 @@ describe('useStreamingTimeseriesResult', () => {
 
       const {result, rerender} = renderHook(
         (tableData: UseInfiniteLogsQueryResult) =>
-          useStreamingTimeseriesResult(tableData, mockTimeseriesData, 0n),
+          useStreamingTimeseriesResult({
+            tableData,
+            timeseriesResult: mockTimeseriesData,
+            timeseriesIngestDelay: 0n,
+          }),
         {
           initialProps: createMockTableData([]),
           wrapper: createWrapper({

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
@@ -76,11 +76,15 @@ type BufferedTimeseriesGroup = {
  *                                        ↑ Merge the last timeseries bucket with the table data
  */
 
-export function useStreamingTimeseriesResult(
-  tableData: ReturnType<typeof useLogsPageDataQueryResult>,
-  timeseriesResult: ReturnType<typeof useSortedTimeSeries>,
-  timeseriesIngestDelay: bigint
-): ReturnType<typeof useSortedTimeSeries> {
+export function useStreamingTimeseriesResult({
+  tableData,
+  timeseriesIngestDelay,
+  timeseriesResult,
+}: {
+  tableData: ReturnType<typeof useLogsPageDataQueryResult>;
+  timeseriesIngestDelay: bigint;
+  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
+}): ReturnType<typeof useSortedTimeSeries> {
   const organization = useOrganization();
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -34,13 +34,13 @@ const makeGroupPreviewRequestUrl = ({groupId}: {groupId: string}) => {
   return `/issues/${groupId}/events/latest/`;
 };
 
-function AllEventsTable({organization, excludedTags, group}: Props) {
+export default function AllEventsTable({organization, excludedTags, group}: Props) {
   const location = useLocation();
   const theme = useTheme();
   const config = getConfigForIssueType(group, group.project);
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
-  const {fields, columnTitles} = useEventColumns(group, organization);
+  const {fields, columnTitles} = useEventColumns({group, organization});
   const now = useMemo(() => Date.now(), []);
 
   const endpointUrl = makeGroupPreviewRequestUrl({
@@ -122,7 +122,13 @@ function AllEventsTable({organization, excludedTags, group}: Props) {
 
 type ColumnInfo = {columnTitles: string[]; fields: string[]};
 
-export const useEventColumns = (group: Group, organization: Organization): ColumnInfo => {
+export function useEventColumns({
+  group,
+  organization,
+}: {
+  group: Group;
+  organization: Organization;
+}): ColumnInfo {
   return useMemo(() => {
     const isPerfIssue = group.issueCategory === IssueCategory.PERFORMANCE;
     const isReplayEnabled =
@@ -175,7 +181,7 @@ export const useEventColumns = (group: Group, organization: Organization): Colum
       columnTitles,
     };
   }, [group, organization]);
-};
+}
 
 const getPlatformColumns = (
   platform: PlatformKey | undefined,
@@ -226,5 +232,3 @@ const getPlatformColumns = (
 
   return platformColumns;
 };
-
-export default AllEventsTable;

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -312,15 +312,15 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
    * This is not closer to the GroupEventHeader because it is unmounted
    * between route changes like latest event => eventId
    */
-  const previousEvent = useMemoWithPrevious<typeof event | null>(
-    previousInstance => {
+  const previousEvent = useMemoWithPrevious<typeof event | null>({
+    factory: previousInstance => {
       if (event) {
         return event;
       }
       return previousInstance;
     },
-    [event]
-  );
+    deps: [event],
+  });
 
   // If the environment changes, we need to refetch the group, but we can
   // still display the previous group while the new group is loading.
@@ -328,8 +328,8 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     cachedGroup: typeof groupData | null;
     previousEnvironments: typeof environments | null;
     previousGroupData: typeof groupData | null;
-  }>(
-    previousInstance => {
+  }>({
+    factory: previousInstance => {
       // Preserve the previous group if:
       // - New group is not yet available
       // - Previously we had group data
@@ -355,8 +355,8 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
         previousGroupData: null,
       };
     },
-    [groupData, environments, groupId]
-  );
+    deps: [groupData, environments, groupId],
+  });
 
   const group = groupData ?? previousGroupData.cachedGroup ?? null;
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -66,15 +66,15 @@ function GroupEventDetails() {
   const eventWithMeta = useMemo(() => withMeta(event), [event]);
   const project = useProjectFromSlug({organization, projectSlug: group?.project?.slug});
   const prevEnvironment = usePrevious(environments);
-  const prevEvent = useMemoWithPrevious<typeof event | null>(
-    previousInstance => {
+  const prevEvent = useMemoWithPrevious<typeof event | null>({
+    factory: previousInstance => {
       if (event) {
         return event;
       }
       return previousInstance;
     },
-    [event]
-  );
+    deps: [event],
+  });
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   // load the data

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -130,7 +130,7 @@ export function EventDetailsContent({
     projectId: project.id,
   });
 
-  useCopyIssueDetails(group, event);
+  useCopyIssueDetails({group, event});
 
   // default to show on error or isPromptDismissed === undefined
   const showFeedback = !isPromptDismissed || promptError || hasStreamlinedUI;

--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -84,7 +84,9 @@ describe('EventList', () => {
 
   it('renders the list using a discover event query', async () => {
     renderAllEvents();
-    const {result} = renderHook(() => useEventColumns(group, organization));
+    const {result} = renderHook(useEventColumns, {
+      initialProps: {group, organization},
+    });
 
     expect(await screen.findByText('All Events')).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -34,7 +34,7 @@ export function EventList({group}: EventListProps) {
   const organization = useOrganization();
   const routes = useRoutes();
   const [_error, setError] = useState('');
-  const {fields, columnTitles} = useEventColumns(group, organization);
+  const {fields, columnTitles} = useEventColumns({group, organization});
   const eventView = useIssueDetailsEventView({
     group,
     queryProps: {

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -390,7 +390,7 @@ describe('useCopyIssueDetails', () => {
     });
 
     it('calls useCopyToClipboard hook', () => {
-      renderHook(() => useCopyIssueDetails(group, event));
+      renderHook(useCopyIssueDetails, {initialProps: {group, event}});
 
       // Check that the hook was called
       expect(copyToClipboardModule.default).toHaveBeenCalled();
@@ -399,7 +399,7 @@ describe('useCopyIssueDetails', () => {
     it('sets up hotkeys with the correct callbacks', () => {
       const useHotkeysMock = jest.spyOn(require('sentry/utils/useHotkeys'), 'useHotkeys');
 
-      renderHook(() => useCopyIssueDetails(group, event));
+      renderHook(useCopyIssueDetails, {initialProps: {group, event}});
 
       expect(useHotkeysMock).toHaveBeenCalledWith([
         {
@@ -423,7 +423,7 @@ describe('useCopyIssueDetails', () => {
         return Promise.resolve(text);
       });
 
-      renderHook(() => useCopyIssueDetails(group, undefined));
+      renderHook(useCopyIssueDetails, {initialProps: {group, event: undefined}});
 
       // Trigger the keyboard event (command+alt+c)
       const keyboardEvent = new KeyboardEvent('keydown', {
@@ -451,7 +451,7 @@ describe('useCopyIssueDetails', () => {
         return Promise.resolve(text);
       });
 
-      renderHook(() => useCopyIssueDetails(group, event));
+      renderHook(useCopyIssueDetails, {initialProps: {group, event}});
 
       // Trigger the keyboard event (command+alt+c)
       const keyboardEvent = new KeyboardEvent('keydown', {

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
@@ -189,7 +189,7 @@ export const issueAndEventToMarkdown = (
   return markdownText;
 };
 
-export const useCopyIssueDetails = (group: Group, event?: Event) => {
+export function useCopyIssueDetails({group, event}: {group: Group; event?: Event}) {
   const organization = useOrganization();
 
   // These aren't guarded by useAiConfig because they are both non fetching, and should only return data when it's fetched elsewhere.
@@ -233,4 +233,4 @@ export const useCopyIssueDetails = (group: Group, event?: Event) => {
       skipPreventDefault: NODE_ENV === 'development',
     },
   ]);
-};
+}

--- a/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
@@ -66,9 +66,9 @@ export function TraceStateProvider(props: TraceStateProviderProps): React.ReactN
     // We only want to decode on load
   }, []);
 
-  const [traceState, traceDispatch, traceStateEmitter] = useDispatchingReducer(
-    TraceReducer,
-    {
+  const [traceState, traceDispatch, traceStateEmitter] = useDispatchingReducer({
+    reducer: TraceReducer,
+    initialState: {
       rovingTabIndex: {
         index: null,
         items: null,
@@ -89,8 +89,8 @@ export function TraceStateProvider(props: TraceStateProviderProps): React.ReactN
         current_tab: null,
         last_clicked_tab: null,
       },
-    }
-  );
+    },
+  });
 
   useLayoutEffect(() => {
     if (props.preferencesStorageKey) {

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -39,14 +39,17 @@ export function ReplaySummaryContextProvider({
     setupAcknowledgement.orgHasAcknowledged;
   const hasMobileSummary = organization.features.includes('replay-ai-summaries-mobile');
 
-  const summaryResult = useReplaySummary(replay, {
-    staleTime: 0,
-    enabled: Boolean(
-      replay.getReplay().id &&
-        projectSlug &&
-        hasAiSummary &&
-        (!mobileProject || hasMobileSummary)
-    ),
+  const summaryResult = useReplaySummary({
+    replay,
+    options: {
+      staleTime: 0,
+      enabled: Boolean(
+        replay.getReplay().id &&
+          projectSlug &&
+          hasAiSummary &&
+          (!mobileProject || hasMobileSummary)
+      ),
+    },
   });
   useEmitTimestampChanges();
 

--- a/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
@@ -243,7 +243,7 @@ describe('useReplaySummary', () => {
       // Update the segment count and expect a POST.
       mockReplayRecord.count_segments = 2;
       mockReplay.getReplay = jest.fn().mockReturnValue(mockReplayRecord);
-      rerender();
+      rerender({replay: mockReplay});
 
       await waitFor(() => {
         expect(mockPostRequest).toHaveBeenCalledWith(

--- a/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
@@ -55,7 +55,8 @@ describe('useReplaySummary', () => {
         body: mockSummaryData,
       });
 
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -73,7 +74,8 @@ describe('useReplaySummary', () => {
         statusCode: 500,
         body: {detail: 'Internal server error'},
       });
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -95,12 +97,10 @@ describe('useReplaySummary', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(
-        () => useReplaySummary(mockReplay, {enabled: false, staleTime: 0}),
-        {
-          organization: mockOrganization,
-        }
-      );
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay, options: {enabled: false, staleTime: 0}},
+        organization: mockOrganization,
+      });
 
       // The hook should not make API calls when disabled
       expect(result.current.summaryData).toBeUndefined();
@@ -117,12 +117,10 @@ describe('useReplaySummary', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(
-        () => useReplaySummary(mockReplay, {enabled: true, staleTime: 0}),
-        {
-          organization: mockOrganization,
-        }
-      );
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay, options: {enabled: true, staleTime: 0}},
+        organization: mockOrganization,
+      });
 
       await waitFor(() => {
         expect(result.current.summaryData).toBeDefined();
@@ -142,7 +140,8 @@ describe('useReplaySummary', () => {
         body: responsePromise,
       });
 
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -165,7 +164,8 @@ describe('useReplaySummary', () => {
         body: {status: ReplaySummaryStatus.PROCESSING, data: undefined},
       });
 
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -184,7 +184,8 @@ describe('useReplaySummary', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -200,7 +201,8 @@ describe('useReplaySummary', () => {
         body: {status: ReplaySummaryStatus.ERROR, data: undefined},
       });
 
-      const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
+      const {result} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
         organization: mockOrganization,
       });
 
@@ -227,12 +229,10 @@ describe('useReplaySummary', () => {
         method: 'POST',
       });
 
-      const {result, rerender} = renderHookWithProviders(
-        () => useReplaySummary(mockReplay),
-        {
-          organization: mockOrganization,
-        }
-      );
+      const {result, rerender} = renderHookWithProviders(useReplaySummary, {
+        initialProps: {replay: mockReplay},
+        organization: mockOrganization,
+      });
 
       await waitFor(() => {
         expect(result.current.isPending).toBe(false);

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -76,10 +76,13 @@ function createAISummaryQueryKey(
   return [`/projects/${orgSlug}/${projectSlug}/replays/${replayId}/summarize/`];
 }
 
-export function useReplaySummary(
-  replay: ReplayReader,
-  options?: UseApiQueryOptions<SummaryResponse>
-): UseReplaySummaryResult {
+export function useReplaySummary({
+  replay,
+  options,
+}: {
+  replay: ReplayReader;
+  options?: UseApiQueryOptions<SummaryResponse>;
+}): UseReplaySummaryResult {
   const organization = useOrganization();
   const replayRecord = replay.getReplay();
   const project = useProjectFromId({project_id: replayRecord?.project_id});

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -76,13 +76,11 @@ function createAISummaryQueryKey(
   return [`/projects/${orgSlug}/${projectSlug}/replays/${replayId}/summarize/`];
 }
 
-export function useReplaySummary({
-  replay,
-  options,
-}: {
+export function useReplaySummary(props: {
   replay: ReplayReader;
   options?: UseApiQueryOptions<SummaryResponse>;
 }): UseReplaySummaryResult {
+  const {replay, options} = props;
   const organization = useOrganization();
   const replayRecord = replay.getReplay();
   const project = useProjectFromId({project_id: replayRecord?.project_id});

--- a/static/gsApp/views/subscriptionPage/usageLog.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.tsx
@@ -108,10 +108,10 @@ export default function UsageLog() {
     {staleTime: 0}
   );
 
-  const eventNames = useMemoWithPrevious<string[] | null>(
-    previous => auditLogs?.eventNames ?? previous,
-    [auditLogs?.eventNames]
-  );
+  const eventNames = useMemoWithPrevious<string[] | null>({
+    factory: previous => auditLogs?.eventNames ?? previous,
+    deps: [auditLogs?.eventNames],
+  });
 
   const handleEventFilter = (value: string | undefined) => {
     if (typeof value === 'string') {


### PR DESCRIPTION
This is only updating hooks that are already tested, as discovered by https://github.com/getsentry/sentry/pull/106492

Some other hooks, and even `useFetchEventsTimeSeries` which is in here, are not changed.

Related to https://github.com/getsentry/frontend-tsc/issues/97



