### PR TITLE
bug(code-review): Update initial data defaults for repo settings to falsy if doesn't exist

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -26,10 +26,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
       apiEndpoint={`/organizations/${organization.slug}/repos/settings/`}
       initialData={
         {
-          enabledCodeReview:
-            repoWithSettings?.settings?.enabledCodeReview ??
-            organization.autoEnableCodeReview ??
-            true,
+          enabledCodeReview: repoWithSettings?.settings?.enabledCodeReview ?? false,
           codeReviewTriggers:
             repoWithSettings?.settings?.codeReviewTriggers ??
             organization.defaultCodeReviewTriggers ??

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,3 +1,7 @@
+import {Fragment} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {t, tct} from 'sentry/locale';
@@ -16,58 +20,67 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
   const canWrite = useCanWriteSettings();
 
   return (
-    <Form
-      allowUndo
-      saveOnBlur
-      apiMethod="PUT"
-      apiEndpoint={`/organizations/${organization.slug}/repos/settings/`}
-      initialData={
-        {
-          enabledCodeReview: repoWithSettings?.settings?.enabledCodeReview ?? false,
-          codeReviewTriggers: repoWithSettings?.settings?.codeReviewTriggers ?? [],
-          repositoryIds: [repoWithSettings.id],
-        } satisfies RepositorySettings
-      }
-    >
-      <JsonForm
-        disabled={!canWrite}
-        forms={[
+    <Fragment>
+      {canWrite ? null : (
+        <Alert data-test-id="org-permission-alert" variant="warning">
+          {t(
+            'These settings can only be edited by users with the organization owner or manager role.'
+          )}
+        </Alert>
+      )}
+      <Form
+        allowUndo
+        saveOnBlur
+        apiMethod="PUT"
+        apiEndpoint={`/organizations/${organization.slug}/repos/settings/`}
+        initialData={
           {
-            title: t('AI Code Review'),
-            fields: [
-              {
-                name: 'enabledCodeReview',
-                label: t('Enable Code Review'),
-                help: t('Seer will review your PRs and flag potential bugs.'),
-                type: 'boolean',
-                getData: data => ({
-                  enabledCodeReview: data.enabledCodeReview,
-                  repositoryIds: [repoWithSettings.id],
-                }),
-              },
-              {
-                name: 'codeReviewTriggers',
-                label: t('Code Review Triggers'),
-                help: tct(
-                  'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
-                  {code: <code />}
-                ),
-                type: 'choice',
-                multiple: true,
-                choices: [
-                  ['on_ready_for_review', t('On Ready for Review')],
-                  ['on_new_commit', t('On New Commit')],
-                ],
-                formatMessageValue: false,
-                getData: data => ({
-                  codeReviewTriggers: data.codeReviewTriggers,
-                  repositoryIds: [repoWithSettings.id],
-                }),
-              },
-            ],
-          },
-        ]}
-      />
-    </Form>
+            enabledCodeReview: repoWithSettings?.settings?.enabledCodeReview ?? false,
+            codeReviewTriggers: repoWithSettings?.settings?.codeReviewTriggers ?? [],
+            repositoryIds: [repoWithSettings.id],
+          } satisfies RepositorySettings
+        }
+      >
+        <JsonForm
+          disabled={!canWrite}
+          forms={[
+            {
+              title: t('AI Code Review'),
+              fields: [
+                {
+                  name: 'enabledCodeReview',
+                  label: t('Enable Code Review'),
+                  help: t('Seer will review your PRs and flag potential bugs.'),
+                  type: 'boolean',
+                  getData: data => ({
+                    enabledCodeReview: data.enabledCodeReview,
+                    repositoryIds: [repoWithSettings.id],
+                  }),
+                },
+                {
+                  name: 'codeReviewTriggers',
+                  label: t('Code Review Triggers'),
+                  help: tct(
+                    'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                    {code: <code />}
+                  ),
+                  type: 'choice',
+                  multiple: true,
+                  choices: [
+                    ['on_ready_for_review', t('On Ready for Review')],
+                    ['on_new_commit', t('On New Commit')],
+                  ],
+                  formatMessageValue: false,
+                  getData: data => ({
+                    codeReviewTriggers: data.codeReviewTriggers,
+                    repositoryIds: [repoWithSettings.id],
+                  }),
+                },
+              ],
+            },
+          ]}
+        />
+      </Form>
+    </Fragment>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,6 +1,5 @@
-import {Fragment} from 'react';
-
 import {Alert} from '@sentry/scraps/alert';
+import {Stack} from '@sentry/scraps/layout/stack';
 
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -20,7 +19,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
   const canWrite = useCanWriteSettings();
 
   return (
-    <Fragment>
+    <Stack gap="lg">
       {canWrite ? null : (
         <Alert data-test-id="org-permission-alert" variant="warning">
           {t(
@@ -81,6 +80,6 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
           ]}
         />
       </Form>
-    </Fragment>
+    </Stack>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,10 +1,7 @@
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {t, tct} from 'sentry/locale';
-import {
-  DEFAULT_CODE_REVIEW_TRIGGERS,
-  type RepositoryWithSettings,
-} from 'sentry/types/integrations';
+import {type RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 
 import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
@@ -27,10 +24,7 @@ export default function RepoDetailsForm({organization, repoWithSettings}: Props)
       initialData={
         {
           enabledCodeReview: repoWithSettings?.settings?.enabledCodeReview ?? false,
-          codeReviewTriggers:
-            repoWithSettings?.settings?.codeReviewTriggers ??
-            organization.defaultCodeReviewTriggers ??
-            DEFAULT_CODE_REVIEW_TRIGGERS,
+          codeReviewTriggers: repoWithSettings?.settings?.codeReviewTriggers ?? [],
           repositoryIds: [repoWithSettings.id],
         } satisfies RepositorySettings
       }


### PR DESCRIPTION
This PR aims to fix a minor inconsistency between the list view and the detail view for the seer code review repository settings where the list view was falling back to false if settings didn't exist, but the detail view was falling back to the org defaults and then true in the event the repository settings doesn't exist.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
