### PR TITLE
feat(explore): Search api on search in vis dropdown

### DIFF
--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -76,7 +76,7 @@ function ToolbarGroupByItem({
   onColumnChange,
   onColumnDelete,
 }: ToolbarGroupByItemProps) {
-  const [search, setSearch] = useState<string>('');
+  const [search, setSearch] = useState<string | undefined>(undefined);
   const debouncedSearch = useDebouncedValue(search, 200);
 
   return (
@@ -92,7 +92,7 @@ function ToolbarGroupByItem({
         onColumnDelete={onColumnDelete}
         groupBys={groupBys}
         onSearch={setSearch}
-        onClose={() => setSearch('')}
+        onClose={() => setSearch(undefined)}
       />
     </TraceItemAttributeProvider>
   );

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -197,8 +197,8 @@ function VisualizeDropdown({
   onSearch,
   onClose,
 }: VisualizeDropdownProps & {onClose: () => void; onSearch: (search: string) => void}) {
-  const {tags: stringTags} = useTraceItemTags('string');
-  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
+  const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
 
   const aggregateOptions = useMemo(
     () =>
@@ -261,6 +261,7 @@ function VisualizeDropdown({
       onDelete={onDelete}
       parsedFunction={parsedFunction}
       label={label}
+      loading={numberTagsLoading || stringTagsLoading}
       onSearch={onSearch}
       onClose={onClose}
     />

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,5 +1,5 @@
 import type {MouseEventHandler, ReactNode} from 'react';
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -7,6 +7,7 @@ import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect
 import {IconHide} from 'sentry/icons/iconHide';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -24,6 +25,7 @@ import {
   updateVisualizeAggregate,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   isVisualizeEquation,
@@ -124,7 +126,7 @@ export function ToolbarVisualize({
         }
 
         return (
-          <VisualizeDropdown
+          <ToolbarVisualizeItem
             key={group}
             canDelete={canDelete}
             onDelete={() => onDelete(group)}
@@ -158,13 +160,43 @@ interface VisualizeDropdownProps {
   visualize: Visualize;
 }
 
+function ToolbarVisualizeItem({
+  canDelete,
+  label,
+  onDelete,
+  onReplace,
+  visualize,
+}: VisualizeDropdownProps) {
+  const [search, setSearch] = useState<string | undefined>(undefined);
+  const debouncedSearch = useDebouncedValue(search, 200);
+  return (
+    <TraceItemAttributeProvider
+      enabled
+      traceItemType={TraceItemDataset.SPANS}
+      search={debouncedSearch}
+    >
+      <VisualizeDropdown
+        canDelete={canDelete}
+        onDelete={onDelete}
+        onReplace={onReplace}
+        visualize={visualize}
+        label={label}
+        onSearch={setSearch}
+        onClose={() => setSearch(undefined)}
+      />
+    </TraceItemAttributeProvider>
+  );
+}
+
 function VisualizeDropdown({
   canDelete,
   onDelete,
   onReplace,
   visualize,
   label,
-}: VisualizeDropdownProps) {
+  onSearch,
+  onClose,
+}: VisualizeDropdownProps & {onClose: () => void; onSearch: (search: string) => void}) {
   const {tags: stringTags} = useTraceItemTags('string');
   const {tags: numberTags} = useTraceItemTags('number');
 
@@ -229,6 +261,8 @@ function VisualizeDropdown({
       onDelete={onDelete}
       parsedFunction={parsedFunction}
       label={label}
+      onSearch={onSearch}
+      onClose={onClose}
     />
   );
 }


### PR DESCRIPTION
This PR updates the visualize toolbar on the Explore -> Traces page to fetch the attributes list from the API to help narrow down searches for users, as well as handle the case where they might have more than 3000 attributes to choose from (the API hard limit)

This PR also includes a fix for the group by dropdown where the default value was an empty string and not undefined so it was not using a cached response as it had an empty `substringMatch` query param.

Ticket: EXP-710