### PR TITLE
fix(ACI): Fix workflow environment field

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -47,7 +47,9 @@ class WorkflowValidator(CamelSnakeSerializer):
         help_text=WORKFLOW_CONFIG_HELP_TEXT,
     )
     environment = EnvironmentField(
-        required=False, help_text="The name of the environment for the alert to evaluate in"
+        required=False,
+        allow_null=True,
+        help_text="The name of the environment for the alert to evaluate in",
     )
 
     triggers = BaseDataConditionGroupValidator(

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -273,12 +273,14 @@ class WorkflowValidator(CamelSnakeSerializer):
         with transaction.atomic(router.db_for_write(Workflow)):
             when_condition_group = condition_group_validator.create(validated_value["triggers"])
 
+            environment = validated_value.get("environment")
+
             workflow = Workflow.objects.create(
                 name=validated_value["name"],
                 enabled=validated_value["enabled"],
                 config=validated_value["config"],
                 organization_id=self.context["organization"].id,
-                environment_id=validated_value.get("environment_id"),
+                environment_id=environment.id if environment else None,
                 when_condition_group=when_condition_group,
                 created_by_id=self.context["request"].user.id,
             )

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from sentry import audit_log, features
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.db import models
 from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
@@ -45,9 +46,9 @@ class WorkflowValidator(CamelSnakeSerializer):
         required=False,
         help_text=WORKFLOW_CONFIG_HELP_TEXT,
     )
-    environment_id = serializers.IntegerField(
+    environment = EnvironmentField(
         required=False, help_text="The name of the environment for the alert to evaluate in"
-    )  # TODO fix this, we pass the name, not the ID
+    )
 
     triggers = BaseDataConditionGroupValidator(
         required=False,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -96,6 +96,36 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert response.status_code == 200
         assert updated_workflow.name == "Updated Workflow"
 
+    def test_update_add_environment(self) -> None:
+        assert self.workflow.environment_id is None
+
+        self.valid_workflow["environment"] = self.environment.name
+        response = self.get_success_response(
+            self.organization.slug, self.workflow.id, raw_data=self.valid_workflow
+        )
+        updated_workflow = Workflow.objects.get(id=response.data.get("id"))
+
+        assert response.status_code == 200
+        assert response.data["environment"] == self.environment.name
+        assert updated_workflow.environment_id == self.environment.id
+
+    def test_update_environment(self) -> None:
+        self.workflow.environment_id = self.environment.id
+        self.workflow.save()
+        self.workflow.refresh_from_db()
+        assert self.workflow.environment_id == self.environment.id
+
+        test_environment = self.create_environment(name="test", project=self.project)
+        self.valid_workflow["environment"] = test_environment.name
+        response = self.get_success_response(
+            self.organization.slug, self.workflow.id, raw_data=self.valid_workflow
+        )
+        updated_workflow = Workflow.objects.get(id=response.data.get("id"))
+
+        assert response.status_code == 200
+        assert response.data["environment"] == test_environment.name
+        assert updated_workflow.environment_id == test_environment.id
+
     @responses.activate
     def test_update_add_sentry_app_action(self) -> None:
         """

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -542,6 +542,19 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             data=new_workflow.get_audit_log_data(),
         )
 
+    def test_create_workflow__with_environment(self) -> None:
+        self.valid_workflow["environment"] = self.environment.name
+        response = self.get_success_response(
+            self.organization.slug,
+            raw_data=self.valid_workflow,
+        )
+
+        assert response.status_code == 201
+        new_workflow = Workflow.objects.get(id=response.data["id"])
+        assert response.data == serialize(new_workflow)
+        assert response.data["environment"] == self.environment.name
+        assert new_workflow.environment_id == self.environment.id
+
     def test_create_workflow__with_config(self) -> None:
         self.valid_workflow["config"] = {"frequency": 100}
         response = self.get_success_response(


### PR DESCRIPTION
The workflow validator has `environment_id` but in practice we pass the name of the environment - we're not actually able to create a workflow with an environment from the UI today. This PR fixes that so that you can pass an environment and have it actually saved. 

Fixes https://linear.app/getsentry/issue/ISWF-883/fix-environment-in-workflow-serializer