### PR TITLE
feat(preprod): show callers of status check and dedup head artifacts

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -233,6 +233,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             create_preprod_status_check_task.apply_async(
                 kwargs={
                     "preprod_artifact_id": artifact.id,
+                    "caller": "assemble_endpoint",
                 }
             )
 

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
@@ -88,7 +88,9 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
             try:
                 match check_type:
                     case "size":
-                        create_preprod_status_check_task.delay(preprod_artifact_id=head_artifact.id)
+                        create_preprod_status_check_task.delay(
+                            preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
+                        )
                     case _:
                         continue
             except Exception:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -378,6 +378,7 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             create_preprod_status_check_task.apply_async(
                 kwargs={
                     "preprod_artifact_id": artifact_id_int,
+                    "caller": "artifact_update_endpoint",
                 }
             )
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -17,7 +17,10 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.size_analysis.compare import compare_size_analysis
 from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
-from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
+from sentry.preprod.size_analysis.utils import (
+    build_size_metrics_map,
+    can_compare_size_metrics,
+)
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -48,7 +51,7 @@ def compare_preprod_artifact_size_analysis(
     )
 
     try:
-        artifact = PreprodArtifact.objects.get(
+        artifact: PreprodArtifact = PreprodArtifact.objects.get(
             id=artifact_id,
             project__organization_id=org_id,
             project_id=project_id,
@@ -69,8 +72,8 @@ def compare_preprod_artifact_size_analysis(
         )
         return
 
-    comparisons = []
-    preprod_artifact_status_check_updates = [artifact.id]
+    comparisons: list[dict[str, PreprodArtifactSizeMetrics]] = []
+    preprod_artifact_status_check_updates: set[int] = {artifact.id}
 
     # Create all comparisons with artifact as head
     base_artifact = artifact.get_base_artifact_for_commit().first()
@@ -84,6 +87,7 @@ def compare_preprod_artifact_size_analysis(
             create_preprod_status_check_task.apply_async(
                 kwargs={
                     "preprod_artifact_id": artifact_id,
+                    "caller": "compare_build_config_mismatch",
                 }
             )
             return
@@ -188,7 +192,7 @@ def compare_preprod_artifact_size_analysis(
                 comparisons.append(
                     {"head_metric": head_metric, "base_metric": matching_base_size_metric},
                 )
-                preprod_artifact_status_check_updates.append(head_artifact.id)
+                preprod_artifact_status_check_updates.add(head_artifact.id)
             else:
                 logger.info(
                     "preprod.size_analysis.compare.no_matching_base_size_metric",
@@ -222,6 +226,7 @@ def compare_preprod_artifact_size_analysis(
             create_preprod_status_check_task.apply_async(
                 kwargs={
                     "preprod_artifact_id": artifact_id,
+                    "caller": "compare_completion",
                 }
             )
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -17,10 +17,7 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.size_analysis.compare import compare_size_analysis
 from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
-from sentry.preprod.size_analysis.utils import (
-    build_size_metrics_map,
-    can_compare_size_metrics,
-)
+from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -132,6 +132,7 @@ def assemble_preprod_artifact(
         create_preprod_status_check_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact_id,
+                "caller": "assemble_bundle_error",
             }
         )
 
@@ -170,6 +171,7 @@ def assemble_preprod_artifact(
         create_preprod_status_check_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact_id,
+                "caller": "assemble_dispatch_error",
             }
         )
         return
@@ -631,6 +633,7 @@ def _assemble_preprod_artifact_size_analysis(
         create_preprod_status_check_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact_id,
+                "caller": "assemble_completion",
             }
         )
 
@@ -873,7 +876,7 @@ def detect_expired_preprod_artifacts() -> None:
             )
             try:
                 create_preprod_status_check_task.apply_async(
-                    kwargs={"preprod_artifact_id": artifact_id}
+                    kwargs={"preprod_artifact_id": artifact_id, "caller": "expired_artifact"}
                 )
             except Exception:
                 logger.exception(

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -79,7 +79,9 @@ preprod_artifact_search_config = SearchConfig.create_from(
     retry=Retry(times=3, delay=60, on=(ApiRateLimitedError,)),
     silo_mode=SiloMode.REGION,
 )
-def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) -> None:
+def create_preprod_status_check_task(
+    preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
+) -> None:
     try:
         preprod_artifact: PreprodArtifact | None = PreprodArtifact.objects.get(
             id=preprod_artifact_id
@@ -87,20 +89,20 @@ def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) ->
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id},
+            extra={"artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     if not preprod_artifact or not isinstance(preprod_artifact, PreprodArtifact):
         logger.error(
             "preprod.status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id},
+            extra={"artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     logger.info(
         "preprod.status_checks.create.start",
-        extra={"artifact_id": preprod_artifact.id},
+        extra={"artifact_id": preprod_artifact.id, "caller": caller},
     )
 
     if not preprod_artifact.commit_comparison:

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_status_checks.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_status_checks.py
@@ -41,7 +41,9 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
 
             assert response.data["success"] is True
             assert response.data["check_types"] == ["size"]
-            mock_task.delay.assert_called_once_with(preprod_artifact_id=artifact.id)
+            mock_task.delay.assert_called_once_with(
+                preprod_artifact_id=artifact.id, caller="rerun_endpoint"
+            )
 
     def test_invalid_check_types(self):
         commit_comparison = self.create_commit_comparison(

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -213,7 +213,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
             # Should call create_preprod_status_check_task for the head artifact
             mock_status_check_task.apply_async.assert_called_once_with(
-                kwargs={"preprod_artifact_id": head_artifact.id}
+                kwargs={"preprod_artifact_id": head_artifact.id, "caller": "compare_completion"}
             )
 
     def test_compare_preprod_artifact_size_analysis_success_as_base(self):
@@ -360,7 +360,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
             # Should still call create_preprod_status_check_task once for the artifact
             mock_status_check_task.apply_async.assert_called_once_with(
-                kwargs={"preprod_artifact_id": artifact.id}
+                kwargs={"preprod_artifact_id": artifact.id, "caller": "compare_completion"}
             )
 
     def test_compare_preprod_artifact_size_analysis_cannot_compare_metrics(self):
@@ -432,7 +432,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
             # Should still call create_preprod_status_check_task once for the head artifact
             mock_status_check_task.apply_async.assert_called_once_with(
-                kwargs={"preprod_artifact_id": head_artifact.id}
+                kwargs={"preprod_artifact_id": head_artifact.id, "caller": "compare_completion"}
             )
 
     def test_compare_preprod_artifact_size_analysis_different_build_configurations_as_head(self):
@@ -496,7 +496,10 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
             # Should still call create_preprod_status_check_task once for the head artifact
             mock_status_check_task.apply_async.assert_called_once_with(
-                kwargs={"preprod_artifact_id": head_artifact.id}
+                kwargs={
+                    "preprod_artifact_id": head_artifact.id,
+                    "caller": "compare_completion",
+                }
             )
 
     def test_compare_preprod_artifact_size_analysis_different_build_configurations_as_base(self):
@@ -570,7 +573,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             # Should still call create_preprod_status_check_task once for the base artifact
             # but not for the head artifact (since should_update_status_check remains False)
             mock_status_check_task.apply_async.assert_called_once_with(
-                kwargs={"preprod_artifact_id": base_artifact.id}
+                kwargs={"preprod_artifact_id": base_artifact.id, "caller": "compare_completion"}
             )
 
 


### PR DESCRIPTION
It looks like we have some extra status checks being called but hard to definitively tell without extra logging.