### PR TITLE
fix(sentry-apps): Prevent race condition on service hook sentry app rpc

### DIFF
--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -385,7 +385,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 auth_context=auth_context,
             )
         except SentryAppSentryError as e:
-            return RpcServiceHookProjectsResult(error=RpcSentryAppError.from_exc(e))
+            return RpcEmptyResult(error=RpcSentryAppError.from_exc(e))
         try:
             hook = ServiceHook.objects.get(
                 installation_id=installation.id, organization_id=organization_id

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -321,7 +321,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             )
         with transaction.atomic(router.db_for_write(ServiceHookProject)):
             # Materialize the queryset once to avoid TOCTOU between validation and deletion
-            hook_projects = list(ServiceHookProject.objects.filter(service_hook_id=hook.id))
+            hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id)
             # Validate that the service hooks the caller is attempting to modify match
             # the database. Prevents a TOCTOU race condition.
             current_project_ids = {hp.project_id for hp in hook_projects}
@@ -333,7 +333,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                         status_code=409,
                     ),
                 )
-            deletions.exec_sync_many(hook_projects)
+            deletions.exec_sync_many(list(hook_projects))
 
         return RpcEmptyResult()
 

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -218,8 +218,12 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             extra_project_ids = [p for p in extra_projects_to_fetch if isinstance(p, int)]
             extra_project_slugs = [p for p in extra_projects_to_fetch if isinstance(p, str)]
             extra_projects = list(
-                Project.objects.filter(id__in=extra_project_ids).union(
-                    Project.objects.filter(slug__in=extra_project_slugs)
+                Project.objects.filter(
+                    id__in=extra_project_ids, organization_id=organization_id
+                ).union(
+                    Project.objects.filter(
+                        slug__in=extra_project_slugs, organization_id=organization_id
+                    )
                 )
             )
         return RpcServiceHookProjectsResult(

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -385,7 +385,10 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 auth_context=auth_context,
             )
         except SentryAppSentryError as e:
-            return RpcEmptyResult(error=RpcSentryAppError.from_exc(e))
+            return RpcEmptyResult(
+                success=False,
+                error=RpcSentryAppError.from_exc(e),
+            )
         try:
             hook = ServiceHook.objects.get(
                 installation_id=installation.id, organization_id=organization_id
@@ -405,11 +408,12 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
             projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
             for project in projects:
                 if not access.has_project_access(project):
-                    return RpcServiceHookProjectsResult(
+                    return RpcEmptyResult(
+                        success=False,
                         error=RpcSentryAppError(
                             message="Some projects are not accessible",
                             status_code=403,
-                        )
+                        ),
                     )
             deletions.exec_sync_many(list(hook_projects))
 

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -242,7 +242,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         hook_projects = list(
             ServiceHookProject.objects.filter(service_hook_id=hook.id).order_by("project_id")
         )
-        projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
+        projects = Project.objects.filter(
+            id__in={hp.project_id for hp in hook_projects}, organization_id=organization_id
+        )
         if any(not access.has_project_access(project) for project in projects):
             return RpcServiceHookProjectsResult(
                 error=RpcSentryAppError(
@@ -325,7 +327,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                     "project_id", flat=True
                 )
             )
-            current_projects = Project.objects.filter(id__in=current_project_ids)
+            current_projects = Project.objects.filter(
+                id__in=current_project_ids, organization_id=organization_id
+            )
 
             projects_to_add = new_project_ids - current_project_ids
             projects_to_remove = current_project_ids - new_project_ids
@@ -400,7 +404,9 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         with transaction.atomic(router.db_for_write(ServiceHookProject)):
             hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id)
 
-            projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
+            projects = Project.objects.filter(
+                id__in={hp.project_id for hp in hook_projects}, organization_id=organization_id
+            )
             if any(not access.has_project_access(project) for project in projects):
                 return RpcEmptyResult(
                     success=False,

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -329,7 +329,7 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 success=False,
                 error=RpcSentryAppError(
                     message="The service hooks have changed during your request. Please try again after a moment.",
-                    status_code=400,
+                    status_code=409,
                 ),
             )
         deletions.exec_sync_many(list(hook_projects))

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -216,10 +216,11 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
         extra_projects: list[Project] = []
         if extra_projects_to_fetch:
             extra_project_ids = [p for p in extra_projects_to_fetch if isinstance(p, int)]
-            extra_projects = Project.objects.filter(id__in=extra_project_ids)
             extra_project_slugs = [p for p in extra_projects_to_fetch if isinstance(p, str)]
-            extra_projects = extra_projects.union(
-                Project.objects.filter(slug__in=extra_project_slugs)
+            extra_projects = list(
+                Project.objects.filter(id__in=extra_project_ids).union(
+                    Project.objects.filter(slug__in=extra_project_slugs)
+                )
             )
         return RpcServiceHookProjectsResult(
             projects=[serialize_project(p) for p in projects],

--- a/src/sentry/sentry_apps/services/region/impl.py
+++ b/src/sentry/sentry_apps/services/region/impl.py
@@ -239,8 +239,8 @@ class DatabaseBackedSentryAppRegionService(SentryAppRegionService):
                 )
             )
 
-        hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id).order_by(
-            "project_id"
+        hook_projects = list(
+            ServiceHookProject.objects.filter(service_hook_id=hook.id).order_by("project_id")
         )
         projects = Project.objects.filter(id__in={hp.project_id for hp in hook_projects})
         for project in projects:

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -8,7 +8,6 @@ from typing import Any
 from pydantic.fields import Field
 
 from sentry.hybridcloud.rpc import RpcModel
-from sentry.projects.services.project.model import RpcProject
 from sentry.sentry_apps.utils.errors import (
     SentryAppBaseError,
     SentryAppErrorType,
@@ -86,10 +85,8 @@ class RpcServiceHookProject(RpcModel):
 
 
 class RpcServiceHookProjectsResult(RpcModel):
-    projects: list[RpcProject] = Field(default_factory=list)
     service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
     error: RpcSentryAppError | None = None
-    extra_projects: list[RpcProject] = Field(default_factory=list)
 
 
 class RpcTimeSeriesPoint(RpcModel):

--- a/src/sentry/sentry_apps/services/region/model.py
+++ b/src/sentry/sentry_apps/services/region/model.py
@@ -89,6 +89,7 @@ class RpcServiceHookProjectsResult(RpcModel):
     projects: list[RpcProject] = Field(default_factory=list)
     service_hook_projects: list[RpcServiceHookProject] = Field(default_factory=list)
     error: RpcSentryAppError | None = None
+    extra_projects: list[RpcProject] = Field(default_factory=list)
 
 
 class RpcTimeSeriesPoint(RpcModel):

--- a/src/sentry/sentry_apps/services/region/serial.py
+++ b/src/sentry/sentry_apps/services/region/serial.py
@@ -1,0 +1,20 @@
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.models.servicehook import ServiceHookProject
+from sentry.sentry_apps.services.region.model import RpcPlatformExternalIssue, RpcServiceHookProject
+
+
+def serialize_service_hook_project(project: ServiceHookProject) -> RpcServiceHookProject:
+    return RpcServiceHookProject(
+        id=project.id,
+        project_id=project.project_id,
+    )
+
+
+def serialize_platform_external_issue(issue: PlatformExternalIssue) -> RpcPlatformExternalIssue:
+    return RpcPlatformExternalIssue(
+        id=issue.id,
+        group_id=issue.group_id,
+        service_type=issue.service_type,
+        display_name=issue.display_name,
+        web_url=issue.web_url,
+    )

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -107,8 +107,13 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
+        extra_projects_to_fetch: list[int | str] | None = None,
     ) -> RpcServiceHookProjectsResult:
-        """Returns the project IDs associated with an installation's service hook."""
+        """
+        Returns the project IDs associated with an installation's service hook.
+        Allows extra project IDs or slugs to be fetched for control endpoints to do access validation.
+        This has only been added for compatability with the legacy region API, and to combine RPC calls.
+        """
         pass
 
     @regional_rpc_method(ByOrganizationId())

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -6,6 +6,7 @@
 import abc
 from typing import Any
 
+from sentry.auth.services.auth import AuthenticationContext
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationIdAttribute
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app import RpcSentryApp, RpcSentryAppInstallation
@@ -107,12 +108,11 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
-        extra_projects_to_fetch: list[int | str] | None = None,
+        auth_context: AuthenticationContext,
     ) -> RpcServiceHookProjectsResult:
         """
-        Returns the project IDs associated with an installation's service hook.
-        Allows extra project IDs or slugs to be fetched for control endpoints to do access validation.
-        This has only been added for compatability with the legacy region API, and to combine RPC calls.
+        Returns the service hook projects associated with an installation.
+        Validates that the caller has access to all required projects.
         """
         pass
 
