### PR TITLE
ref(timeseries): Move timeseries code to base

### DIFF
--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
@@ -8,12 +7,10 @@ from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute
 from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.utils.snuba import SnubaTSResult, process_value
+from sentry.utils.snuba import process_value
 
 logger = logging.getLogger(__name__)
 
@@ -115,68 +112,6 @@ class Occurrences(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             params.debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        """Run a simple timeseries query (no groupby)."""
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        """Run the query"""
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-
-        """Process the results"""
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-        if len(result.timeseries) == 0:
-            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )
 
     @classmethod

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
@@ -9,12 +8,9 @@ from sentry.models.project import Project
 from sentry.search.eap import constants
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.ourlogs")
 
@@ -85,65 +81,4 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             debug=debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        """Run the query"""
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-
-        """Process the results"""
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-        if len(result.timeseries) == 0:
-            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )

--- a/src/sentry/snuba/preprod_size.py
+++ b/src/sentry/snuba/preprod_size.py
@@ -1,17 +1,13 @@
 import logging
-from datetime import timedelta
 
 import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 
 from sentry.search.eap.preprod_size.definitions import PREPROD_SIZE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.preprod_size")
 
@@ -62,64 +58,4 @@ class PreprodSize(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             debug=debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-
-        if len(result.timeseries) == 0:
-            # The RPC only zerofills for us when there are results; if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )

--- a/src/sentry/snuba/profile_functions.py
+++ b/src/sentry/snuba/profile_functions.py
@@ -1,17 +1,13 @@
 import logging
-from datetime import timedelta
 
 import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 
 from sentry.search.eap.profile_functions.definitions import PROFILE_FUNCTIONS_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.profile_functions")
 
@@ -58,65 +54,4 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             debug=debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        """Run the query"""
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-
-        """Process the results"""
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-        if len(result.timeseries) == 0:
-            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -61,7 +61,7 @@ from sentry.search.eap.types import (
 )
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
-from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key
+from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key, zerofill
 from sentry.utils import json, snuba_rpc
 from sentry.utils.snuba import SnubaTSResult, process_value
 
@@ -691,7 +691,87 @@ class RPCBase:
         comparison_delta: timedelta | None = None,
         additional_queries: AdditionalQueries | None = None,
     ) -> SnubaTSResult:
-        raise NotImplementedError()
+        """Make the query"""
+        cls.validate_granularity(params)
+        search_resolver = cls.get_resolver(params, config)
+        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
+            search_resolver=search_resolver,
+            params=params,
+            query_string=query_string,
+            y_axes=y_axes,
+            groupby=[],
+            referrer=referrer,
+            sampling_mode=sampling_mode,
+            additional_queries=additional_queries,
+        )
+
+        """Run the query"""
+        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
+
+        """Process the results"""
+        result = ProcessedTimeseries()
+        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
+        if params.debug:
+            set_debug_meta(final_meta, rpc_response.meta, rpc_request)
+        for resolved_field in aggregates + groupbys:
+            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
+
+        for timeseries in rpc_response.result_timeseries:
+            processed = cls.process_timeseries_list([timeseries])
+            if len(result.timeseries) == 0:
+                result = processed
+            else:
+                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
+                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
+                        existing.update(new)
+        if len(result.timeseries) == 0:
+            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
+            result.timeseries = zerofill(
+                [],
+                params.start_date,
+                params.end_date,
+                params.timeseries_granularity_secs,
+                ["time"],
+            )
+
+        if comparison_delta is not None:
+            if len(rpc_request.expressions) != 1:
+                raise InvalidSearchQuery("Only one column can be selected for comparison queries")
+
+            comp_query_params = params.copy()
+            assert comp_query_params.start is not None, "start is required"
+            assert comp_query_params.end is not None, "end is required"
+            comp_query_params.start = comp_query_params.start_date - comparison_delta
+            comp_query_params.end = comp_query_params.end_date - comparison_delta
+
+            search_resolver = cls.get_resolver(comp_query_params, config)
+            comp_rpc_request, aggregates, groupbys = cls.get_timeseries_query(
+                search_resolver=search_resolver,
+                params=comp_query_params,
+                query_string=query_string,
+                y_axes=y_axes,
+                groupby=[],
+                referrer=referrer,
+                sampling_mode=sampling_mode,
+                additional_queries=additional_queries,
+            )
+            comp_rpc_response = snuba_rpc.timeseries_rpc([comp_rpc_request])[0]
+
+            if comp_rpc_response.result_timeseries:
+                timeseries = comp_rpc_response.result_timeseries[0]
+                processed = cls.process_timeseries_list([timeseries])
+                for existing, new in zip(result.timeseries, processed.timeseries):
+                    existing["comparisonCount"] = new[timeseries.label]
+            else:
+                for existing in result.timeseries:
+                    existing["comparisonCount"] = 0
+
+        return SnubaTSResult(
+            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
+            params.start,
+            params.end,
+            params.granularity_secs,
+        )
 
     @classmethod
     @sentry_sdk.trace

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -679,6 +679,7 @@ class RPCBase:
         )
 
     @classmethod
