### PR TITLE
feat(db): Add model name to EncryptedField metrics tags

### DIFF
--- a/src/sentry/db/models/fields/encryption/_base.py
+++ b/src/sentry/db/models/fields/encryption/_base.py
@@ -77,6 +77,10 @@ class EncryptedField(Field):
             },
         }
 
+    def __set_name__(self, owner: type, name: str) -> None:
+        super().__set_name__(owner, name)  # type: ignore[misc]
+        self._model_name = owner.__name__
+
     @sentry_sdk.trace
     def _format_encrypted_value(
         self, encrypted_data: bytes, marker: str, key_id: str | None = None
@@ -120,6 +124,7 @@ class EncryptedField(Field):
         tags = {
             "method": encryption_method,
             "field_type": self.__class__.__name__,
+            "model": getattr(self, "_model_name", "unknown"),
         }
 
         try:
@@ -280,6 +285,7 @@ class EncryptedField(Field):
                 tags = {
                     "method": method_name,
                     "field_type": self.__class__.__name__,
+                    "model": getattr(self, "_model_name", "unknown"),
                     "marker": marker,
                 }
 


### PR DESCRIPTION
Add model name to EncryptedField encryption/decryption metrics tags.

Uses `__set_name__` to capture the Django model class name where the
EncryptedField is defined. This allows metrics for `database.encrypted_field.encrypt`
and `database.encrypted_field.decrypt` to be tagged with the model name,
providing better observability into which models are using encrypted fields
and their encryption/decryption performance characteristics.

Closes [TET-1725: Add table/model name as a tag to metrics](https://linear.app/getsentry/issue/TET-1725/add-tablemodel-name-as-a-tag-to-metrics)