### PR TITLE
chore(cells): deprecate group-activities endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_activities.py
+++ b/src/sentry/issues/endpoints/group_activities.py
@@ -3,7 +3,9 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -15,6 +17,7 @@ class GroupActivitiesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-activities"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve all the Activities for a Group

--- a/tests/sentry/issues/endpoints/test_group_activities.py
+++ b/tests/sentry/issues/endpoints/test_group_activities.py
@@ -10,7 +10,7 @@ class GroupActivitiesEndpointTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/activities/"
+        url = f"/api/0/organizations/{group.organization.id}/issues/{group.id}/activities/"
         response = self.client.get(
             url,
             format="json",
@@ -32,7 +32,7 @@ class GroupActivitiesEndpointTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/activities/"
+        url = f"/api/0/organizations/{group.organization.id}/issues/{group.id}/activities/"
         response = self.client.get(
             url,
             format="json",


### PR DESCRIPTION
Add deprecation decorators to GroupActivitiesEndpoint and update tests to use the org-scoped variant's URL pattern. Follow-up PR coming to update frontend references. 