### PR TITLE
ref(sentry-apps): Convert service hook projects endpoint to use RPC

### DIFF
--- a/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
+++ b/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
@@ -93,6 +93,7 @@ SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY = {
     "ProjectUserStatsEndpoint",
     "ProjectUsersEndpoint",
     "ReleaseThresholdEndpoint",
+    "SentryAppInstallationServiceHookProjectsEndpoint",
     "SentryAppRequestsEndpoint",
     "SentryAppWebhookRequestsEndpoint",
     "SentryAppsStatsEndpoint",

--- a/src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py
@@ -1,23 +1,17 @@
-from django.db import router, transaction
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import deletions
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import all_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.projects.services.project.service import project_service
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
 from sentry.sentry_apps.api.serializers.servicehookproject import ServiceHookProjectSerializer
-from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
-
-
-class ProjectAccessError(Exception):
-    pass
+from sentry.sentry_apps.services.region import sentry_app_region_service
 
 
 class ServiceHookProjectsInputSerializer(serializers.Serializer):
@@ -52,7 +46,7 @@ class ServiceHookProjectsInputSerializer(serializers.Serializer):
         return value
 
 
-@region_silo_endpoint
+@all_silo_endpoint
 class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBaseEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
@@ -61,65 +55,16 @@ class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBase
         "DELETE": ApiPublishStatus.PRIVATE,
     }
 
-    def _replace_hook_projects(
-        self, installation: RpcSentryAppInstallation, new_project_ids: set[int], request: Request
-    ) -> list[ServiceHookProject]:
-        with transaction.atomic(router.db_for_write(ServiceHookProject)):
-            hook = ServiceHook.objects.get(installation_id=installation.id)
-            existing_project_ids = set(
-                ServiceHookProject.objects.filter(service_hook_id=hook.id).values_list(
-                    "project_id", flat=True
-                )
-            )
-
-            # Determine which projects to add and which to remove
-            projects_to_add = new_project_ids - existing_project_ids
-            projects_to_remove = existing_project_ids - new_project_ids
-
-            for p in projects_to_remove:
-                p_obj = project_service.get_by_id(
-                    organization_id=installation.organization_id, id=p
-                )
-                if not request.access.has_project_access(p_obj):
-                    raise ProjectAccessError("Can not remove projects that are not accessible")
-
-            self._delete_servicehookprojects(hook.id, projects_to_remove)
-            added_hook_projects = self._add_servicehookprojects(hook.id, projects_to_add)
-
-            kept_project_ids = existing_project_ids & new_project_ids
-            return sorted(
-                added_hook_projects
-                + list(ServiceHookProject.objects.filter(project_id__in=kept_project_ids)),
-                key=lambda x: x.project_id,
-            )
-
-    def _delete_servicehookprojects(self, service_hook_id: int, project_ids: set[int]) -> None:
-        ServiceHookProject.objects.filter(
-            service_hook_id=service_hook_id, project_id__in=project_ids
-        ).delete()
-
-    def _add_servicehookprojects(
-        self, service_hook_id: int, project_ids: set[int]
-    ) -> list[ServiceHookProject]:
-        res = []
-        for project_id in project_ids:
-            res.append(
-                ServiceHookProject.objects.create(
-                    project_id=project_id,
-                    service_hook_id=service_hook_id,
-                )
-            )
-        return res
-
     def get(self, request: Request, installation: RpcSentryAppInstallation) -> Response:
-        hook = ServiceHook.objects.get(installation_id=installation.id)
-        hook_projects = list(ServiceHookProject.objects.filter(service_hook_id=hook.id))
+        result = sentry_app_region_service.get_service_hook_projects(
+            organization_id=installation.organization_id,
+            installation=installation,
+        )
+        if result.error:
+            return self.respond_rpc_sentry_app_error(result.error)
 