+    @sentry_sdk.trace
     def run_timeseries_query(
         cls,
         *,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from collections import defaultdict
-from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
@@ -16,11 +15,9 @@ from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from sentry import options
-from sentry.exceptions import InvalidSearchQuery
 from sentry.models.project import Project
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING, SUPPORTED_STATS_TYPES
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import (
     AdditionalQueries,
@@ -29,12 +26,9 @@ from sentry.search.eap.types import (
     SupportedTraceItemType,
 )
 from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.snuba.rpc_dataset_common import set_debug_meta
 from sentry.utils import json, snuba_rpc
-from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
 
@@ -80,102 +74,6 @@ class Spans(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             params.debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        """Make the query"""
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        """Run the query"""
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-
-        """Process the results"""
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        if params.debug:
-            set_debug_meta(final_meta, rpc_response.meta, rpc_request)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-        if len(result.timeseries) == 0:
-            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        if comparison_delta is not None:
-            if len(rpc_request.expressions) != 1:
-                raise InvalidSearchQuery("Only one column can be selected for comparison queries")
-
-            comp_query_params = params.copy()
-            assert comp_query_params.start is not None, "start is required"
-            assert comp_query_params.end is not None, "end is required"
-            comp_query_params.start = comp_query_params.start_date - comparison_delta
-            comp_query_params.end = comp_query_params.end_date - comparison_delta
-
-            search_resolver = cls.get_resolver(comp_query_params, config)
-            comp_rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-                search_resolver=search_resolver,
-                params=comp_query_params,
-                query_string=query_string,
-                y_axes=y_axes,
-                groupby=[],
-                referrer=referrer,
-                sampling_mode=sampling_mode,
-                additional_queries=additional_queries,
-            )
-            comp_rpc_response = snuba_rpc.timeseries_rpc([comp_rpc_request])[0]
-
-            if comp_rpc_response.result_timeseries:
-                timeseries = comp_rpc_response.result_timeseries[0]
-                processed = cls.process_timeseries_list([timeseries])
-                for existing, new in zip(result.timeseries, processed.timeseries):
-                    existing["comparisonCount"] = new[timeseries.label]
-            else:
-                for existing in result.timeseries:
-                    existing["comparisonCount"] = 0
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )
 
     @classmethod

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
@@ -8,13 +7,10 @@ from sentry.api.serializers.models.project import get_has_trace_metrics
 from sentry.models.project import Project
 from sentry.search.eap import constants
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
 from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
-from sentry.snuba.discover import zerofill
-from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.trace_metrics")
 
@@ -75,66 +71,4 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
                 additional_queries=additional_queries,
             ),
             debug=debug,
