### PR TITLE
fix(aci): Default alert builder action filters to 'all'

### DIFF
--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -200,7 +200,7 @@ const initialAutomationBuilderState: AutomationBuilderState = {
   actionFilters: [
     {
       id: '0',
-      logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+      logicType: DataConditionGroupLogicType.ALL,
       conditions: [],
       actions: [],
     },

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -167,7 +167,7 @@ describe('AutomationNewSettings', () => {
             environment: null,
             actionFilters: [
               {
-                logicType: 'any-short',
+                logicType: 'all',
                 conditions: [
                   {
                     type: 'tagged_event',


### PR DESCRIPTION
This matches the behavior of issue alerts and is a bit more intuitive as the default.

<img width="638" height="448" alt="CleanShot 2026-01-20 at 10 37 11@2x" src="https://github.com/user-attachments/assets/11620742-1b3c-4db4-8ef3-13658563b3be" />
