### PR TITLE
Add logging for abnormally long EVALSHA in spans buffer (#106496)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3086,6 +3086,13 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Latency threshold in milliseconds for logging slow EVALSHA pipeline operations
+register(
+    "spans.buffer.evalsha-latency-threshold",
+    type=Int,
+    default=100,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Segments consumer
 register(

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -81,6 +81,7 @@ from sentry import options
 from sentry.constants import DataCategory
 from sentry.models.project import Project
 from sentry.processing.backpressure.memory import ServiceMemory, iter_cluster_memory_usage
+from sentry.spans.buffer_logger import BufferLogger
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.utils import metrics, redis
 from sentry.utils.outcomes import Outcome, track_outcome
@@ -166,6 +167,7 @@ class SpansBuffer:
         self._current_compression_level = None
         self._zstd_compressor: zstandard.ZstdCompressor | None = None
         self._zstd_decompressor = zstandard.ZstdDecompressor()
+        self._buffer_logger = BufferLogger()
 
     @cached_property
     def client(self) -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -250,7 +252,10 @@ class SpansBuffer:
             assert len(result_meta) == len(results)
 
             for (project_and_trace, parent_span_id), result in zip(result_meta, results):
-                redirect_depth, set_key, has_root_span = result
+                redirect_depth, set_key, has_root_span, evalsha_latency_ms = result
+
+                # Log individual EVALSHA latency for this trace
+                self._buffer_logger.log(project_and_trace, evalsha_latency_ms)
 
                 shard = self.assigned_shards[
                     int(project_and_trace.split(":")[1], 16) % len(self.assigned_shards)

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+import time
+
+from sentry import options
+
+logger = logging.getLogger(__name__)
+
+MAX_ENTRIES = 1000
+LOGGING_ENTRIES = 50
+LOGGING_INTERVAL = 5  # seconds
+
+
+class BufferLogger:
+    """
+    Tracks slow EVALSHA operations and logs the most problematic
+    project/trace combinations.
+
+    This logger keeps a bounded map (max 1000 entries) of project_and_trace keys
+    to their occurrence counts and maximum latencies. When the configured latency
+    threshold is exceeded, affected keys are recorded. Every 5 seconds, the top 50
+    entries by count are logged at INFO level, then the tracked data is cleared.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[int, float]] = {}
+        self._last_log_time: float | None = None
+
+    def log(self, project_and_trace: str, latency_ms: int) -> None:
+        """
+        Record a single EVALSHA operation and periodically log the top offenders.
+        """
+        if len(self._data) < MAX_ENTRIES:
+            threshold = options.get("spans.buffer.evalsha-latency-threshold")
+
+            if latency_ms <= threshold:
+                return
+
+            if not self._last_log_time:
+                self._last_log_time = time.time()
+
+            if project_and_trace in self._data:
+                count, max_latency = self._data[project_and_trace]
+                self._data[project_and_trace] = (count + 1, max(max_latency, latency_ms))
+            else:
+                self._data[project_and_trace] = (1, latency_ms)
+
+        if time.time() - (self._last_log_time or 0.0) >= LOGGING_INTERVAL:
+            if len(self._data) > LOGGING_ENTRIES:
+                sorted_items = sorted(self._data.items(), key=lambda x: x[1][0], reverse=True)
+            else:
+                sorted_items = list(self._data.items())
+
+            if len(sorted_items) > 0:
+                entries_str = [
+                    f"{key}:{count}:{max_latency}"
+                    for key, (count, max_latency) in sorted_items[:50]
+                ]
+
+                logger.info(
+                    "spans.buffer.slow_evalsha_operations",
+                    extra={
+                        "top_slow_operations": entries_str,
+                        "num_tracked_keys": len(self._data),
+                        "pruned_list": len(self._data) == MAX_ENTRIES,
+                    },
+                )
+            self._data.clear()
+            self._last_log_time = None

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -22,6 +22,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.backpressure-seconds": 10,
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.compression.level": 0,
+    "spans.buffer.evalsha-latency-threshold": 100,
 }
 
 

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from sentry.spans.buffer_logger import BufferLogger
+from sentry.testutils.helpers.options import override_options
+
+
+class TestBufferLogger:
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_logs_only_above_threshold_with_repeating_traces(self, mock_time, mock_logger):
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            mock_time.time.side_effect = [
+                1000.0,
+                1000.0,
+                1000.0,
+                1000.0,
+                1006.0,
+            ]
+
+            buffer_logger = BufferLogger()
+
+            # Log below threshold - should not be recorded, no time calls
+            buffer_logger.log("project1:trace1", latency_ms=50)
+            assert len(buffer_logger._data) == 0
+
+            # Log above threshold - should be recorded (calls time.time() twice)
+            buffer_logger.log("project1:trace1", latency_ms=150)
+            assert buffer_logger._data["project1:trace1"] == (1, 150)
+
+            buffer_logger.log("project1:trace1", latency_ms=200)
+            assert buffer_logger._data["project1:trace1"] == (2, 200)
+
+            buffer_logger.log("project2:trace2", latency_ms=120)
+            assert buffer_logger._data["project2:trace2"] == (1, 120)
+
+            buffer_logger.log("project1:trace1", latency_ms=180)
+
+            # Verify logging was called
+            assert mock_logger.info.call_count == 1
+
+            # Verify exact log content
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "spans.buffer.slow_evalsha_operations"
+            extra = call_args[1]["extra"]
+
+            # Check that logged entries include the correct format
+            entries = extra["top_slow_operations"]
+            assert "project1:trace1:3:200" in entries  # count=3, max_latency=200
+            assert "project2:trace2:1:120" in entries  # count=1, max_latency=120
+            assert extra["num_tracked_keys"] == 2  # only 2 unique keys tracked
+
+            # Verify data was cleared after logging
+            assert len(buffer_logger._data) == 0
+            assert buffer_logger._last_log_time is None
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_clears_old_traces_after_logging_period(self, mock_time, mock_logger):
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            mock_time.time.side_effect = [
+                1000.0,
+                1000.0,
+                6000.0,
+                1013.0,
+            ]
+
+            buffer_logger = BufferLogger()
+
+            buffer_logger.log("old_project1:trace1", latency_ms=151)
+            assert len(buffer_logger._data) == 1
+            assert mock_logger.info.call_count == 0
+
+            buffer_logger.log("old_project1:trace1", latency_ms=170)
+            assert len(buffer_logger._data) == 0
+
+            # First logging should have occurred
+            assert mock_logger.info.call_count == 1
+            first_call = mock_logger.info.call_args
+            first_entries = first_call[1]["extra"]["top_slow_operations"]
+            assert "old_project1:trace1:2:170" in first_entries
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    @mock.patch("sentry.spans.buffer_logger.time")
+    def test_logs_only_top_50_when_more_than_1000_traces(self, mock_time, mock_logger):
+        """
+        Test that when MAX_ENTRIES (1000) is reached, no more traces are recorded.
+        Also verifies that entries with > LOGGING_ENTRIES (50) are sorted by count.
+        """
+        with override_options({"spans.buffer.evalsha-latency-threshold": 100}):
+            time_calls = (
+                [1000.0, 1000.0]  # First log: set + check
+                + [1000.0] * 1200  # Logs 2-1000: check only
+                + [1006.0]  # 1000th entry triggers logging
+            )
+            mock_time.time.side_effect = time_calls
+
+            buffer_logger = BufferLogger()
+
+            for i in range(10):
+                buffer_logger.log("high_project:trace", latency_ms=150)
+
+            for i in range(1100):
+                buffer_logger.log(f"high_project{i}:trace{i}", latency_ms=150)
+
+            assert len(buffer_logger._data) == 1000
+
+            mock_time.time.side_effect = [10000.0]
+
+            buffer_logger.log("trigger:trace", latency_ms=150)
+
+            # Verify logging occurred
+            assert mock_logger.info.call_count == 1
+
+            # Verify exact log content
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "spans.buffer.slow_evalsha_operations"
+            extra = call_args[1]["extra"]
+
+            # Top 50 entries are logged (implementation logs all, not just top 50)
+            entries_list = extra["top_slow_operations"]
+            assert len(entries_list) == 50
+
+            # Verify entries are sorted by count (descending) since > LOGGING_ENTRIES
+            # Check that first entries have highest counts
+            assert entries_list[0] == "high_project:trace:10:150"
+
+            # Verify total tracked keys
+            assert extra["num_tracked_keys"] == 1000
+
+    @mock.patch("sentry.spans.buffer_logger.logger")
+    def test_no_logging_when_no_data(self, mock_logger):
+        """Test that nothing is logged when _data is empty."""
+        buffer_logger = BufferLogger()
+
+        # Internal state check - no data
+        assert len(buffer_logger._data) == 0
+
+        # Even if we somehow trigger the logging path, it should not log
+        # This is testing the internal behavior, but we can't easily trigger
+        # the logging path without going through log() method
+        # So we just verify initial state
+        assert mock_logger.info.call_count == 0


### PR DESCRIPTION
We are observing sustained high latency in the EVALSHA commands in the 
spans buffer. These seem localized on one Redis shard. So chances are
this is caused by a single trace as we use organization id and trace id
to map a key to a slot.

It seems there was no increase in volume of requests but everything
running
in the LUA script cannot be broken down. So we need some observability
from the client side. THe goal here is to identify some traces causing
slow
EVALSHA.

1. Return the elapsed time every time we run the LUA script to add a
batch
of spans 
2. Introduce BufferLogger that receives the latency for all the calls
and decide
when it is time to log: log the 50 most common trace ids with high
latency.
  IT only records at most 1000 spans