-        )
-
-    @classmethod
-    @sentry_sdk.trace
-    def run_timeseries_query(
-        cls,
-        *,
-        params: SnubaParams,
-        query_string: str,
-        y_axes: list[str],
-        referrer: str,
-        config: SearchResolverConfig,
-        sampling_mode: SAMPLING_MODES | None,
-        comparison_delta: timedelta | None = None,
-        additional_queries: AdditionalQueries | None = None,
-    ) -> SnubaTSResult:
-        cls.validate_granularity(params)
-        search_resolver = cls.get_resolver(params, config)
-
-        rpc_request, aggregates, groupbys = cls.get_timeseries_query(
-            search_resolver=search_resolver,
-            params=params,
-            query_string=query_string,
-            y_axes=y_axes,
-            groupby=[],
-            referrer=referrer,
-            sampling_mode=sampling_mode,
-            additional_queries=additional_queries,
-        )
-
-        """Run the query"""
-        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
-
-        """Process the results"""
-        result = rpc_dataset_common.ProcessedTimeseries()
-        final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
-        for resolved_field in aggregates + groupbys:
-            final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
-
-        for timeseries in rpc_response.result_timeseries:
-            processed = cls.process_timeseries_list([timeseries])
-            if len(result.timeseries) == 0:
-                result = processed
-            else:
-                for attr in ["timeseries", "confidence", "sample_count", "sampling_rate"]:
-                    for existing, new in zip(getattr(result, attr), getattr(processed, attr)):
-                        existing.update(new)
-        if len(result.timeseries) == 0:
-            # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
-            result.timeseries = zerofill(
-                [],
-                params.start_date,
-                params.end_date,
-                params.timeseries_granularity_secs,
-                ["time"],
-            )
-
-        return SnubaTSResult(
-            {"data": result.timeseries, "processed_timeseries": result, "meta": final_meta},
-            params.start,
-            params.end,
-            params.granularity_secs,
         )

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -1,4 +1,6 @@
 import logging
+from datetime import timedelta
+from typing import Any
 
 import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
@@ -8,6 +10,7 @@ from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolv
 from sentry.search.eap.uptime_results.definitions import UPTIME_RESULT_DEFINITIONS
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
+from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.uptime_results")
 
@@ -50,3 +53,42 @@ class UptimeResults(rpc_dataset_common.RPCBase):
             ),
             debug,
         )
+
+    @classmethod
+    def run_timeseries_query(
+        cls,
+        *,
+        params: SnubaParams,
+        query_string: str,
+        y_axes: list[str],
+        referrer: str,
+        config: SearchResolverConfig,
+        sampling_mode: SAMPLING_MODES | None,
+        comparison_delta: timedelta | None = None,
+        additional_queries: AdditionalQueries | None = None,
+    ) -> SnubaTSResult:
+        """Wasn't implemented before a refactor to move the timeseries code into RPCBase, but can just delete this
+        function entirely if we want timeseries"""
+        raise NotImplementedError()
+
+    @classmethod
+    @sentry_sdk.trace
+    def run_top_events_timeseries_query(
+        cls,
+        *,
+        params: SnubaParams,
+        query_string: str,
+        y_axes: list[str],
+        raw_groupby: list[str],
+        orderby: list[str] | None,
+        limit: int,
+        include_other: bool,
+        referrer: str,
+        config: SearchResolverConfig,
+        sampling_mode: SAMPLING_MODES | None,
+        equations: list[str] | None = None,
+        additional_queries: AdditionalQueries | None = None,
+    ) -> Any:
+        """Since run_timeseries_query isn't implemented, this is also being marked as not implemented, should be able to
+        just delete this if top_events are wanted on this dataset"""
+        raise NotImplementedError()


### PR DESCRIPTION
- This code was identical in every dataset except for the comparison_delta stuff, which isn't run when the param is None anyways so feels pretty safe
- The only dataset that never implemented timeseries was uptime_results, so keeping that the same just to keep this as no-op as possible
- Also minor cleanup in the endpoint code