### PR TITLE
chore(aci): default test_post_process.py to workflow engine

### DIFF
--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from hashlib import md5
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 from django.db import router
@@ -49,8 +49,6 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.userreport import UserReport
 from sentry.replays.lib import kafka as replays_kafka
 from sentry.replays.lib.kafka import clear_replay_publisher
-from sentry.rules import init_registry
-from sentry.rules.actions.base import EventAction
 from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.silo.base import SiloMode
@@ -102,7 +100,7 @@ class EventMatcher:
         return matching_id
 
 
-class BasePostProgressGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
+class BasePostProcessGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_event(self, data, project_id, assert_no_errors=True):
         pass
@@ -113,9 +111,18 @@ class BasePostProgressGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
     ):
         pass
 
+    @pytest.fixture(autouse=True)
+    def with_feature_flags(self):
+        with override_options(
+            {
+                "workflow_engine.issue_alert.group.type_id.ga": [1, 1006, 2001, 1018, 6001],
+            }
+        ):
+            yield
 
-class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+
+class CorePostProcessGroupTestMixin(BasePostProcessGroupMixin):
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
     @patch("sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound.delay")
     @patch("sentry.signals.event_processed.send_robust")
@@ -124,7 +131,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
         mock_signal,
         mock_process_resource_change_bound,
         mock_process_service_hook,
-        mock_processor,
+        mock_process_workflows_event,
     ):
         min_ago = before_now(minutes=1).isoformat()
         event = self.store_event(
@@ -145,15 +152,15 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             cache_key=cache_key,
         )
 
-        assert mock_processor.call_count == 0
+        assert mock_process_workflows_event.apply_async.call_count == 0
         assert mock_process_service_hook.call_count == 0
         assert mock_process_resource_change_bound.call_count == 0
 
         # transaction events do not call event.processed
         assert mock_signal.call_count == 0
 
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_no_cache_abort(self, mock_processor: MagicMock) -> None:
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_no_cache_abort(self, mock_process_workflows_event: MagicMock) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
 
         self.call_post_process_group(
@@ -164,7 +171,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             cache_key="total-rubbish",
         )
 
-        assert mock_processor.call_count == 0
+        assert mock_process_workflows_event.apply_async.call_count == 0
 
     def test_processing_cache_cleared(self) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
@@ -192,7 +199,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
         assert event_processing_store.get(cache_key) is None
 
 
