### PR TITLE
fix(tests): Use `assert_any_call` to address task severity flake

### DIFF
--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -248,9 +248,7 @@ class TestGetEventSeverity(TestCase):
 
         severity, reason = _get_severity_score(event)
 
-        mock_metrics_incr.assert_called_with(
-            "issues.severity.error", tags={"reason": "max_retries"}
-        )
+        mock_metrics_incr.assert_any_call("issues.severity.error", tags={"reason": "max_retries"})
         assert severity == 1.0
         assert reason == "microservice_max_retry"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
@@ -283,7 +281,7 @@ class TestGetEventSeverity(TestCase):
 
         severity, reason = _get_severity_score(event)
 
-        mock_metrics_incr.assert_called_with("issues.severity.error", tags={"reason": "timeout"})
+        mock_metrics_incr.assert_any_call("issues.severity.error", tags={"reason": "timeout"})
         assert severity == 1.0
         assert reason == "microservice_timeout"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
@@ -319,7 +317,7 @@ class TestGetEventSeverity(TestCase):
         severity, reason = _get_severity_score(event)
 
         mock_capture_exception.assert_called_once_with()
-        mock_metrics_incr.assert_called_with("issues.severity.error", tags={"reason": "unknown"})
+        mock_metrics_incr.assert_any_call("issues.severity.error", tags={"reason": "unknown"})
         assert severity == 1.0
         assert reason == "microservice_error"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1


### PR DESCRIPTION
We've been getting some flakes in master, it seems the `.incr` ordering is non deterministic (?) so `any` should find it from all calls rather than just the most recent