### PR TITLE
feat(attribute-breakdown): Open in expanded modal

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -482,3 +482,13 @@ export async function openInsightInfoModal(options: InsightInfoModalOptions) {
 
   openModal(deps => <InsightInfoModal {...deps} {...options} />);
 }
+
+export async function openAttributeBreakdownViewerModal(
+  options: import('sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal').AttributeBreakdownViewerModalOptions
+) {
+  const {default: Modal, modalCss} = await import(
+    'sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal'
+  );
+
+  openModal(deps => <Modal {...deps} {...options} />, {modalCss});
+}

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -20,6 +20,7 @@ import type {IssueOwnership} from 'sentry/types/group';
 import type {MissingMember, Organization, OrgRole, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Theme} from 'sentry/utils/theme';
+import type {AttributeBreakdownViewerModalOptions} from 'sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal';
 
 export type ModalOptions = ModalTypes['options'];
 export type ModalRenderProps = ModalTypes['renderProps'];
@@ -484,7 +485,7 @@ export async function openInsightInfoModal(options: InsightInfoModalOptions) {
 }
 
 export async function openAttributeBreakdownViewerModal(
-  options: import('sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal').AttributeBreakdownViewerModalOptions
+  options: AttributeBreakdownViewerModalOptions
 ) {
   const {default: Modal, modalCss} = await import(
     'sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal'

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -1,10 +1,6 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import ProjectsStore from 'sentry/stores/projectsStore';
 
 import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
 
@@ -16,18 +12,15 @@ jest.mock('echarts-for-react/lib/core', () => {
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
+const stubProps = {
+  Header: stubEl,
+  Footer: stubEl as ModalRenderProps['Footer'],
+  Body: stubEl as ModalRenderProps['Body'],
+  CloseButton: stubEl,
+  closeModal: () => undefined,
+};
+
 describe('AttributeBreakdownViewerModal', () => {
-  const organization = OrganizationFixture();
-  const project = ProjectFixture();
-
-  beforeEach(() => {
-    ProjectsStore.loadInitialData([project]);
-  });
-
-  afterEach(() => {
-    ProjectsStore.reset();
-  });
-
   describe('single mode', () => {
     const mockAttributeDistribution = {
       attributeName: 'browser.name',
@@ -43,16 +36,11 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the modal with attribute name as title', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -61,16 +49,11 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the population percentage indicator', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       // Total values: 500 + 300 + 200 = 1000, cohortCount = 1000 => 100%
@@ -80,16 +63,11 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the chart', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -98,16 +76,11 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the table with attribute values', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       // Table should have column headers
@@ -130,16 +103,11 @@ describe('AttributeBreakdownViewerModal', () => {
 
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={cohortCount}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('cell', {name: '25%'})).toBeInTheDocument();
@@ -149,16 +117,11 @@ describe('AttributeBreakdownViewerModal', () => {
       const cohortCount = 0;
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={cohortCount}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -171,16 +134,11 @@ describe('AttributeBreakdownViewerModal', () => {
       };
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
@@ -211,17 +169,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the modal with attribute name as title', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -230,17 +183,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders population percentage indicators for both cohorts', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       // Cohort 1: (500 + 300) / 800 = 100%
@@ -251,17 +199,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the chart', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -270,17 +213,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders the table with cohort comparison columns', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       // Table should have column headers
@@ -298,17 +236,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('renders attribute values in the table', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       // Table should have attribute values
@@ -320,17 +253,12 @@ describe('AttributeBreakdownViewerModal', () => {
     it('handles zero cohort totals without crashing', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={mockAttribute}
           cohort1Total={0}
           cohort2Total={0}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -339,11 +267,7 @@ describe('AttributeBreakdownViewerModal', () => {
     it('handles empty cohorts', () => {
       render(
         <AttributeBreakdownViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
+          {...stubProps}
           mode="comparison"
           attribute={{
             attributeName: 'empty.attribute',
@@ -353,8 +277,7 @@ describe('AttributeBreakdownViewerModal', () => {
           }}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {organization}
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -1,0 +1,363 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import ProjectsStore from 'sentry/stores/projectsStore';
+
+import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
+
+jest.mock('echarts-for-react/lib/core', () => {
+  return jest.fn(({style}) => {
+    return <div style={{...style, background: 'green'}}>echarts mock</div>;
+  });
+});
+
+const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
+
+describe('AttributeBreakdownViewerModal', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+  });
+
+  afterEach(() => {
+    ProjectsStore.reset();
+  });
+
+  describe('single mode', () => {
+    const mockAttributeDistribution = {
+      attributeName: 'browser.name',
+      values: [
+        {label: 'Chrome', value: 500},
+        {label: 'Firefox', value: 300},
+        {label: 'Safari', value: 200},
+      ],
+    };
+
+    const mockCohortCount = 1000;
+
+    it('renders the modal with attribute name as title', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
+    });
+
+    it('renders the population percentage indicator', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      // Total values: 500 + 300 + 200 = 1000, cohortCount = 1000 => 100%
+      expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+
+    it('renders the chart', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByText('echarts mock')).toBeInTheDocument();
+    });
+
+    it('renders the table with attribute values', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      // Table should have column headers
+      expect(screen.getByRole('columnheader', {name: 'Value'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Count'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Percentage'})).toBeInTheDocument();
+
+      // Table should have attribute values
+      expect(screen.getByRole('cell', {name: 'Chrome'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Firefox'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Safari'})).toBeInTheDocument();
+    });
+
+    it('calculates percentage correctly', () => {
+      const cohortCount = 1000;
+      const attributeDistribution = {
+        attributeName: 'test.attribute',
+        values: [{label: 'Value A', value: 250}],
+      };
+
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={attributeDistribution}
+          cohortCount={cohortCount}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('cell', {name: '25%'})).toBeInTheDocument();
+    });
+
+    it('handles zero cohort count without crashing', () => {
+      const cohortCount = 0;
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={cohortCount}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
+    });
+
+    it('handles empty values array', () => {
+      const attributeDistribution = {
+        attributeName: 'empty.attribute',
+        values: [],
+      };
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="single"
+          attributeDistribution={attributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
+    });
+  });
+
+  describe('comparison mode', () => {
+    const mockAttribute = {
+      attributeName: 'browser.name',
+      cohort1: [
+        {label: 'Chrome', value: 500},
+        {label: 'Firefox', value: 300},
+      ],
+      cohort2: [
+        {label: 'Chrome', value: 400},
+        {label: 'Firefox', value: 350},
+        {label: 'Safari', value: 250},
+      ],
+      order: {
+        rrf: 0.5,
+        rrr: 0.3,
+      },
+    };
+
+    const mockCohort1Total = 800;
+    const mockCohort2Total = 1000;
+
+    it('renders the modal with attribute name as title', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
+    });
+
+    it('renders population percentage indicators for both cohorts', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      // Cohort 1: (500 + 300) / 800 = 100%
+      // Cohort 2: (400 + 350 + 250) / 1000 = 100%
+      expect(screen.getAllByText('100%')).toHaveLength(2);
+    });
+
+    it('renders the chart', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByText('echarts mock')).toBeInTheDocument();
+    });
+
+    it('renders the table with cohort comparison columns', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      // Table should have column headers
+      expect(screen.getByRole('columnheader', {name: 'Value'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', {name: 'Selected Count'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Selected %'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', {name: 'Baseline Count'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Baseline %'})).toBeInTheDocument();
+    });
+
+    it('renders attribute values in the table', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      // Table should have attribute values
+      expect(screen.getByRole('cell', {name: 'Chrome'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Firefox'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Safari'})).toBeInTheDocument();
+    });
+
+    it('handles zero cohort totals without crashing', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={0}
+          cohort2Total={0}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
+    });
+
+    it('handles empty cohorts', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          mode="comparison"
+          attribute={{
+            attributeName: 'empty.attribute',
+            cohort1: [],
+            cohort2: [],
+            order: {rrf: 0, rrr: 0},
+          }}
+          cohort1Total={mockCohort1Total}
+          cohort2Total={mockCohort2Total}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -464,8 +464,8 @@ export default function AttributeBreakdownViewerModal(props: Props) {
         </Flex>
       </Header>
       <Body>
-        <Flex direction="column" gap="2xl" height={600}>
-          <Container height={MODAL_CHART_HEIGHT}>
+        <Flex direction="column" gap="2xl" height="600px">
+          <Container height={`${MODAL_CHART_HEIGHT}px`}>
             <BaseChart
               height={MODAL_CHART_HEIGHT}
               isGroupedByDate={false}

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -50,7 +50,9 @@ type ComparisonModeOptions = {
   mode: 'comparison';
 };
 
-type AttributeBreakdownViewerModalOptions = SingleModeOptions | ComparisonModeOptions;
+export type AttributeBreakdownViewerModalOptions =
+  | SingleModeOptions
+  | ComparisonModeOptions;
 
 type Props = ModalRenderProps & AttributeBreakdownViewerModalOptions;
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -46,9 +46,7 @@ type ComparisonModeOptions = {
   mode: 'comparison';
 };
 
-export type AttributeBreakdownViewerModalOptions =
-  | SingleModeOptions
-  | ComparisonModeOptions;
+type AttributeBreakdownViewerModalOptions = SingleModeOptions | ComparisonModeOptions;
 
 type Props = ModalRenderProps & AttributeBreakdownViewerModalOptions;
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -27,7 +27,11 @@ import {
   MODAL_CHART_HEIGHT,
 } from './constants';
 import {formatComparisonModeTooltip, formatSingleModeTooltip} from './tooltips';
-import {calculateAttributePopulationPercentage, percentageFormatter} from './utils';
+import {
+  calculateAttributePopulationPercentage,
+  distributionToSeriesData,
+  percentageFormatter,
+} from './utils';
 
 type RankedAttribute = AttributeBreakdownsComparison['rankedAttributes'][number];
 type CohortData = RankedAttribute['cohort1'];
@@ -97,18 +101,6 @@ function distributionToTableData(
       },
     },
   };
-}
-
-function distributionToSeriesData(
-  values: AttributeDistribution[number]['values'],
-  cohortCount: number
-): Array<{label: string; value: number}> {
-  return values
-    .map(value => ({
-      label: value.label,
-      value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
-    }))
-    .slice(0, CHART_MAX_SERIES_LENGTH);
 }
 
 function cohortsToTableData(

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -103,10 +103,12 @@ function distributionToSeriesData(
   values: AttributeDistribution[number]['values'],
   cohortCount: number
 ): Array<{label: string; value: number}> {
-  return values.map(value => ({
-    label: value.label,
-    value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
-  }));
+  return values
+    .map(value => ({
+      label: value.label,
+      value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
+    }))
+    .slice(0, CHART_MAX_SERIES_LENGTH);
 }
 
 function cohortsToTableData(

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -1,0 +1,557 @@
+import {Fragment, useCallback, useMemo} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import type {TooltipComponentFormatterCallbackParams} from 'echarts';
+
+import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {t} from 'sentry/locale';
+import type {
+  TabularColumn,
+  TabularData,
+} from 'sentry/views/dashboards/widgets/common/types';
+import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
+import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+
+import type {AttributeDistribution} from './attributeDistributionContent';
+import {
+  CHART_AXIS_LABEL_FONT_SIZE,
+  CHART_BASELINE_SERIES_NAME,
+  CHART_MAX_BAR_WIDTH,
+  CHART_MAX_SERIES_LENGTH,
+  CHART_SELECTED_SERIES_NAME,
+  COHORT_2_COLOR,
+  MODAL_CHART_HEIGHT,
+} from './constants';
+import {formatComparisonModeTooltip, formatSingleModeTooltip} from './tooltips';
+import {calculateAttributePopulationPercentage, percentageFormatter} from './utils';
+
+type RankedAttribute = AttributeBreakdownsComparison['rankedAttributes'][number];
+type CohortData = RankedAttribute['cohort1'];
+
+// Discriminated union for single vs comparison mode
+type SingleModeOptions = {
+  attributeDistribution: AttributeDistribution[number];
+  cohortCount: number;
+  mode: 'single';
+};
+
+type ComparisonModeOptions = {
+  attribute: RankedAttribute;
+  cohort1Total: number;
+  cohort2Total: number;
+  mode: 'comparison';
+};
+
+export type AttributeBreakdownViewerModalOptions =
+  | SingleModeOptions
+  | ComparisonModeOptions;
+
+type Props = ModalRenderProps & AttributeBreakdownViewerModalOptions;
+
+// Data computation types
+type SingleModeData = {
+  attributeName: string;
+  maxSeriesValue: number;
+  populationPercentages: {primary: number};
+  seriesData: {single: Array<{label: string; value: number}>};
+  tableColumns: TabularColumn[];
+  tableData: TabularData;
+  xAxisData: string[];
+};
+
+type ComparisonModeData = {
+  attributeName: string;
+  maxSeriesValue: number;
+  populationPercentages: {primary: number; secondary: number};
+  seriesData: {
+    [CHART_BASELINE_SERIES_NAME]: Array<{label: string; value: number}>;
+    [CHART_SELECTED_SERIES_NAME]: Array<{label: string; value: number}>;
+  };
+  tableColumns: TabularColumn[];
+  tableData: TabularData;
+  xAxisData: string[];
+};
+
+function distributionToTableData(
+  values: AttributeDistribution[number]['values'],
+  cohortCount: number
+): TabularData {
+  return {
+    data: values.map(v => ({
+      [t('Value')]: v.label,
+      [t('Count')]: v.value,
+      [t('Percentage')]: cohortCount === 0 ? 0 : v.value / cohortCount,
+    })),
+    meta: {
+      fields: {
+        [t('Value')]: 'string',
+        [t('Count')]: 'integer',
+        [t('Percentage')]: 'percentage',
+      },
+      units: {
+        [t('Value')]: null,
+        [t('Count')]: null,
+        [t('Percentage')]: null,
+      },
+    },
+  };
+}
+
+function distributionToSeriesData(
+  values: AttributeDistribution[number]['values'],
+  cohortCount: number
+): Array<{label: string; value: number}> {
+  return values.map(value => ({
+    label: value.label,
+    value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
+  }));
+}
+
+function cohortsToTableData(
+  cohort1: CohortData,
+  cohort2: CohortData,
+  cohort1Total: number,
+  cohort2Total: number
+): TabularData {
+  const cohort1Map = new Map(cohort1.map(({label, value}) => [label, value]));
+  const cohort2Map = new Map(cohort2.map(({label, value}) => [label, value]));
+
+  const uniqueLabels = new Set([...cohort1Map.keys(), ...cohort2Map.keys()]);
+
+  const data = Array.from(uniqueLabels)
+    .map(label => {
+      const selectedVal = cohort1Map.get(label) ?? 0;
+      const baselineVal = cohort2Map.get(label) ?? 0;
+
+      const selectedPercentage = cohort1Total === 0 ? 0 : selectedVal / cohort1Total;
+      const baselinePercentage = cohort2Total === 0 ? 0 : baselineVal / cohort2Total;
+
+      return {
+        [t('Value')]: label,
+        [t('Selected Count')]: selectedVal,
+        [t('Selected %')]: selectedPercentage,
+        [t('Baseline Count')]: baselineVal,
+        [t('Baseline %')]: baselinePercentage,
+        _sortValue: selectedPercentage,
+      };
+    })
+    .sort((a, b) => b._sortValue - a._sortValue)
+    .map(({_sortValue: _, ...rest}) => rest);
+
+  return {
+    data,
+    meta: {
+      fields: {
+        [t('Value')]: 'string',
+        [t('Selected Count')]: 'integer',
+        [t('Selected %')]: 'percentage',
+        [t('Baseline Count')]: 'integer',
+        [t('Baseline %')]: 'percentage',
+      },
+      units: {
+        [t('Value')]: null,
+        [t('Selected Count')]: null,
+        [t('Selected %')]: null,
+        [t('Baseline Count')]: null,
+        [t('Baseline %')]: null,
+      },
+    },
+  };
+}
+
+function cohortsToSeriesData(
+  cohort1: CohortData,
+  cohort2: CohortData,
+  seriesTotals: {
+    [CHART_BASELINE_SERIES_NAME]: number;
+    [CHART_SELECTED_SERIES_NAME]: number;
+  }
+): {
+  [CHART_BASELINE_SERIES_NAME]: Array<{label: string; value: number}>;
+  [CHART_SELECTED_SERIES_NAME]: Array<{label: string; value: number}>;
+} {
+  const cohort1Map = new Map(cohort1.map(({label, value}) => [label, value]));
+  const cohort2Map = new Map(cohort2.map(({label, value}) => [label, value]));
+
+  const uniqueLabels = new Set([...cohort1Map.keys(), ...cohort2Map.keys()]);
+
+  const seriesData = Array.from(uniqueLabels)
+    .map(label => {
+      const selectedVal = cohort1Map.get(label) ?? 0;
+      const baselineVal = cohort2Map.get(label) ?? 0;
+
+      const selectedPercentage =
+        seriesTotals[CHART_SELECTED_SERIES_NAME] === 0
+          ? 0
+          : (selectedVal / seriesTotals[CHART_SELECTED_SERIES_NAME]) * 100;
+      const baselinePercentage =
+        seriesTotals[CHART_BASELINE_SERIES_NAME] === 0
+          ? 0
+          : (baselineVal / seriesTotals[CHART_BASELINE_SERIES_NAME]) * 100;
+
+      return {
+        label,
+        selectedValue: selectedPercentage,
+        baselineValue: baselinePercentage,
+        sortValue: selectedPercentage,
+      };
+    })
+    .sort((a, b) => b.sortValue - a.sortValue)
+    .slice(0, CHART_MAX_SERIES_LENGTH);
+
+  const selectedSeriesData: Array<{label: string; value: number}> = [];
+  const baselineSeriesData: Array<{label: string; value: number}> = [];
+
+  for (const {label, selectedValue, baselineValue} of seriesData) {
+    selectedSeriesData.push({label, value: selectedValue});
+    baselineSeriesData.push({label, value: baselineValue});
+  }
+
+  return {
+    [CHART_SELECTED_SERIES_NAME]: selectedSeriesData,
+    [CHART_BASELINE_SERIES_NAME]: baselineSeriesData,
+  };
+}
+
+// Extract single mode data computation
+function computeSingleModeData(
+  attributeDistribution: AttributeDistribution[number],
+  cohortCount: number
+): SingleModeData {
+  const singleSeriesData = distributionToSeriesData(
+    attributeDistribution.values,
+    cohortCount
+  );
+
+  const singleMaxValue =
+    singleSeriesData.length === 0 ? 0 : Math.max(...singleSeriesData.map(v => v.value));
+
+  const singlePopulation = calculateAttributePopulationPercentage(
+    attributeDistribution.values,
+    cohortCount
+  );
+
+  const singleTableData = distributionToTableData(
+    attributeDistribution.values,
+    cohortCount
+  );
+  const singleTableColumns: TabularColumn[] = [
+    {key: t('Value'), type: 'string'},
+    {key: t('Count'), type: 'integer'},
+    {key: t('Percentage'), type: 'percentage'},
+  ];
+
+  return {
+    attributeName: attributeDistribution.attributeName,
+    maxSeriesValue: singleMaxValue,
+    populationPercentages: {primary: singlePopulation},
+    seriesData: {single: singleSeriesData},
+    tableColumns: singleTableColumns,
+    tableData: singleTableData,
+    xAxisData: singleSeriesData.map(v => v.label),
+  };
+}
+
+// Extract comparison mode data computation
+function computeComparisonModeData(
+  attribute: RankedAttribute,
+  cohort1Total: number,
+  cohort2Total: number
+): ComparisonModeData {
+  const seriesTotals = {
+    [CHART_SELECTED_SERIES_NAME]: cohort1Total,
+    [CHART_BASELINE_SERIES_NAME]: cohort2Total,
+  };
+  const comparisonSeriesData = cohortsToSeriesData(
+    attribute.cohort1,
+    attribute.cohort2,
+    seriesTotals
+  );
+  const selectedSeries = comparisonSeriesData[CHART_SELECTED_SERIES_NAME];
+  const baselineSeries = comparisonSeriesData[CHART_BASELINE_SERIES_NAME];
+  const comparisonMaxValue =
+    selectedSeries.length === 0 && baselineSeries.length === 0
+      ? 0
+      : Math.max(
+          ...selectedSeries.map(c => c.value),
+          ...baselineSeries.map(c => c.value)
+        );
+  const comparisonPopulation = {
+    primary: calculateAttributePopulationPercentage(attribute.cohort1, cohort1Total),
+    secondary: calculateAttributePopulationPercentage(attribute.cohort2, cohort2Total),
+  };
+  const comparisonTableData = cohortsToTableData(
+    attribute.cohort1,
+    attribute.cohort2,
+    cohort1Total,
+    cohort2Total
+  );
+  const comparisonTableColumns: TabularColumn[] = [
+    {key: t('Value'), type: 'string'},
+    {key: t('Selected Count'), type: 'integer'},
+    {key: t('Selected %'), type: 'percentage'},
+    {key: t('Baseline Count'), type: 'integer'},
+    {key: t('Baseline %'), type: 'percentage'},
+  ];
+
+  return {
+    attributeName: attribute.attributeName,
+    maxSeriesValue: comparisonMaxValue,
+    populationPercentages: comparisonPopulation,
+    seriesData: comparisonSeriesData,
+    tableColumns: comparisonTableColumns,
+    tableData: comparisonTableData,
+    xAxisData: selectedSeries.map(c => c.label),
+  };
+}
+
+// Extract chart series creation
+function createSingleModeChartSeries(
+  seriesData: {single: Array<{label: string; value: number}>},
+  primaryColor: string
+) {
+  return [
+    {
+      type: 'bar' as const,
+      data: seriesData.single.map(v => v.value),
+      itemStyle: {
+        color: primaryColor,
+      },
+      barMaxWidth: CHART_MAX_BAR_WIDTH,
+      animation: false,
+    },
+  ];
+}
+
+function createComparisonModeChartSeries(
+  seriesData: {
+    [CHART_BASELINE_SERIES_NAME]: Array<{label: string; value: number}>;
+    [CHART_SELECTED_SERIES_NAME]: Array<{label: string; value: number}>;
+  },
+  primaryColor: string,
+  secondaryColor: string
+) {
+  return [
+    {
+      type: 'bar' as const,
+      data: seriesData[CHART_SELECTED_SERIES_NAME].map(c => c.value),
+      name: CHART_SELECTED_SERIES_NAME,
+      itemStyle: {
+        color: primaryColor,
+      },
+      barMaxWidth: CHART_MAX_BAR_WIDTH,
+      animation: false,
+    },
+    {
+      type: 'bar' as const,
+      data: seriesData[CHART_BASELINE_SERIES_NAME].map(c => c.value),
+      name: CHART_BASELINE_SERIES_NAME,
+      itemStyle: {
+        color: secondaryColor,
+      },
+      barMaxWidth: CHART_MAX_BAR_WIDTH,
+      animation: false,
+    },
+  ];
+}
+
+// Extract population indicator component
+type PopulationIndicatorProps = {
+  color: string;
+  percentage: number;
+  tooltipTitle: string;
+};
+
+function PopulationIndicatorComponent({
+  color,
+  percentage,
+  tooltipTitle,
+}: PopulationIndicatorProps) {
+  return (
+    <PopulationIndicator color={color}>
+      <Tooltip showUnderline title={tooltipTitle}>
+        {percentageFormatter(percentage)}
+      </Tooltip>
+    </PopulationIndicator>
+  );
+}
+
+export default function AttributeBreakdownViewerModal(props: Props) {
+  const {Header, Body, mode} = props;
+  const theme = useTheme();
+
+  const primaryColor = theme.chart.getColorPalette(0)?.[0];
+  const secondaryColor = COHORT_2_COLOR;
+
+  // Compute data based on mode
+  const singleModeData = useMemo(() => {
+    if (mode === 'single') {
+      return computeSingleModeData(props.attributeDistribution, props.cohortCount);
+    }
+    return null;
+  }, [mode, props]);
+
+  const comparisonModeData = useMemo(() => {
+    if (mode === 'comparison') {
+      return computeComparisonModeData(
+        props.attribute,
+        props.cohort1Total,
+        props.cohort2Total
+      );
+    }
+    return null;
+  }, [mode, props]);
+
+  const computedData = singleModeData ?? comparisonModeData!;
+
+  const tooltipFormatter = useCallback(
+    (p: TooltipComponentFormatterCallbackParams) => {
+      if (mode === 'single') {
+        return formatSingleModeTooltip(p);
+      }
+      return formatComparisonModeTooltip(p, primaryColor, secondaryColor);
+    },
+    [mode, primaryColor, secondaryColor]
+  );
+
+  const tooltipConfig: TooltipOption = useMemo(
+    () => ({
+      trigger: 'axis',
+      appendToBody: true,
+      renderMode: 'html',
+      formatter: tooltipFormatter,
+    }),
+    [tooltipFormatter]
+  );
+
+  const chartSeries = useMemo(() => {
+    if (mode === 'single') {
+      return createSingleModeChartSeries(
+        computedData.seriesData as {single: Array<{label: string; value: number}>},
+        primaryColor
+      );
+    }
+    return createComparisonModeChartSeries(
+      computedData.seriesData as {
+        [CHART_BASELINE_SERIES_NAME]: Array<{label: string; value: number}>;
+        [CHART_SELECTED_SERIES_NAME]: Array<{label: string; value: number}>;
+      },
+      primaryColor,
+      secondaryColor
+    );
+  }, [mode, computedData.seriesData, primaryColor, secondaryColor]);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Flex align="center" gap="xl">
+          <h3>{computedData.attributeName}</h3>
+          {mode === 'single' ? (
+            <PopulationIndicatorComponent
+              color={primaryColor}
+              percentage={computedData.populationPercentages.primary}
+              tooltipTitle={t(
+                '%s of spans in your query have this attribute populated',
+                percentageFormatter(computedData.populationPercentages.primary)
+              )}
+            />
+          ) : (
+            <Flex gap="sm">
+              <PopulationIndicatorComponent
+                color={primaryColor}
+                percentage={computedData.populationPercentages.primary}
+                tooltipTitle={t(
+                  '%s of selected cohort has this attribute populated',
+                  percentageFormatter(computedData.populationPercentages.primary)
+                )}
+              />
+              <PopulationIndicatorComponent
+                color={secondaryColor}
+                percentage={comparisonModeData!.populationPercentages.secondary}
+                tooltipTitle={t(
+                  '%s of baseline cohort has this attribute populated',
+                  percentageFormatter(comparisonModeData!.populationPercentages.secondary)
+                )}
+              />
+            </Flex>
+          )}
+        </Flex>
+      </Header>
+      <Body>
+        <Flex direction="column" gap="2xl" height={600}>
+          <Container height={MODAL_CHART_HEIGHT}>
+            <BaseChart
+              height={MODAL_CHART_HEIGHT}
+              isGroupedByDate={false}
+              tooltip={tooltipConfig}
+              grid={{
+                left: 40,
+                right: 20,
+                bottom: 60,
+                top: 20,
+                containLabel: false,
+              }}
+              xAxis={{
+                show: true,
+                type: 'category',
+                data: computedData.xAxisData,
+                truncate: 14,
+                axisLabel: {
+                  hideOverlap: true,
+                  showMaxLabel: true,
+                  showMinLabel: true,
+                  color: theme.tokens.content.secondary,
+                  interval: 0,
+                  fontSize: CHART_AXIS_LABEL_FONT_SIZE,
+                  rotate: computedData.xAxisData.length > 15 ? 45 : 0,
+                },
+              }}
+              yAxis={{
+                type: 'value',
+                interval: computedData.maxSeriesValue < 1 ? 1 : undefined,
+                axisLabel: {
+                  fontSize: 12,
+                  formatter: (value: number) => {
+                    return percentageFormatter(value);
+                  },
+                },
+              }}
+              series={chartSeries}
+            />
+          </Container>
+
+          <TableWidgetVisualization
+            scrollable
+            tableData={computedData.tableData}
+            columns={computedData.tableColumns}
+          />
+        </Flex>
+      </Body>
+    </Fragment>
+  );
+}
+
+const PopulationIndicator = styled(Flex)<{color?: string}>`
+  align-items: center;
+  font-size: ${p => p.theme.fontSize.sm};
+  font-weight: 500;
+  color: ${p => p.color || p.theme.colors.gray500};
+
+  &::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: ${p => p.color || p.theme.colors.gray500};
+    margin-right: ${p => p.theme.space.xs};
+  }
+`;
+
+export const modalCss = css`
+  width: 100%;
+  max-width: 1000px;
+`;

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -26,7 +26,7 @@ import {
   COHORT_2_COLOR,
   MODAL_CHART_HEIGHT,
 } from './constants';
-import {formatComparisonModeTooltip, formatSingleModeTooltip} from './tooltips';
+import {useFormatComparisonModeTooltip, useFormatSingleModeTooltip} from './tooltips';
 import {
   calculateAttributePopulationPercentage,
   distributionToSeriesData,
@@ -372,6 +372,7 @@ function PopulationIndicatorComponent({
 export default function AttributeBreakdownViewerModal(props: Props) {
   const {Header, Body, mode} = props;
   const theme = useTheme();
+  const formatSingleModeTooltip = useFormatSingleModeTooltip();
 
   const primaryColor = theme.chart.getColorPalette(0)?.[0];
   const secondaryColor = COHORT_2_COLOR;
@@ -389,14 +390,19 @@ export default function AttributeBreakdownViewerModal(props: Props) {
     return computeSingleModeData(props.attributeDistribution, props.cohortCount);
   }, [mode, props]);
 
+  const formatComparisonModeTooltip = useFormatComparisonModeTooltip(
+    primaryColor,
+    secondaryColor
+  );
+
   const tooltipFormatter = useCallback(
     (p: TooltipComponentFormatterCallbackParams) => {
       if (mode === 'comparison') {
-        return formatComparisonModeTooltip(p, primaryColor, secondaryColor);
+        return formatComparisonModeTooltip(p);
       }
       return formatSingleModeTooltip(p);
     },
-    [mode, primaryColor, secondaryColor]
+    [mode, formatComparisonModeTooltip, formatSingleModeTooltip]
   );
 
   const tooltipConfig: TooltipOption = useMemo(

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -21,7 +21,6 @@ import {
   CHART_AXIS_LABEL_FONT_SIZE,
   CHART_BASELINE_SERIES_NAME,
   CHART_MAX_BAR_WIDTH,
-  CHART_MAX_SERIES_LENGTH,
   CHART_SELECTED_SERIES_NAME,
   COHORT_2_COLOR,
   MODAL_CHART_HEIGHT,
@@ -29,6 +28,7 @@ import {
 import {useFormatComparisonModeTooltip, useFormatSingleModeTooltip} from './tooltips';
 import {
   calculateAttributePopulationPercentage,
+  cohortsToSeriesData,
   distributionToSeriesData,
   percentageFormatter,
 } from './utils';
@@ -156,60 +156,6 @@ function cohortsToTableData(
         [t('Baseline %')]: null,
       },
     },
-  };
-}
-
-function cohortsToSeriesData(
-  cohort1: CohortData,
-  cohort2: CohortData,
-  seriesTotals: {
-    [CHART_BASELINE_SERIES_NAME]: number;
-    [CHART_SELECTED_SERIES_NAME]: number;
-  }
-): {
-  [CHART_BASELINE_SERIES_NAME]: Array<{label: string; value: number}>;
-  [CHART_SELECTED_SERIES_NAME]: Array<{label: string; value: number}>;
-} {
-  const cohort1Map = new Map(cohort1.map(({label, value}) => [label, value]));
-  const cohort2Map = new Map(cohort2.map(({label, value}) => [label, value]));
-
-  const uniqueLabels = new Set([...cohort1Map.keys(), ...cohort2Map.keys()]);
-
-  const seriesData = Array.from(uniqueLabels)
-    .map(label => {
-      const selectedVal = cohort1Map.get(label) ?? 0;
-      const baselineVal = cohort2Map.get(label) ?? 0;
-
-      const selectedPercentage =
-        seriesTotals[CHART_SELECTED_SERIES_NAME] > 0
-          ? (selectedVal / seriesTotals[CHART_SELECTED_SERIES_NAME]) * 100
-          : 0;
-      const baselinePercentage =
-        seriesTotals[CHART_BASELINE_SERIES_NAME] > 0
-          ? (baselineVal / seriesTotals[CHART_BASELINE_SERIES_NAME]) * 100
-          : 0;
-
-      return {
-        label,
-        selectedValue: selectedPercentage,
-        baselineValue: baselinePercentage,
-        sortValue: selectedPercentage,
-      };
-    })
-    .sort((a, b) => b.sortValue - a.sortValue)
-    .slice(0, CHART_MAX_SERIES_LENGTH);
-
-  const selectedSeriesData: Array<{label: string; value: number}> = [];
-  const baselineSeriesData: Array<{label: string; value: number}> = [];
-
-  for (const {label, selectedValue, baselineValue} of seriesData) {
-    selectedSeriesData.push({label, value: selectedValue});
-    baselineSeriesData.push({label, value: baselineValue});
-  }
-
-  return {
-    [CHART_SELECTED_SERIES_NAME]: selectedSeriesData,
-    [CHART_BASELINE_SERIES_NAME]: baselineSeriesData,
   };
 }
 
@@ -524,7 +470,7 @@ export default function AttributeBreakdownViewerModal(props: Props) {
 
 const PopulationIndicator = styled(Flex)<{color?: string}>`
   align-items: center;
-  font-size: ${p => p.theme.fontSize.sm};
+  font-size: ${p => p.theme.font.size.sm};
   font-weight: 500;
   color: ${p => p.color || p.theme.colors.gray500};
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -1,24 +1,22 @@
 import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {Theme} from '@emotion/react';
-import type {TooltipComponentFormatterCallbackParams} from 'echarts';
 
+import {Button} from '@sentry/scraps/button/button';
 import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
 
+import {openAttributeBreakdownViewerModal} from 'sentry/actionCreators/modal';
 import {Flex} from 'sentry/components/core/layout';
-import {tct} from 'sentry/locale';
+import {IconExpand} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
-import {escape} from 'sentry/utils';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
-import {
-  CHART_MAX_BAR_WIDTH,
-  CHART_MAX_SERIES_LENGTH,
-  CHART_TOOLTIP_MAX_VALUE_LENGTH,
-} from './constants';
+import {CHART_MAX_BAR_WIDTH, CHART_MAX_SERIES_LENGTH} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
+import {formatSingleModeTooltip} from './tooltips';
 import {
-  calculateAttrubutePopulationPercentage,
+  calculateAttributePopulationPercentage,
   percentageFormatter,
   tooltipActionsHtmlRenderer,
 } from './utils';
@@ -63,48 +61,9 @@ export function Chart({
 
   const populationPercentage = useMemo(
     () =>
-      calculateAttrubutePopulationPercentage(attributeDistribution.values, cohortCount),
+      calculateAttributePopulationPercentage(attributeDistribution.values, cohortCount),
     [attributeDistribution.values, cohortCount]
   );
-
-  const toolTipFormatter = useCallback((p: TooltipComponentFormatterCallbackParams) => {
-    const data = Array.isArray(p) ? p[0]?.data : p.data;
-    const pct = percentageFormatter(Number(data));
-
-    const value = Array.isArray(p) ? p[0]?.name : p.name;
-    const truncatedValue = value
-      ? value.length > CHART_TOOLTIP_MAX_VALUE_LENGTH
-        ? `${value.slice(0, CHART_TOOLTIP_MAX_VALUE_LENGTH)}...`
-        : value
-      : '\u2014';
-    const escapedTruncatedValue = escape(truncatedValue);
-    return `
-      <div class="tooltip-series" style="padding: 0;">
-        <div
-          class="tooltip-label"
-          style="
-            display: flex;
-            justify-content: space-between;
-            gap: 20px;
-            margin: 0 auto;
-            padding: 8px 15px;
-            min-width: 100px;
-            cursor: default;
-            max-width: 300px;
-          "
-        >
-          <strong
-            style="
-              word-break: break-word;
-              white-space: normal;
-              overflow-wrap: anywhere;
-            "
-          >${escapedTruncatedValue}</strong>
-          <span>${pct}</span>
-        </div>
-      </div>
-    `.trim();
-  }, []);
 
   const actionsHtmlRenderer = useCallback(
     (value: string) =>
@@ -114,7 +73,7 @@ export function Chart({
 
   const tooltipConfig = useAttributeBreakdownsTooltip({
     chartRef,
-    formatter: toolTipFormatter,
+    formatter: formatSingleModeTooltip,
     chartWidth,
     actionsHtmlRenderer,
   });
@@ -145,7 +104,7 @@ export function Chart({
             {attributeDistribution.attributeName}
           </AttributeBreakdownsComponent.ChartTitle>
         </Tooltip>
-        <Flex gap="sm">
+        <Flex gap="sm" align="center">
           <AttributeBreakdownsComponent.PopulationIndicator color={color}>
             <Tooltip
               showUnderline
@@ -159,6 +118,19 @@ export function Chart({
               {percentageFormatter(populationPercentage)}
             </Tooltip>
           </AttributeBreakdownsComponent.PopulationIndicator>
+          <Button
+            size="zero"
+            borderless
+            icon={<IconExpand size="xs" />}
+            aria-label={t('Expand chart')}
+            onClick={() =>
+              openAttributeBreakdownViewerModal({
+                mode: 'single',
+                attributeDistribution,
+                cohortCount,
+              })
+            }
+          />
         </Flex>
       </AttributeBreakdownsComponent.ChartHeaderWrapper>
       <AttributeBreakdownsComponent.Chart

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -12,26 +12,15 @@ import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
-import {CHART_MAX_BAR_WIDTH, CHART_MAX_SERIES_LENGTH} from './constants';
+import {CHART_MAX_BAR_WIDTH} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
 import {formatSingleModeTooltip} from './tooltips';
 import {
   calculateAttributePopulationPercentage,
+  distributionToSeriesData,
   percentageFormatter,
   tooltipActionsHtmlRenderer,
 } from './utils';
-
-function distributionToSeriesData(
-  values: AttributeDistribution[number]['values'],
-  cohortCount: number
-): Array<{label: string; value: number}> {
-  const seriesData = values.slice(0, CHART_MAX_SERIES_LENGTH).map(value => ({
-    label: value.label,
-    value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
-  }));
-
-  return seriesData;
-}
 
 export function Chart({
   attributeDistribution,

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -14,7 +14,7 @@ import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttri
 import type {AttributeDistribution} from './attributeDistributionContent';
 import {CHART_MAX_BAR_WIDTH} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
-import {formatSingleModeTooltip} from './tooltips';
+import {useFormatSingleModeTooltip} from './tooltips';
 import {
   calculateAttributePopulationPercentage,
   distributionToSeriesData,
@@ -33,6 +33,7 @@ export function Chart({
 }) {
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
+  const formatSingleModeTooltip = useFormatSingleModeTooltip();
 
   const color = theme.chart.getColorPalette(0)?.[0];
 

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -20,7 +20,7 @@ import {
   COHORT_2_COLOR,
 } from './constants';
 import {AttributeBreakdownsComponent} from './styles';
-import {formatComparisonModeTooltip} from './tooltips';
+import {useFormatComparisonModeTooltip} from './tooltips';
 import {
   calculateAttributePopulationPercentage,
   percentageFormatter,
@@ -138,10 +138,14 @@ export function Chart({
     [attribute.cohort1, attribute.cohort2, cohort1Total, cohort2Total]
   );
 
+  const formatComparisonModeTooltip = useFormatComparisonModeTooltip(
+    cohort1Color,
+    cohort2Color
+  );
   const toolTipFormatter = useCallback(
     (p: Parameters<typeof formatComparisonModeTooltip>[0]) =>
-      formatComparisonModeTooltip(p, cohort1Color, cohort2Color),
-    [cohort1Color, cohort2Color]
+      formatComparisonModeTooltip(p),
+    [formatComparisonModeTooltip]
   );
 
   const actionsHtmlRenderer = useCallback(

--- a/static/app/views/explore/components/attributeBreakdowns/constants.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/constants.tsx
@@ -8,3 +8,8 @@ export const CHARTS_PER_PAGE = CHARTS_COLUMN_COUNT * 4;
 
 export const CHART_SELECTION_ALERT_KEY =
   'attribute-breakdowns-chart-selection-alert-dismissed';
+
+export const CHART_SELECTED_SERIES_NAME = 'selected';
+export const CHART_BASELINE_SERIES_NAME = 'baseline';
+export const COHORT_2_COLOR = '#A29FAA';
+export const MODAL_CHART_HEIGHT = 300;

--- a/static/app/views/explore/components/attributeBreakdowns/tooltips.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/tooltips.tsx
@@ -5,8 +5,6 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {useRenderToString} from '@sentry/scraps/renderToString';
 import {Text} from '@sentry/scraps/text';
 
-import {escape} from 'sentry/utils';
-
 import {
   CHART_BASELINE_SERIES_NAME,
   CHART_SELECTED_SERIES_NAME,
@@ -28,7 +26,6 @@ export function useFormatSingleModeTooltip() {
           ? `${value.slice(0, CHART_TOOLTIP_MAX_VALUE_LENGTH)}...`
           : value
         : '\u2014';
-      const escapedTruncatedValue = escape(truncatedValue);
 
       return renderToString(
         // need to set padding on the `style` prop directly because the `padding` props
@@ -51,7 +48,7 @@ export function useFormatSingleModeTooltip() {
                 textAlign: 'center',
               }}
             >
-              {escapedTruncatedValue}
+              {truncatedValue}
             </strong>
             <Text size="sm" variant="muted">
               {pct}
@@ -93,7 +90,6 @@ export function useFormatComparisonModeTooltip(
         name.length > CHART_TOOLTIP_MAX_VALUE_LENGTH
           ? `${name.slice(0, CHART_TOOLTIP_MAX_VALUE_LENGTH)}...`
           : name;
-      const escapedTruncatedName = escape(truncatedName);
 
       return renderToString(
         <Container className="tooltip-series" style={{padding: 0}}>
@@ -114,7 +110,7 @@ export function useFormatComparisonModeTooltip(
                 textAlign: 'center',
               }}
             >
-              {escapedTruncatedName}
+              {truncatedName}
             </strong>
             <Flex as="span" align="center" justify="between" gap="2xl">
               <Flex align="center" gap="sm">

--- a/static/app/views/explore/components/attributeBreakdowns/tooltips.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/tooltips.tsx
@@ -1,0 +1,102 @@
+import type {TooltipComponentFormatterCallbackParams} from 'echarts';
+
+import {escape} from 'sentry/utils';
+
+import {
+  CHART_BASELINE_SERIES_NAME,
+  CHART_SELECTED_SERIES_NAME,
+  CHART_TOOLTIP_MAX_VALUE_LENGTH,
+} from './constants';
+import {percentageFormatter} from './utils';
+
+export function formatSingleModeTooltip(
+  p: TooltipComponentFormatterCallbackParams
+): string {
+  const data = Array.isArray(p) ? p[0]?.data : p.data;
+  const pct = percentageFormatter(Number(data));
+
+  const value = Array.isArray(p) ? p[0]?.name : p.name;
+  const truncatedValue = value
+    ? value.length > CHART_TOOLTIP_MAX_VALUE_LENGTH
+      ? `${value.slice(0, CHART_TOOLTIP_MAX_VALUE_LENGTH)}...`
+      : value
+    : '\u2014';
+  const escapedTruncatedValue = escape(truncatedValue);
+  return `
+    <div class="tooltip-series" style="padding: 0;">
+      <div
+        class="tooltip-label"
+        style="
+          display: flex;
+          justify-content: space-between;
+          gap: 20px;
+          margin: 0 auto;
+          padding: 8px 15px;
+          min-width: 100px;
+          cursor: default;
+          max-width: 300px;
+        "
+      >
+        <strong
+          style="
+            word-break: break-word;
+            white-space: normal;
+            overflow-wrap: anywhere;
+          "
+        >${escapedTruncatedValue}</strong>
+        <span>${pct}</span>
+      </div>
+    </div>
+  `.trim();
+}
+
+export function formatComparisonModeTooltip(
+  p: TooltipComponentFormatterCallbackParams,
+  primaryColor: string,
+  secondaryColor: string
+): string {
+  if (!Array.isArray(p)) {
+    return '\u2014';
+  }
+
+  const selectedParam = p.find(s => s.seriesName === CHART_SELECTED_SERIES_NAME);
+  const baselineParam = p.find(s => s.seriesName === CHART_BASELINE_SERIES_NAME);
+
+  if (!selectedParam || !baselineParam) {
+    return '\u2014';
+  }
+
+  const selectedValue = selectedParam.value;
+  const baselineValue = baselineParam.value;
+  const selectedPct = percentageFormatter(Number(selectedValue));
+  const baselinePct = percentageFormatter(Number(baselineValue));
+
+  const name = selectedParam.name ?? baselineParam.name ?? '';
+  const truncatedName =
+    name.length > CHART_TOOLTIP_MAX_VALUE_LENGTH
+      ? `${name.slice(0, CHART_TOOLTIP_MAX_VALUE_LENGTH)}...`
+      : name;
+  const escapedTruncatedName = escape(truncatedName);
+
+  return `
+    <div class="tooltip-series" style="padding: 0;">
+      <div class="tooltip-label" style="display: flex; flex-direction: column; align-items: stretch; gap: 8px; margin: 0 auto; padding: 8px 15px; min-width: 100px; max-width: 300px; cursor: default;">
+        <strong style="word-break: break-word; white-space: normal; overflow-wrap: anywhere; text-align: center;">${escapedTruncatedName}</strong>
+        <span style="display: flex; align-items: center; justify-content: space-between; gap: 20px;">
+          <span style="display: flex; align-items: center; gap: 6px;">
+            <span style="width: 8px; height: 8px; border-radius: 50%; background-color: ${primaryColor}; display: inline-block;"></span>
+            selected
+          </span>
+          <span>${selectedPct}</span>
+        </span>
+        <span style="display: flex; align-items: center; justify-content: space-between; gap: 20px;">
+          <span style="display: flex; align-items: center; gap: 6px;">
+            <span style="width: 8px; height: 8px; border-radius: 50%; background-color: ${secondaryColor}; display: inline-block;"></span>
+            baseline
+          </span>
+          <span>${baselinePct}</span>
+        </span>
+      </div>
+    </div>
+  `.trim();
+}

--- a/static/app/views/explore/components/attributeBreakdowns/utils.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/utils.tsx
@@ -1,9 +1,10 @@
 import {t} from 'sentry/locale';
 import {escape} from 'sentry/utils';
 import type {Theme} from 'sentry/utils/theme';
+import type {AttributeDistribution} from 'sentry/views/explore/components/attributeBreakdowns/attributeDistributionContent';
 import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 
-import {CHART_AXIS_LABEL_FONT_SIZE} from './constants';
+import {CHART_AXIS_LABEL_FONT_SIZE, CHART_MAX_SERIES_LENGTH} from './constants';
 
 export function calculateAttributePopulationPercentage(
   values: Array<{
@@ -124,4 +125,16 @@ export function tooltipActionsHtmlRenderer(
   ]
     .join('\n')
     .trim();
+}
+
+export function distributionToSeriesData(
+  values: AttributeDistribution[number]['values'],
+  cohortCount: number
+): Array<{label: string; value: number}> {
+  return values
+    .map(value => ({
+      label: value.label,
+      value: cohortCount === 0 ? 0 : (value.value / cohortCount) * 100,
+    }))
+    .slice(0, CHART_MAX_SERIES_LENGTH);
 }

--- a/static/app/views/explore/components/attributeBreakdowns/utils.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/utils.tsx
@@ -5,7 +5,7 @@ import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip'
 
 import {CHART_AXIS_LABEL_FONT_SIZE} from './constants';
 
-export function calculateAttrubutePopulationPercentage(
+export function calculateAttributePopulationPercentage(
   values: Array<{
     label: string;
     value: number;


### PR DESCRIPTION
This PR adds the functionality for users to be able to expand their attribute breakdown charts (single, and comparison mode) into a modal with the chart and table data so they can inspect the data more closely.

Ticket: EXP-714

Screenshots:

Single mode:
<img width="995" height="740" alt="Screenshot 2026-01-20 at 10 42 34" src="https://github.com/user-attachments/assets/2677b904-2da4-4c8c-a913-e267f31ec6b3" />

Comparison mode:
<img width="1006" height="743" alt="Screenshot 2026-01-20 at 10 40 30" src="https://github.com/user-attachments/assets/930fa150-4e3f-460a-8518-347ba6da579a" />