### PR TITLE
fix(ai-drawer): Accomodate pretty/raw button in json viewer component

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1369,6 +1369,8 @@ function MultilineJSON({
 const MultilineTextWrapperMonospace = styled(MultilineTextWrapper)`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
+  /* Reserve vertical space for the hoverable Pretty/Raw segmented control (form height + top/bottom spacing) */
+  min-height: calc(${p => p.theme.form.xs.height} + (${p => p.theme.space.xs} * 2));
   pre {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
The `MultilineTextWrapperMonospace` component requires a min-height while 
`MultilineTextWrapper` does not due to font size differences:

- `MultilineTextWrapper` uses default 14px font, which naturally renders 
  ~36px tall with padding, providing adequate space for the absolutely 
  positioned Pretty/Raw segmented control
  
- `MultilineTextWrapperMonospace` uses smaller 12px monospace font for code 
  display, which would naturally render shorter (~32px). Without min-height, 
  short JSON values creates cramped layouts
  
The min-height calculation ensures the container is always tall enough to 
accommodate the segmented control (form height + spacing) regardless of 
content length or font size.


| Before | After |
|--------|-------|
| <img width="1370" height="211" alt="image" src="https://github.com/user-attachments/assets/032301a7-9cde-4fd1-8e43-1ec3f9e462ea" /> | <img width="1366" height="233" alt="image" src="https://github.com/user-attachments/assets/1850fa0f-ab48-4895-bb28-63431f32df03" /> |


closes: https://linear.app/getsentry/issue/TET-1729/output-prettyraw-button-spacing-looks-off

