### PR TITLE
fix(tests): renderWithOnboardingLayout utility shouldn't have a fix platformKey

### DIFF
--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -84,7 +84,7 @@ export function renderWithOnboardingLayout<
         otlp_traces: 'test-otlp_traces',
         otlp_logs: 'test-otlp_logs',
       }}
-      platformKey="java-spring-boot"
+      platformKey={project.platform ?? 'other'}
       activeProductSelection={selectedProducts}
       projectKeyId={projectKey}
     />,


### PR DESCRIPTION
Because the platformKey is static - java-spring-boot - enabling Metrics for this platform is causing the JavaScript tests to fail, even though they shouldn’t ([see](https://github.com/getsentry/sentry/pull/106508#issuecomment-3772156311)).