### PR TITLE
docs(agents): Standardize on uv run for all Python commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,16 +56,6 @@ cd /path/to/sentry && source .venv/bin/activate && pytest tests/...
 - Always use `required_permissions: ['all']` when running Python commands to avoid sandbox permission issues
 - The `.venv/bin/` prefix ensures you're using the correct Python interpreter and dependencies
 
-#### For Human Developers (interactive shells)
-
-Run `direnv allow` once to trust the `.envrc` file. After that, direnv will automatically activate the virtual environment when you cd into the directory.
-
-```bash
-cd /path/to/sentry
-direnv allow  # Only needed once, or after .envrc changes
-# Now pytest, python, etc. will automatically use .venv
-```
-
 ### Backend Development Commands
 
 #### Setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,27 +34,29 @@ This section contains critical command execution instructions that apply across 
 
 ### Python Command Execution Requirements
 
-**CRITICAL**: When running Python commands (pytest, mypy, pre-commit, etc.), you MUST use the virtual environment.
+**CRITICAL**: When running Python commands (pytest, mypy, pre-commit, etc.), you MUST use `uv run` to ensure the correct virtual environment is used.
 
 #### For AI Agents (automated commands)
 
-Use the full relative path to virtualenv executables:
+Use `uv run` to execute Python commands:
 
 ```bash
-cd /path/to/sentry && .venv/bin/pytest tests/...
-cd /path/to/sentry && .venv/bin/python -m mypy ...
+cd /path/to/sentry && uv run pytest tests/...
+cd /path/to/sentry && uv run python -m mypy ...
+cd /path/to/sentry && uv run pre-commit run --files src/sentry/path/to/file.py
 ```
 
-Or source the activate script in your command:
+If `uv` is not in PATH, use the full path:
 
 ```bash
-cd /path/to/sentry && source .venv/bin/activate && pytest tests/...
+cd /path/to/sentry && .devenv/bin/uv run pytest tests/...
 ```
 
 **Important for AI agents:**
 
 - Always use `required_permissions: ['all']` when running Python commands to avoid sandbox permission issues
-- The `.venv/bin/` prefix ensures you're using the correct Python interpreter and dependencies
+- `uv run` automatically uses the correct Python interpreter and dependencies from `.venv`
+- `uv` is installed via `devenv sync` at `.devenv/bin/uv` and is added to PATH by direnv
 
 ### Backend Development Commands
 
@@ -81,30 +83,30 @@ devservices serve
 
 ```bash
 # Preferred: Run pre-commit hooks on specific files
-pre-commit run --files src/sentry/path/to/file.py
+uv run pre-commit run --files src/sentry/path/to/file.py
 
 # Run all pre-commit hooks
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 #### Testing
 
 ```bash
 # Run Python tests (always use these parameters)
-pytest -svv --reuse-db
+uv run pytest -svv --reuse-db
 
 # Run specific test file
-pytest -svv --reuse-db tests/sentry/api/test_base.py
+uv run pytest -svv --reuse-db tests/sentry/api/test_base.py
 ```
 
 #### Database Operations
 
 ```bash
 # Run migrations
-sentry django migrate
+uv run sentry django migrate
 
 # Create new migration