-class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
+class DeriveCodeMappingsProcessGroupTestMixin(BasePostProcessGroupMixin):
     def _create_event(
         self,
         data: dict[str, Any],
@@ -323,37 +330,11 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
             assert mock_derive_code_mappings.delay.call_count == 2
 
 
-class RuleProcessorTestMixin(BasePostProgressGroupMixin):
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_rule_processor_backwards_compat(self, mock_processor: MagicMock) -> None:
-        event = self.create_event(data={}, project_id=self.project.id)
-
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        mock_processor.assert_called_once_with(EventMatcher(event), True, False, True, False, False)
-        mock_processor.return_value.apply.assert_called_once_with()
-
-        mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
-
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_rule_processor(self, mock_processor: MagicMock) -> None:
+class WorkflowEngineTestMixin(BasePostProcessGroupMixin):
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_workflow_engine(self, mock_process_workflows_event: MagicMock) -> None:
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
         self.call_post_process_group(
             is_new=True,
             is_regression=False,
@@ -361,66 +342,10 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_processor.return_value.apply.assert_called_once_with()
+        assert mock_process_workflows_event.apply_async.call_count == 1
 
-        mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
-
-    @mock_redis_buffer()
-    def test_rule_processor_buffer_values(self) -> None:
-        # Test that pending buffer values for `times_seen` are applied to the group and that alerts
-        # fire as expected
-        from sentry.models.rule import Rule
-
-        MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
-
-        with (
-            mock.patch("sentry.buffer.backend.get", buffer.backend.get),
-            mock.patch("sentry.buffer.backend.incr", buffer.backend.incr),
-            patch("sentry.constants._SENTRY_RULES", MOCK_RULES),
-            patch("sentry.rules.rules", init_registry()) as rules,
-        ):
-            MockAction = mock.Mock()
-            MockAction.id = "tests.sentry.tasks.post_process.tests.MockAction"
-            MockAction.return_value = mock.Mock(spec=EventAction)
-            MockAction.return_value.after.return_value = []
-            rules.add(MockAction)
-
-            conditions = [
-                {
-                    "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
-                    "value": 10,
-                },
-            ]
-            actions = [{"id": "tests.sentry.tasks.post_process.tests.MockAction"}]
-            Rule.objects.filter(project=self.project).delete()
-            self.create_project_rule(condition_data=conditions, action_data=actions)
-
-            event = self.create_event(
-                data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
-            )
-            event_2 = self.create_event(
-                data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
-            )
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event,
-            )
-            event.group.update(times_seen=2)
-            assert MockAction.return_value.after.call_count == 0
-
-            buffer.backend.incr(Group, {"times_seen": 15}, filters={"id": event.group.id})
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event_2,
-            )
-            assert MockAction.return_value.after.call_count == 1
-
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_group_refresh(self, mock_processor: MagicMock) -> None:
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_group_refresh(self, mock_process_workflows_event: MagicMock) -> None:
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group1 = event.group
@@ -432,11 +357,6 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
         with self.tasks():
             merge_groups([group1.id], group2.id)
 
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
         self.call_post_process_group(
             is_new=True,
             is_regression=False,
@@ -444,211 +364,26 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
         # Ensure that rule processing sees the merged group.
-        mock_processor.assert_called_with(
-            EventMatcher(event, group=group2), True, False, True, False, False
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group2.id,
+                "group_state": {
+                    "id": group2.id,
+                    "is_new": True,
+                    "is_regression": False,
+                    "is_new_group_environment": True,
+                },
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers=ANY,
         )
 
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_group_last_seen_buffer(self, mock_processor: MagicMock) -> None:
-        first_event_date = timezone.now() - timedelta(days=90)
-        event1 = self.create_event(
-            data={"message": "testing"},
-            project_id=self.project.id,
-        )
-        group1 = event1.group
-        group1.update(last_seen=first_event_date)
 
-        event2 = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-
-        # Mock set the last_seen value to the first event date
-        # To simulate the update to last_seen being buffered
-        event2.group.last_seen = first_event_date
-        event2.group.update(last_seen=first_event_date)
-        assert event2.group_id == group1.id
-
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
-        self.call_post_process_group(
-            is_new=False,
-            is_regression=True,
-            is_new_group_environment=False,
-            event=event2,
-        )
-        mock_processor.assert_called_with(
-            EventMatcher(event2, group=group1), False, True, False, False, False
-        )
-        sent_group_date: datetime = mock_processor.call_args[0][0].group.last_seen
-        # Check that last_seen was updated to be at least the new event's date
-        assert abs(sent_group_date - event2.datetime) < timedelta(seconds=10)
-
-
-class ServiceHooksTestMixin(BasePostProgressGroupMixin):
-    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    def test_service_hook_fires_on_new_event(self, mock_process_service_hook: MagicMock) -> None:
-        event = self.create_event(data={}, project_id=self.project.id)
-        hook = self.create_service_hook(
-            project=self.project,
-            organization=self.project.organization,
-            actor=self.user,
-            events=["event.created"],
-        )
-
-        with self.feature("projects:servicehooks"):
-            self.call_post_process_group(
-                is_new=False,
-                is_regression=False,
-                is_new_group_environment=False,
-                event=event,
-            )
-
-        mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id,
-            project_id=self.project.id,
-            group_id=event.group_id,
-            event_id=event.event_id,
-        )
-
-    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_service_hook_fires_on_alert(
-        self, mock_processor: MagicMock, mock_process_service_hook: MagicMock
-    ) -> None:
-        event = self.create_event(data={}, project_id=self.project.id)
-
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
-        hook = self.create_service_hook(
-            project=self.project,
-            organization=self.project.organization,
-            actor=self.user,
-            events=["event.alert"],
-        )
-
-        with self.feature("projects:servicehooks"):
-            self.call_post_process_group(
-                is_new=False,
-                is_regression=False,
-                is_new_group_environment=False,
-                event=event,
-            )
-
-        mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id,
-            project_id=self.project.id,
-            group_id=event.group_id,
-            event_id=event.event_id,
-        )
-
-    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_service_hook_does_not_fire_without_alert(
-        self, mock_processor, mock_process_service_hook
-    ):
-        event = self.create_event(data={}, project_id=self.project.id)
-
-        mock_processor.return_value.apply.return_value = []
-
-        self.create_service_hook(
-            project=self.project,
-            organization=self.project.organization,
-            actor=self.user,
-            events=["event.alert"],
-        )
-
-        with self.feature("projects:servicehooks"):
-            self.call_post_process_group(
-                is_new=False,
-                is_regression=False,
-                is_new_group_environment=False,
-                event=event,
-            )
-
-        assert not mock_process_service_hook.delay.mock_calls
-
-    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    def test_service_hook_does_not_fire_without_event(
-        self, mock_process_service_hook: MagicMock
-    ) -> None:
-        event = self.create_event(data={}, project_id=self.project.id)
-
-        self.create_service_hook(
-            project=self.project, organization=self.project.organization, actor=self.user, events=[]
-        )
-
-        with self.feature("projects:servicehooks"):
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=False,
-                event=event,
-            )
-
-        assert not mock_process_service_hook.delay.mock_calls
-
-    @with_feature("organizations:workflow-engine-single-process-workflows")
-    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
-    def test_workflow_engine_single_processing(
-        self, mock_process_event: MagicMock, mock_processor: MagicMock
-    ) -> None:
-        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        # With the workflow engine feature flag enabled, RuleProcessor should not be called
-        assert mock_processor.call_count == 0
-
-        # Call the function inside process_workflow_engine
-        assert mock_process_event.apply_async.call_count == 1
-
-    @with_feature("organizations:workflow-engine-single-process-workflows")
-    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
-    def test_workflow_engine_single_processing__ignore_archived(
-        self, mock_process_event, mock_processor
-    ):
-        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-        group = event.group
-        group.update(status=GroupStatus.IGNORED)
-
-        mock_callback = Mock()
-        mock_futures = [Mock()]
-
-        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        # With the workflow engine feature flag enabled, RuleProcessor should not be called
-        assert mock_processor.call_count == 0
-
-        # Don't process workflows for ignored issue
-        assert mock_process_event.apply_async.call_count == 0
-
-
-class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
+class ResourceChangeBoundsTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_on_new_group(self, delay: MagicMock) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
@@ -774,9 +509,9 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
         assert not delay.called
 
 
