### PR TITLE
feat(dashboards/insights): allow >90 days pickable

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -987,6 +987,7 @@ class DashboardDetail extends Component<Props, State> {
                 </StyledPageHeader>
                 <HookHeader organization={organization} />
                 <FiltersBar
+                  dashboard={dashboard}
                   dashboardPermissions={dashboard.permissions}
                   dashboardCreator={dashboard.createdBy}
                   filters={{}} // Default Dashboards don't have filters set
@@ -1196,6 +1197,7 @@ class DashboardDetail extends Component<Props, State> {
                                 />
                               ) : null}
                               <FiltersBar
+                                dashboard={modifiedDashboard ?? dashboard}
                                 filters={(modifiedDashboard ?? dashboard).filters}
                                 dashboardPermissions={dashboard.permissions}
                                 dashboardCreator={dashboard.createdBy}

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -10,11 +10,13 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {ToggleOnDemand} from 'sentry/utils/performance/contexts/onDemandControl';
 import {ReleasesProvider} from 'sentry/utils/releases/releasesProvider';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useUser} from 'sentry/utils/useUser';
@@ -32,8 +34,58 @@ import {
 
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import ReleasesSelectControl from './releasesSelectControl';
-import type {DashboardFilters, DashboardPermissions, GlobalFilter} from './types';
-import {DashboardFilterKeys} from './types';
+import type {
+  DashboardDetails,
+  DashboardFilters,
+  DashboardPermissions,
+  GlobalFilter,
+  Widget,
+} from './types';
+import {DashboardFilterKeys, WidgetType} from './types';
+
+/**
+ * Maps widget types to data categories for determining max pickable days
+ */
+function getDataCategoriesFromWidgets(
+  widgets: Widget[]
+): [DataCategory, ...DataCategory[]] {
+  const categories = new Set<DataCategory>();
+
+  for (const widget of widgets) {
+    const widgetType = widget.widgetType ?? WidgetType.DISCOVER;
+
+    switch (widgetType) {
+      case WidgetType.SPANS:
+        categories.add(DataCategory.SPANS);
+        break;
+      case WidgetType.TRANSACTIONS:
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+      case WidgetType.TRACEMETRICS:
+        categories.add(DataCategory.TRACE_METRICS);
+        break;
+      case WidgetType.LOGS:
+        categories.add(DataCategory.LOG_ITEM);
+        break;
+      case WidgetType.ERRORS:
+      case WidgetType.DISCOVER:
+      case WidgetType.ISSUE:
+      case WidgetType.RELEASE:
+      case WidgetType.METRICS:
+      default:
+        // For error-like widgets, use TRANSACTIONS as a safe default
+        // since it has the most permissive date range
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+    }
+  }
+
+  // Return as tuple with at least one element (required by useMaxPickableDays)
+  const categoriesArray = Array.from(categories);
+  return categoriesArray.length > 0
+    ? (categoriesArray as [DataCategory, ...DataCategory[]])
+    : [DataCategory.TRANSACTIONS];
+}
 
 export type FiltersBarProps = {
   filters: DashboardFilters;
@@ -42,6 +94,7 @@ export type FiltersBarProps = {
   isPreview: boolean;
   location: Location;
   onDashboardFilterChange: (activeFilters: DashboardFilters) => void;
+  dashboard?: DashboardDetails;
   dashboardCreator?: User;
   dashboardPermissions?: DashboardPermissions;
   onCancel?: () => void;
@@ -52,6 +105,7 @@ export type FiltersBarProps = {
 
 export default function FiltersBar({
   filters,
+  dashboard,
   dashboardPermissions,
   dashboardCreator,
   hasUnsavedChanges,
@@ -73,6 +127,19 @@ export default function FiltersBar({
   const prebuiltDashboardFilters: GlobalFilter[] = prebuiltDashboardId
     ? (PREBUILT_DASHBOARDS[prebuiltDashboardId].filters.globalFilter ?? [])
     : [];
+
+  // Determine data categories based on widget types in the dashboard
+  const dataCategories = useMemo(() => {
+    if (!dashboard?.widgets || dashboard.widgets.length === 0) {
+      // Default to TRANSACTIONS if no widgets
+      return [DataCategory.TRANSACTIONS] as [DataCategory, ...DataCategory[]];
+    }
+
+    return getDataCategoriesFromWidgets(dashboard.widgets);
+  }, [dashboard?.widgets]);
+
+  // Calculate maxPickableDays based on the data categories
+  const maxPickableDaysOptions = useMaxPickableDays({dataCategories});
 
   const hasEditAccess = checkUserHasEditAccess(
     currentUser,
@@ -131,6 +198,7 @@ export default function FiltersBar({
         />
         <DatePageFilter
           disabled={isEditingDashboard}
+          maxPickableDays={maxPickableDaysOptions.maxPickableDays}
           onChange={() => {
             trackAnalytics('dashboards2.filter.change', {
               organization,

--- a/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
+++ b/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
@@ -21,6 +21,10 @@ const DISABLED_OPTIONS = ['90d'];
 export function InsightsModuleDatePageFilter() {
   const organization = useOrganization();
 
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   const legacyDateFilterProps: DatePageFilterProps = useMemo(() => {
     const dateFilterProps: DatePageFilterProps = {};
 
@@ -49,14 +53,13 @@ export function InsightsModuleDatePageFilter() {
         return true;
       };
       dateFilterProps.menuFooter = <UpsellFooterHook />;
+    } else {
+      dateFilterProps.maxPickableDays = maxPickableDays.maxPickableDays;
     }
 
     return dateFilterProps;
-  }, [organization]);
+  }, [organization, maxPickableDays.maxPickableDays]);
 
-  const maxPickableDays = useMaxPickableDays({
-    dataCategories: [DataCategory.SPANS],
-  });
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
 
   const props = organization.features.includes('downsampled-page-filter')


### PR DESCRIPTION
Allow >90 days for dashboards and insights. A warning message occurs in dashboards to notify users that data might be missing for certain dashboards. Insights query limit is still respected and prioritized over maxPickableDays 


<img width="466" height="373" alt="image" src="https://github.com/user-attachments/assets/717eedb9-7a30-4030-bc22-c94a71141c85" />

<img width="575" height="441" alt="image" src="https://github.com/user-attachments/assets/e3e6253c-535b-46d5-a76f-80815cc097d5" />

<img width="567" height="570" alt="image" src="https://github.com/user-attachments/assets/ada6defa-8a2b-4caf-8929-2ebcc2612e4e" />
