### PR TITLE
feat(crons-detector-schedule-preview): Preventing status smearing wit…

### DIFF
--- a/src/sentry/monitors/constants.py
+++ b/src/sentry/monitors/constants.py
@@ -55,3 +55,10 @@ class PermitCheckInStatus(Enum):
     This status is used when an unknown monitor slug is seen and has yet to
     have been assigned a seat.
     """
+
+
+class ScheduleSampleStatus(Enum):
+    OK = "ok"
+    ERROR = "error"
+    SUB_FAILURE_ERROR = "sub_failure_error"
+    SUB_RECOVERY_OK = "sub_recovery_ok"

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
@@ -30,11 +30,10 @@ from sentry.monitors.validators import ConfigValidator
 
 MAX_UNIX_TIMESTAMP_SECONDS = 253402300799
 
-SUB_THRESHOLD_STATUSES = {
-    ScheduleSampleStatus.SUB_FAILURE_ERROR,
-    ScheduleSampleStatus.SUB_RECOVERY_OK,
+SUB_THRESHOLD_STATUS_VALUES = {
+    ScheduleSampleStatus.SUB_FAILURE_ERROR.value,
+    ScheduleSampleStatus.SUB_RECOVERY_OK.value,
 }
-SUB_THRESHOLD_STATUS_VALUES = {status.value for status in SUB_THRESHOLD_STATUSES}
 
 
 class SampleScheduleBucketsConfigValidator(ConfigValidator):
@@ -167,7 +166,7 @@ class OrganizationMonitorScheduleSampleBucketsEndpoint(OrganizationEndpoint):
             # when bucket intervals are larger than the frequency in the schedule.
             # Sub-threshold statuses dominate the bucket in this case, it should be the only
             # status present in the bucket.
-            is_sub_threshold_status = status in SUB_THRESHOLD_STATUSES
+            is_sub_threshold_status = status.value in SUB_THRESHOLD_STATUS_VALUES
             bucket_has_sub_threshold_status = any(
                 existing_status in SUB_THRESHOLD_STATUS_VALUES for existing_status in stats.keys()
             )

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_buckets.py
@@ -21,6 +21,7 @@ from sentry.monitors.constants import (
     SAMPLE_OPEN_PERIOD_RATIO,
     SAMPLE_PADDING_RATIO_OF_THRESHOLD,
     SAMPLE_PADDING_TICKS_MIN_COUNT,
+    ScheduleSampleStatus,
 )
 from sentry.monitors.models import ScheduleType
 from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
@@ -28,6 +29,12 @@ from sentry.monitors.types import IntervalUnit
 from sentry.monitors.validators import ConfigValidator
 
 MAX_UNIX_TIMESTAMP_SECONDS = 253402300799
+
+SUB_THRESHOLD_STATUSES = {
+    ScheduleSampleStatus.SUB_FAILURE_ERROR,
+    ScheduleSampleStatus.SUB_RECOVERY_OK,
+}
+SUB_THRESHOLD_STATUS_VALUES = {status.value for status in SUB_THRESHOLD_STATUSES}
 
 
 class SampleScheduleBucketsConfigValidator(ConfigValidator):
@@ -48,7 +55,9 @@ class SampleScheduleBucketsConfigValidator(ConfigValidator):
     interval = serializers.IntegerField(min_value=1, max_value=MAX_UNIX_TIMESTAMP_SECONDS)
 
 
-def _get_tick_statuses(num_ticks: int, failure_threshold: int, recovery_threshold: int):
+def _get_tick_statuses(
+    num_ticks: int, failure_threshold: int, recovery_threshold: int
+) -> list[ScheduleSampleStatus]:
     if num_ticks <= 0:
         return []
 
@@ -73,11 +82,11 @@ def _get_tick_statuses(num_ticks: int, failure_threshold: int, recovery_threshol
     middle_errors = open_period + remaining
 
     return (
-        ["ok"] * padding
-        + ["sub_failure_error"] * sub_failure_threshold
-        + ["error"] * middle_errors
-        + ["sub_recovery_ok"] * sub_recovery_threshold
-        + ["ok"] * padding
+        [ScheduleSampleStatus.OK] * padding
+        + [ScheduleSampleStatus.SUB_FAILURE_ERROR] * sub_failure_threshold
+        + [ScheduleSampleStatus.ERROR] * middle_errors
+        + [ScheduleSampleStatus.SUB_RECOVERY_OK] * sub_recovery_threshold
+        + [ScheduleSampleStatus.OK] * padding
     )
 
 
@@ -153,7 +162,26 @@ class OrganizationMonitorScheduleSampleBucketsEndpoint(OrganizationEndpoint):
             bucket_index = (tick_ts - window_start_ts) // bucket_interval
             bucket_start = window_start_ts + bucket_index * bucket_interval
             stats = bucket_stats.setdefault(bucket_start, {})
-            stats[status] = stats.get(status, 0) + 1
+
+            # Prevent status smearing when multiple ticks are grouped into a bucket
+            # when bucket intervals are larger than the frequency in the schedule.
+            # Sub-threshold statuses dominate the bucket in this case, it should be the only
+            # status present in the bucket.
+            is_sub_threshold_status = status in SUB_THRESHOLD_STATUSES
+            bucket_has_sub_threshold_status = any(
+                existing_status in SUB_THRESHOLD_STATUS_VALUES for existing_status in stats.keys()
+            )
+
+            if is_sub_threshold_status:
+                if stats and not bucket_has_sub_threshold_status:
+                    stats.clear()
+                stats[status.value] = stats.get(status.value, 0) + 1
+                continue
+
+            if bucket_has_sub_threshold_status:
+                continue
+
+            stats[status.value] = stats.get(status.value, 0) + 1
 
         duration = window_end_ts - window_start_ts
         num_buckets = (duration // bucket_interval) + 1

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_buckets.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_buckets.py
@@ -129,15 +129,15 @@ class SampleScheduleBucketsTest(APITestCase):
         expected_bucket_stats = [
             {"ok": 2},
             {"ok": 2},
-            {"ok": 1, "sub_failure_error": 1},
+            {"sub_failure_error": 1},  # sub-failure error dominates the bucket
             {"error": 2},
             {"error": 2},
             {"error": 2},
             {"error": 2},
             {"error": 2},
             {"error": 2},
-            {"error": 1, "sub_recovery_ok": 1},
-            {"sub_recovery_ok": 1, "ok": 1},
+            {"sub_recovery_ok": 1},  # sub-recovery ok dominates the bucket
+            {"sub_recovery_ok": 1},  # sub-recovery ok dominates the bucket
             {"ok": 2},
             {"ok": 2},
         ]


### PR DESCRIPTION
…h sub-threshold ticks.

At large thresholds, the bucket interval exceeds the interval of the schedule being previewed. So we group multiple ticks into the same bucket. A bucket therefore can contain multiple statuses.

We don't want this in the UI, makes the issue open period boundaries less intuitive. This should only show the sub-threshold
status:
<img width="395" height="176" alt="Screenshot 2026-01-20 at 4 31 51 PM" src="https://github.com/user-attachments/assets/e686de1a-974b-43a0-a3b9-784a6cf1338d" />
