### PR TITLE
feat(dashboards): allow linked dashboards in line chart full screen

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1116,7 +1116,8 @@ function ViewerTableV2({
             field,
             meta as MetaType,
             widget,
-            organization
+            organization,
+            dashboardFilters
           )!;
 
           // For SPANS widgets, the customRenderer already returns a link, so we shouldn't wrap it

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -158,6 +158,13 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
           fieldAliases: [''],
           conditions: `${SpanFields.DB_SYSTEM}:[${Object.values(SupportedDatabaseSystem).join(',')}]`,
           orderby: `-p75(${SpanFields.SPAN_SELF_TIME})`,
+          linkedDashboards: [
+            {
+              dashboardId: '-1',
+              field: SpanFields.NORMALIZED_DESCRIPTION,
+              staticDashboardId: 3,
+            },
+          ],
         },
       ],
       limit: 3,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -200,102 +200,6 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
   2
 );
 
-const THIRD_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
-  [
-    {
-      id: 'jobs-table',
-      title: 'Jobs',
-      description: '',
-      displayType: DisplayType.TABLE,
-      thresholds: null,
-      interval: '1h',
-      queries: [
-        {
-          name: '',
-          fields: [
-            `count(${SpanFields.SPAN_DURATION})`,
-            `equation|count_if(${SpanFields.TRACE_STATUS},equals,internal_error) / count(${SpanFields.SPAN_DURATION})`,
-          ],
-          aggregates: [
-            `count(${SpanFields.SPAN_DURATION})`,
-            `equation|count_if(${SpanFields.TRACE_STATUS},equals,internal_error) / count(${SpanFields.SPAN_DURATION})`,
-          ],
-          columns: [],
-          fieldMeta: [null, {valueType: 'percentage', valueUnit: null}],
-          fieldAliases: ['Jobs', 'Error Rate'],
-          conditions: `${SpanFields.SPAN_OP}:queue.process`,
-          orderby: `-count(${SpanFields.SPAN_DURATION})`,
-        },
-      ],
-      limit: 4,
-      widgetType: WidgetType.SPANS,
-    },
-    {
-      id: 'queries-by-time-spent-table',
-      title: 'Queries by Time Spent',
-      description: '',
-      displayType: DisplayType.TABLE,
-      interval: '1h',
-      tableWidths: [-1, -1],
-      queries: [
-        {
-          name: '',
-          fields: [
-            SpanFields.NORMALIZED_DESCRIPTION,
-            `sum(${SpanFields.SPAN_SELF_TIME})`,
-          ],
-          columns: [SpanFields.NORMALIZED_DESCRIPTION],
-          fieldAliases: ['Query Description', 'Time Spent'],
-          aggregates: [`sum(${SpanFields.SPAN_SELF_TIME})`],
-          conditions: `${SpanFields.DB_SYSTEM}:[${Object.values(SupportedDatabaseSystem).join(',')}]`,
-          orderby: `-sum(${SpanFields.SPAN_SELF_TIME})`,
-          linkedDashboards: [
-            {
-              dashboardId: '-1',
-              field: SpanFields.NORMALIZED_DESCRIPTION,
-              staticDashboardId: 3,
-            },
-          ],
-        },
-      ],
-      widgetType: WidgetType.SPANS,
-      limit: 3,
-    },
-    {
-      id: 'cache-miss-rates-table',
-      title: 'Cache Miss Rates',
-      description: '',
-      displayType: DisplayType.TABLE,
-      thresholds: null,
-      interval: '1h',
-      tableWidths: [-1, -1, -1, -1],
-      queries: [
-        {
-          name: '',
-          fields: [
-            SpanFields.TRANSACTION,
-            'equation|count_if(cache.hit,equals,false)',
-            `count(${SpanFields.SPAN_DURATION})`,
-            `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
-          ],
-          aggregates: [
-            'equation|count_if(cache.hit,equals,false)',
-            `count(${SpanFields.SPAN_DURATION})`,
-            `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
-          ],
-          columns: [SpanFields.TRANSACTION],
-          fieldMeta: [null, null, null, {valueType: 'percentage', valueUnit: null}],
-          fieldAliases: ['', 'Cache Misses', 'Cache Calls', 'Cache Miss Rate'],
-          conditions: `${SpanFields.SPAN_OP}:[cache.get,cache.get_item]`,
-          orderby: '-equation[1]',
-        },
-      ],
-      widgetType: WidgetType.SPANS,
-    },
-  ],
-  4
-);
-
 const TRANSACTIONS_TABLE: Widget = {
   id: 'backend-overview-transactions-table',
   title: 'Transactions',
@@ -385,10 +289,5 @@ export const BACKEND_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
       },
     ],
   },
-  widgets: [
-    ...FIRST_ROW_WIDGETS,
-    ...SECOND_ROW_WIDGETS,
-    ...THIRD_ROW_WIDGETS,
-    TRANSACTIONS_TABLE,
-  ],
+  widgets: [...FIRST_ROW_WIDGETS, ...SECOND_ROW_WIDGETS, TRANSACTIONS_TABLE],
 };


### PR DESCRIPTION
1. Remove bottom 3 table legend breakdown widgets

| Before | After |
|--------|--------|
| <img width="1606" height="1120" alt="image" src="https://github.com/user-attachments/assets/8a978c03-48e7-40b2-b60b-0978252bb0ce" /> | <img width="1628" height="727" alt="image" src="https://github.com/user-attachments/assets/dbcc278f-3932-4941-bd19-4d2f562cd377" /> | 

2. Add support for dashboard links in full screen table of line widget. This will be the replacement for the bottom 3 table widgets, for example in the queries by time spent chart full screen
<img width="1185" height="1091" alt="image" src="https://github.com/user-attachments/assets/b655ebc5-1141-48b5-a530-eff20fbfbd4a" />
