### PR TITLE
chore(feedback): re-assign sessions feedback to replay team, laravel&nextjs to performance

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -111,9 +111,9 @@ export function DomainViewHeader({
 
   const feedbackConfig: Array<[boolean, {owner: string; source: string}]> = [
     [isAgentMonitoring, {owner: 'telemetry-experience', source: 'agent-monitoring'}],
-    [!!isLaravelInsights, {owner: 'telemetry-experience', source: 'laravel-insights'}],
+    [!!isLaravelInsights, {owner: 'performance', source: 'laravel-insights'}],
     [isSessionsInsights, {owner: 'replay', source: 'sessions-insights'}],
-    [!!isNextJsInsights, {owner: 'telemetry-experience', source: 'nextjs-insights'}],
+    [!!isNextJsInsights, {owner: 'performance', source: 'nextjs-insights'}],
   ];
 
   const activeFeedback = feedbackConfig.find(([condition]) => condition)?.[1];

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -109,21 +109,23 @@ export function DomainViewHeader({
       })),
   ];
 
-  const feedbackOptions =
-    isAgentMonitoring || isLaravelInsights || isNextJsInsights || isSessionsInsights
-      ? {
-          tags: {
-            ['feedback.source']: isAgentMonitoring
-              ? 'agent-monitoring'
-              : isLaravelInsights
-                ? 'laravel-insights'
-                : isSessionsInsights
-                  ? 'sessions-insights'
-                  : 'nextjs-insights',
-            ['feedback.owner']: 'telemetry-experience',
-          },
-        }
-      : undefined;
+  const feedbackConfig: Array<[boolean, {owner: string; source: string}]> = [
+    [isAgentMonitoring, {owner: 'telemetry-experience', source: 'agent-monitoring'}],
+    [!!isLaravelInsights, {owner: 'telemetry-experience', source: 'laravel-insights'}],
+    [isSessionsInsights, {owner: 'replay', source: 'sessions-insights'}],
+    [!!isNextJsInsights, {owner: 'telemetry-experience', source: 'nextjs-insights'}],
+  ];
+
+  const activeFeedback = feedbackConfig.find(([condition]) => condition)?.[1];
+
+  const feedbackOptions = activeFeedback
+    ? {
+        tags: {
+          ['feedback.source']: activeFeedback.source,
+          ['feedback.owner']: activeFeedback.owner,
+        },
+      }
+    : undefined;
   return (
     <Fragment>
       <Layout.Header unified={unified}>


### PR DESCRIPTION
- Sessions Insights feedback is currently wrongly assigned to `telemetry-experience` since [this PR](https://github.com/getsentry/sentry/pull/101341)
- Re-assign the sessions insights feedback to replay, and refactor the code to be less nested-ternary

Closes TET-1750