### PR TITLE
chore(cells): Remove relay.public_keys.post capture message

### DIFF
--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -1,4 +1,3 @@
-import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -24,8 +23,6 @@ class RelayPublicKeysEndpoint(Endpoint):
         calling_relay = request.relay
         relay_ids = request.relay_request_data.get("relay_ids") or ()
 
-        # This log line is to verify that this endpoint is not being used before we deprecate it.
-        sentry_sdk.capture_message("relay.public_keys.post")
         legacy_public_keys = dict.fromkeys(relay_ids)
         public_keys = dict.fromkeys(relay_ids)
 


### PR DESCRIPTION
Removes the capture_message call that was used to verify endpoint usage before deprecation.

We won't be removing/deprecating this endpoint within sentry. Instead, synapse will be routing this to 'any cell' and relying on relay records being replicated between cells.

Fixes SENTRY-5GER