-class InboxTestMixin(BasePostProgressGroupMixin):
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_group_inbox_regression(self, mock_processor: MagicMock) -> None:
+class InboxTestMixin(BasePostProcessGroupMixin):
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_group_inbox_regression(self, mock_process_workflows_event: MagicMock) -> None:
         new_event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group = new_event.group
@@ -797,7 +532,23 @@ class InboxTestMixin(BasePostProgressGroupMixin):
         assert group.status == GroupStatus.UNRESOLVED
         assert group.substatus == GroupSubStatus.NEW
 
-        mock_processor.assert_called_with(EventMatcher(new_event), True, True, False, False, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": new_event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": {
+                    "id": group.id,
+                    "is_new": True,
+                    "is_regression": True,
+                    "is_new_group_environment": False,
+                },
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
 
         # resolve the new issue so regression actually happens
         group.status = GroupStatus.RESOLVED
@@ -821,9 +572,24 @@ class InboxTestMixin(BasePostProgressGroupMixin):
             event=regressed_event,
         )
 
-        mock_processor.assert_called_with(
-            EventMatcher(regressed_event), False, True, False, False, False
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": regressed_event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": {
+                    "id": group.id,
+                    "is_new": False,
+                    "is_regression": True,
+                    "is_new_group_environment": False,
+                },
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
         )
+
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
         assert group.substatus == GroupSubStatus.REGRESSED
@@ -832,7 +598,7 @@ class InboxTestMixin(BasePostProgressGroupMixin):
         ).exists()
 
 
-class AssignmentTestMixin(BasePostProgressGroupMixin):
+class AssignmentTestMixin(BasePostProcessGroupMixin):
     def make_ownership(self, extra_rules=None):
         self.user_2 = self.create_user()
         self.create_team_membership(team=self.team, user=self.user_2)
