### PR TITLE
fix(agent-insights): Trace drawer open event fired too often

### DIFF
--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -87,6 +87,7 @@ const rightAlignColumns = new Set([
 ]);
 
 export function TracesTable() {
+  const {openTraceViewDrawer} = useTraceViewDrawer();
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
     columns: defaultColumnOrder,
   });
@@ -233,9 +234,16 @@ export function TracesTable() {
 
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<string>, dataRow: TableData) => {
-      return <BodyCell column={column} dataRow={dataRow} query={combinedQuery} />;
+      return (
+        <BodyCell
+          column={column}
+          dataRow={dataRow}
+          query={combinedQuery}
+          openTraceViewDrawer={openTraceViewDrawer}
+        />
+      );
     },
-    [combinedQuery]
+    [combinedQuery, openTraceViewDrawer]
   );
 
   return (
@@ -265,14 +273,15 @@ const BodyCell = memo(function BodyCell({
   column,
   dataRow,
   query,
+  openTraceViewDrawer,
 }: {
   column: GridColumnHeader<string>;
   dataRow: TableData;
+  openTraceViewDrawer: (traceSlug: string, spanId?: string, timestamp?: number) => void;
   query: string;
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const {openTraceViewDrawer} = useTraceViewDrawer();
 
   switch (column.key) {
     case 'traceId':


### PR DESCRIPTION
The `useTraceViewDrawer()` hook fires the `agent-monitoring.drawer.open` analytics event on mount if the trace url param is set.
As it was used inside the BodyCell component, it would fire this event for each cell in the table (60 times).

This PR moves the hook into the parent (TracesTable) component.