-        for hp in hook_projects:
-            p_obj = project_service.get_by_id(
-                organization_id=installation.organization_id, id=hp.project_id
-            )
-            if not request.access.has_project_access(p_obj):
+        for project in result.projects:
+            if not request.access.has_project_access(project):
                 return Response(
                     status=400,
                     data={"error": "Some projects are not accessible"},
@@ -127,7 +72,7 @@ class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBase
 
         return self.paginate(
             request=request,
-            queryset=hook_projects,
+            queryset=result.service_hook_projects,
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(
                 x, request.user, access=request.access, serializer=ServiceHookProjectSerializer()
@@ -146,33 +91,53 @@ class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBase
 
         projects = serializer.validated_data["projects"]
 
-        # convert slugs to ids if needed
+        # Convert slugs to ids if needed and check access
         org_id = installation.organization_id
-        project_ids = set()
+        project_ids = []
         for project in set(projects):
             if isinstance(project, int):
                 project_obj = project_service.get_by_id(organization_id=org_id, id=project)
             else:
                 project_obj = project_service.get_by_slug(organization_id=org_id, slug=project)
             if project_obj and request.access.has_project_access(project_obj):
-                project_ids.add(project_obj.id)
+                project_ids.append(project_obj.id)
             else:
                 return Response(
                     status=400,
                     data={"error": f"Project '{project}' does not exist or is not accessible"},
                 )
 
-        try:
-            hook_projects = self._replace_hook_projects(installation, project_ids, request)
-        except ProjectAccessError:
-            return Response(
-                status=400,
-                data={"error": "Some projects affected by this request are not accessible"},
-            )
+        current_result = sentry_app_region_service.get_service_hook_projects(
+            organization_id=installation.organization_id,
+            installation=installation,
+        )
+        if current_result.error:
+            return self.respond_rpc_sentry_app_error(current_result.error)
+
+        current_project_ids = {hp.project_id for hp in current_result.service_hook_projects}
+        project_ids_to_remove = current_project_ids - set(project_ids)
+        projects_to_remove = [
+            project for project in current_result.projects if project.id in project_ids_to_remove
+        ]
+        for project in projects_to_remove:
+            if not request.access.has_project_access(project):
+                return Response(
+                    status=400,
+                    data={"error": "Some projects affected by this request are not accessible"},
+                )
+
+        result = sentry_app_region_service.set_service_hook_projects(
+            organization_id=installation.organization_id,
+            installation=installation,
+            project_ids=project_ids,
+        )
+
+        if result.error:
+            return self.respond_rpc_sentry_app_error(result.error)
 
         return self.paginate(
             request=request,
-            queryset=hook_projects,
+            queryset=result.service_hook_projects,
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(
                 x, request.user, access=request.access, serializer=ServiceHookProjectSerializer()
@@ -180,16 +145,27 @@ class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBase
         )
 
     def delete(self, request: Request, installation: RpcSentryAppInstallation) -> Response:
-        hook = ServiceHook.objects.get(installation_id=installation.id)
-        hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id)
-        for hp in hook_projects:
-            p_obj = project_service.get_by_id(
-                organization_id=installation.organization_id, id=hp.project_id
-            )
-            if not request.access.has_project_access(p_obj):
+        current_result = sentry_app_region_service.get_service_hook_projects(
+            organization_id=installation.organization_id,
+            installation=installation,
+        )
+
+        if current_result.error:
+            return self.respond_rpc_sentry_app_error(current_result.error)
+
+        for project in current_result.projects:
+            if not request.access.has_project_access(project):
                 return Response(
                     status=400,
                     data={"error": "Some projects affected by this request are not accessible"},
                 )
-        deletions.exec_sync_many(list(hook_projects))
+
+        result = sentry_app_region_service.delete_service_hook_projects(
+            organization_id=installation.organization_id,
+            installation=installation,
+        )
+
+        if result.error:
+            return self.respond_rpc_sentry_app_error(result.error)
+
         return Response(status=204)


### PR DESCRIPTION
Convert service hook projects endpoint from region-only to all-silo by moving access validation to the region RPC service.
Pass AuthenticationContext from endpoint to RPC methods for proper permission checks.

Requires https://github.com/getsentry/sentry/pull/106526 to deploy