### PR TITLE
feat(security): allow collection of COOP reports

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -580,7 +580,7 @@ CSP_REPORT_ONLY = True
 
 COOP_ENABLED = False
 COOP_REPORT_ONLY = True
-COOP_REPORT_TO = None
+COOP_REPORT_TO: str | None = None
 
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -578,6 +578,10 @@ if ENVIRONMENT == "development":
 # To enforce CSP (block violated resources), update the following parameter to False
 CSP_REPORT_ONLY = True
 
+COOP_ENABLED = False
+COOP_REPORT_ONLY = True
+COOP_REPORT_TO = None
+
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned

--- a/src/sentry/middleware/security.py
+++ b/src/sentry/middleware/security.py
@@ -1,6 +1,9 @@
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
+
+from sentry.utils import json
 
 
 class SecurityHeadersMiddleware(MiddlewareMixin):
@@ -13,4 +16,28 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
             response.setdefault("X-Frame-Options", "deny")
         response.setdefault("X-Content-Type-Options", "nosniff")
         response.setdefault("X-XSS-Protection", "1; mode=block")
+
+        # Add COOP and Report-To headers if COOP_ENABLED
+        if getattr(settings, "COOP_ENABLED", False):
+            coop_report_to = getattr(settings, "COOP_REPORT_TO", None)
+
+            coop_value = "same-origin"
+            if coop_report_to:
+                coop_value += '; report-to="coop-endpoint"'
+
+            coop_header = "Cross-Origin-Opener-Policy-Report-Only"
+            if not getattr(settings, "COOP_REPORT_ONLY", True):
+                coop_header = "Cross-Origin-Opener-Policy"
+
+            response[coop_header] = coop_value
+
+            if coop_report_to:
+                response["Report-To"] = json.dumps(
+                    {
+                        "group": "coop-endpoint",
+                        "max_age": 86400,
+                        "endpoints": [{"url": coop_report_to}],
+                    }
+                )
+
         return response

--- a/tests/sentry/middleware/test_security.py
+++ b/tests/sentry/middleware/test_security.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from functools import cached_property
+from unittest import TestCase
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from sentry.middleware.security import SecurityHeadersMiddleware
+from sentry.utils import json
+
+
+class SecurityHeadersMiddlewareTest(TestCase):
+    middleware = cached_property(SecurityHeadersMiddleware)
+
+    @cached_property
+    def factory(self):
+        return RequestFactory()
+
+    def test_standard_headers_set(self) -> None:
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["X-Content-Type-Options"] == "nosniff"
+        assert processed_response["X-XSS-Protection"] == "1; mode=block"
+        assert processed_response["X-Frame-Options"] == "deny"
+
+    def test_x_frame_options_not_set_for_jira_extensions(self) -> None:
+        request = self.factory.get("/extensions/jira/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "X-Frame-Options" not in processed_response
+        assert processed_response["X-Content-Type-Options"] == "nosniff"
+        assert processed_response["X-XSS-Protection"] == "1; mode=block"
+
+    def test_coop_headers_not_set_when_disabled(self) -> None:
+        """Test that COOP headers are not set when COOP_ENABLED=False (default)"""
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "Cross-Origin-Opener-Policy" not in processed_response
+        assert "Cross-Origin-Opener-Policy-Report-Only" not in processed_response
+        assert "Report-To" not in processed_response
+
+    @override_settings(COOP_ENABLED=True)
+    def test_coop_headers_set_when_enabled_without_report_to(self) -> None:
+        """Test that COOP headers are set when COOP_ENABLED=True and COOP_REPORT_TO=None"""
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Cross-Origin-Opener-Policy-Report-Only"] == "same-origin"
+        assert "Cross-Origin-Opener-Policy" not in processed_response
+        assert "Report-To" not in processed_response
+
+    @override_settings(COOP_ENABLED=True, COOP_REPORT_ONLY=False)
+    def test_coop_headers_set_when_enabled_report_only_false_without_report_to(self) -> None:
+        """Test that COOP headers are set when COOP_ENABLED=True, COOP_REPORT_ONLY=False, and COOP_REPORT_TO=None"""
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Cross-Origin-Opener-Policy"] == "same-origin"
+        assert "Cross-Origin-Opener-Policy-Report-Only" not in processed_response
+        assert "Report-To" not in processed_response
+
+    @override_settings(COOP_ENABLED=True, COOP_REPORT_TO="https://example.com/callback/")
+    def test_coop_headers_set_when_enabled_with_report_to(self) -> None:
+        """Test that COOP headers are set when COOP_ENABLED=True and COOP_REPORT_TO is configured"""
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Cross-Origin-Opener-Policy-Report-Only"]
+            == 'same-origin; report-to="coop-endpoint"'
+        )
+
+        report_to = json.loads(processed_response["Report-To"])
+        assert report_to["group"] == "coop-endpoint"
+        assert report_to["max_age"] == 86400
+        assert len(report_to["endpoints"]) == 1
+        assert report_to["endpoints"][0]["url"] == "https://example.com/callback/"
+
+    @override_settings(
+        COOP_ENABLED=True, COOP_REPORT_ONLY=False, COOP_REPORT_TO="https://example.com/callback/"
+    )
+    def test_coop_headers_set_when_enabled_report_only_false_with_report_to(self) -> None:
+        """Test that COOP headers are set when COOP_ENABLED=True, COOP_REPORT_ONLY=False, and COOP_REPORT_TO is configured"""
+        request = self.factory.get("/")
+        response = HttpResponse()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Cross-Origin-Opener-Policy"]
+            == 'same-origin; report-to="coop-endpoint"'
+        )
+
+        report_to = json.loads(processed_response["Report-To"])
+        assert report_to["group"] == "coop-endpoint"
+        assert report_to["max_age"] == 86400
+        assert len(report_to["endpoints"]) == 1
+        assert report_to["endpoints"][0]["url"] == "https://example.com/callback/"

