### PR TITLE
fix(span-buffer): Add debug logging option for span buffer subsegments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3100,6 +3100,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# List of trace_ids to enable debug logging for. Empty = debug off.
+# When set, logs detailed metrics about zunionstore set sizes, key existence, and trace structure.
+register(
+    "spans.buffer.debug-traces",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Segments consumer
 register(
     "spans.process-segments.consumer.enable",

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -232,11 +232,14 @@ class SpansBuffer:
 
                     _, _, trace_id = project_and_trace.partition(":")
                     if trace_id in debug_traces:
-                        if self._debug_trace_logger is None:
-                            self._debug_trace_logger = DebugTraceLogger(self.client)
-                        self._debug_trace_logger.log_subsegment_info(
-                            project_and_trace, parent_span_id, subsegment
-                        )
+                        try:
+                            if self._debug_trace_logger is None:
+                                self._debug_trace_logger = DebugTraceLogger(self.client)
+                            self._debug_trace_logger.log_subsegment_info(
+                                project_and_trace, parent_span_id, subsegment
+                            )
+                        except Exception:
+                            logger.exception("Failed to log debug trace info")
 
                     p.execute_command(
                         "EVALSHA",

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -180,6 +180,58 @@ class SpansBuffer:
     def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
         return f"span-buf:z:{{{project_and_trace}}}:{span_id}".encode("ascii")
 
+    def _log_debug_trace_info(
+        self,
+        project_and_trace: str,
+        parent_span_id: str,
+        subsegment: list[Span],
+    ) -> None:
+        """
+        Debug logging for traces specified in spans.buffer.debug-traces option.
+        Logs zunionstore source set sizes and dumps spans info in the subsegment.
+        """
+        spans = []
+        span_keys = []
+        for span in subsegment:
+            # dump each span's id, segment_id and parent_span_id
+            spans.append(
+                {
+                    "span_id": span.span_id,
+                    "parent_span_id": span.parent_span_id,
+                    "segment_id": span.segment_id,
+                }
+            )
+            if span.span_id != parent_span_id:
+                span_keys.append(self._get_span_key(project_and_trace, span.span_id))
+
+        set_sizes: dict[str, int] = {}
+
+        if span_keys:
+            with self.client.pipeline(transaction=False) as p:
+                for key in span_keys:
+                    p.zcard(key)
+                results = p.execute()
+
+            for i, key in enumerate(span_keys):
+                key_str = key.decode("ascii")
+                set_sizes[key_str] = results[i]
+
+        num_existing_keys = sum(1 for size in set_sizes.values() if size > 0)
+
+        logger.info(
+            "spans.buffer.debug_subsegment",
+            extra={
+                "project_and_trace": project_and_trace,
+                "parent_span_id": parent_span_id,
+                "num_spans_in_subsegment": len(subsegment),
+                "zunion_span_key_count": len(span_keys),
+                "zunion_existing_key_count": num_existing_keys,
+                "set_sizes": set_sizes,
+                "total_set_sizes": sum(set_sizes.values()),
+                "subsegment_spans": spans,
+            },
+        )
+
     @metrics.wraps("spans.buffer.process_spans")
     def process_spans(self, spans: Sequence[Span], now: int):
         """
@@ -200,6 +252,7 @@ class SpansBuffer:
         timeout = options.get("spans.buffer.timeout")
         root_timeout = options.get("spans.buffer.root-timeout")
         max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
+        debug_traces = set(options.get("spans.buffer.debug-traces"))
 
         result_meta = []
         is_root_span_count = 0
@@ -226,6 +279,11 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
                     byte_count = sum(len(span.payload) for span in subsegment)
+
+                    _, _, trace_id = project_and_trace.partition(":")
+                    if trace_id in debug_traces:
+                        self._log_debug_trace_info(project_and_trace, parent_span_id, subsegment)
+
                     p.execute_command(
                         "EVALSHA",
                         add_buffer_sha,

--- a/src/sentry/spans/debug_trace_logger.py
+++ b/src/sentry/spans/debug_trace_logger.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from sentry_redis_tools.clients import RedisCluster, StrictRedis
+
+logger = logging.getLogger(__name__)
+
+
+class DebugTraceLogger:
+    """
+    Logs debug information for specific traces specified in the
+    spans.buffer.debug-traces option. The information includes zunionstore
+    source set sizes, key existence, and dumps of all spans in the subsegment.
+    """
+
+    def __init__(self, client: RedisCluster[bytes] | StrictRedis[bytes]) -> None:
+        self._client = client
+
+    def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
+        return f"span-buf:z:{{{project_and_trace}}}:{span_id}".encode("ascii")
+
+    def log_subsegment_info(
+        self,
+        project_and_trace: str,
+        parent_span_id: str,
+        subsegment: Sequence[Any],
+    ) -> None:
+        spans = []
+        span_keys = []
+        for span in subsegment:
+            spans.append(
+                {
+                    "span_id": span.span_id,
+                    "parent_span_id": span.parent_span_id,
+                    "segment_id": span.segment_id,
+                }
+            )
+            if span.span_id != parent_span_id:
+                span_keys.append(self._get_span_key(project_and_trace, span.span_id))
+
+        set_sizes: dict[str, int] = {}
+
+        if span_keys:
+            with self._client.pipeline(transaction=False) as p:
+                for key in span_keys:
+                    p.zcard(key)
+                results = p.execute()
+
+            for i, key in enumerate(span_keys):
+                key_str = key.decode("ascii")
+                set_sizes[key_str] = results[i]
+
+        num_existing_keys = sum(1 for size in set_sizes.values() if size > 0)
+
+        logger.info(
+            "spans.buffer.debug_subsegment",
+            extra={
+                "project_and_trace": project_and_trace,
+                "parent_span_id": parent_span_id,
+                "num_spans_in_subsegment": len(subsegment),
+                "zunion_span_key_count": len(span_keys),
+                "zunion_existing_key_count": num_existing_keys,
+                "set_sizes": set_sizes,
+                "total_set_sizes": sum(set_sizes.values()),
+                "subsegment_spans": spans,
+            },
+        )

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -23,6 +23,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.compression.level": 0,
     "spans.buffer.evalsha-latency-threshold": 100,
+    "spans.buffer.debug-traces": [],
 }
 
 

--- a/tests/sentry/spans/test_debug_trace_logger.py
+++ b/tests/sentry/spans/test_debug_trace_logger.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+from unittest import mock
+
+from sentry.spans.debug_trace_logger import DebugTraceLogger
+
+
+class MockSpan(NamedTuple):
+    span_id: str
+    parent_span_id: str | None
+    segment_id: str | None
+
+
+class TestDebugTraceLogger:
+
+    @mock.patch("sentry.spans.debug_trace_logger.logger")
+    def test_logs_subsegment_info_with_no_span_keys(self, mock_logger):
+        """Test logging when parent_span_id matches the only span's span_id."""
+        mock_client = mock.MagicMock()
+
+        debug_logger = DebugTraceLogger(mock_client)
+        subsegment = [MockSpan(span_id="abc123", parent_span_id=None, segment_id=None)]
+
+        debug_logger.log_subsegment_info(
+            project_and_trace="123:trace456",
+            parent_span_id="abc123",
+            subsegment=subsegment,
+        )
+
+        assert mock_logger.info.call_count == 1
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "spans.buffer.debug_subsegment"
+
+        extra = call_args[1]["extra"]
+        assert extra["project_and_trace"] == "123:trace456"
+        assert extra["parent_span_id"] == "abc123"
+        assert extra["num_spans_in_subsegment"] == 1
+        assert extra["zunion_span_key_count"] == 0
+        assert extra["zunion_existing_key_count"] == 0
+        assert extra["set_sizes"] == {}
+        assert extra["total_set_sizes"] == 0
+        assert extra["subsegment_spans"] == [
+            {"span_id": "abc123", "parent_span_id": None, "segment_id": None}
+        ]
+
+        # No Redis calls should be made when there are no span keys
+        mock_client.pipeline.assert_not_called()
+
+    @mock.patch("sentry.spans.debug_trace_logger.logger")
+    def test_logs_subsegment_info_with_span_keys(self, mock_logger):
+        """Test logging with multiple spans where some have different span_ids."""
+        mock_client = mock.MagicMock()
+        mock_pipeline = mock.MagicMock()
+        mock_client.pipeline.return_value.__enter__ = mock.MagicMock(return_value=mock_pipeline)
+        mock_client.pipeline.return_value.__exit__ = mock.MagicMock(return_value=False)
+        mock_pipeline.execute.return_value = [5, 0]  # First key has 5 items, second is empty
+
+        debug_logger = DebugTraceLogger(mock_client)
+        subsegment = [
+            MockSpan(span_id="parent123", parent_span_id=None, segment_id=None),
+            MockSpan(span_id="child1", parent_span_id="parent123", segment_id=None),
+            MockSpan(span_id="child2", parent_span_id="parent123", segment_id="seg1"),
+        ]
+
+        debug_logger.log_subsegment_info(
+            project_and_trace="456:trace789",
+            parent_span_id="parent123",
+            subsegment=subsegment,
+        )
+
+        assert mock_logger.info.call_count == 1
+        call_args = mock_logger.info.call_args
+        extra = call_args[1]["extra"]
+
+        assert extra["project_and_trace"] == "456:trace789"
+        assert extra["parent_span_id"] == "parent123"
+        assert extra["num_spans_in_subsegment"] == 3
+        assert extra["zunion_span_key_count"] == 2
+        assert extra["zunion_existing_key_count"] == 1  # Only first key has size > 0
+        assert extra["total_set_sizes"] == 5
+        assert len(extra["set_sizes"]) == 2
+        assert len(extra["subsegment_spans"]) == 3
+
+        # Verify Redis pipeline was called with zcard for the child span keys
+        assert mock_pipeline.zcard.call_count == 2
+
+    @mock.patch("sentry.spans.debug_trace_logger.logger")
+    def test_span_key_format(self, mock_logger):
+        """Test that span keys are generated in the correct format."""
+        mock_client = mock.MagicMock()
+        mock_pipeline = mock.MagicMock()
+        mock_client.pipeline.return_value.__enter__ = mock.MagicMock(return_value=mock_pipeline)
+        mock_client.pipeline.return_value.__exit__ = mock.MagicMock(return_value=False)
+        mock_pipeline.execute.return_value = [3]
+
+        debug_logger = DebugTraceLogger(mock_client)
+        subsegment = [
+            MockSpan(span_id="parent", parent_span_id=None, segment_id=None),
+            MockSpan(span_id="child", parent_span_id="parent", segment_id=None),
+        ]
+
+        debug_logger.log_subsegment_info(
+            project_and_trace="111:trace222",
+            parent_span_id="parent",
+            subsegment=subsegment,
+        )
+
+        # Verify the key format
+        expected_key = b"span-buf:z:{111:trace222}:child"
+        mock_pipeline.zcard.assert_called_once_with(expected_key)
+
+        # Verify the key appears in set_sizes with correct format
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert "span-buf:z:{111:trace222}:child" in extra["set_sizes"]
+        assert extra["set_sizes"]["span-buf:z:{111:trace222}:child"] == 3


### PR DESCRIPTION
Refs STREAM-696

Add `spans.buffer.debug-traces` option to enable targeted debug logging for specific trace_ids. When enabled, logs zunionstore source set sizes (spans within the subsegment) and logs key existence info before the add-buffer lua script is ran.