### PR TITLE
fix(checkout): Reactive but debounced volume sliders

### DIFF
--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -59,21 +59,17 @@ export function renderPerformanceHovercard() {
 }
 
 function VolumeSliders({
+  currentSliderValues,
   checkoutTier,
   activePlan,
   organization,
-  formData,
   subscription,
   onReservedChange,
 }: Pick<
   StepProps,
-  | 'activePlan'
-  | 'checkoutTier'
-  | 'organization'
-  | 'onUpdate'
-  | 'formData'
-  | 'subscription'
+  'activePlan' | 'checkoutTier' | 'organization' | 'onUpdate' | 'subscription'
 > & {
+  currentSliderValues: Partial<Record<DataCategory, number>>;
   onReservedChange: (value: number, category: DataCategory) => void;
 }) {
   const renderPerformanceUnitDecoration = () => (
@@ -102,7 +98,7 @@ function VolumeSliders({
           }
 
           const eventBucket = utils.getBucket({
-            events: formData.reserved[category],
+            events: currentSliderValues[category],
             buckets: activePlan.planCategories[category],
           });
 
@@ -170,7 +166,7 @@ function VolumeSliders({
                   <SpaceBetweenGrid>
                     <VolumeAmount>
                       {formatReservedWithUnits(
-                        formData.reserved[category] ?? null,
+                        currentSliderValues[category] ?? null,
                         category,
                         {
                           isAbbreviated: !isByteCategory(category),
@@ -201,7 +197,7 @@ function VolumeSliders({
                             getPlanCategoryName({plan: activePlan, category})
                           )
                     }
-                    value={formData.reserved[category] ?? ''}
+                    value={currentSliderValues[category] ?? ''}
                     allowedValues={allowedValues}
                     onChange={value =>
                       defined(value) && typeof value === 'number'

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -142,7 +142,7 @@ function ReserveAdditionalVolume({
             onUpdate={onUpdate}
             subscription={subscription}
             onReservedChange={(newReserved, category) => {
-              setReserved({...reserved, [category]: newReserved});
+              setReserved(prev => ({...prev, [category]: newReserved}));
               debouncedReservedChange(newReserved, category);
             }}
             currentSliderValues={reserved}

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -56,6 +56,9 @@ function ReserveAdditionalVolume({
       return acc + (bucket?.price ?? 0);
     }, 0);
   }, [formData.reserved, activePlan]);
+  const [reserved, setReserved] = useState<Partial<Record<DataCategory, number>>>(
+    formData.reserved
+  );
 
   const handleReservedChange = useCallback(
     (value: number, category: DataCategory) => {
@@ -137,9 +140,12 @@ function ReserveAdditionalVolume({
             activePlan={activePlan}
             organization={organization}
             onUpdate={onUpdate}
-            formData={formData}
             subscription={subscription}
-            onReservedChange={debouncedReservedChange}
+            onReservedChange={(newReserved, category) => {
+              setReserved({...reserved, [category]: newReserved});
+              debouncedReservedChange(newReserved, category);
+            }}
+            currentSliderValues={reserved}
           />
         </Stack>
       )}

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -48,17 +48,17 @@ function ReserveAdditionalVolume({
               }).price > 0
           )
   );
+  const [reserved, setReserved] = useState<Partial<Record<DataCategory, number>>>(
+    formData.reserved
+  );
   const reservedVolumeTotal = useMemo(() => {
-    return Object.entries(formData.reserved).reduce((acc, [category, value]) => {
+    return Object.entries(reserved).reduce((acc, [category, value]) => {
       const bucket = activePlan.planCategories?.[category as DataCategory]?.find(
         b => b.events === value
       );
       return acc + (bucket?.price ?? 0);
     }, 0);
-  }, [formData.reserved, activePlan]);
-  const [reserved, setReserved] = useState<Partial<Record<DataCategory, number>>>(
-    formData.reserved
-  );
+  }, [reserved, activePlan]);
 
   const handleReservedChange = useCallback(
     (value: number, category: DataCategory) => {


### PR DESCRIPTION
Updates the slider behavior to retain debouncing to reduce redundant API calls, but ensure the current volume slider value is immediately reflected in the slider UI

### before

https://github.com/user-attachments/assets/67fc673e-13e1-4e2a-8242-4ad19fb8a135

### after

https://github.com/user-attachments/assets/391c2e09-e480-4687-8133-c0760b695232

