### PR TITLE
chore(cells): deprecate group-details endpoint

### DIFF
--- a/fixtures/events/issue_detection/n-plus-one-api-calls/not-n-plus-one-api-calls.json
+++ b/fixtures/events/issue_detection/n-plus-one-api-calls/not-n-plus-one-api-calls.json
@@ -70,7 +70,11 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/organizations/?member=1"},
+      "data": {
+        "http.method": "GET",
+        "type": "fetch",
+        "url": "/api/0/organizations/?member=1"
+      },
       "hash": "cbc1d1c7a6500a75"
     },
     {
@@ -141,7 +145,11 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
+      "data": {
+        "http.method": "GET",
+        "type": "fetch",
+        "url": "/api/0/subscriptions/sentry/"
+      },
       "hash": "d09dea4693554039"
     },
     {
@@ -698,7 +706,7 @@
       "timestamp": 1668493712.796,
       "start_timestamp": 1668493711.677,
       "exclusive_time": 1118.999958,
-      "description": "GET /api/0/issues/1888481/?collapse=release",
+      "description": "GET /api/0/organizations/sentry/issues/1888481/?collapse=release",
       "op": "http.client",
       "span_id": "895caf36a21300a2",
       "parent_span_id": "9e4e36110481b5b5",
@@ -708,7 +716,7 @@
       "data": {
         "http.method": "GET",
         "type": "fetch",
-        "url": "/api/0/issues/1888481/?collapse=release"
+        "url": "/api/0/organizations/sentry/issues/1888481/?collapse=release"
       },
       "hash": "33a59c92255fb9b2"
     },

--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -43,8 +43,8 @@ class IssueDetailsPage(BasePage):
     def go_back_to_issues(self):
         self.global_selection.go_back_to_issues()
 
-    def api_issue_get(self, groupid):
-        return self.client.get(f"/api/0/issues/{groupid}/")
+    def api_issue_get(self, group):
+        return self.client.get(f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/")
 
     def go_to_subtab(self, key):
         tabs = self.browser.find_element(by=By.CSS_SELECTOR, value='[role="tablist"]')

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -12,6 +12,7 @@ from sentry import features, tagstore, tsdb
 from sentry.api import client
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environment_func, get_environments
 from sentry.api.helpers.group_index import (
     delete_group_list,
@@ -22,6 +23,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.group_stream import get_actions, get_available_issue_plugins
 from sentry.api.serializers.models.plugin import PluginSerializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.constants import get_issue_tsdb_group_model
@@ -132,6 +134,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
         return hourly_stats, daily_stats
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve an Issue
@@ -310,6 +313,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             )
             raise
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
     def put(self, request: Request, group: Group) -> Response:
         """
         Update an Issue
@@ -390,6 +394,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             )
             return Response(e.body, status=e.status_code)
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
     def delete(self, request: Request, group: Group) -> Response:
         """
         Remove an Issue

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -52,7 +52,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.resolve_issue()
         self.wait_for_loading()
 
-        res = self.page.api_issue_get(event.group.id)
+        res = self.page.api_issue_get(event.group)
         assert res.status_code == 200, res
         assert res.data["status"] == "resolved"
 
@@ -63,7 +63,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.archive_issue()
         self.wait_for_loading()
 
-        res = self.page.api_issue_get(event.group.id)
+        res = self.page.api_issue_get(event.group)
         assert res.status_code == 200, res
         assert res.data["status"] == "ignored"
 
@@ -74,7 +74,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.bookmark_issue()
         self.wait_for_loading()
 
-        res = self.page.api_issue_get(event.group.id)
+        res = self.page.api_issue_get(event.group)
         assert res.status_code == 200, res
         assert res.data["isBookmarked"]
 
@@ -84,7 +84,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.assign_to(self.user.email)
 
-        res = self.page.api_issue_get(event.group.id)
+        res = self.page.api_issue_get(event.group)
         assert res.status_code == 200, res
         assert res.data["assignedTo"]
 
@@ -106,6 +106,6 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.mark_reviewed()
 
-        res = self.page.api_issue_get(event.group.id)
+        res = self.page.api_issue_get(event.group)
         assert res.status_code == 200, res
         assert "inbox" not in res.data

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -37,7 +37,7 @@ class AuthenticationTest(AuthProviderTestCase):
             f"/api/0/organizations/{self.organization.slug}/",
             f"/api/0/projects/{self.organization.slug}/{self.project.slug}/",
             f"/api/0/teams/{self.organization.slug}/{self.team.slug}/",
-            f"/api/0/issues/{group_id}/",
+            f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/",
             # this uses the internal API, which once upon a time was broken
             f"/api/0/issues/{group_id}/events/latest/",
         )

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -87,7 +87,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.setup_user(user, self.team)
         self.login_as(user)
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user.username})
         assert response.status_code == 200, response.content
