### PR TITLE
chore(api): deprecate legacy group-notes endpoint URL

### DIFF
--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -2,13 +2,16 @@ from datetime import timedelta
 
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -16,7 +19,6 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import comment_created
 from sentry.types.activity import ActivityType
-from sentry.utils.auth import AuthenticatedHttpRequest
 
 
 @region_silo_endpoint
@@ -26,7 +28,8 @@ class GroupNotesEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: AuthenticatedHttpRequest, group: Group) -> Response:
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
+    def get(self, request: Request, group: Group) -> Response:
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
 
         return self.paginate(
@@ -37,7 +40,8 @@ class GroupNotesEndpoint(GroupEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: AuthenticatedHttpRequest, group: Group) -> Response:
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
+    def post(self, request: Request, group: Group) -> Response:
         serializer = NoteSerializer(
             data=request.data,
             context={

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -42,6 +43,9 @@ class GroupNotesEndpoint(GroupEndpoint):
 
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
     def post(self, request: Request, group: Group) -> Response:
+        if not request.user.is_authenticated:
+            raise PermissionDenied(detail="Key doesn't have permission to create Note")
+
         serializer = NoteSerializer(
             data=request.data,
             context={


### PR DESCRIPTION
Add deprecation decorator to GroupNotesEndpoint for cellularization. Frontend already uses the correct org scoped url
Deprecated URL: sentry-api-0-group-notes
