### PR TITLE
feat(preprod): Check quota and run only available features

### DIFF
--- a/src/sentry/preprod/producer.py
+++ b/src/sentry/preprod/producer.py
@@ -41,11 +41,7 @@ def produce_preprod_artifact_to_kafka(
     requested_features: list[PreprodFeature] | None = None,
 ) -> None:
     if requested_features is None:
-        # TODO(preprod): wire up to quota system and remove this default
-        requested_features = [
-            PreprodFeature.SIZE_ANALYSIS,
-            PreprodFeature.BUILD_DISTRIBUTION,
-        ]
+        requested_features = []
     payload_data = {
         "artifact_id": str(artifact_id),
         "project_id": str(project_id),


### PR DESCRIPTION
Follow up to #106455. This checks the size and distro quota just prior to sending the analysis job to Kafka.
The current logic is:
- If we have size quota request size analysis
- If we have distribution quota request distribution processing
- In all cases enqueue the job (to get the minimal processing)

Also update the user 'rerun analysis' endpoint to respect quota - but not the admin one.

This should not effect any current users - gating is managed on the billing side and currently unlimited while
in EA.