### PR TITLE
fix(preprod): correctly attribute rate limiting errors

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -12,10 +12,7 @@ from sentry.api.event_search import SearchConfig, SearchFilter, parse_search_que
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
 from sentry.integrations.base import IntegrationInstallation
-from sentry.integrations.github.status_check import (
-    GitHubCheckConclusion,
-    GitHubCheckStatus,
-)
+from sentry.integrations.github.status_check import GitHubCheckConclusion, GitHubCheckStatus
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.source_code_management.metrics import (

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -831,37 +831,32 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
             except ApiForbiddenError as e:
                 lifecycle.record_failure(e)
                 error_message = str(e).lower()
-                # Github uses 403 codes for some rate limiting errors which are captured as ApiForbiddenError
                 if "rate limit exceeded" in error_message:
                     raise ApiRateLimitedError("GitHub rate limit exceeded") from e
-
+                if (
+                    "resource not accessible" in error_message
+                    or "insufficient" in error_message
+                    or "permission" in error_message
+                ):
+                    logger.exception(
+                        "preprod.status_checks.create.insufficient_permissions",
+                        extra={
+                            "organization_id": self.organization_id,
+                            "integration_id": self.integration_id,
+                            "repo": repo,
+                            "error_message": str(e),
+                        },
+                    )
+                    raise IntegrationConfigurationError(
+                        "GitHub App lacks permissions to create check runs. "
+                        "Please ensure the app has the required permissions and that "
+                        "the organization has accepted any updated permissions."
+                    ) from e
                 raise
             except ApiError as e:
                 lifecycle.record_failure(e)
-                # Only convert specific permission 403s as IntegrationConfigurationError
-                # GitHub can return 403 for various reasons (rate limits, temporary issues, permissions)
-                if e.code == 403:
-                    error_message = str(e).lower()
-                    if (
-                        "resource not accessible" in error_message
-                        or "insufficient" in error_message
-                        or "permission" in error_message
-                    ):
-                        logger.exception(
-                            "preprod.status_checks.create.insufficient_permissions",
-                            extra={
-                                "organization_id": self.organization_id,
-                                "integration_id": self.integration_id,
-                                "repo": repo,
-                                "error_message": str(e),
-                            },
-                        )
-                        raise IntegrationConfigurationError(
-                            "GitHub App lacks permissions to create check runs. "
-                            "Please ensure the app has the required permissions and that "
-                            "the organization has accepted any updated permissions."
-                        ) from e
-                elif e.code and 400 <= e.code < 500 and e.code != 429:
+                # 403s are handled by ApiForbiddenError above
+                if e.code and 400 <= e.code < 500 and e.code not in (403, 429):
                     logger.exception(
                         "preprod.status_checks.create.client_error",
                         extra={

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -69,7 +69,7 @@ preprod_artifact_search_config = SearchConfig.create_from(
     name="sentry.preprod.tasks.create_preprod_status_check",
     namespace=preprod_tasks,
     processing_deadline_duration=30,
-    retry=Retry(times=3, delay=60, ignore=(IntegrationConfigurationError,)),
+    retry=Retry(times=3, delay=60, on=(ApiRateLimitedError,)),
     silo_mode=SiloMode.REGION,
 )
 def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) -> None:


### PR DESCRIPTION
Ultimately doesn't change any behavior since we were still retrying off the old error type, but should let us better attribute how often rate limiting is happening. In our backend logs you can see these come back as 403 which triggers some ApiForbidden error logic in our base integrations code:

```
File "/usr/src/sentry/src/sentry/shared_integrations/client/base.py", line 280, in _request
    raise ApiError.from_response(error_resp, url=full_url) from e
sentry.shared_integrations.exceptions.ApiForbiddenError: {"message":"API rate limit exceeded for installation ID XXX. If you reach out to GitHub Support for help, please include the request ID XXXX and timestamp XXXX UTC. For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service)","documentation_url":"https://docs.github.com/rest/overview/rate-limits-for-the-rest-api","status":"403"}"
```