@@ -123,12 +123,13 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
-        project_ids: list[int],
-        existing_project_ids: list[int],
+        project_identifiers: list[int | str],
+        auth_context: AuthenticationContext,
     ) -> RpcServiceHookProjectsResult:
         """
-        Replaces all service hook projects with the given project IDs. Requires the existing project IDs to
-        prevent a race condition, confirming the caller is modifying what they intended.
+        Replaces all service hook projects with the given project identifiers (either ID or slug).
+        Accepts both due to a compatibility requirement with an active endpoint.
+        Validates that the caller has access to all required projects.
         """
         pass
 
@@ -139,11 +140,11 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
-        existing_project_ids: list[int],
+        auth_context: AuthenticationContext,
     ) -> RpcEmptyResult:
         """
-        Deletes service hook projects for an installation. Requires the existing project IDs to
-        prevent a race condition, confirming the caller is modifying what they intended.
+        Deletes service hook projects for an installation.
+        Validates that the caller has access to all required projects.
         """
         pass
 

--- a/src/sentry/sentry_apps/services/region/service.py
+++ b/src/sentry/sentry_apps/services/region/service.py
@@ -119,8 +119,12 @@ class SentryAppRegionService(RpcService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         project_ids: list[int],
+        existing_project_ids: list[int],
     ) -> RpcServiceHookProjectsResult:
-        """Replaces all service hook projects with the given project IDs."""
+        """
+        Replaces all service hook projects with the given project IDs. Requires the existing project IDs to
+        prevent a race condition, confirming the caller is modifying what they intended.
+        """
         pass
 
     @regional_rpc_method(ByOrganizationId())
@@ -130,8 +134,12 @@ class SentryAppRegionService(RpcService):
         *,
         organization_id: int,
         installation: RpcSentryAppInstallation,
+        existing_project_ids: list[int],
     ) -> RpcEmptyResult:
-        """Deletes all service hook projects for an installation."""
+        """
+        Deletes service hook projects for an installation. Requires the existing project IDs to
+        prevent a race condition, confirming the caller is modifying what they intended.
+        """
         pass
 
     @regional_rpc_method(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1574,7 +1574,7 @@ class Factories:
     def create_service_hook_project_for_installation(
         project_id: int,
         installation_id: int,
-    ) -> ServiceHook:
+    ) -> ServiceHookProject:
         hook = ServiceHook.objects.get(installation_id=installation_id)
         return ServiceHookProject.objects.create(service_hook_id=hook.id, project_id=project_id)
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -155,7 +155,7 @@ from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallat
 from sentry.sentry_apps.models.sentry_app_installation_for_provider import (
     SentryAppInstallationForProvider,
 )
-from sentry.sentry_apps.models.servicehook import ServiceHook
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.services.hook import hook_service
 from sentry.sentry_apps.token_exchange.grant_exchanger import GrantExchanger
 from sentry.services.eventstore.models import Event
@@ -1568,6 +1568,15 @@ class Factories:
             url=url,
         ).id
         return ServiceHook.objects.get(id=hook_id)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_service_hook_project_for_installation(
+        project_id: int,
+        installation_id: int,
+    ) -> ServiceHook:
+        hook = ServiceHook.objects.get(installation_id=installation_id)
+        return ServiceHookProject.objects.create(service_hook_id=hook.id, project_id=project_id)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -443,6 +443,9 @@ class Fixtures:
     def create_service_hook(self, *args, **kwargs):
         return Factories.create_service_hook(*args, **kwargs)
 
+    def create_service_hook_project_for_installation(self, *args, **kwargs):
+        return Factories.create_service_hook_project_for_installation(*args, **kwargs)
+
     def create_userreport(self, *args, **kwargs):
         return Factories.create_userreport(*args, **kwargs)
 

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -254,6 +254,7 @@ class TestSentryAppRegionService(TestCase):
             organization_id=self.org.id,
             installation=self.rpc_installation,
             project_ids=[project2.id, project3.id],
+            existing_project_ids=[self.project.id, project2.id],
         )
 
         assert result.error is None
@@ -281,6 +282,7 @@ class TestSentryAppRegionService(TestCase):
         result = sentry_app_region_service.delete_service_hook_projects(
             organization_id=self.org.id,
             installation=self.rpc_installation,
+            existing_project_ids=[self.project.id, project2.id],
         )
 
         assert result.success is True

--- a/tests/sentry/sentry_apps/services/test_region_service.py
+++ b/tests/sentry/sentry_apps/services/test_region_service.py
@@ -6,9 +6,10 @@ from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
 from sentry.auth.services.auth.model import AuthenticationContext
+from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
-from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.app.serial import serialize_sentry_app_installation
 from sentry.sentry_apps.services.region import sentry_app_region_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -31,13 +32,8 @@ class TestSentryAppRegionService(TestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.org, slug=self.sentry_app.slug, user=self.user
         )
-        self.rpc_installation = app_service.get_many(filter=dict(uuids=[self.install.uuid]))[0]
+        self.rpc_installation = serialize_sentry_app_installation(self.install)
         self.auth_context = AuthenticationContext(user=serialize_rpc_user(self.user))
