### PR TITLE
feat(utils): Add `useQueryStateWithLocalStorage` hook

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -59,6 +59,8 @@ const config: KnipConfig = {
     '!static/**/{fixtures,__fixtures__}/**!',
     // helper files for tests - it's fine that they are only used in tests
     '!static/**/*{t,T}estUtils*.{js,mjs,ts,tsx}!',
+    // utility hook only used in tests (intentionally)
+    '!static/app/utils/url/useQueryStateWithLocalStorage.tsx!',
     // helper files for stories - it's fine that they are only used in tests
     '!static/app/**/__stories__/*.{js,mjs,ts,tsx}!',
     '!static/app/stories/**/*.{js,mjs,ts,tsx}!',

--- a/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
@@ -1,0 +1,147 @@
+import {withNuqsTestingAdapter} from 'nuqs/adapters/testing';
+
+import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import localStorageWrapper from 'sentry/utils/localStorage';
+import {useQueryStateWithLocalStorage} from 'sentry/utils/url/useQueryStateWithLocalStorage';
+
+describe('useQueryStateWithLocalStorage', () => {
+  beforeEach(() => {
+    localStorageWrapper.clear();
+  });
+
+  it('returns default value when neither URL nor localStorage has value', () => {
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter(),
+      }
+    );
+
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('returns localStorage value when URL is empty', () => {
+    localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('fromStorage'));
+
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter(),
+      }
+    );
+
+    expect(result.current[0]).toBe('fromStorage');
+  });
+
+  it('returns URL value when URL has value (URL takes precedence)', () => {
+    localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('fromStorage'));
+
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: {testParam: 'fromURL'},
+        }),
+      }
+    );
+
+    expect(result.current[0]).toBe('fromURL');
+  });
+
+  it('syncs localStorage when URL changes', async () => {
+    renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: {testParam: 'newURLValue'},
+        }),
+      }
+    );
+
+    await waitFor(() => {
+      const storedValue = localStorageWrapper.getItem('testNamespace:testParam');
+      expect(storedValue).toBe(JSON.stringify('newURLValue'));
+    });
+  });
+
+  it('setValue updates both URL and localStorage', async () => {
+    const onUrlUpdate = jest.fn();
+
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter({onUrlUpdate}),
+      }
+    );
+
+    act(() => {
+      result.current[1]('newValue');
+    });
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryString: expect.stringContaining('testParam=newValue'),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const storedValue = localStorageWrapper.getItem('testNamespace:testParam');
+      expect(storedValue).toBe(JSON.stringify('newValue'));
+    });
+  });
+
+  it('works with enum-like string types', async () => {
+    type SortOption = 'date' | 'name' | 'size';
+
+    localStorageWrapper.setItem('myNamespace:sort', JSON.stringify('name'));
+
+    const onUrlUpdate = jest.fn();
+
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage<SortOption>('sort', 'myNamespace', 'date'),
+      {
+        wrapper: withNuqsTestingAdapter({onUrlUpdate}),
+      }
+    );
+
+    expect(result.current[0]).toBe('name');
+
+    act(() => {
+      result.current[1]('size');
+    });
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryString: expect.stringContaining('sort=size'),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const storedValue = localStorageWrapper.getItem('myNamespace:sort');
+      expect(storedValue).toBe(JSON.stringify('size'));
+    });
+  });
+
+  it('does not sync localStorage if URL value matches localStorage', () => {
+    localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('sameValue'));
+
+    const {result} = renderHook(
+      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: {testParam: 'sameValue'},
+        }),
+      }
+    );
+
+    expect(result.current[0]).toBe('sameValue');
+
+    const storedValue = localStorageWrapper.getItem('testNamespace:testParam');
+    expect(storedValue).toBe(JSON.stringify('sameValue'));
+  });
+});

