### PR TITLE
  feat(admin): Restrict /manage/ endpoint to non-SaaS modes

### DIFF
--- a/src/sentry/status_checks/warnings.py
+++ b/src/sentry/status_checks/warnings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urljoin
 
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 from sentry.utils.warnings import WarningSet
 
@@ -14,6 +14,13 @@ class WarningStatusCheck(StatusCheck):
         self.__warning_set = warning_set
 
     def check(self) -> list[Problem]:
+
+        url = None
+        try:
+            url = urljoin(reverse("sentry-admin-overview"), "status/warnings/")
+        except NoReverseMatch:
+            url = None
+
         if self.__warning_set:
             return [
                 Problem(
@@ -26,7 +33,7 @@ class WarningStatusCheck(StatusCheck):
                     # We need this manual URL building as this page is moved to react
                     # and only the top-level entrypoint is defined and addressable in
                     # our backend Django app.
-                    url=urljoin(reverse("sentry-admin-overview"), "status/warnings/"),
+                    url=url,
                 )
             ]
         else:

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -11,6 +11,7 @@ from sentry.api.endpoints.oauth_userinfo import OAuthUserInfoEndpoint
 from sentry.api.endpoints.warmup import WarmupEndpoint
 from sentry.auth.providers.saml2.provider import SAML2AcceptACSView, SAML2MetadataView, SAML2SLSView
 from sentry.charts.endpoints import serve_chartcuterie_config
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.feedback.endpoints.error_page_embed import ErrorPageEmbedView
 from sentry.integrations.web.doc_integration_avatar import DocIntegrationAvatarPhotoView
 from sentry.integrations.web.organization_integration_setup import OrganizationIntegrationSetupView
@@ -109,6 +110,16 @@ if settings.DEBUG:
             r"^_static/[^/]+/[^/]+/images/favicon\.(ico|png)$",
             generic.dev_favicon,
             name="sentry-dev-favicon",
+        ),
+    ]
+
+if settings.SENTRY_MODE != SentryMode.SAAS:
+    # Admin endpoint only available in self-hosted mode
+    urlpatterns += [
+        re_path(
+            r"^manage/",
+            react_page_view,
+            name="sentry-admin-overview",
         ),
     ]
 
@@ -481,12 +492,6 @@ urlpatterns += [
     ),
     # Relocation
     re_path(r"^relocation/", generic_react_page_view, name="sentry-relocation"),
-    # Admin
-    re_path(
-        r"^manage/",
-        react_page_view,
-        name="sentry-admin-overview",
-    ),
     # Admin UI (for local dev)
     re_path(
         r"^_admin/",

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -498,3 +498,5 @@ class ReactPageViewTest(TestCase):
                 f"sentry-admin-overview should exist in SINGLE_TENANT mode. "
                 f"SENTRY_MODE={django_settings.SENTRY_MODE}"
             )
+
+        reload(sentry.web.urls)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -1,7 +1,11 @@
 from fnmatch import fnmatch
+from importlib import reload
 
+from django.conf import settings as django_settings
+from django.test import override_settings
 from django.urls import URLResolver, get_resolver, reverse
 
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
@@ -451,4 +455,46 @@ class ReactPageViewTest(TestCase):
             assert (
                 '<link rel="preconnect" href="https://s1.sentry-cdn.com"'
                 in response_body.decode("utf-8")
+            )
+
+    def test_manage_endpoint_only_available_in_non_saas_mode(self) -> None:
+        import sentry.web.urls
+
+        # Test that manage/ route does NOT exist in SAAS mode
+        with override_settings(SENTRY_MODE=SentryMode.SAAS):
+            reload(sentry.web.urls)
+
+            has_admin_route = any(
+                getattr(pattern, "name", None) == "sentry-admin-overview"
+                for pattern in sentry.web.urls.urlpatterns
+            )
+            assert not has_admin_route, (
+                f"sentry-admin-overview should not exist in SAAS mode. "
+                f"SENTRY_MODE={django_settings.SENTRY_MODE}"
+            )
+
+        # Test that manage/ route IS registered in SELF_HOSTED mode
+        with override_settings(SENTRY_MODE=SentryMode.SELF_HOSTED):
+            reload(sentry.web.urls)
+
+            has_admin_route = any(
+                getattr(pattern, "name", None) == "sentry-admin-overview"
+                for pattern in sentry.web.urls.urlpatterns
+            )
+            assert has_admin_route, (
+                f"sentry-admin-overview should exist in SELF_HOSTED mode. "
+                f"SENTRY_MODE={django_settings.SENTRY_MODE}"
+            )
+
+        # Test that manage/ route IS registered in SINGLE_TENANT mode
+        with override_settings(SENTRY_MODE=SentryMode.SINGLE_TENANT):
+            reload(sentry.web.urls)
+
+            has_admin_route = any(
+                getattr(pattern, "name", None) == "sentry-admin-overview"
+                for pattern in sentry.web.urls.urlpatterns
+            )
+            assert has_admin_route, (
+                f"sentry-admin-overview should exist in SINGLE_TENANT mode. "
+                f"SENTRY_MODE={django_settings.SENTRY_MODE}"
             )


### PR DESCRIPTION
Moves the admin UI endpoint (/manage/) behind a conditional check that only registers it when SENTRY_MODE is not SAAS. This ensures admin functionality is only available in self-hosted and single-tenant deployments.

The admin endpoint for SaaS is `_admin/`, which is unchanged. We just want to disable `manage/` for SaaS.

ref: https://linear.app/getsentry/issue/ECO-945

The changes:
  - src/sentry/web/urls.py: Conditionally register the /manage/ endpoint only when not in SaaS mode
  - tests/sentry/web/frontend/test_react_page.py: Add test coverage verifying the endpoint is accessible in SELF_HOSTED and SINGLE_TENANT modes but not accessible in SAAS mode

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
