### PR TITLE
fix(aci): handle fallthroughType in email action translator

### DIFF
--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -769,7 +769,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "targetIdentifier": "",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "fallthrough_type": "NoOne",
+        "fallthroughType": "NoOne",
         "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
     },
     # AllMembers Fallthrough (targetIdentifier is None)
@@ -785,7 +785,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "targetIdentifier": "None",
-        "fallthrough_type": "NoOne",
+        "fallthroughType": "NoOne",
         "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
     },
     # ActiveMembers Fallthrough

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -101,6 +101,7 @@ class EmailFieldMappingKeys(StrEnum):
     """
 
     FALLTHROUGH_TYPE_KEY = "fallthrough_type"
+    FALLTHROUGH_TYPE_KEY_V2 = "fallthroughType"
     TARGET_TYPE_KEY = "targetType"
 
 
@@ -577,12 +578,19 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
             self.action.get(EmailFieldMappingKeys.TARGET_TYPE_KEY.value)
             == ActionTargetType.ISSUE_OWNERS.value
         ):
+            fallthrough_type: str | None = self.action.get(
+                EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value,
+                None,
+            )
+            if fallthrough_type is None:
+                fallthrough_type = self.action.get(
+                    EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY_V2.value,
+                    FallthroughChoiceType.ACTIVE_MEMBERS.value,
+                )
+
             return dataclasses.asdict(
                 EmailDataBlob(
-                    fallthrough_type=self.action.get(
-                        EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value,
-                        FallthroughChoiceType.ACTIVE_MEMBERS.value,
-                    ),
+                    fallthrough_type=str(fallthrough_type),
                 )
             )
         return {}

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core import mail
 
 from sentry.eventstream.types import EventStreamEventType
@@ -133,6 +134,15 @@ class NotifyEmailFormTest(TestCase):
 
 class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
     rule_cls = NotifyEmailAction
+
+    @pytest.fixture(autouse=True)
+    def with_feature_flags(self):
+        with override_options(
+            {
+                "workflow_engine.issue_alert.group.type_id.ga": [1],
+            }
+        ):
+            yield
 
     def setUp(self):
         self.one_min_ago = before_now(minutes=1).isoformat()

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -563,6 +563,11 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
             if target_identifier in ("None", "", None):
                 target_identifier = None
 
+            # Convert fallthroughType (camelCase) to fallthrough_type (snake_case)
+            # to match the Action data schema
+            if "fallthroughType" in action_data:
+                action_data["fallthrough_type"] = action_data.pop("fallthroughType")
+
             action = self.create_action(
                 type=Action.Type.EMAIL,
                 data=action_data,

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -115,10 +115,14 @@ class TestNotificationActionMigrationUtils(TestCase):
                     else:
                         # For unmapped fields, check directly with empty string default
                         if action.type == Action.Type.EMAIL and field == "fallthrough_type":
-                            # for email actions, the default value for fallthrough_type should be "ActiveMembers"
-                            assert action.data.get(field) == compare_dict.get(
-                                field, "ActiveMembers"
+                            fallthrough_fields = ["fallthrough_type", "fallthroughType"]
+                            assert any(
+                                [
+                                    action.data.get(field) == compare_dict.get(f, "ActiveMembers")
+                                    for f in fallthrough_fields
+                                ]
                             )
+                            # for email actions, the default value for fallthrough_type should be "ActiveMembers"
                         else:
                             assert action.data.get(field) == compare_dict.get(field, "")
                 # Ensure no extra fields
@@ -131,7 +135,7 @@ class TestNotificationActionMigrationUtils(TestCase):
                 if key not in exclude_keys:
                     if (
                         action.type == Action.Type.EMAIL
-                        and key == "fallthrough_type"
+                        and (key == "fallthrough_type" or key == "fallthroughType")
                         and action.config.get("target_type") != ActionTarget.ISSUE_OWNERS
                     ):
                         # for email actions, fallthrough_type should only be set for when targetType is ISSUE_OWNERS


### PR DESCRIPTION
The UI calls the API with `fallthroughType` for old Rules with email actions, and we previously were assuming that only `fallthrough_type` is used for Rules. We should account for both and we'll need a backfill migration to correct this for old `Rules` migrated to `Workflows`.

Examples
https://github.com/getsentry/sentry/blob/bd8d642b110e539938a108219cc57110ac5f5998/src/sentry/apidocs/examples/issue_alert_examples.py#L123-L130

https://github.com/getsentry/sentry/blob/bd8d642b110e539938a108219cc57110ac5f5998/src/sentry/api/endpoints/project_rules.py#L481-L492