--- a/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
@@ -12,7 +12,12 @@ describe('useQueryStateWithLocalStorage', () => {
 
   it('returns default value when neither URL nor localStorage has value', () => {
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter(),
       }
@@ -25,7 +30,12 @@ describe('useQueryStateWithLocalStorage', () => {
     localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('fromStorage'));
 
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter(),
       }
@@ -38,7 +48,12 @@ describe('useQueryStateWithLocalStorage', () => {
     localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('fromStorage'));
 
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter({
           searchParams: {testParam: 'fromURL'},
@@ -51,7 +66,12 @@ describe('useQueryStateWithLocalStorage', () => {
 
   it('syncs localStorage when URL changes', async () => {
     renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter({
           searchParams: {testParam: 'newURLValue'},
@@ -69,7 +89,12 @@ describe('useQueryStateWithLocalStorage', () => {
     const onUrlUpdate = jest.fn();
 
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter({onUrlUpdate}),
       }
@@ -101,7 +126,12 @@ describe('useQueryStateWithLocalStorage', () => {
     const onUrlUpdate = jest.fn();
 
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage<SortOption>('sort', 'myNamespace', 'date'),
+      () =>
+        useQueryStateWithLocalStorage<SortOption>({
+          key: 'sort',
+          namespace: 'myNamespace',
+          defaultValue: 'date',
+        }),
       {
         wrapper: withNuqsTestingAdapter({onUrlUpdate}),
       }
@@ -131,7 +161,12 @@ describe('useQueryStateWithLocalStorage', () => {
     localStorageWrapper.setItem('testNamespace:testParam', JSON.stringify('sameValue'));
 
     const {result} = renderHook(
-      () => useQueryStateWithLocalStorage('testParam', 'testNamespace', 'default'),
+      () =>
+        useQueryStateWithLocalStorage({
+          key: 'testParam',
+          namespace: 'testNamespace',
+          defaultValue: 'default',
+        }),
       {
         wrapper: withNuqsTestingAdapter({
           searchParams: {testParam: 'sameValue'},

--- a/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.spec.tsx
@@ -298,4 +298,50 @@ describe('useQueryStateWithLocalStorage', () => {
       'useQueryStateWithLocalStorage: parser should not have .withDefault() configured'
     );
   });
+
+  it('handles empty string values correctly', () => {
+    // Set empty string in localStorage
+    localStorageWrapper.setItem('testNamespace:testParam', '');
+
+    const {result} = renderHook(
+      () =>
+        useQueryStateWithLocalStorage(
+          'testParam',
+          'testNamespace:testParam',
+          parseAsString,
+          'defaultValue'
+        ),
+      {
+        wrapper: withNuqsTestingAdapter(),
+      }
+    );
+
+    // Empty string from localStorage should be returned, not the default
+    expect(result.current[0]).toBe('');
+  });
+
+  it('syncs empty string URL values to localStorage', async () => {
+    const {result} = renderHook(
+      () =>
+        useQueryStateWithLocalStorage(
+          'testParam',
+          'testNamespace:testParam',
+          parseAsString,
+          'defaultValue'
+        ),
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: {testParam: ''},
+        }),
+      }
+    );
+
+    expect(result.current[0]).toBe('');
+
+    // Empty string from URL should be synced to localStorage
+    await waitFor(() => {
+      const storedValue = localStorageWrapper.getItem('testNamespace:testParam');
+      expect(storedValue).toBe('');
+    });
+  });
 });

--- a/static/app/utils/url/useQueryStateWithLocalStorage.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.tsx
@@ -1,5 +1,5 @@
 import {useEffect} from 'react';
-import {parseAsString, useQueryState} from 'nuqs';
+import {parseAsString, useQueryState, type Parser} from 'nuqs';
 
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
@@ -8,29 +8,55 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
  * URL takes precedence over localStorage, enabling URL sharing while
  * maintaining user preferences across sessions.
  *
+ * Supports any data type via Nuqs parsers (parseAsString, parseAsInteger,
+ * parseAsBoolean, parseAsArrayOf, etc.). The parser handles URL serialization
+ * while localStorage uses JSON for storage.
+ *
  * @param props - Configuration object
  * @param props.key - The URL query parameter name
  * @param props.namespace - The localStorage namespace (key will be `namespace:key`)
  * @param props.defaultValue - The default value if neither source has a value
+ * @param props.parser - Nuqs parser for the value type (defaults to parseAsString)
  * @returns Tuple of [effectiveValue, setValue]
  *
  * @example
+ * // String values (parser optional, defaults to parseAsString)
  * const [sortBy, setSortBy] = useQueryStateWithLocalStorage({
  *   key: 'sortBy',
  *   namespace: 'dashboards',
  *   defaultValue: 'date',
  * });
+ *
+ * @example
+ * // Integer values
+ * const [pageSize, setPageSize] = useQueryStateWithLocalStorage({
+ *   key: 'pageSize',
+ *   namespace: 'dashboards',
+ *   defaultValue: 50,
+ *   parser: parseAsInteger,
+ * });
+ *
+ * @example
+ * // Boolean values
+ * const [enabled, setEnabled] = useQueryStateWithLocalStorage({
+ *   key: 'enabled',
+ *   namespace: 'dashboards',
+ *   defaultValue: false,
+ *   parser: parseAsBoolean,
+ * });
  */
-export function useQueryStateWithLocalStorage<T extends string>({
+export function useQueryStateWithLocalStorage<T>({
   key,
   namespace,
   defaultValue,
+  parser = parseAsString as Parser<T>,
 }: {
   defaultValue: T;
   key: string;
   namespace: string;
+  parser?: Parser<T>;
 }): [T, (value: T) => void] {
-  const [urlValue, setUrlValue] = useQueryState(key, parseAsString);
+  const [urlValue, setUrlValue] = useQueryState(key, parser);
 
   const localStorageKey = `${namespace}:${key}`;
 
@@ -39,11 +65,11 @@ export function useQueryStateWithLocalStorage<T extends string>({
     defaultValue
   );
 
-  const effectiveValue = (urlValue ?? localStorageValue ?? defaultValue) as T;
+  const effectiveValue = urlValue ?? localStorageValue ?? defaultValue;
 
   useEffect(() => {
-    if (urlValue && urlValue !== localStorageValue) {
-      setLocalStorageValue(urlValue as T);
+    if (urlValue !== null && urlValue !== undefined && urlValue !== localStorageValue) {
+      setLocalStorageValue(urlValue);
     }
   }, [urlValue, localStorageValue, setLocalStorageValue]);
 

--- a/static/app/utils/url/useQueryStateWithLocalStorage.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.tsx
@@ -1,53 +1,112 @@
-import {useCallback, useEffect} from 'react';
-import {useQueryState, type SingleParserBuilder} from 'nuqs';
+import {useCallback, useEffect, useState} from 'react';
+import {useQueryState, type GenericParserBuilder, type MultiParserBuilder} from 'nuqs';
 
 import {defined} from 'sentry/utils';
 import localStorageWrapper from 'sentry/utils/localStorage';
 
 /**
+ * Type guard to detect if a parser is a MultiParserBuilder.
+ * Multi parsers require special handling for localStorage.
+ */
+function isMultiParser<T>(
+  parser: GenericParserBuilder<T>
+): parser is MultiParserBuilder<T> {
+  return (parser as MultiParserBuilder<T>).type === 'multi';
+}
+
+/**
+ * Parse a value from localStorage based on parser type.
+ * - Single parsers: parse string directly
+ * - Multi parsers: parse JSON array first, then pass to parser
+ */
+function parseFromLocalStorage<T>(
+  stored: string,
+  parser: GenericParserBuilder<T>
+): T | null {
+  if (isMultiParser(parser)) {
+    try {
+      const array = JSON.parse(stored);
+      if (Array.isArray(array)) {
+        return parser.parse(array);
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+  return parser.parse(stored);
+}
+
+/**
+ * Serialize a value to localStorage based on parser type.
+ * - Single parsers: serialize returns string directly
+ * - Multi parsers: serialize returns Array<string>, store as JSON
+ */
+function serializeToLocalStorage<T>(value: T, parser: GenericParserBuilder<T>): string {
+  if (isMultiParser(parser)) {
+    const serialized = parser.serialize(value);
+    return JSON.stringify(serialized);
+  }
+  return parser.serialize(value);
+}
+
+/**
  * Hook that syncs state between URL query parameters and localStorage.
- * URL takes precedence over localStorage, enabling URL sharing while
- * maintaining user preferences across sessions.
+ * After initial mount, URL becomes the single source of truth. On mount, if URL
+ * is empty and localStorage has a value, the URL is populated with that value.
  *
- * Supports any data type via Nuqs parsers (parseAsString, parseAsInteger,
- * parseAsBoolean, parseAsArrayOf, etc.). The parser handles both URL and
- * localStorage serialization/deserialization.
+ * Supports both SingleParserBuilder (parseAsString, parseAsInteger, parseAsArrayOf)
+ * and MultiParserBuilder for maximum flexibility.
  *
  * **Important**: Pass the parser WITHOUT `.withDefault()` - use the separate
- * `defaultValue` parameter instead. This ensures localStorage values are
- * properly prioritized over defaults.
+ * `defaultValue` parameter instead. This is enforced at runtime.
  *
  * @param queryKey - The URL query parameter name
  * @param localStorageKey - The localStorage key
- * @param parser - Nuqs parser WITHOUT .withDefault(). Pass the base parser (parseAsString, parseAsInteger, etc.)
- * @param defaultValue - The default value when neither URL nor localStorage has a value
- * @returns Tuple of [effectiveValue, setValue]
+ * @param parser - Nuqs parser WITHOUT .withDefault()
+ * @param defaultValue - The default value when URL has no value
+ * @returns Tuple of [value, setValue] where setValue accepts value or null to clear
  *
  * @example
- * // String values with default
+ * // String values
  * const [sortBy, setSortBy] = useQueryStateWithLocalStorage(
  *   'sortBy',
  *   'dashboards:sortBy',
  *   parseAsString,
  *   'date'
  * );
+ * setSortBy('name'); // Set to 'name'
+ * setSortBy(null);   // Clear and return to default 'date'
+ *
+ * @example
+ * // Array with parseAsArrayOf (SingleParser)
+ * const [tags, setTags] = useQueryStateWithLocalStorage(
+ *   'tags',
+ *   'filters:tags',
+ *   parseAsArrayOf(parseAsString),
+ *   []
+ * );
  */
 export function useQueryStateWithLocalStorage<T>(
   queryKey: string,
   localStorageKey: string,
-  parser: SingleParserBuilder<T & {}>,
+  parser: GenericParserBuilder<T>,
   defaultValue: T
-): [T, (value: T & {}) => void] {
+): [T, (value: T | null) => void] {
   // Detect if parser has a default value configured (runtime check)
   // Parsers with .withDefault() have a 'defaultValue' property
   //
   // If the parser has `.withDefault()`, it will _always_ return that default
-  // instead of `null` when there's no URL param. This breaks our priority order
-  // (URL > localStorage > default) because we can't distinguish between:
-  //   1. No URL param exists (should fall back to localStorage)
-  //   2. URL param explicitly set to the default value (should use that)
-  // Both would return the same value, making localStorage never take effect.
-  if ('defaultValue' in parser && defined(parser.defaultValue)) {
+  // instead of `null` when there's no URL param. This breaks our priority
+  // because we need the parser to return null when there's no URL value.
+  //
+  // Note: MultiParsers may have internal defaultValue handling that's different,
+  // so we skip this check for them.
+  if (
+    !isMultiParser(parser) &&
+    'defaultValue' in parser &&
+    defined(parser.defaultValue)
+  ) {
     throw new Error(
       `useQueryStateWithLocalStorage: parser should not have .withDefault() configured. ` +
         `Pass the base parser and use the separate defaultValue parameter instead.`
@@ -57,43 +116,63 @@ export function useQueryStateWithLocalStorage<T>(
   // The authoritative state is from the URL parameter
   const [urlValue, setUrlValue] = useQueryState(queryKey, parser);
 
-  // The fallback state is read from `localStorage` directly. We are not using
-  // `useLocalStorageState` because we want to do the deserialization ourselves
-  // according to Nuqs configuration.
-  const stored = localStorageWrapper.getItem(localStorageKey);
-  const localStorageValue = defined(stored) ? parser.parse(stored) : null;
+  // Track whether we've initialized from localStorage
+  const [initialized, setInitialized] = useState(false);
 
-  const effectiveValue = urlValue ?? localStorageValue ?? defaultValue;
+  // On mount, read localStorage ONCE and populate URL if empty
+  // This ensures localStorage is only read on mount, not on every render
+  useEffect(() => {
+    if (!initialized && !defined(urlValue)) {
+      const stored = localStorageWrapper.getItem(localStorageKey);
+      if (defined(stored)) {
+        const parsed = parseFromLocalStorage(stored, parser);
+        if (defined(parsed)) {
+          // Cast to satisfy Nuqs's type signature (T & {} excludes null/undefined)
+          setUrlValue(parsed as T & {});
+        }
+      }
+      setInitialized(true);
+    }
+  }, [initialized, urlValue, localStorageKey, parser, setUrlValue]);
 
-  // Synchronize the URL state and the `localStorage` state by writing the URL
-  // state into `localStorage`. This can happen on hook initialization, if the
-  // URL query state has been updated by the user by some means other than
-  // `setValue`.
+  // After initialization, URL is the single source of truth
+  const effectiveValue = urlValue ?? defaultValue;
+
+  // Synchronize URL changes to localStorage
+  // This happens when URL is updated by external means (e.g., browser back/forward)
   useEffect(() => {
     if (defined(urlValue)) {
+      const storedRaw = localStorageWrapper.getItem(localStorageKey);
+      const storedValue = defined(storedRaw)
+        ? parseFromLocalStorage(storedRaw, parser)
+        : null;
+
       // Use parser's equality check if available (for arrays, objects, etc.)
-      // Otherwise fall back to strict equality
       const areEqual =
-        defined(localStorageValue) && 'eq' in parser && typeof parser.eq === 'function'
-          ? parser.eq(urlValue, localStorageValue)
-          : urlValue === localStorageValue;
+        defined(storedValue) && 'eq' in parser && typeof parser.eq === 'function'
+          ? parser.eq(urlValue, storedValue)
+          : urlValue === storedValue;
 
       if (!areEqual) {
-        const serializedUrlValue = parser.serialize(urlValue);
+        const serializedUrlValue = serializeToLocalStorage(urlValue, parser);
         localStorageWrapper.setItem(localStorageKey, serializedUrlValue);
       }
     }
-  }, [parser, urlValue, localStorageValue, localStorageKey]);
+  }, [parser, urlValue, localStorageKey]);
 
   const setValue = useCallback(
-    (value: T & {}) => {
-      // `setURLValue` is async in Nuqs. Maybe it's because of throttling.
-      // Normally we might want to `await` the Promise from `setUrlValue` but it'd
-      // be bad for us to have the Nuqs state and the `localStorage` state be out
-      // of sync because the `useEffect` above might re-run.
-      setUrlValue(value);
-      const serializedValue = parser.serialize(value);
-      localStorageWrapper.setItem(localStorageKey, serializedValue);
+    (value: T | null) => {
+      if (value === null) {
+        // Clear both URL and localStorage
+        setUrlValue(null);
+        localStorageWrapper.removeItem(localStorageKey);
+      } else {
+        // Set value in both URL and localStorage
+        // Cast to satisfy Nuqs's type signature (T & {} excludes null/undefined)
+        setUrlValue(value as T & {});
+        const serializedValue = serializeToLocalStorage(value, parser);
+        localStorageWrapper.setItem(localStorageKey, serializedValue);
+      }
     },
     [setUrlValue, parser, localStorageKey]
   );

--- a/static/app/utils/url/useQueryStateWithLocalStorage.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.tsx
@@ -8,23 +8,28 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
  * URL takes precedence over localStorage, enabling URL sharing while
  * maintaining user preferences across sessions.
  *
- * @param key - The URL query parameter name
- * @param namespace - The localStorage namespace (key will be `namespace:key`)
- * @param defaultValue - The default value if neither source has a value
+ * @param props - Configuration object
+ * @param props.key - The URL query parameter name
+ * @param props.namespace - The localStorage namespace (key will be `namespace:key`)
+ * @param props.defaultValue - The default value if neither source has a value
  * @returns Tuple of [effectiveValue, setValue]
  *
  * @example
- * const [sortBy, setSortBy] = useQueryStateWithLocalStorage(
- *   'sortBy',
- *   'dashboards',
- *   'date'
- * );
+ * const [sortBy, setSortBy] = useQueryStateWithLocalStorage({
+ *   key: 'sortBy',
+ *   namespace: 'dashboards',
+ *   defaultValue: 'date',
+ * });
  */
-export function useQueryStateWithLocalStorage<T extends string>(
-  key: string,
-  namespace: string,
-  defaultValue: T
-): [T, (value: T) => void] {
+export function useQueryStateWithLocalStorage<T extends string>({
+  key,
+  namespace,
+  defaultValue,
+}: {
+  defaultValue: T;
+  key: string;
+  namespace: string;
+}): [T, (value: T) => void] {
   const [urlValue, setUrlValue] = useQueryState(key, parseAsString);
 
   const localStorageKey = `${namespace}:${key}`;

--- a/static/app/utils/url/useQueryStateWithLocalStorage.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.tsx
@@ -1,0 +1,51 @@
+import {useEffect} from 'react';
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+
+/**
+ * Hook that syncs state between URL query parameters and localStorage.
+ * URL takes precedence over localStorage, enabling URL sharing while
+ * maintaining user preferences across sessions.
+ *
+ * @param key - The URL query parameter name
+ * @param namespace - The localStorage namespace (key will be `namespace:key`)
+ * @param defaultValue - The default value if neither source has a value
+ * @returns Tuple of [effectiveValue, setValue]
+ *
+ * @example
+ * const [sortBy, setSortBy] = useQueryStateWithLocalStorage(
+ *   'sortBy',
+ *   'dashboards',
+ *   'date'
+ * );
+ */
+export function useQueryStateWithLocalStorage<T extends string>(
+  key: string,
+  namespace: string,
+  defaultValue: T
+): [T, (value: T) => void] {
+  const [urlValue, setUrlValue] = useQueryState(key, parseAsString);
+
+  const localStorageKey = `${namespace}:${key}`;
+
+  const [localStorageValue, setLocalStorageValue] = useLocalStorageState<T>(
+    localStorageKey,
+    defaultValue
+  );
+
+  const effectiveValue = (urlValue ?? localStorageValue ?? defaultValue) as T;
+
+  useEffect(() => {
+    if (urlValue && urlValue !== localStorageValue) {
+      setLocalStorageValue(urlValue as T);
+    }
+  }, [urlValue, localStorageValue, setLocalStorageValue]);
+
+  const setValue = (value: T) => {
+    setUrlValue(value);
+    setLocalStorageValue(value);
+  };
+
+  return [effectiveValue, setValue];
+}

--- a/static/app/utils/url/useQueryStateWithLocalStorage.tsx
+++ b/static/app/utils/url/useQueryStateWithLocalStorage.tsx
@@ -61,7 +61,7 @@ export function useQueryStateWithLocalStorage<T>(
   // `useLocalStorageState` because we want to do the deserialization ourselves
   // according to Nuqs configuration.
   const stored = localStorageWrapper.getItem(localStorageKey);
-  const localStorageValue = stored ? parser.parse(stored) : null;
+  const localStorageValue = defined(stored) ? parser.parse(stored) : null;
 
   const effectiveValue = urlValue ?? localStorageValue ?? defaultValue;
 


### PR DESCRIPTION
Adds a reusable hook that syncs state between URL query parameters and localStorage. URL takes precedence (for sharing), with localStorage providing session persistence.

Supports any data type via Nuqs parsers (strings, integers, booleans, arrays, etc.).

## API

```typescript
const [pageSize, setPageSize] = useQueryStateWithLocalStorage({
  queryKey: 'sort',
  localStorageKey: 'dashboards:sort',
  defaultValue: 50,
  parser: parseAsInteger,
});

```

Creates URL param (e.g., `?sort=date`) and localStorage key (e.g., `dashboards:sort`).

## Use Cases

- Filter/sort preferences needing both persistence and URL shareability
- View modes, page sizes, or toggle states
- Any state benefiting from both localStorage and URL sharing

## Gotchas

The only major gotcha is `defaultValue`. Nuqs has a `.withDefault` API, but we cannot allow using it here. If a parser has `.withDefault` it'll never return `null` and we don't know when to fall back to `localStorage`. I figured that a `defaultValue` is a natural enough API in React land, and we have error checking around the gotcha, and an explanation.