### PR TITLE
fix(releases): Use mobile_app_info for preprod build count query

### DIFF
--- a/src/sentry/releases/endpoints/organization_release_meta.py
+++ b/src/sentry/releases/endpoints/organization_release_meta.py
@@ -84,7 +84,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
         if parsed_version and release_project_ids:
             number_of_preprod_builds = PreprodArtifact.objects.filter(
                 app_id=parsed_version.app_id,
-                build_version=parsed_version.build_version,
+                mobile_app_info__build_version=parsed_version.build_version,
                 project_id__in=release_project_ids,
             ).count()
         else:


### PR DESCRIPTION
The preprodBuildCount query was reading from the deprecated `PreprodArtifact.build_version` field instead of the new `PreprodArtifactMobileAppInfo.build_version` field. This was missed when PR #105847 updated other endpoints to use the new model.

This caused `preprodBuildCount` to always be `0` for new uploads (after PR #105847 was deployed), which affects:
- Mobile Builds tab visibility on release detail pages for non-mobile projects
- The count badge displayed on the Mobile Builds tab

### Before - Python project with mobile builds,  not showing Mobile Builds tab

<img width="643" height="314" alt="Screenshot 2026-01-19 at 16 26 40" src="https://github.com/user-attachments/assets/3fb9f5e9-9a5b-4280-b684-ec9233c01f15" />

### After

<img width="613" height="254" alt="Screenshot 2026-01-19 at 17 54 22" src="https://github.com/user-attachments/assets/b8b6b3ab-3ee5-4d33-b9ac-41c377e15e4b" />

### Before - Mobile project, not showing count on Mobile Builds tab

<img width="609" height="229" alt="Screenshot 2026-01-19 at 16 21 19" src="https://github.com/user-attachments/assets/bb100549-78d3-4111-bd44-093f813ec32c" />

### After

<img width="617" height="238" alt="Screenshot 2026-01-19 at 16 21 48" src="https://github.com/user-attachments/assets/9dfef683-86a0-409a-b61f-9d200701856a" />
