### PR TITLE
fix(ai-trace): List disappears on breakpoint change

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -93,16 +93,15 @@ export function AISpanList({
 
   return (
     <Stack padding="2xs" gap="xs" overflow="hidden">
-      {nodesByTransaction.entries().map(([transaction, transactionNodes]) => (
-        <Fragment key={transaction.id}>
-          <TransactionWrapper
-            canCollapse={nodesByTransaction.size > 1}
-            transaction={transaction}
-            nodes={transactionNodes}
-            onSelectNode={onSelectNode}
-            selectedNodeKey={selectedNodeKey}
-          />
-        </Fragment>
+      {Array.from(nodesByTransaction.entries()).map(([transaction, transactionNodes]) => (
+        <TransactionWrapper
+          key={transaction.id}
+          canCollapse={nodesByTransaction.size > 1}
+          transaction={transaction}
+          nodes={transactionNodes}
+          onSelectNode={onSelectNode}
+          selectedNodeKey={selectedNodeKey}
+        />
       ))}
     </Stack>
   );


### PR DESCRIPTION
### Problem

`nodesByTransaction.entries()` creates an iterator, which React is in general able to handle and it renders without problems.
However, as breakpoints change the Stack component re-renders but the children / iterator is still the same instance as before, which already has finished iterating. Therefore, nothing remains to render and the list vanishes.

### Solution

Transform the iterator into an array before passing it as children.