@@ -1373,8 +1139,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             project_id=self.project.id,
         )
 
-        cache.set(ASSIGNEE_EXISTS_KEY(event.group.id), True)
-        cache.set(ISSUE_OWNERS_DEBOUNCE_KEY(event.group.id), timezone.now().timestamp())
+        assignee_cache_key = "assignee_exists:1:%s" % event.group.id
+        owner_cache_key = "owner_exists:1:%s" % event.group.id
+
+        for key in [assignee_cache_key, owner_cache_key]:
+            cache.set(key, True)
 
         self.call_post_process_group(
             is_new=False,
@@ -1453,7 +1222,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         mock_incr.assert_any_call("sentry.tasks.post_process.handle_owner_assignment.debounce")
 
     @patch("sentry.utils.metrics.incr")
-    def test_no_debounce_when_ownership_changes(self, mock_incr: MagicMock) -> None:
+    def test_timestamp_invalidation_when_ownership_changes(self, mock_incr: MagicMock) -> None:
         self.make_ownership()
         event = self.create_event(
             data={
@@ -1493,9 +1262,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         )
 
     @patch("sentry.utils.metrics.incr")
-    def test_debounces_handle_owner_assignments_when_ownership_older(
-        self, mock_incr: MagicMock
-    ) -> None:
+    def test_timestamp_debounce_when_ownership_older(self, mock_incr: MagicMock) -> None:
         self.make_ownership()
         event = self.create_event(
             data={
@@ -1605,7 +1372,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             )
 
 
-class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
+class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
     github_blame_return_value = {
         "commitId": "asdfwreqr",
         "committedDate": (timezone.now() - timedelta(days=2)),
@@ -1779,11 +1546,11 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
         )
 
 
-class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
+class SnoozeTestSkipSnoozeMixin(BasePostProcessGroupMixin):
     @patch("sentry.signals.issue_unignored.send_robust")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     def test_invalidates_snooze_issue_platform(
-        self, mock_processor: MagicMock, mock_send_unignored_robust: MagicMock
+        self, mock_process_workflows_event: MagicMock, mock_send_unignored_robust: MagicMock
     ) -> None:
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group = event.group
@@ -1800,7 +1567,18 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
         assert GroupInbox.objects.filter(group=group, reason=GroupInboxReason.NEW.value).exists()
         GroupInbox.objects.filter(group=group).delete()  # Delete so it creates the UNIGNORED entry.
         Activity.objects.filter(group=group).delete()
-        mock_processor.assert_called_with(EventMatcher(event), True, False, True, False, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": ANY,
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
 
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group.status = GroupStatus.IGNORED
@@ -1815,7 +1593,18 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
             is_new_group_environment=True,
             event=event,
         )
-        mock_processor.assert_called_with(EventMatcher(event), False, False, True, True, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": event.group.id,
+                "group_state": ANY,
+                "has_reappeared": True,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
 
         if should_detect_escalation:
             assert not GroupSnooze.objects.filter(id=snooze.id).exists()
@@ -1845,11 +1634,11 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
             assert not mock_send_unignored_robust.called
 
 
-class SnoozeTestMixin(BasePostProgressGroupMixin):
+class SnoozeTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.signals.issue_unignored.send_robust")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     def test_invalidates_snooze(
-        self, mock_processor: MagicMock, mock_send_unignored_robust: MagicMock
+        self, mock_process_workflows_event: MagicMock, mock_send_unignored_robust: MagicMock
     ) -> None:
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
@@ -1866,7 +1655,23 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         GroupInbox.objects.filter(group=group).delete()  # Delete so it creates the UNIGNORED entry.
         Activity.objects.filter(group=group).delete()
 
-        mock_processor.assert_called_with(EventMatcher(event), True, False, True, False, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": {
+                    "id": group.id,
+                    "is_new": True,
+                    "is_regression": False,
+                    "is_new_group_environment": True,
+                },
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
 
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group.status = GroupStatus.IGNORED
@@ -1882,7 +1687,23 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_processor.assert_called_with(EventMatcher(event), False, False, True, True, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": {
+                    "id": group.id,
+                    "is_new": False,
+                    "is_regression": False,
+                    "is_new_group_environment": True,
+                },
+                "has_reappeared": True,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
         group.refresh_from_db()
@@ -1899,9 +1720,9 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
     @mock_redis_buffer()
     @override_settings(SENTRY_BUFFER="sentry.buffer.redis.RedisBuffer")
     @patch("sentry.signals.issue_unignored.send_robust")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     def test_invalidates_snooze_with_buffers(
-        self, mock_processor: MagicMock, send_robust: MagicMock
+        self, mock_process_workflows_event: MagicMock, send_robust: MagicMock
     ) -> None:
         with (
             mock.patch("sentry.buffer.backend.get", buffer.backend.get),
@@ -1937,8 +1758,8 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             )
             assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_maintains_valid_snooze(self, mock_processor: MagicMock) -> None:
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_maintains_valid_snooze(self, mock_process_workflows_event: MagicMock) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         assert group.status == GroupStatus.UNRESOLVED
@@ -1952,7 +1773,23 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_processor.assert_called_with(EventMatcher(event), True, False, True, False, False)
+        mock_process_workflows_event.apply_async.assert_called_with(
+            kwargs={
+                "event_id": event.event_id,
+                "occurrence_id": ANY,
+                "group_id": group.id,
+                "group_state": {
+                    "id": group.id,
+                    "is_new": True,
+                    "is_regression": False,
+                    "is_new_group_environment": True,
+                },
+                "has_reappeared": False,
+                "has_escalated": False,
+                "start_timestamp_seconds": ANY,
+            },
+            headers=ANY,
+        )
 
         assert GroupSnooze.objects.filter(id=snooze.id).exists()
         group.refresh_from_db()
@@ -2009,7 +1846,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
 
 
 @patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection")
-class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
+class SDKCrashMonitoringTestMixin(BasePostProcessGroupMixin):
     @with_feature("organizations:sdk-crash-detection")
     @override_options(
         {
@@ -2119,7 +1956,7 @@ class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
 @mock.patch.object(replays_kafka, "get_kafka_producer_cluster_options")
 @mock.patch.object(replays_kafka, "KafkaPublisher")
 @mock.patch("sentry.utils.metrics.incr")
-class ReplayLinkageTestMixin(BasePostProgressGroupMixin):
+class ReplayLinkageTestMixin(BasePostProcessGroupMixin):
     def test_replay_linkage(
         self, incr: MagicMock, kafka_producer: MagicMock, kafka_publisher: MagicMock
     ) -> None:
@@ -2228,7 +2065,7 @@ class ReplayLinkageTestMixin(BasePostProgressGroupMixin):
         incr.assert_any_call("post_process.process_replay_link.id_sampled")
 
 
-class UserReportEventLinkTestMixin(BasePostProgressGroupMixin):
+class UserReportEventLinkTestMixin(BasePostProcessGroupMixin):
     def test_user_report_gets_environment(self) -> None:
         project = self.create_project()
         environment = Environment.objects.create(
@@ -2377,7 +2214,7 @@ class UserReportEventLinkTestMixin(BasePostProgressGroupMixin):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 0
 
 
-class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
+class DetectBaseUrlsForUptimeTestMixin(BasePostProcessGroupMixin):
     def assert_organization_key(self, organization: Organization, exists: bool) -> None:
         key = get_organization_bucket_key(organization)
         cluster = get_cluster()
@@ -2427,7 +2264,7 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
 @patch("sentry.analytics.record")
 @patch("sentry.utils.metrics.incr")
 @patch("sentry.utils.metrics.distribution")
-class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
+class CheckIfFlagsSentTestMixin(BasePostProcessGroupMixin):
     def test_set_has_flags(
         self, mock_dist: MagicMock, mock_incr: MagicMock, mock_record: MagicMock
     ) -> None:
@@ -2476,7 +2313,7 @@ class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
         )
 
 
-class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
+class DetectNewEscalationTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
     def test_has_escalated(self, mock_run_post_process_job: MagicMock) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
@@ -2698,7 +2535,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         assert group.substatus == GroupSubStatus.NEW
 
 
-class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
+class ProcessSimilarityTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.post_process.safe_execute")
     def test_process_similarity(self, mock_safe_execute: MagicMock) -> None:
         from sentry import similarity
@@ -2756,7 +2593,7 @@ class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
         self.assert_not_called_with(mock_safe_execute)
 
 
-class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
+class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
@@ -3118,7 +2955,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_generate_summary_and_run_automation.assert_not_called()
 
 
-class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
+class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
     """Tests for the triage signals V0 flow behind the organizations:triage-signals-v0-org feature flag."""
 
     @patch(
@@ -3444,7 +3281,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
         mock_run_automation.assert_not_called()
 
 
-class SeerAutomationHelperFunctionsTestMixin(BasePostProgressGroupMixin):
+class SeerAutomationHelperFunctionsTestMixin(BasePostProcessGroupMixin):
     """Unit tests for is_issue_eligible_for_seer_automation."""
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -3519,8 +3356,7 @@ class PostProcessGroupErrorTest(
     KickOffSeerAutomationTestMixin,
     TriageSignalsV0TestMixin,
     SeerAutomationHelperFunctionsTestMixin,
-    RuleProcessorTestMixin,
-    ServiceHooksTestMixin,
+    WorkflowEngineTestMixin,
     SnoozeTestMixin,
     SnoozeTestSkipSnoozeMixin,
     SDKCrashMonitoringTestMixin,
@@ -3585,12 +3421,12 @@ class PostProcessGroupErrorTest(
         assert generic_metrics_backend_mock.call_count == 1
         metric_incr_mock.assert_any_call(
             "sentry.tasks.post_process.post_process_group.completed",
-            tags={"issue_category": "error", "pipeline": "process_rules"},
+            tags={"issue_category": "error", "pipeline": "process_workflow_engine_issue_alerts"},
         )
         metric_timer_mock.assert_any_call(
             "tasks.post_process.run_post_process_job.pipeline.duration",
             tags={
-                "pipeline": "process_rules",
+                "pipeline": "process_workflow_engine_issue_alerts",
                 "issue_category": "error",
                 "is_reprocessed": False,
             },
@@ -3602,7 +3438,7 @@ class PostProcessGroupPerformanceTest(
     SnubaTestCase,
     CorePostProcessGroupTestMixin,
     InboxTestMixin,
-    RuleProcessorTestMixin,
+    WorkflowEngineTestMixin,
     SnoozeTestMixin,
     SnoozeTestSkipSnoozeMixin,
     PerformanceIssueTestCase,
@@ -3633,18 +3469,18 @@ class PostProcessGroupPerformanceTest(
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_rules")
+    @patch("sentry.tasks.post_process.process_workflow_engine_issue_alerts")
     @patch("sentry.tasks.post_process.run_post_process_job")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.transaction_processed.send_robust")
     @patch("sentry.signals.event_processed.send_robust")
     def test_full_pipeline_with_group_states(
         self,
         event_processed_signal_mock,
         transaction_processed_signal_mock,
-        mock_processor,
+        mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_rules,
+        mock_process_workflow_engine_issue_alerts,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
@@ -3654,10 +3490,14 @@ class PostProcessGroupPerformanceTest(
         # TODO(jangjodi): Fix this ordering test; side_effects should be a function (lambda),
         # but because post-processing is async, this causes the assert to fail because it doesn't
         # wait for the side effects to happen
-        call_order = [mock_handle_owner_assignment, mock_handle_auto_assignment, mock_process_rules]
+        call_order = [
+            mock_handle_owner_assignment,
+            mock_handle_auto_assignment,
+            mock_process_workflow_engine_issue_alerts,
+        ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_rules.side_effect = None
+        mock_process_workflow_engine_issue_alerts.side_effect = None
 
         post_process_group(
             is_new=True,
@@ -3671,12 +3511,12 @@ class PostProcessGroupPerformanceTest(
         )
 
         assert event_processed_signal_mock.call_count == 0
-        assert mock_processor.call_count == 0
+        assert mock_process_workflows_event.apply_async.call_count == 0
         assert run_post_process_job_mock.call_count == 1
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_rules,
+            mock_process_workflow_engine_issue_alerts,
         ]
 
 
@@ -3724,7 +3564,7 @@ class PostProcessGroupGenericTest(
     OccurrenceTestMixin,
     CorePostProcessGroupTestMixin,
     InboxTestMixin,
-    RuleProcessorTestMixin,
+    WorkflowEngineTestMixin,
     SnoozeTestMixin,
     KickOffSeerAutomationTestMixin,
     TriageSignalsV0TestMixin,
@@ -3766,8 +3606,8 @@ class PostProcessGroupGenericTest(
         # We don't use the cache for generic issues, so skip this test
         pass
 
-    @patch("sentry.rules.processing.processor.RuleProcessor")
-    def test_occurrence_deduping(self, mock_processor: MagicMock) -> None:
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
+    def test_occurrence_deduping(self, mock_process_workflows_event: MagicMock) -> None:
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         self.call_post_process_group(
@@ -3776,8 +3616,7 @@ class PostProcessGroupGenericTest(
             is_new_group_environment=False,
             event=event,
         )
-        assert mock_processor.call_count == 1
-        mock_processor.assert_called_with(EventMatcher(event), True, True, False, False, False)
+        assert mock_process_workflows_event.apply_async.call_count == 1
 
         # Calling this again should do nothing, since we've already processed this occurrence.
         self.call_post_process_group(
@@ -3788,30 +3627,34 @@ class PostProcessGroupGenericTest(
         )
 
         # Make sure we haven't called this again, since we should exit early.
-        assert mock_processor.call_count == 1
+        assert mock_process_workflows_event.apply_async.call_count == 1
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_rules")
+    @patch("sentry.tasks.post_process.process_workflow_engine_issue_alerts")
     @patch("sentry.tasks.post_process.run_post_process_job")
-    @patch("sentry.rules.processing.processor.RuleProcessor")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.event_processed.send_robust")
     @patch("sentry.utils.snuba.raw_query")
     def test_full_pipeline_with_group_states(
         self,
         snuba_raw_query_mock,
         event_processed_signal_mock,
-        mock_processor,
+        mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_rules,
+        mock_process_workflow_engine_issue_alerts,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-        call_order = [mock_handle_owner_assignment, mock_handle_auto_assignment, mock_process_rules]
+        call_order = [
+            mock_handle_owner_assignment,
+            mock_handle_auto_assignment,
+            mock_process_workflow_engine_issue_alerts,
+        ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_rules.side_effect = None
+        mock_process_workflow_engine_issue_alerts.side_effect = None
         self.call_post_process_group(
             is_new=False,
             is_regression=True,
@@ -3819,12 +3662,12 @@ class PostProcessGroupGenericTest(
             event=event,
         )
         assert event_processed_signal_mock.call_count == 0
-        assert mock_processor.call_count == 0
+        assert mock_process_workflows_event.apply_async.call_count == 0
         assert run_post_process_job_mock.call_count == 1
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_rules,
+            mock_process_workflow_engine_issue_alerts,
         ]
         assert snuba_raw_query_mock.call_count == 0
 
@@ -3843,7 +3686,7 @@ class PostProcessGroupFeedbackTest(
     OccurrenceTestMixin,
     CorePostProcessGroupTestMixin,
     InboxTestMixin,
-    RuleProcessorTestMixin,
+    WorkflowEngineTestMixin,
     SnoozeTestMixin,
 ):
     def create_event(
@@ -4173,7 +4016,7 @@ class PostProcessGroupFeedbackTest(
         assert not mock_delay.called
 
 
-class ProcessDataForwardingTest(BasePostProgressGroupMixin, SnubaTestCase):
+class ProcessDataForwardingTest(BasePostProcessGroupMixin, SnubaTestCase):
     DEFAULT_FORWARDER_CONFIGS = {
         DataForwarderProviderSlug.SQS: {
             "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",


### PR DESCRIPTION
Replace `RuleProcessor` references and tests with workflow engine equivalents in `test_post_process.py.`

We are already fully running all events through workflow engine, this just makes sure the tests are up to date.

The service hooks test mixin was deleted because we now fire service hooks through the workflow engine task, and it's tested separately.