### PR TITLE
feat(seer): Return seer preference `automation_handoff` from the bulk endpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -171,17 +171,15 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                 or AutofixAutomationTuningSettings.OFF.value
             )
             seer_pref = seer_preferences_map.get(str(project.id)) or {}
-            automated_run_stopping_point = seer_pref.get(
-                "automated_run_stopping_point", AutofixStoppingPoint.CODE_CHANGES.value
-            )
-            repos_count = len(seer_pref.get("repositories") or [])
-
             results.append(
                 {
                     "projectId": project.id,
-                    "autofixAutomationTuning": autofix_automation_tuning,
-                    "automatedRunStoppingPoint": automated_run_stopping_point,
-                    "reposCount": repos_count,
+                    "autofixAutomationTuning": autofix_automation_tuning,  # project options
+                    "automatedRunStoppingPoint": seer_pref.get(
+                        "automated_run_stopping_point", AutofixStoppingPoint.CODE_CHANGES.value
+                    ),
+                    "automationHandoff": seer_pref.get("automation_handoff"),
+                    "reposCount": len(seer_pref.get("repositories") or []),
                 }
             )
         return results

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -37,12 +37,14 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                 "projectId": project1.id,
                 "autofixAutomationTuning": AutofixAutomationTuningSettings.OFF.value,
                 "automatedRunStoppingPoint": AutofixStoppingPoint.CODE_CHANGES.value,
+                "automationHandoff": None,
                 "reposCount": 0,
             },
             {
                 "projectId": project2.id,
                 "autofixAutomationTuning": AutofixAutomationTuningSettings.OFF.value,
                 "automatedRunStoppingPoint": AutofixStoppingPoint.CODE_CHANGES.value,
+                "automationHandoff": None,
                 "reposCount": 0,
             },
         ]
@@ -129,12 +131,14 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                 "projectId": project1.id,
                 "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
                 "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+                "automationHandoff": None,
                 "reposCount": 1,
             },
             {
                 "projectId": project2.id,
                 "autofixAutomationTuning": AutofixAutomationTuningSettings.HIGH.value,
                 "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+                "automationHandoff": None,
                 "reposCount": 0,
             },
         ]


### PR DESCRIPTION
This returns more detailed data about background agent config in the Settings > Project > Seer list page.

