### PR TITLE
chore(api): update suspect flags/tags tests to use org-scoped URLs

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
@@ -51,7 +51,9 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
         )
 
         with self.feature(self.features):
-            response = self.client.get(f"/api/0/issues/{group.id}/suspect/flags/")
+            response = self.client.get(
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/suspect/flags/"
+            )
 
         assert response.status_code == 200
         assert response.json() == {
@@ -91,13 +93,17 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
     def test_get_no_flag_access(self) -> None:
         """Does not have feature-flag access."""
         group = self.create_group()
-        response = self.client.get(f"/api/0/issues/{group.id}/suspect/flags/")
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/suspect/flags/"
+        )
         assert response.status_code == 404
 
     def test_get_no_group(self) -> None:
         """Group not found."""
         with self.feature(self.features):
-            response = self.client.get("/api/0/issues/22/suspect/flags/")
+            response = self.client.get(
+                f"/api/0/organizations/{self.organization.slug}/issues/22/suspect/flags/"
+            )
             assert response.status_code == 404
 
     def _mock_event(

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
@@ -40,7 +40,9 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
         )
 
         with self.feature(self.features):
-            response = self.client.get(f"/api/0/issues/{group.id}/suspect/tags/")
+            response = self.client.get(
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/suspect/tags/"
+            )
 
         assert response.status_code == 200
         assert response.json() == {
@@ -53,13 +55,17 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
     def test_get_no_tag_access(self) -> None:
         """Does not have feature-tag access."""
         group = self.create_group()
-        response = self.client.get(f"/api/0/issues/{group.id}/suspect/tags/")
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/suspect/tags/"
+        )
         assert response.status_code == 404
 
     def test_get_no_group(self) -> None:
         """Group not found."""
         with self.feature(self.features):
-            response = self.client.get("/api/0/issues/22/suspect/tags/")
+            response = self.client.get(
+                f"/api/0/organizations/{self.organization.slug}/issues/22/suspect/tags/"
+            )
             assert response.status_code == 404
 
     def _mock_event(


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/104471 sets the non-org scoped url to be deprecated, updates the tests to use the correct url