-
-    def create_service_hook_project(self, project_id: int) -> ServiceHookProject:
-        with assume_test_silo_mode_of(ServiceHook):
-            hook = ServiceHook.objects.get(installation_id=self.install.id)
-            return ServiceHookProject.objects.create(service_hook_id=hook.id, project_id=project_id)
 
     @responses.activate
     def test_get_select_options(self) -> None:
@@ -223,8 +219,12 @@ class TestSentryAppRegionService(TestCase):
     def test_get_service_hook_projects(self) -> None:
         project2 = self.create_project(organization=self.org)
 
-        self.create_service_hook_project(project_id=self.project.id)
-        self.create_service_hook_project(project_id=project2.id)
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=self.project.id
+        )
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=project2.id
+        )
 
         result = sentry_app_region_service.get_service_hook_projects(
             organization_id=self.org.id,
@@ -250,13 +250,17 @@ class TestSentryAppRegionService(TestCase):
         project2 = self.create_project(organization=self.org)
         project3 = self.create_project(organization=self.org)
 
-        self.create_service_hook_project(project_id=self.project.id)
-        self.create_service_hook_project(project_id=project2.id)
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=self.project.id
+        )
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=project2.id
+        )
 
         result = sentry_app_region_service.set_service_hook_projects(
             organization_id=self.org.id,
             installation=self.rpc_installation,
-            project_identifiers=[project2.id, project3.id],
+            project_identifiers=[project2.id, project3.slug],
             auth_context=self.auth_context,
         )
 
@@ -276,11 +280,53 @@ class TestSentryAppRegionService(TestCase):
                 service_hook_id=hook.id, project_id=project3.id
             ).exists()
 
+    def test_set_service_hook_projects_access(self) -> None:
+        organization = self.create_organization()
+        with assume_test_silo_mode_of(Organization):
+            organization.flags.allow_joinleave = False
+            organization.save()
+        project = self.create_project(organization=organization)
+        project2 = self.create_project(organization=organization)
+
+        member_user = self.create_user(email="member@example.com")
+        self.create_member(organization=organization, user=member_user, role="member")
+        member_auth_context = AuthenticationContext(user=serialize_rpc_user(member_user))
+
+        install = self.create_sentry_app_installation(
+            organization=organization, slug=self.sentry_app.slug, user=member_user
+        )
+        self.create_service_hook_project_for_installation(
+            installation_id=install.id, project_id=project.id
+        )
+
+        # Member user should not have access to set service hook projects
+        rpc_installation = serialize_sentry_app_installation(install)
+        result = sentry_app_region_service.set_service_hook_projects(
+            organization_id=organization.id,
+            installation=rpc_installation,
+            project_identifiers=[project2.id],
+            auth_context=member_auth_context,
+        )
+
+        assert result.error is not None
+        assert result.error.status_code == 403
+
+        # Original project should still be there
+        with assume_test_silo_mode_of(ServiceHook):
+            hook = ServiceHook.objects.get(installation_id=install.id)
+            assert ServiceHookProject.objects.filter(
+                service_hook_id=hook.id, project_id=project.id
+            ).exists()
+
     def test_delete_service_hook_projects(self) -> None:
         project2 = self.create_project(organization=self.org)
 
-        self.create_service_hook_project(project_id=self.project.id)
-        self.create_service_hook_project(project_id=project2.id)
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=self.project.id
+        )
+        self.create_service_hook_project_for_installation(
+            installation_id=self.install.id, project_id=project2.id
+        )
 
         result = sentry_app_region_service.delete_service_hook_projects(
             organization_id=self.org.id,
@@ -293,27 +339,6 @@ class TestSentryAppRegionService(TestCase):
         with assume_test_silo_mode_of(ServiceHook):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             assert not ServiceHookProject.objects.filter(service_hook_id=hook.id).exists()
-
-    def test_set_service_hook_projects_invalid_project(self) -> None:
-        self.create_service_hook_project(project_id=self.project.id)
-
-        result = sentry_app_region_service.set_service_hook_projects(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            project_identifiers=[self.project.id, 99999999],  # Invalid project ID
-            auth_context=self.auth_context,
-        )
-
-        assert result.error is not None
-        assert result.error.status_code == 400
-        assert "not accessible" in result.error.message or "does not exist" in result.error.message
-
-        # Original project should still be there
-        with assume_test_silo_mode_of(ServiceHook):
-            hook = ServiceHook.objects.get(installation_id=self.install.id)
-            assert ServiceHookProject.objects.filter(
-                service_hook_id=hook.id, project_id=self.project.id
-            ).exists()
 
     def test_get_interaction_stats(self) -> None:
         now = before_now(days=1)


### PR DESCRIPTION
Move project access validation from control endpoints to the region RPC service for service hook projects.
This ensures access checks happen atomically with data operations, replacing the previous TOCTOU protection.