### PR TITLE
feat(onboarding): Add sentryTanstackStart vite plugin

### DIFF
--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -205,6 +205,37 @@ export default createServerEntry(
         {
           type: 'text',
           text: tct(
+            'Add the [code:sentryTanstackStart] plugin to your [configFile:vite.config.ts] file:',
+            {code: <code />, configFile: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'TypeScript',
+              language: 'typescript',
+              filename: 'vite.config.ts',
+              code: `import { defineConfig } from "vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+
+export default defineConfig({
+  plugins: [
+    sentryTanstackStart({
+      org: "${params.organization.slug}",
+      project: "${params.project.slug}",
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+    tanstackStart(),
+  ],
+});`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
             'For production monitoring, you need to move the Sentry server config file to your build output. Since [hostingLink:TanStack Start is designed to work with any hosting provider], the exact location will depend on where your build artifacts are deployed (for example, [code:/dist], [code:.output/server] or a platform-specific directory).',
             {
               code: <code />,
@@ -337,7 +368,14 @@ const route = createRoute({
         {
           type: 'text',
           text: tct(
-            "The stack traces in your Sentry errors probably won't look like your actual code. To fix this, upload your source maps to Sentry. Since TanStack Start uses Vite, you can use the Sentry Vite plugin to automatically upload source maps. Follow the [link:Vite source maps guide] to set this up.",
+            'If you configured the [code:sentryTanstackStart] Vite plugin as shown above, source maps will be automatically uploaded to Sentry during the build process and deleted from your build output afterwards.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
+            'For alternative source map upload methods, follow the [link:Vite source maps guide].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite/" />

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -205,7 +205,7 @@ export default createServerEntry(
         {
           type: 'text',
           text: tct(
-            'Add the [code:sentryTanstackStart] plugin to your [configFile:vite.config.ts] file:',
+            'Add the [code:sentryTanstackStart] Vite plugin to your [configFile:vite.config.ts] file:',
             {code: <code />, configFile: <code />}
           ),
         },
@@ -217,8 +217,8 @@ export default createServerEntry(
               language: 'typescript',
               filename: 'vite.config.ts',
               code: `import { defineConfig } from "vite";
-import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({
   plugins: [

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -222,12 +222,12 @@ import { sentryTanstackStart } from "@sentry/tanstackstart-react";
 
 export default defineConfig({
   plugins: [
+    tanstackStart(),
     sentryTanstackStart({
       org: "${params.organization.slug}",
       project: "${params.project.slug}",
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
-    tanstackStart(),
   ],
 });`,
             },


### PR DESCRIPTION
We recently added the `sentryTanstackStart` vite plugin to the Tanstack Start SDK. This plugin currently manages source maps upload for the user, but will in the future also enable other features. Updating the onboarding to reflect this.
