### PR TITLE
chore(explorer-index): remove debug code

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1258,7 +1258,7 @@ register(
     "seer.explorer_index.run_frequency.minutes",
     type=Int,
     default=1440,  # 24 hours
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1254,6 +1254,12 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.explorer_index.run_frequency.minutes",
+    type=Int,
+    default=1440,  # 24 hours
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}
 register(

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -51,12 +51,14 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
             return
 
         with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):
-            if (
+            has_feature = (
                 features.batch_has(FEATURE_NAMES, project.organization)
                 and not bool(project.organization.get_option("sentry:hide_ai_features"))
                 and get_seer_org_acknowledgement(project.organization)
-            ):
-                yield project.id, project.organization_id
+            )
+
+        if has_feature:
+            yield project.id, project.organization_id
 
 
 @instrumented_task(

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -77,7 +77,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
 @instrumented_task(
     name="sentry.tasks.seer_explorer_index.schedule_explorer_index",
     namespace=seer_tasks,
-    processing_deadline_duration=30,
+    processing_deadline_duration=60,
 )
 def schedule_explorer_index() -> None:
     """


### PR DESCRIPTION
- Removes some extra logging I added to debug s4s.
- Makes EXPLORER_INDEX_RUN_FREQUENCY an option
so that I can do a staged rollout without having to wait 24 hours.
- Checks all seer flags (not just explorer index)