### PR TITLE
feat(ai-insights): support tool.call attribute

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -293,11 +293,32 @@ export function hasAIInputAttribute(
     getTraceNodeAttribute('gen_ai.input.messages', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.system_instructions', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.request.messages', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.tool.call.arguments', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.embeddings.input', node, event, attributes) ||
     getTraceNodeAttribute('ai.input_messages', node, event, attributes) ||
     getTraceNodeAttribute('ai.prompt', node, event, attributes)
   );
+}
+
+/**
+ * Gets AI tool input, checking gen_ai.tool.call.arguments first, falling back to gen_ai.tool.input.
+ */
+function getAIToolInput(
+  node: EapSpanNode | SpanNode | TransactionNode,
+  attributes?: TraceItemResponseAttribute[],
+  event?: EventTransaction
+) {
+  const toolCallArgs = getTraceNodeAttribute(
+    'gen_ai.tool.call.arguments',
+    node,
+    event,
+    attributes
+  );
+  if (toolCallArgs) {
+    return toolCallArgs;
+  }
+  return getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes);
 }
 
 function useInvalidRoleDetection(roles: string[]) {
@@ -348,7 +369,7 @@ export function AIInputSection({
 
   const messages = defined(promptMessages) && parseAIMessages(promptMessages.toString());
 
-  const toolArgs = getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes);
+  const toolArgs = getAIToolInput(node, attributes, event);
   const embeddingsInput = getTraceNodeAttribute(
     'gen_ai.embeddings.input',
     node,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -162,9 +162,30 @@ export function hasAIOutputAttribute(
     getTraceNodeAttribute('gen_ai.output.messages', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.text', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.object', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.tool.call.result', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.response.tool_calls', node, event, attributes) ||
     getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes)
   );
+}
+
+/**
+ * Gets AI tool output, checking gen_ai.tool.call.result first, falling back to gen_ai.tool.output.
+ */
+function getAIToolOutput(
+  node: EapSpanNode | SpanNode | TransactionNode,
+  attributes?: TraceItemResponseAttribute[],
+  event?: EventTransaction
+) {
+  const toolCallResult = getTraceNodeAttribute(
+    'gen_ai.tool.call.result',
+    node,
+    event,
+    attributes
+  );
+  if (toolCallResult) {
+    return toolCallResult;
+  }
+  return getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes);
 }
 
 export function AIOutputSection({
@@ -185,7 +206,7 @@ export function AIOutputSection({
     attributes,
     event
   );
-  const toolOutput = getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes);
+  const toolOutput = getAIToolOutput(node, attributes, event);
 
   if (!responseText && !responseObject && !toolCalls && !toolOutput) {
     return null;


### PR DESCRIPTION
Part of [TET-1731: Update to latest otel spec](https://linear.app/getsentry/issue/TET-1731/update-to-latest-otel-spec)

Followup of https://github.com/getsentry/sentry/pull/106442

adds support for `gen_ai.tool.call` attribute