### PR TITLE
chore: Split explorer index projects over 23h

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1246,12 +1246,7 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "seer.explorer_index.run_frequency.minutes",
-    type=Int,
-    default=1440,  # 24 hours
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
+
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}
 register(

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -40,6 +40,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
         Tuple of (project_id, organization_id)
     """
     projects = Project.objects.filter(status=ObjectStatus.ACTIVE).select_related("organization")
+    current_hour = django_timezone.now().hour
 
     for project in RangeQuerySetWrapper(
         projects,
@@ -52,7 +53,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
         if not project.flags.has_transactions:
             continue
 
-        if project.id % 23 != django_timezone.now().hour:
+        if project.id % 23 != current_hour:
             continue
 
         with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -18,7 +18,6 @@ from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.statistical_detectors import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
-from sentry.utils.cache import cache
 from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger("sentry.tasks.seer_explorer_indexer")
@@ -49,6 +48,12 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
         if options.get("seer.explorer_index.killswitch.enable"):
             logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
             return
+
+        if not project.flags.has_transactions:
+            continue
+
+        if project.id % 23 != django_timezone.now().hour:
+            continue
 
         with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):
             batch_result = features.batch_has(FEATURE_NAMES, organization=project.organization)
@@ -90,17 +95,6 @@ def schedule_explorer_index() -> None:
         logger.info("seer.explorer_index.enable flag is disabled")
         return
 
-    last_run = cache.get(LAST_RUN_CACHE_KEY)
-
-    # Default is 24 hours, making it an option so we can trigger
-    # the run at higher frequencies as we roll it out.
-    explorer_index_run_frequency = timedelta(
-        minutes=options.get("seer.explorer_index.run_frequency.minutes")
-    )
-    if last_run and last_run > django_timezone.now() - explorer_index_run_frequency:
-        logger.info("Index updated less than 24 hours ago, skiping")
-        return
-
     now = django_timezone.now()
 
     projects = get_seer_explorer_enabled_projects()
@@ -110,8 +104,6 @@ def schedule_explorer_index() -> None:
     scheduled_count = 0
     for _ in projects:
         scheduled_count += 1
-
-    cache.set(LAST_RUN_CACHE_KEY, now, LAST_RUN_CACHE_TIMEOUT)
 
     logger.info(
         "Successfully scheduled explorer index jobs for valid projects",
@@ -139,9 +131,7 @@ def dispatch_explorer_index_projects(
     batch: list[tuple[int, int]] = []
     count = 0
 
-    explorer_index_run_frequency = timedelta(
-        minutes=options.get("seer.explorer_index.run_frequency.minutes")
-    )
+    explorer_index_run_frequency = timedelta(hours=1)
 
     for project_id, org_id in all_projects:
         batch.append((project_id, org_id))

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -26,8 +26,8 @@ LAST_RUN_CACHE_KEY = "seer:explorer_index:last_run"
 LAST_RUN_CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours
 
 EXPLORER_INDEX_PROJECTS_PER_BATCH = 100
-# Use a larger prime number to spread indexing tasks throughout the day
-EXPLORER_INDEX_DISPATCH_STEP = timedelta(seconds=127)
+# Use a larger prime number to prevent thundering
+EXPLORER_INDEX_DISPATCH_STEP = timedelta(seconds=37)
 
 FEATURE_NAMES = ["organizations:gen-ai-features", "organizations:seer-explorer-index"]
 

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -17,11 +17,11 @@ from sentry.tasks.seer_explorer_index import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils.cache import cache
 
 
 @django_db_all
 class TestGetSeerExplorerEnabledProjects(TestCase):
+    @freeze_time("2024-01-15 12:00:00")
     def test_returns_projects_with_feature_flag(self):
         org1 = self.create_organization()
         org2 = self.create_organization()
@@ -33,6 +33,13 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         project3 = self.create_project(organization=org2)
         project4 = self.create_project(organization=org3)
         project5 = self.create_project(organization=org4)
+
+        project1.flags.has_transactions = True
+        project1.save()
+        project2.flags.has_transactions = True
+        project2.save()
+        project3.flags.has_transactions = True
+        project3.save()
 
         PromptsActivity.objects.create(
             organization_id=org1.id,
@@ -56,17 +63,25 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             result = list(get_seer_explorer_enabled_projects())
 
         project_ids = [p[0] for p in result]
-        assert project1.id in project_ids
-        assert project2.id in project_ids
-        assert project3.id in project_ids
+        expected_ids = []
+        for p in [project1, project2, project3]:
+            if p.id % 23 == 12:
+                expected_ids.append(p.id)
+
+        assert all(pid in project_ids for pid in expected_ids)
         assert project4.id not in project_ids
         assert project5.id not in project_ids
-        assert result[0] == (project1.id, org1.id)
 
+    @freeze_time("2024-01-15 12:00:00")
     def test_excludes_inactive_projects(self):
         org = self.create_organization()
         active_project = self.create_project(organization=org)
         inactive_project = self.create_project(organization=org)
+
+        active_project.flags.has_transactions = True
+        active_project.save()
+        inactive_project.flags.has_transactions = True
+        inactive_project.save()
 
         inactive_project.update(status=ObjectStatus.PENDING_DELETION)
 
@@ -86,7 +101,8 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             result = list(get_seer_explorer_enabled_projects())
 
         project_ids = [p[0] for p in result]
-        assert active_project.id in project_ids
+        if active_project.id % 23 == 12:
+            assert active_project.id in project_ids
         assert inactive_project.id not in project_ids
 
     def test_returns_empty_without_feature_flag(self):
@@ -127,9 +143,13 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert len(result) == 0
         assert project.id not in [p[0] for p in result]
 
+    @freeze_time("2024-01-15 12:00:00")
     def test_excludes_projects_without_seer_acknowledgement(self):
         org = self.create_organization()
         project = self.create_project(organization=org)
+
+        project.flags.has_transactions = True
+        project.save()
 
         with self.feature(
             {
@@ -142,13 +162,72 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert len(result) == 0
         assert project.id not in [p[0] for p in result]
 
+    @freeze_time("2024-01-15 12:00:00")
+    def test_excludes_projects_without_transactions(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        PromptsActivity.objects.create(
+            organization_id=org.id,
+            project_id=0,
+            user_id=self.user.id,
+            feature="seer_autofix_setup_acknowledged",
+        )
+
+        with self.feature(
+            {
+                "organizations:gen-ai-features": [org.slug],
+                "organizations:seer-explorer-index": [org.slug],
+            }
+        ):
+            result = list(get_seer_explorer_enabled_projects())
+
+        assert len(result) == 0
+        assert project.id not in [p[0] for p in result]
+
+    @freeze_time("2024-01-15 12:00:00")
+    def test_includes_only_projects_matching_hour_shard(self):
+        org = self.create_organization()
+
+        matching_project = None
+        non_matching_project = None
+
+        for i in range(100):
+            p = self.create_project(organization=org)
+            p.flags.has_transactions = True
+            p.save()
+            if p.id % 23 == 12 and matching_project is None:
+                matching_project = p
+            elif p.id % 23 != 12 and non_matching_project is None:
+                non_matching_project = p
+
+            if matching_project and non_matching_project:
+                break
+
+        PromptsActivity.objects.create(
+            organization_id=org.id,
+            project_id=0,
+            user_id=self.user.id,
+            feature="seer_autofix_setup_acknowledged",
+        )
+
+        with self.feature(
+            {
+                "organizations:gen-ai-features": [org.slug],
+                "organizations:seer-explorer-index": [org.slug],
+            }
+        ):
+            result = list(get_seer_explorer_enabled_projects())
+
+        project_ids = [p[0] for p in result]
+        if matching_project:
+            assert matching_project.id in project_ids
+        if non_matching_project:
+            assert non_matching_project.id not in project_ids
+
 
 @django_db_all
 class TestScheduleExplorerIndex(TestCase):
-    def setUp(self):
-        super().setUp()
-        cache.clear()
-
     def test_skips_when_option_disabled(self):
         with self.options({"seer.explorer_index.enable": False}):
             with mock.patch(
@@ -160,7 +239,10 @@ class TestScheduleExplorerIndex(TestCase):
     @freeze_time("2024-01-15 12:00:00")
     def test_schedules_projects_with_option_enabled(self):
         org = self.create_organization()
-        self.create_project(organization=org)
+        project = self.create_project(organization=org)
+
+        project.flags.has_transactions = True
+        project.save()
 
         PromptsActivity.objects.create(
             organization_id=org.id,
@@ -169,9 +251,7 @@ class TestScheduleExplorerIndex(TestCase):
             feature="seer_autofix_setup_acknowledged",
         )
 
-        with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.run_frequency.minutes": 1440}
-        ):
+        with self.options({"seer.explorer_index.enable": True}):
             with self.feature(
                 {
                     "organizations:gen-ai-features": [org.slug],
@@ -185,38 +265,6 @@ class TestScheduleExplorerIndex(TestCase):
                     schedule_explorer_index()
                     mock_dispatch.assert_called_once()
 
-    @freeze_time("2024-01-15 12:00:00")
-    def test_respects_cache_interval(self):
-        org = self.create_organization()
-        self.create_project(organization=org)
-
-        PromptsActivity.objects.create(
-            organization_id=org.id,
-            project_id=0,
-            user_id=self.user.id,
-            feature="seer_autofix_setup_acknowledged",
-        )
-
-        with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.run_frequency.minutes": 1440}
-        ):
-            with self.feature(
-                {
-                    "organizations:gen-ai-features": [org.slug],
-                    "organizations:seer-explorer-index": [org.slug],
-                }
-            ):
-                with mock.patch(
-                    "sentry.tasks.seer_explorer_index.dispatch_explorer_index_projects"
-                ) as mock_dispatch:
-                    mock_dispatch.return_value = iter([])
-
-                    schedule_explorer_index()
-                    assert mock_dispatch.call_count == 1
-
-                    schedule_explorer_index()
-                    assert mock_dispatch.call_count == 1
-
 
 @django_db_all
 class TestDispatchExplorerIndexProjects(TestCase):
@@ -225,11 +273,10 @@ class TestDispatchExplorerIndexProjects(TestCase):
         timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         projects = [(i, 1) for i in range(150)]
 
-        with self.options({"seer.explorer_index.run_frequency.minutes": 1440}):
-            with mock.patch(
-                "sentry.tasks.seer_explorer_index.run_explorer_index_for_projects.apply_async"
-            ) as mock_task:
-                result = list(dispatch_explorer_index_projects(iter(projects), timestamp))
+        with mock.patch(
+            "sentry.tasks.seer_explorer_index.run_explorer_index_for_projects.apply_async"
+        ) as mock_task:
+            result = list(dispatch_explorer_index_projects(iter(projects), timestamp))
 
         assert mock_task.call_count == 2
         assert len(mock_task.call_args_list[0][1]["args"][0]) == 100


### PR DESCRIPTION
Flagpole evaluations take about 10ms, which lets us evaluate about 60k projects
in 10 min. This is not fast enough. This PR is doing a couple things:
- checks has_transaction flag since indexer only runs when transactions are enabled
- splits up the projects over 23 hours (same logic as the seer job last hour is used for cleanup)