### PR TITLE
fix(aci): Hide 'All environments' option in uptime detector form

### DIFF
--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -68,7 +68,7 @@ export function NewCronDetectorForm() {
       initialFormData={{
         scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
       }}
-      noEnvironment
+      environment={false}
       disabledCreate={
         showingPlatformGuide
           ? t(
@@ -88,7 +88,7 @@ export function EditExistingCronDetectorForm({detector}: {detector: CronDetector
       detector={detector}
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
       savedDetectorToFormData={cronSavedDetectorToFormData}
-      noEnvironment
+      environment={false}
     >
       <CronDetectorForm detector={detector} />
     </EditDetectorLayout>

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -23,9 +23,8 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   detector: TDetector;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
-  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
+  environment?: React.ComponentProps<typeof DetectorBaseFields>['environment'];
   mapFormErrors?: (error: any) => any;
-  noEnvironment?: boolean;
   previewChart?: React.ReactNode;
 };
 
@@ -40,8 +39,7 @@ export function EditDetectorLayout<
   formDataToEndpointPayload,
   savedDetectorToFormData,
   mapFormErrors,
-  noEnvironment,
-  envFieldProps,
+  environment,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
@@ -75,10 +73,7 @@ export function EditDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields
-            noEnvironment={noEnvironment}
-            envFieldProps={envFieldProps}
-          />
+          <DetectorBaseFields environment={environment} />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -22,9 +22,8 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
   disabledCreate?: string;
-  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
+  environment?: React.ComponentProps<typeof DetectorBaseFields>['environment'];
   mapFormErrors?: (error: any) => any;
-  noEnvironment?: boolean;
   previewChart?: React.ReactNode;
 };
 
@@ -37,8 +36,7 @@ export function NewDetectorLayout<
   initialFormData,
   disabledCreate,
   mapFormErrors,
-  noEnvironment,
-  envFieldProps,
+  environment,
   previewChart,
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
@@ -87,10 +85,7 @@ export function NewDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields
-            noEnvironment={noEnvironment}
-            envFieldProps={envFieldProps}
-          />
+          <DetectorBaseFields environment={environment} />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -7,6 +7,7 @@ import {AutomateSection} from 'sentry/views/detectors/components/forms/automateS
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
 import {DescribeSection} from 'sentry/views/detectors/components/forms/common/describeSection';
 import {useSetAutomaticName} from 'sentry/views/detectors/components/forms/common/useSetAutomaticName';
+import type {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
 import {UptimeDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/uptime/detect';
@@ -17,6 +18,9 @@ import {
 import {UptimeRegionWarning} from 'sentry/views/detectors/components/forms/uptime/regionWarning';
 import {UptimeDetectorResolveSection} from 'sentry/views/detectors/components/forms/uptime/resolve';
 import {UptimeDetectorVerificationSection} from 'sentry/views/detectors/components/forms/uptime/verification';
+
+const ENVIRONMENT_CONFIG: React.ComponentProps<typeof DetectorBaseFields>['environment'] =
+  {includeAllEnvironments: false, fieldProps: {required: true}};
 
 function UptimeDetectorForm() {
   const theme = useTheme();
@@ -58,7 +62,7 @@ export function NewUptimeDetectorForm() {
       detectorType="uptime_domain_failure"
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       initialFormData={{}}
-      envFieldProps={{required: true}}
+      environment={ENVIRONMENT_CONFIG}
     >
       <UptimeDetectorForm />
     </NewDetectorLayout>
@@ -71,7 +75,7 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
       detector={detector}
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       savedDetectorToFormData={uptimeSavedDetectorToFormData}
-      envFieldProps={{required: true}}
+      environment={ENVIRONMENT_CONFIG}
     >
       <UptimeDetectorForm />
     </EditDetectorLayout>

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -797,6 +797,10 @@ describe('DetectorEdit', () => {
       await userEvent.click(bodyInput);
       await userEvent.paste('{"test": "data"}');
 
+      await selectEvent.openMenu(screen.getByLabelText('Select Environment'));
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'All Environments'})
+      ).not.toBeInTheDocument();
       await selectEvent.select(screen.getByLabelText('Select Environment'), 'production');
 
       await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));


### PR DESCRIPTION
Fixes ID-1235

Also does a small refactor of the props to allow better configuration of the environment field

<img width="1122" height="644" alt="CleanShot 2026-01-20 at 09 50 52@2x" src="https://github.com/user-attachments/assets/bb1b65ca-e47f-43be-a9d4-6be6e12374aa" />