--- a/tests/sentry/middleware/test_security.py
+++ b/tests/sentry/middleware/test_security.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from functools import cached_property
 from unittest import TestCase
 
-from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
+from rest_framework.response import Response
 
 from sentry.middleware.security import SecurityHeadersMiddleware
 from sentry.utils import json
@@ -19,7 +19,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
 
     def test_standard_headers_set(self) -> None:
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert processed_response["X-Content-Type-Options"] == "nosniff"
@@ -28,7 +28,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
 
     def test_x_frame_options_not_set_for_jira_extensions(self) -> None:
         request = self.factory.get("/extensions/jira/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert "X-Frame-Options" not in processed_response
@@ -38,7 +38,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
     def test_coop_headers_not_set_when_disabled(self) -> None:
         """Test that COOP headers are not set when COOP_ENABLED=False (default)"""
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert "Cross-Origin-Opener-Policy" not in processed_response
@@ -49,7 +49,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
     def test_coop_headers_set_when_enabled_without_report_to(self) -> None:
         """Test that COOP headers are set when COOP_ENABLED=True and COOP_REPORT_TO=None"""
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert processed_response["Cross-Origin-Opener-Policy-Report-Only"] == "same-origin"
@@ -60,7 +60,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
     def test_coop_headers_set_when_enabled_report_only_false_without_report_to(self) -> None:
         """Test that COOP headers are set when COOP_ENABLED=True, COOP_REPORT_ONLY=False, and COOP_REPORT_TO=None"""
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert processed_response["Cross-Origin-Opener-Policy"] == "same-origin"
@@ -71,7 +71,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
     def test_coop_headers_set_when_enabled_with_report_to(self) -> None:
         """Test that COOP headers are set when COOP_ENABLED=True and COOP_REPORT_TO is configured"""
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert (
@@ -91,7 +91,7 @@ class SecurityHeadersMiddlewareTest(TestCase):
     def test_coop_headers_set_when_enabled_report_only_false_with_report_to(self) -> None:
         """Test that COOP headers are set when COOP_ENABLED=True, COOP_REPORT_ONLY=False, and COOP_REPORT_TO is configured"""
         request = self.factory.get("/")
-        response = HttpResponse()
+        response = Response()
         processed_response = self.middleware.process_response(request, response)
 
         assert (


### PR DESCRIPTION
Allow setting of [COOP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy) that intends to protect Sentry instances against [some cross-origin attacks](https://xsleaks.dev/).

Django provides a native setting `SECURE_CROSS_ORIGIN_OPENER_POLICY` (since https://github.com/django/django/pull/14189) but we want to be more flexible with the rollout and also collect violation reports before enforcing the policy.

This PR does not change the behavior because `COOP_ENABLED = False` is set by default.