### PR TITLE
feat(ACI): Publish workflow engine API docs

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -155,6 +155,16 @@ OPENAPI_TAGS = [
         },
     },
     {
+        "name": "Monitors",
+        "x-sidebar-name": "Monitors and Alerts",
+        "description": "Endpoints for Monitors and Alerts",
+        "x-display-description": False,
+        "externalDocs": {
+            "description": "Found an error? Let us know.",
+            "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/monitors/&template=api_error_template.md",
+        },
+    },
+    {
         "name": "Integrations",
         "x-sidebar-name": "Integrations",
         "description": "Endpoints for Integrations",

--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -156,7 +156,7 @@ OPENAPI_TAGS = [
     },
     {
         "name": "Monitors",
-        "x-sidebar-name": "Monitors and Alerts",
+        "x-sidebar-name": "Monitors & Alerts",
         "description": "Endpoints for Monitors and Alerts",
         "x-display-description": False,
         "externalDocs": {

--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -250,7 +250,7 @@ class WorkflowEngineExamples:
                 },
                 "openIssues": 0,
             },
-            status_codes=["201"],
+            status_codes=["200"],
             response_only=True,
         )
     ]
@@ -520,7 +520,7 @@ class WorkflowEngineExamples:
                     "openIssues": 0,
                 },
             ],
-            status_codes=["201"],
+            status_codes=["200"],
             response_only=True,
         )
     ]
@@ -686,7 +686,7 @@ class WorkflowEngineExamples:
                     "lastTriggered": None,
                 },
             ],
-            status_codes=["201"],
+            status_codes=["200"],
             response_only=True,
         )
     ]

--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -339,6 +339,8 @@ class WorkflowEngineExamples:
                 },
                 "openIssues": 0,
             },
+            status_codes=["200"],
+            response_only=True,
         )
     ]
     LIST_ORG_DETECTORS = [

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -423,7 +423,7 @@ class DetectorParams:
         location="path",
         required=True,
         type=int,
-        description="The ID of the detector you'd like to query.",
+        description="The ID of the monitor you'd like to query.",
     )
 
     QUERY = OpenApiParameter(
@@ -431,7 +431,7 @@ class DetectorParams:
         location="query",
         required=False,
         type=str,
-        description="An optional search query for filtering detectors.",
+        description="An optional search query for filtering monitors.",
     )
 
     SORT = OpenApiParameter(
@@ -457,7 +457,7 @@ Prefix with `-` to sort in descending order.
         location="query",
         required=False,
         type=int,
-        description="The ID of the detector you'd like to query.",
+        description="The ID of the monitor you'd like to query.",
         many=True,
     )
 
@@ -467,7 +467,7 @@ Prefix with `-` to sort in descending order.
         required=False,
         type=str,
         many=True,
-        description="Filter by detector type(s). Can be specified multiple times.",
+        description="Filter by monitor type(s). Can be specified multiple times.",
     )
 
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -64,7 +64,7 @@ def get_detector_validator(
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Workflows"])
+@extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     def convert_args(self, request: Request, detector_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
@@ -88,9 +88,9 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         return args, kwargs
 
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
-        "PUT": ApiPublishStatus.EXPERIMENTAL,
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
 
@@ -105,7 +105,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             DetectorParams.DETECTOR_ID,
         ],
         responses={
-            201: DetectorSerializer,
+            200: DetectorSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -143,13 +143,13 @@ def get_detector_validator(
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Workflows"])
+@extend_schema(tags=["Monitors"])
 class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
-        "POST": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
 
@@ -244,7 +244,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             DetectorParams.ID,
         ],
         responses={
-            201: inline_sentry_response_serializer(
+            200: inline_sentry_response_serializer(
                 "ListDetectorSerializerResponse", list[DetectorSerializerResponse]
             ),
             400: RESPONSE_BAD_REQUEST,
@@ -447,7 +447,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Delete an Organization's Detectors",
+        operation_id="Bulk Delete Monitors",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
@@ -466,7 +466,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request: Request, organization: Organization) -> Response:
         """
-        Delete an Organization's Detectors
+        Bulk delete Monitors for a given organization
         """
         if not request.user.is_authenticated:
             return self.respond(status=status.HTTP_401_UNAUTHORIZED)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -34,12 +34,12 @@ from sentry.workflow_engine.models import Workflow
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Workflows"])
+@extend_schema(tags=["Monitors"])
 class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
-        "PUT": ApiPublishStatus.EXPERIMENTAL,
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
 
@@ -70,7 +70,7 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
         return Response(serialized_workflow)
 
     @extend_schema(
-        operation_id="Update an Alert",
+        operation_id="Update an Alert by ID",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             WorkflowParams.WORKFLOW_ID,

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -111,13 +111,13 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Workflows"])
+@extend_schema(tags=["Monitors"])
 class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
-        "POST": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (OrganizationWorkflowPermission,)
@@ -190,7 +190,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
             OrganizationParams.PROJECT,
         ],
         responses={
-            201: inline_sentry_response_serializer(
+            200: inline_sentry_response_serializer(
                 "ListWorkflowSerializer", list[WorkflowSerializerResponse]
             ),
             400: RESPONSE_BAD_REQUEST,
@@ -270,7 +270,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Create an Alert",
+        operation_id="Create an Alert for an Organization",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
         ],
@@ -370,7 +370,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Delete an Organization's Alerts",
+        operation_id="Bulk Delete Alerts",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             WorkflowParams.QUERY,

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -42,7 +42,7 @@ class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     workflowIds: list[str]
     dateCreated: datetime
     dateUpdated: datetime
-    dataSources: list[dict]
+    dataSources: list[dict] | None
     conditionGroup: dict | None
     config: dict
     enabled: bool

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -34,8 +34,8 @@ class TriggerSerializerResponse(TypedDict):
     id: str
     organizationId: str
     logicType: str
-    conditions: list[ConditionSerializerResponse] | None
-    actions: list[ActionSerializerResponse] | None
+    conditions: list[ConditionSerializerResponse] | list[Any]
+    actions: list[ActionSerializerResponse] | list[Any]
 
 
 class WorkflowSerializerResponse(TypedDict):


### PR DESCRIPTION
Add the sidebar item and set the publish status to public for all the workflow engine endpoints we intend to document for launch. 

<img width="1346" height="819" alt="Screenshot 2026-01-20 at 2 35 12 PM" src="https://github.com/user-attachments/assets/cb8a2aed-bfa0-49bd-8838-06f88889bd4a" />

A follow up item will be to mark all the old alerts endpoints as deprecated and link to these new docs.