-sentry django makemigrations
+uv run sentry django makemigrations
 
 # Update migration after rebase conflict (handles renaming, dependencies, lockfile)
 ./bin/update-migration <migration_name_or_number> <app_label>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,145 @@ sentry/
 └── config/               # Configuration files
 ```
 
+## Command Execution Guide
+
+This section contains critical command execution instructions that apply across all Sentry development.
+
+### Python Command Execution Requirements
+
+**CRITICAL**: When running Python commands (pytest, mypy, pre-commit, etc.), you MUST use the virtual environment.
+
+#### For AI Agents (automated commands)
+
+Use the full relative path to virtualenv executables:
+
+```bash
+cd /path/to/sentry && .venv/bin/pytest tests/...
+cd /path/to/sentry && .venv/bin/python -m mypy ...
+```
+
+Or source the activate script in your command:
+
+```bash
+cd /path/to/sentry && source .venv/bin/activate && pytest tests/...
+```
+
+**Important for AI agents:**
+
+- Always use `required_permissions: ['all']` when running Python commands to avoid sandbox permission issues
+- The `.venv/bin/` prefix ensures you're using the correct Python interpreter and dependencies
+
+#### For Human Developers (interactive shells)
+
+Run `direnv allow` once to trust the `.envrc` file. After that, direnv will automatically activate the virtual environment when you cd into the directory.
+
+```bash
+cd /path/to/sentry
+direnv allow  # Only needed once, or after .envrc changes
+# Now pytest, python, etc. will automatically use .venv
+```
+
+### Backend Development Commands
+
+#### Setup
+
+```bash
+# Install dependencies and setup development environment
+make develop
+
+# Or use the newer devenv command
+devenv sync
+
+# Activate the Python virtual environment (required for running tests and Python commands)
+direnv allow
+
+# Start dev dependencies
+devservices up
+
+# Start the development server
+devservices serve
+```
+
+#### Linting
+
+```bash
+# Preferred: Run pre-commit hooks on specific files
+pre-commit run --files src/sentry/path/to/file.py
+
+# Run all pre-commit hooks
+pre-commit run --all-files
+```
+
+#### Testing
+
+```bash
+# Run Python tests (always use these parameters)
+pytest -svv --reuse-db
+
+# Run specific test file
+pytest -svv --reuse-db tests/sentry/api/test_base.py
+```
+
+#### Database Operations
+
+```bash
+# Run migrations
+sentry django migrate
+
+# Create new migration
+sentry django makemigrations
+
+# Update migration after rebase conflict (handles renaming, dependencies, lockfile)
+./bin/update-migration <migration_name_or_number> <app_label>
+# Example: ./bin/update-migration 0101_workflow_when_condition_group_unique workflow_engine
+
+# Reset database
+make reset-db
+```
+
+### Frontend Development Commands
+
+#### Development Setup
+
+```bash
+# Start the development server
+pnpm run dev
+
+# Start only the UI development server with hot reload
+pnpm run dev-ui
+```
+
+#### Typechecking
+
+Typechecking only works on the entire project. Individual files cannot be checked.
+
+```bash
+pnpm run typecheck
+```
+
+#### Linting
+
+```bash
+# JavaScript/TypeScript linting
+pnpm run lint:js
+
+# Linting for specific file(s)
+pnpm run lint:js components/avatar.tsx [...other files]
+
+# Fix linting issues
+pnpm run fix
+```
+
+#### Testing
+
+```bash
+# Run JavaScript tests (always use CI flag)
+CI=true pnpm test <file_path>
+
+# Run specific test file(s)
+CI=true pnpm test components/avatar.spec.tsx
+```
+
 > For detailed development patterns, see nested AGENTS.md files:
 >
 > - **Backend patterns**: `src/AGENTS.md`
@@ -47,9 +186,9 @@ Cursor is configured to automatically load relevant AGENTS.md files based on the
 
 ## Backend
 
-For backend development patterns, commands, security guidelines, and architecture, see `src/AGENTS.md`.
+For backend development patterns, security guidelines, and architecture, see `src/AGENTS.md`.
 For backend testing patterns and best practices, see `tests/AGENTS.md`.
 
 ## Frontend
 
-For frontend development patterns, commands, design system guidelines, and React testing best practices, see `static/AGENTS.md`.
+For frontend development patterns, design system guidelines, and React testing best practices, see `static/AGENTS.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "sentry"
 # see setup.cfg for versioning; we only have this here to make uv happy
 # which we intend to use for dependency management, not packaging
 version = "0.0.0"