@@ -140,7 +140,7 @@ class AssignedNotificationAPITest(APITestCase):
             context={"commitId": commit.id},
         )
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user.username})
         assert response.status_code == 200, response.content
@@ -171,7 +171,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.setup_user(user, self.team)
         self.login_as(user)
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user.username})
         assert response.status_code == 200, response.content
@@ -219,7 +219,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.organization.refresh_from_db()
         assert self.organization.flags.enhanced_privacy.is_set is True
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user.username})
         assert response.status_code == 200, response.content
@@ -272,7 +272,7 @@ class AssignedNotificationAPITest(APITestCase):
 
         assert self.organization.flags.enhanced_privacy.is_set is False
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user.username})
         assert response.status_code == 200, response.content
@@ -341,7 +341,7 @@ class AssignedNotificationAPITest(APITestCase):
             context={"commitId": commit2.id},
         )
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with self.tasks():
             response = self.client.put(url, format="json", data={"assignedTo": user1.username})
         assert response.status_code == 200, response.content
@@ -368,7 +368,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.setup_user(user2, self.team)
         self.login_as(user1)
 
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
 
         # assign to user 1
         with self.tasks():
@@ -446,7 +446,7 @@ class AssignedNotificationAPITest(APITestCase):
 
         self.login_as(user1)
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         # assign to team1
         with self.tasks():

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -168,7 +168,7 @@ class ActivityNotificationTest(APITestCase):
         Test that an email AND Slack notification are sent with
         the expected values when an issue is unassigned.
         """
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with assume_test_silo_mode(SiloMode.REGION):
             GroupAssignee.objects.create(
                 group=self.group,
@@ -237,7 +237,7 @@ class ActivityNotificationTest(APITestCase):
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved.
         """
-        url = f"/api/0/issues/{self.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
         with assume_test_silo_mode(SiloMode.REGION):
             with self.tasks():
                 response = self.client.put(url, format="json", data={"status": "resolved"})
@@ -457,7 +457,7 @@ class ActivityNotificationTest(APITestCase):
         """
         release = self.create_release()
         with assume_test_silo_mode(SiloMode.REGION):
-            url = f"/api/0/issues/{self.group.id}/"
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/"
             with self.tasks():
                 response = self.client.put(
                     url,

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -27,7 +27,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         environment = Environment.get_or_create(group.project, "production")
         environment2 = Environment.get_or_create(group.project, "staging")
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         with mock.patch(
             "sentry.issues.endpoints.group_details.tsdb.backend.get_range",
@@ -73,7 +73,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         ][-1]
         group = event.group
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -101,7 +101,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         with mock.patch("sentry.tagstore.backend.get_release_tags") as get_release_tags:
             response = self.client.get(url, format="json")
@@ -126,7 +126,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -149,7 +149,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         group = event.group
         add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        url = f"/api/0/issues/{group.id}/?expand=inbox"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/?expand=inbox"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -168,7 +168,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         group = event.group
-        url = f"/api/0/issues/{group.id}/?expand=owners"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/?expand=owners"
 
         self.login_as(user=self.user)
         # Test with no owner
@@ -200,7 +200,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         group = event.group
         generate_and_save_forecasts([group])
 
-        url = f"/api/0/issues/{group.id}/?expand=forecast"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/?expand=forecast"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -216,7 +216,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             priority=PriorityLevel.LOW,
         )
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data["priority"] == "low"
@@ -229,7 +229,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             status=GroupStatus.IGNORED,
             priority=PriorityLevel.LOW,
         )
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         get_response_before = self.client.get(url, format="json")
         assert get_response_before.status_code == 200, get_response_before.content
@@ -258,7 +258,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         group = event.group
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.put(
             url, {"assignedTo": "admin@localhost", "status": "unresolved"}, format="json"
         )
@@ -291,7 +291,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         )
         group = event.group
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         response = self.client.get(url, {"collapse": ["stats"]}, format="json")
         assert response.status_code == 200
@@ -312,7 +312,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event.group.id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert int(response.data["id"]) == event.group.id
@@ -323,7 +323,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         """Test that a user cannot delete a error issue"""
         self.login_as(user=self.user)
         group = self.create_group(status=GroupStatus.RESOLVED, project=self.project)
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         with patch(
             "sentry.api.helpers.group_index.delete.delete_groups_for_project.apply_async"
@@ -350,7 +350,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             project=self.project,
             type=PerformanceSlowDBQueryGroupType.type_id,
         )
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
 
         with patch(
             "sentry.api.helpers.group_index.delete.delete_groups_for_project.apply_async"


### PR DESCRIPTION
Add deprecation notices to GroupDetailsEndpoint and update all tests to use the org-scoped variant's URL pattern. Follow-up PR incoming for frontend tests.