### PR TITLE
chore(ownership): Decrease `code_owners_auto_sync` task processing deadline duration

### DIFF
--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -18,7 +18,7 @@ from sentry.taskworker.retry import Retry
     name="sentry.tasks.code_owners_auto_sync",
     namespace=issues_tasks,
     retry=Retry(times=3, delay=60),
-    processing_deadline_duration=300,
+    processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
 )
 @retry(on=(Commit.DoesNotExist,))


### PR DESCRIPTION
With the improvements made in https://github.com/getsentry/sentry/pull/106108, we don't need as long of a processing deadline duration for the `code_owners_auto_sync` task. 60 seconds is plenty.