+requires-python = ">=3.13"
 dependencies = [
     "beautifulsoup4>=4.7.1",
     "boto3>=1.34.128",

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,6 +1,6 @@
 # Backend Development Guide
 
-> For critical commands and security guidelines, see `/AGENTS.md` in the repository root.
+> For critical commands, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
 ## Overview
 
@@ -45,40 +45,6 @@ sentry/
 ├── devenv/               # Development environment config
 ├── migrations/           # Database migrations
 └── config/               # Configuration files
-```
-
-## Command Execution Requirements
-
-**CRITICAL**: When running Python commands (pytest, mypy, pre-commit, etc.), you MUST use the virtual environment.
-
-### For AI Agents (automated commands)
-
-Use the full relative path to virtualenv executables:
-
-```bash
-cd /path/to/sentry && .venv/bin/pytest tests/...
-cd /path/to/sentry && .venv/bin/python -m mypy ...
-```
-
-Or source the activate script in your command:
-
-```bash
-cd /path/to/sentry && source .venv/bin/activate && pytest tests/...
-```
-
-**Important for AI agents:**
-
-- Always use `required_permissions: ['all']` when running Python commands to avoid sandbox permission issues
-- The `.venv/bin/` prefix ensures you're using the correct Python interpreter and dependencies
-
-### For Human Developers (interactive shells)
-
-Run `direnv allow` once to trust the `.envrc` file. After that, direnv will automatically activate the virtual environment when you cd into the directory.
-
-```bash
-cd /path/to/sentry
-direnv allow  # Only needed once, or after .envrc changes
-# Now pytest, python, etc. will automatically use .venv
 ```
 
 ## Security Guidelines
@@ -135,66 +101,6 @@ projects = self.get_projects(
   - Perform cleanup operations
   - Convert one exception type to another with additional information
   - Recover from expected error conditions
-
-## Development Commands
-
-### Setup
-
-```bash
-# Install dependencies and setup development environment
-make develop
-
-# Or use the newer devenv command
-devenv sync
-
-# Activate the Python virtual environment (required for running tests and Python commands)
-direnv allow
-
-# Start dev dependencies
-devservices up
-
-# Start the development server
-devservices serve
-```
-
-> **See "Command Execution Requirements" above** for critical `direnv allow` guidance.
-
-### Linting
-
-```bash
-# Preferred: Run pre-commit hooks on specific files
-pre-commit run --files src/sentry/path/to/file.py
-
-# Run all pre-commit hooks
-pre-commit run --all-files
-```
-
-### Testing
-
-```bash
-# Run Python tests (always use these parameters)
-pytest -svv --reuse-db
-
-# Run specific test file
-pytest tests/sentry/api/test_base.py
-```
-
-### Database Operations
-
-```bash
-# Run migrations
-sentry django migrate
-
-# Create new migration
-sentry django makemigrations
-
-# Update migration after rebase conflict (handles renaming, dependencies, lockfile)
-./bin/update-migration <migration_name_or_number> <app_label>
-# Example: ./bin/update-migration 0101_workflow_when_condition_group_unique workflow_engine
-
-# Reset database
-make reset-db
-```
 
 ## Development Services
 

--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -1,6 +1,6 @@
 # Frontend Development Guide
 
-> For critical commands and testing rules, see `/AGENTS.md` in the repository root.
+> For critical commands and testing rules, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
 ## Frontend Tech Stack
 
@@ -12,50 +12,7 @@
 - **Styling**: Emotion (CSS-in-JS), Less
 - **Testing**: Jest, React Testing Library
 
-## Commands
-
-### Development Setup
-
-```bash
-# Start the development server
-pnpm run dev
-
-# Start only the UI development server with hot reload
-pnpm run dev-ui
-```
-
-### Typechecking
-
-Typechecking only works on the entire project. Individual files cannot be checked.
-
-```bash
-pnpm run typecheck
-```
-
-### Linting
-
-```bash
-# JavaScript/TypeScript linting
-pnpm run lint:js
-
-# Linting for specific file(s)
-pnpm run lint:js components/avatar.tsx [...other files]
-
-# Fix linting issues
-pnpm run fix
-```
-
-### Testing
-
-```bash
-# Run JavaScript tests (always use CI flag)
-CI=true pnpm test <file_path>
-
-# Run specific test file(s)
-CI=true pnpm test components/avatar.spec.tsx
-```
-
-### Important Files and Directories
+## Important Files and Directories
 
 - `package.json`: Node.js dependencies and scripts
 - `rspack.config.ts`: Frontend build configuration

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,10 +1,6 @@
 # Python Testing Guide
 
-> For critical test commands, see `/AGENTS.md` in the repository root.
-
-## Running Tests
-
-Always run pytest with these parameters: `pytest -svv --reuse-db` since it is faster to execute.
+> For critical test commands, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
 ## How to Determine Where to Add New Test Cases
 


### PR DESCRIPTION
Updates AGENTS.md, Makefile, and pyproject.toml to use `uv run` as the standard approach for executing Python commands across development and CI.

Changes:
- Add requires-python = ">=3.13" to pyproject.toml (eliminates uv warnings)
- Update AGENTS.md to recommend `uv run` for pytest, pre-commit, mypy, etc.
- Add smart UV variable to Makefile that auto-detects uv location
- Update 11 Makefile targets to use $(UV) for consistency

This works in all environments:
- CI: Uses global uv installed by setup-uv action
- Local with direnv: Uses uv from PATH via .devenv/bin
- Local without direnv: Falls back to .devenv/bin/uv

Fixes inconsistency between different execution methods and modernizes the development workflow to align with uv adoption for dependency management.