### PR TITLE
feat: Remove code-review-beta condition from eligibility guard

### DIFF
--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -142,9 +142,8 @@ def should_create_or_increment_contributor_seat(
 
     Logic:
     1. Require seat-based Seer to be enabled for the organization
-    2. Exclude organizations in code-review-beta cohort (they use a different flow)
-    3. Require code review OR autofix to be enabled for the repo
-    4. Check Seer quota (returns True if contributor has seat OR quota available)
+    2. Require code review OR autofix to be enabled for the repo
+    3. Check Seer quota (returns True if contributor has seat OR quota available)
     """
     if not features.has("organizations:seat-based-seer-enabled", organization):
         return False

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -149,9 +149,6 @@ def should_create_or_increment_contributor_seat(
     if not features.has("organizations:seat-based-seer-enabled", organization):
         return False
 
-    if features.has("organizations:code-review-beta", organization):
-        return False
-
     if not _has_code_review_or_autofix_enabled(organization.id, repo.id):
         return False
 

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -38,18 +38,6 @@ class ShouldCreateOrIncrementContributorSeatTest(TestCase):
         )
         assert result is False
 
-    def test_returns_false_for_code_review_beta_orgs(self):
-        self.create_code_mapping(project=self.project, repo=self.repo)
-        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
-
-        with self.feature(
-            ["organizations:seat-based-seer-enabled", "organizations:code-review-beta"]
-        ):
-            result = should_create_or_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is False
-
     def test_returns_false_when_no_code_review_or_autofix_enabled(self):
         with self.feature("organizations:seat-based-seer-enabled"):
             result = should_create_or_increment_contributor_seat(


### PR DESCRIPTION
We no longer need the code review beta condition because if the user migrates to the new seer billing plan, we should be charging them for seats.

Prior to this, if they migrated to the new plan but were on the beta, they'd still be receiving free seats for their usage during the grace period.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
