### PR TITLE
fix(dashboards): clear message when dataset doesnt support >90 days

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -489,7 +489,7 @@ function useTimeRangeWarning({widget}: {widget: Widget}) {
     (retentionLimitDate && statsPeriodToEnd && retentionLimitDate > statsPeriodToEnd)
   ) {
     return tct(
-      `You've selected a time range longer than the retention period for this dataset. Data older than [numDays] days may be unavailable.`,
+      `You've selected a time range longer than the retention period for some datasets. Data older than [numDays] days may be unavailable.`,
       {
         numDays: retentionLimitDays,
       }


### PR DESCRIPTION
As this is a message that occurs over all widgets, it should same "some datasets" instead of "this dataset"