### PR TITLE
feat(search): Add team: filter for issues by project ownership

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -26,6 +26,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import GroupOwner
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.project import Project
+from sentry.models.projectteam import ProjectTeam
 from sentry.models.release import Release
 from sentry.models.team import Team
 from sentry.search.base import SearchBackend
@@ -246,6 +247,15 @@ def regressed_in_release_filter(versions: Sequence[str], projects: Sequence[Proj
             project__in=projects,
         ).values_list("group_id", flat=True),
     )
+
+
+def team_filter(teams: Sequence[Team], projects: Sequence[Project]) -> Q:
+    """Filter groups from projects owned by the specified teams."""
+    project_ids_owned_by_teams = ProjectTeam.objects.filter(
+        team__in=teams,
+        project__in=projects,
+    ).values_list("project_id", flat=True)
+    return Q(project_id__in=project_ids_owned_by_teams)
 
 
 def seer_actionability_filter(trigger_values: list[float]) -> Q:
@@ -577,6 +587,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "regressed_in_release": QCallbackCondition(
                 functools.partial(regressed_in_release_filter, projects=projects)
             ),
+            "team": QCallbackCondition(functools.partial(team_filter, projects=projects)),
             "detector": QCallbackCondition(_make_detector_filter),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2629,6 +2629,66 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         assert len(results) == 0
 
+    def test_team_filter(self) -> None:
+        other_team = self.create_team(organization=self.organization)
+        other_project = self.create_project(organization=self.organization, teams=[other_team])
+
+        other_team_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-other-team-group"],
+                "event_id": "d" * 32,
+                "timestamp": self.base_datetime.isoformat(),
+                "message": "other team issue",
+                "stacktrace": {"frames": [{"module": "other_team"}]},
+            },
+            project_id=other_project.id,
+        )
+        other_team_group = other_team_event.group
+
+        results = self.make_query(
+            projects=[self.project, other_project],
+            search_filter_query=f"team:{self.team.slug}",
+        )
+        assert set(results) == {self.group1, self.group2}
+
+        results = self.make_query(
+            projects=[self.project, other_project],
+            search_filter_query=f"team:#{self.team.slug}",
+        )
+        assert set(results) == {self.group1, self.group2}
+
+        results = self.make_query(
+            projects=[self.project, other_project],
+            search_filter_query=f"team:{other_team.slug}",
+        )
+        assert set(results) == {other_team_group}
+
+    def test_team_filter_negation(self) -> None:
+        other_team = self.create_team(organization=self.organization)
+        other_project = self.create_project(organization=self.organization, teams=[other_team])
+
+        other_team_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-other-team-group-negation"],
+                "event_id": "e" * 32,
+                "timestamp": self.base_datetime.isoformat(),
+                "message": "other team issue for negation test",
+                "stacktrace": {"frames": [{"module": "other_team"}]},
+            },
+            project_id=other_project.id,
+        )
+        other_team_group = other_team_event.group
+
+        results = self.make_query(
+            projects=[self.project, other_project],
+            search_filter_query=f"!team:{self.team.slug}",
+        )
+        assert set(results) == {other_team_group}
+
+    def test_team_filter_invalid_team(self) -> None:
+        with pytest.raises(InvalidSearchQuery, match="Invalid team"):
+            self.make_query(search_filter_query="team:nonexistent-team")
+
 
 class EventsSnubaSearchTest(TestCase, EventsSnubaSearchTestCases):
     pass


### PR DESCRIPTION
## Summary

Adds a new `team:` search filter that allows filtering issues by the team that owns the project. This addresses #45367.

**Usage:**
- `team:data-engineering` - Issues from projects owned by data-engineering
- `team:#data-engineering` - Same (# prefix supported for consistency with other team references)
- `!team:data-engineering` - Issues NOT from data-engineering's projects

## Changes

- **`src/sentry/issues/issue_search.py`**: Add `team` key mapping and `convert_team_value()` converter
- **`src/sentry/search/snuba/backend.py`**: Add `team_filter()` function and condition
- **`tests/snuba/search/test_backend.py`**: Add tests for team filter, negation, and invalid team handling

## Test plan

- [x] `test_team_filter` - Verifies filtering by team slug with and without # prefix
- [x] `test_team_filter_negation` - Verifies `!team:` excludes issues from team's projects
- [x] `test_team_filter_invalid_team` - Verifies error handling for non-existent teams

🤖 Generated with [Claude Code](https://claude.ai/code)