### PR TITLE
chore(preprod): Fix rule parsing logic for size status checks

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import StrEnum
@@ -45,6 +46,12 @@ RULES_OPTION_KEY = "sentry:preprod_size_status_checks_rules"
 
 preprod_artifact_search_config = SearchConfig.create_from(
     SearchConfig[Literal[True]](),
+    text_operator_keys={
+        "platform",
+        "git_head_ref",
+        "app_id",
+        "build_configuration",
+    },
     key_mappings={
         "platform": ["platform"],
         "git_head_ref": ["git_head_ref"],
@@ -292,7 +299,10 @@ def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
         return []
 
     try:
-        rules_data = json.loads(rules_json)
+        # Handle bytes from project options (json.loads requires str, not bytes)
+        if isinstance(rules_json, bytes):
+            rules_json = rules_json.decode("utf-8")
+        rules_data = json.loads(rules_json) if isinstance(rules_json, str) else rules_json
         if not isinstance(rules_data, list):
             logger.warning(
                 "preprod.status_checks.rules.invalid_format",
@@ -451,7 +461,16 @@ def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str]) -> bo
         for f in group_filters:
             if f.is_in_filter:
                 matches = artifact_value in f.value.value
+            elif f.value.is_wildcard():
+                # Wildcard operators (contains, starts_with, ends_with)
+                # value property returns regex pattern from translate_wildcard()
+                try:
+                    pattern = f.value.value
+                    matches = bool(re.search(pattern, artifact_value))
+                except (re.error, TypeError):
+                    matches = False
             else:
+                # Exact equality match
                 matches = artifact_value == f.value.value
 
             if f.is_negation:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -459,16 +459,18 @@ def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str]) -> bo
 
         group_matches = False
         for f in group_filters:
-            if f.is_in_filter:
-                matches = artifact_value in f.value.value
-            elif f.value.is_wildcard():
+            if f.value.is_wildcard():
                 # Wildcard operators (contains, starts_with, ends_with)
-                # value property returns regex pattern from translate_wildcard()
+                # Works for both single values and IN filters
+                # For IN filters with wildcards, value is a regex alternation pattern
                 try:
                     pattern = f.value.value
                     matches = bool(re.search(pattern, artifact_value))
                 except (re.error, TypeError):
                     matches = False
+            elif f.is_in_filter:
+                # Non-wildcard IN filter
+                matches = artifact_value in f.value.value
             else:
                 # Exact equality match
                 matches = artifact_value == f.value.value


### PR DESCRIPTION
Two issues:

1. We didn't have parsing correct for production (i guess it can be in byte format)
2. We didn't have support for the wildcard rules like "contains" and "starts with"

I think data is handled differently in production vs in testing which is why this wasn't caught