### PR TITLE
ref(grouping): Add fingerprint source to grouping info description

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
+from sentry.grouping.fingerprinting.types import FingerprintInfo
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -202,6 +203,16 @@ def get_fingerprint_type(
             else "custom"
         )
     )
+
+
+def get_custom_fingerprint_type(
+    fingerprint_info: FingerprintInfo,
+) -> Literal["built-in", "custom client", "custom server"]:
+    matched_server_rule = fingerprint_info.get("matched_rule")
+    if matched_server_rule:
+        return "built-in" if matched_server_rule.get("is_builtin") else "custom server"
+    else:
+        return "custom client"
 
 
 def resolve_fingerprint_variable(

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -82,7 +82,8 @@ def _get_new_description(variant: BaseVariant) -> str:
         "checksum": "checksum",
         "csp_local_script_violation": "directive",
         "csp_url": "directive and URL",
-        "custom_fingerprint": "custom fingerprint",
+        "custom_client_fingerprint": "custom client fingerprint",
+        "custom_server_fingerprint": "custom server fingerprint",
         "exception": "exception",  # TODO: hotfix for case in which nothing in the exception contributes
         "exception_message": "exception message",
         "exception_stacktrace": "exception stacktrace",

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from sentry.grouping.fingerprinting.utils import get_custom_fingerprint_type
 from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.grouping.variants import BaseVariant, ComponentVariant, SaltedComponentVariant
 from sentry.models.project import Project
@@ -112,7 +113,8 @@ def _get_new_description(variant: BaseVariant) -> str:
         description_parts.append(stacktrace_descriptor)
 
     if isinstance(variant, SaltedComponentVariant):
-        description_parts.append("and custom fingerprint")
+        custom_fingerprint_type = get_custom_fingerprint_type(variant.fingerprint_info)
+        description_parts.append(f"and {custom_fingerprint_type} fingerprint")
 
     return " ".join(description_parts)
 

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -183,10 +183,8 @@ def _project_has_similarity_grouping_enabled(project: Project) -> bool:
 
 
 def _has_custom_fingerprint(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    fingerprint_variant = variants.get("custom_fingerprint") or variants.get("built_in_fingerprint")
-
-    if fingerprint_variant:
-        record_did_call_seer_metric(event, call_made=False, blocker=fingerprint_variant.type)
+    if any(key.endswith("fingerprint") and "hybrid" not in key for key in variants):
+        record_did_call_seer_metric(event, call_made=False, blocker="custom_fingerprint")
         return True
 
     return False

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.fingerprinting.rules import FingerprintRule
 from sentry.grouping.fingerprinting.types import FingerprintInfo
-from sentry.grouping.fingerprinting.utils import is_default_fingerprint_var
+from sentry.grouping.fingerprinting.utils import (
+    get_custom_fingerprint_type,
+    is_default_fingerprint_var,
+)
 from sentry.grouping.utils import hash_from_values
 
 if TYPE_CHECKING:
@@ -201,7 +204,10 @@ class CustomFingerprintVariant(BaseVariant):
 
     @property
     def key(self) -> str:
-        return "built_in_fingerprint" if self.is_built_in else "custom_fingerprint"
+        fingerprint_type = get_custom_fingerprint_type(self.fingerprint_info)
+        prefix = fingerprint_type.replace(" ", "_").replace("-", "_")
+
+        return f"{prefix}_fingerprint"
 
     def get_hash(self) -> str | None:
         return hash_from_values(self.values)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_client_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -21,7 +21,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_client_fingerprint*
     hash: "69d81763f9ec386fc0c0607ef62cabfa"
     fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
     values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -21,7 +21,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_client.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_client_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
@@ -21,7 +21,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_client_fingerprint*
     hash: "69d81763f9ec386fc0c0607ef62cabfa"
     fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
     values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
@@ -20,7 +20,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -21,7 +21,7 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  custom_fingerprint*
+  custom_server_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     fingerprint_info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_client_fingerprint": {
       "client_values": [
         "celery",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom client fingerprint",
       "hash": "f30afa00b85f5cac5ee0bce01b31f08d",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
         "celery",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "client_values": [
         "celery",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -53,16 +53,16 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_message",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_client_fingerprint": {
       "client_values": [
         "{{ message }}",
         "dogs are great"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom client fingerprint",
       "hash": "69d81763f9ec386fc0c0607ef62cabfa",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
         "FailedToFetchError: Charlie didn't bring 2 balls back!",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -802,12 +802,12 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "e3d593b4335190212ca7c18b8e967fb1",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -801,7 +801,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — in-app frames and custom fingerprint",
+      "description": "exception stacktrace — in-app frames and custom server fingerprint",
       "hash": "19163f3ca34f5995c69d85351ce3d697",
       "hint": null,
       "key": "app_exception_stacktrace_hybrid_fingerprint",
@@ -1609,7 +1609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames and custom fingerprint",
+      "description": "exception stacktrace — all frames and custom server fingerprint",
       "hash": "847950eb44d280e6758d136c763d6ddc",
       "hint": null,
       "key": "system_exception_stacktrace_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "client_values": [
         "{{ default }}",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "5b5ad5a0fbb4deb5e3fc631ce42681ae",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "c5578778212497f1ff3435405e2a4a98",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_client.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_client_fingerprint": {
       "client_values": [
         "celery",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom client fingerprint",
       "hash": "f30afa00b85f5cac5ee0bce01b31f08d",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
         "celery",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "client_values": [
         "celery",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -53,16 +53,16 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_message",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_client_fingerprint": {
       "client_values": [
         "{{ message }}",
         "dogs are great"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom client fingerprint",
       "hash": "69d81763f9ec386fc0c0607ef62cabfa",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
         "FailedToFetchError: Charlie didn't bring 2 balls back!",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
@@ -802,12 +802,12 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_base.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "e3d593b4335190212ca7c18b8e967fb1",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -801,7 +801,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — in-app frames and custom fingerprint",
+      "description": "exception stacktrace — in-app frames and custom server fingerprint",
       "hash": "b0dbf92202bf38adc8710e8ccd55d3df",
       "hint": null,
       "key": "app_exception_stacktrace_hybrid_fingerprint",
@@ -1609,7 +1609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames and custom fingerprint",
+      "description": "exception stacktrace — all frames and custom server fingerprint",
       "hash": "e440cd285687bab8b861ff96fe713929",
       "hint": null,
       "key": "system_exception_stacktrace_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -802,17 +802,17 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "key": "app_exception_stacktrace",
       "type": "component"
     },
-    "custom_fingerprint": {
+    "custom_server_fingerprint": {
       "client_values": [
         "{{ default }}",
         "SoftTimeLimitExceeded",
         "sentry.tasks.store.process_event"
       ],
       "contributes": true,
-      "description": "custom fingerprint",
+      "description": "custom server fingerprint",
       "hash": "554e214208f0372603dc9fa6c1c0965f",
       "hint": null,
-      "key": "custom_fingerprint",
+      "key": "custom_server_fingerprint",
       "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
       "type": "custom_fingerprint",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "5b5ad5a0fbb4deb5e3fc631ce42681ae",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception message and custom fingerprint",
+      "description": "exception message and custom client fingerprint",
       "hash": "c5578778212497f1ff3435405e2a4a98",
       "hint": null,
       "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -23,10 +23,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -17,10 +17,10 @@ fingerprint:
 - '{{ message }}'
 title: '{[*?]}'
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -23,13 +23,13 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -25,13 +25,13 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -25,13 +25,13 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -25,10 +25,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -28,10 +28,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -17,10 +17,10 @@ fingerprint:
 - '{{ message }}'
 title: Hello my sweet Love
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -25,10 +25,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -25,10 +25,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_chained_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
       -> "symcache-error"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -25,10 +25,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_chained_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -28,10 +28,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -23,10 +23,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -28,10 +28,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -27,10 +27,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -23,10 +23,10 @@ fingerprint:
 - '{{ level }}'
 title: Love not found.
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -15,10 +15,10 @@ fingerprint:
 - sdk-nextjs
 title: Es Dee Kay
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -17,10 +17,10 @@ fingerprint:
 - '{{ tags.barfoo }}'
 title: Hello my sweet Love
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -15,12 +15,12 @@ fingerprint:
 - what-is-love
 title: Hello my sweet Love
 variants:
-  custom_fingerprint:
+  custom_server_fingerprint:
     client_values:
     - client-sent
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: message:"*love*" -> "what-is-love"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -23,10 +23,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -26,10 +26,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -23,13 +23,13 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: release:"foo.bar@*" -> "foo.bar-release"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_uses_top_in_app_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_uses_top_in_app_frame.pysnap
@@ -25,10 +25,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: module:"do_dog_stuff" -> "{{ function }}" title="Dogs are great
       ({{ function }})"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -29,10 +29,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}" title="DatabaseUnavailable ({{ transaction }})"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -23,10 +23,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_thread_stacktrace
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: function:"main" -> "in-main"
     type: custom_fingerprint
     values:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -28,10 +28,10 @@ variants:
     hint: ignored because custom server fingerprint takes precedence
     key: app_exception_message
     type: component
-  custom_fingerprint:
+  custom_server_fingerprint:
     contributes: true
     hint: null
-    key: custom_fingerprint
+    key: custom_server_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
       }}{{ module }}"
     type: custom_fingerprint

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_client_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "FailedToFetchError: Charlie didn't bring <int> balls back!"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_client_fingerprint:
   hash: "69d81763f9ec386fc0c0607ef62cabfa"
   fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
   values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_client.pysnap
@@ -167,7 +167,7 @@ app:
             context_line*
               "raise SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_client_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_client_and_server_rule.pysnap
@@ -167,7 +167,7 @@ app:
             context_line*
               "raise SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "FailedToFetchError: Charlie didn't bring <int> balls back!"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_client_fingerprint:
   hash: "69d81763f9ec386fc0c0607ef62cabfa"
   fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
   values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_server_rule.pysnap
@@ -167,7 +167,7 @@ app:
             context_line*
               "raise SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -167,7 +167,7 @@ app:
             context_line*
               "raise SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom_fingerprint:
+custom_server_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   fingerprint_info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]


### PR DESCRIPTION
In grouping info, we differentiate between built-in and custom fingerprints, but when the fingerprint is custom, we don't indicate in the description whether the fingerprint was set in the client or via a custom server rule. And in the description for hybrid fingerprints, we don't differentiate at all.

This PR therefore extracts the current built-in vs. custom fingerprint logic to a new helper, `get_custom_fingerprint_type`, and adds the ability to distinguish between client and server custom fingerprints. It then uses the helper in `CustomFingerprintVariant.key` (which powers the main grouping method description) and in the logic for titling hybrid fingerprints.