### PR TITLE
fix(code review): create repo settings even if org's default code review toggle is false

### DIFF
--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -165,7 +165,7 @@ class Repository(Model):
         if self.provider not in SUPPORTED_PROVIDERS:
             return
 
-        enable_code_review = OrganizationOption.objects.get_value(
+        enabled_code_review = OrganizationOption.objects.get_value(
             organization=self.organization_id,
             key="sentry:auto_enable_code_review",
             default=False,
@@ -180,7 +180,7 @@ class Repository(Model):
 
         RepositorySettings.objects.get_or_create(
             repository_id=self.id,
-            defaults={"enabled_code_review": enable_code_review, "code_review_triggers": triggers},
+            defaults={"enabled_code_review": enabled_code_review, "code_review_triggers": triggers},
         )
 
 

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -165,23 +165,23 @@ class Repository(Model):
         if self.provider not in SUPPORTED_PROVIDERS:
             return
 
-        if OrganizationOption.objects.get_value(
+        enable_code_review = OrganizationOption.objects.get_value(
             organization=self.organization_id,
             key="sentry:auto_enable_code_review",
             default=False,
-        ):
-            triggers = OrganizationOption.objects.get_value(
-                organization=self.organization_id,
-                key="sentry:default_code_review_triggers",
-                default=DEFAULT_CODE_REVIEW_TRIGGERS,
-            )
-            if not isinstance(triggers, list):
-                triggers = DEFAULT_CODE_REVIEW_TRIGGERS
+        )
+        triggers = OrganizationOption.objects.get_value(
+            organization=self.organization_id,
+            key="sentry:default_code_review_triggers",
+            default=DEFAULT_CODE_REVIEW_TRIGGERS,
+        )
+        if not isinstance(triggers, list):
+            triggers = DEFAULT_CODE_REVIEW_TRIGGERS
 
-            RepositorySettings.objects.get_or_create(
-                repository_id=self.id,
-                defaults={"enabled_code_review": True, "code_review_triggers": triggers},
-            )
+        RepositorySettings.objects.get_or_create(
+            repository_id=self.id,
+            defaults={"enabled_code_review": enable_code_review, "code_review_triggers": triggers},
+        )
 
 
 def on_delete(instance, actor: RpcUser | None = None, **kwargs):

--- a/src/sentry/models/repositorysettings.py
+++ b/src/sentry/models/repositorysettings.py
@@ -61,6 +61,7 @@ class RepositorySettings(Model):
     def write_relocation_import(
         self, _s: ImportScope, _f: ImportFlags
     ) -> tuple[int, ImportKind] | None:
+        # Avoid duplicate key violations when RepositorySettings already exists (e.g., created by Repository.save() during import).
         (settings, created) = self.__class__.objects.get_or_create(
             repository_id=self.repository_id, defaults=model_to_dict(self)
         )

--- a/src/sentry/models/repositorysettings.py
+++ b/src/sentry/models/repositorysettings.py
@@ -69,4 +69,4 @@ class RepositorySettings(Model):
             self.pk = settings.pk
             self.save()
 
-        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        return (self.pk, ImportKind.Inserted if created else ImportKind.Overwrite)

--- a/src/sentry/models/repositorysettings.py
+++ b/src/sentry/models/repositorysettings.py
@@ -5,7 +5,6 @@ from enum import StrEnum
 
 from django.contrib.postgres.fields.array import ArrayField
 from django.db import models
-from django.forms import model_to_dict
 
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
@@ -63,7 +62,11 @@ class RepositorySettings(Model):
     ) -> tuple[int, ImportKind] | None:
         # Avoid duplicate key violations when RepositorySettings already exists (e.g., created by Repository.save() during import).
         (settings, created) = self.__class__.objects.get_or_create(
-            repository_id=self.repository_id, defaults=model_to_dict(self)
+            repository=self.repository,
+            defaults={
+                "enabled_code_review": self.enabled_code_review,
+                "code_review_triggers": self.code_review_triggers,
+            },
         )
         if settings:
             self.pk = settings.pk

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -929,11 +929,18 @@ class Factories:
         enabled_code_review: bool = False,
         code_review_triggers: list[str] | None = None,
     ) -> RepositorySettings:
-        return RepositorySettings.objects.create(
+        settings, created = RepositorySettings.objects.get_or_create(
             repository=repository,
-            enabled_code_review=enabled_code_review,
-            code_review_triggers=code_review_triggers or [],
+            defaults={
+                "enabled_code_review": enabled_code_review,
+                "code_review_triggers": code_review_triggers or [],
+            },
         )
+        if not created:
+            settings.enabled_code_review = enabled_code_review
+            settings.code_review_triggers = code_review_triggers or []
+            settings.save(update_fields=["enabled_code_review", "code_review_triggers"])
+        return settings
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -100,7 +100,7 @@ from sentry.models.projectsdk import EventType, ProjectSDK
 from sentry.models.projecttemplate import ProjectTemplate
 from sentry.models.recentsearch import RecentSearch
 from sentry.models.relay import Relay, RelayUsage
-from sentry.models.repositorysettings import CodeReviewTrigger, RepositorySettings
+from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.models.savedsearch import SavedSearch, Visibility
 from sentry.models.search_common import SearchType
@@ -645,7 +645,7 @@ class ExhaustiveFixtures(Fixtures):
         repo.external_id = "https://git.example.com:1234"
         repo.save()
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
             code_review_triggers=[

--- a/tests/sentry/migrations/test_1016_remove_on_command_phrase_trigger.py
+++ b/tests/sentry/migrations/test_1016_remove_on_command_phrase_trigger.py
@@ -10,7 +10,7 @@ class RemoveOnCommandPhraseTriggerTest(TestMigrations):
         org = self.create_organization()
         self.project1 = self.create_project(organization=org)
         self.repo1 = self.create_repo(project=self.project1, name="org/repo1")
-        self.repo_settings1 = RepositorySettings.objects.create(
+        self.repo_settings1 = self.create_repository_settings(
             repository=self.repo1,
             enabled_code_review=True,
             code_review_triggers=["on_command_phrase", "on_ready_for_review", "on_new_commit"],
@@ -18,7 +18,7 @@ class RemoveOnCommandPhraseTriggerTest(TestMigrations):
 
         self.project2 = self.create_project(organization=org)
         self.repo2 = self.create_repo(project=self.project2, name="org/repo2")
-        self.repo_settings2 = RepositorySettings.objects.create(
+        self.repo_settings2 = self.create_repository_settings(
             repository=self.repo2,
             enabled_code_review=True,
             code_review_triggers=["on_ready_for_review", "on_new_commit"],
@@ -26,7 +26,7 @@ class RemoveOnCommandPhraseTriggerTest(TestMigrations):
 
         self.project3 = self.create_project(organization=org)
         self.repo3 = self.create_repo(project=self.project3, name="org/repo3")
-        self.repo_settings3 = RepositorySettings.objects.create(
+        self.repo_settings3 = self.create_repository_settings(
             repository=self.repo3, enabled_code_review=True
         )
 

--- a/tests/sentry/models/test_repository.py
+++ b/tests/sentry/models/test_repository.py
@@ -77,7 +77,7 @@ class RepositoryDeleteEmailTest(TestCase):
 class RepositoryCodeReviewSettingsTest(TestCase):
     """Tests for auto-enabling code review settings on repository creation."""
 
-    def test_no_settings_created_when_auto_enable_disabled(self):
+    def test_settings_created_when_auto_enable_disabled(self):
         org = self.create_organization()
 
         repo = Repository.objects.create(
@@ -86,7 +86,33 @@ class RepositoryCodeReviewSettingsTest(TestCase):
             provider="integrations:github",
         )
 
-        assert not RepositorySettings.objects.filter(repository=repo).exists()
+        settings = RepositorySettings.objects.get(repository=repo)
+        assert settings.enabled_code_review is False
+        assert settings.code_review_triggers == DEFAULT_CODE_REVIEW_TRIGGERS
+
+    def test_settings_created_when_auto_enable_explicitly_disabled(self):
+        org = self.create_organization()
+
+        OrganizationOption.objects.set_value(
+            organization=org,
+            key="sentry:auto_enable_code_review",
+            value=False,
+        )
+        OrganizationOption.objects.set_value(
+            organization=org,
+            key="sentry:default_code_review_triggers",
+            value=["on_new_commit"],
+        )
+
+        repo = Repository.objects.create(
+            organization_id=org.id,
+            name="test-repo",
+            provider="integrations:github",
+        )
+
+        settings = RepositorySettings.objects.get(repository=repo)
+        assert settings.enabled_code_review is False
+        assert settings.code_review_triggers == ["on_new_commit"]
 
     def test_settings_created_when_auto_enable_enabled(self):
         org = self.create_organization()

--- a/tests/sentry/models/test_repository.py
+++ b/tests/sentry/models/test_repository.py
@@ -90,7 +90,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert settings.enabled_code_review is False
         assert settings.code_review_triggers == DEFAULT_CODE_REVIEW_TRIGGERS
 
-    def test_settings_created_when_auto_enable_explicitly_disabled(self):
+    def test_settings_created_when_auto_enable_disabled(self):
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(

--- a/tests/sentry/models/test_repository.py
+++ b/tests/sentry/models/test_repository.py
@@ -77,7 +77,7 @@ class RepositoryDeleteEmailTest(TestCase):
 class RepositoryCodeReviewSettingsTest(TestCase):
     """Tests for auto-enabling code review settings on repository creation."""
 
-    def test_settings_created_when_auto_enable_disabled(self):
+    def test_settings_created_when_no_auto_enable(self):
         org = self.create_organization()
 
         repo = Repository.objects.create(

--- a/tests/sentry/models/test_repositorysettings.py
+++ b/tests/sentry/models/test_repositorysettings.py
@@ -26,7 +26,7 @@ class TestRepositorySettings(TestCase):
         self.repo = self.create_repo(project=self.project)
 
     def test_get_code_review_settings_with_defaults(self) -> None:
-        repo_settings = RepositorySettings.objects.create(repository=self.repo)
+        repo_settings = self.create_repository_settings(repository=self.repo)
 
         settings = repo_settings.get_code_review_settings()
 
@@ -34,7 +34,7 @@ class TestRepositorySettings(TestCase):
         assert settings.triggers == []
 
     def test_get_code_review_settings_with_enabled_and_triggers(self) -> None:
-        repo_settings = RepositorySettings.objects.create(
+        repo_settings = self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
             code_review_triggers=[
@@ -51,7 +51,7 @@ class TestRepositorySettings(TestCase):
         assert CodeReviewTrigger.ON_READY_FOR_REVIEW in settings.triggers
 
     def test_get_code_review_settings_converts_string_triggers_to_enum(self) -> None:
-        repo_settings = RepositorySettings.objects.create(
+        repo_settings = self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
             code_review_triggers=["on_new_commit"],
@@ -63,14 +63,14 @@ class TestRepositorySettings(TestCase):
         assert isinstance(settings.triggers[0], CodeReviewTrigger)
 
     def test_repository_settings_unique_per_repository(self) -> None:
-        RepositorySettings.objects.create(repository=self.repo)
+        self.create_repository_settings(repository=self.repo)
 
         # Creating another settings for the same repo should fail
         with pytest.raises(IntegrityError):
             RepositorySettings.objects.create(repository=self.repo)
 
     def test_repository_settings_deleted_with_repository(self) -> None:
-        repo_settings = RepositorySettings.objects.create(repository=self.repo)
+        repo_settings = self.create_repository_settings(repository=self.repo)
         settings_id = repo_settings.id
 
         self.repo.delete()

--- a/tests/sentry/models/test_repositorysettings.py
+++ b/tests/sentry/models/test_repositorysettings.py
@@ -88,7 +88,9 @@ class TestRepositorySettings(TestCase):
             code_review_triggers=[CodeReviewTrigger.ON_NEW_COMMIT.value],
         )
 
-        pk, import_kind = new_settings.write_relocation_import(ImportScope.Global, ImportFlags())
+        result = new_settings.write_relocation_import(ImportScope.Global, ImportFlags())
+        assert result is not None
+        pk, import_kind = result
 
         assert import_kind == ImportKind.Inserted
         assert pk == new_settings.pk
@@ -106,9 +108,9 @@ class TestRepositorySettings(TestCase):
             repository=self.repo, enabled_code_review=False, code_review_triggers=[]
         )
 
-        pk, import_kind = imported_settings.write_relocation_import(
-            ImportScope.Global, ImportFlags()
-        )
+        result = imported_settings.write_relocation_import(ImportScope.Global, ImportFlags())
+        assert result is not None
+        pk, import_kind = result
 
         assert import_kind == ImportKind.Overwrite
         assert pk == existing_settings.pk

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.models.organizationcontributors import OrganizationContributors
-from sentry.models.repositorysettings import CodeReviewTrigger, RepositorySettings
+from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.seer.code_review.preflight import CodeReviewPreflightService, PreflightDenialReason
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -151,7 +151,7 @@ class TestCodeReviewPreflightService(TestCase):
         self.organization.update_option("sentry:enable_pr_review_test_generation", True)
 
         # Explicitly disable repo code review
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=False,
         )
@@ -183,7 +183,7 @@ class TestCodeReviewPreflightService(TestCase):
 
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
     def test_denied_when_seat_based_org_has_repo_settings_disabled(self) -> None:
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=False,
         )
@@ -200,7 +200,7 @@ class TestCodeReviewPreflightService(TestCase):
     ) -> None:
         mock_check_quota.return_value = True
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
         )
@@ -228,7 +228,7 @@ class TestCodeReviewPreflightService(TestCase):
     def test_returns_repo_settings_when_allowed(self, mock_check_quota: MagicMock) -> None:
         mock_check_quota.return_value = True
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
             code_review_triggers=[
@@ -289,7 +289,7 @@ class TestCodeReviewPreflightService(TestCase):
     ) -> None:
         mock_check_quota.return_value = True
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
             code_review_triggers=[CodeReviewTrigger.ON_NEW_COMMIT.value],
@@ -317,7 +317,7 @@ class TestCodeReviewPreflightService(TestCase):
 
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
     def test_denied_when_missing_integration_id(self) -> None:
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
         )
@@ -335,7 +335,7 @@ class TestCodeReviewPreflightService(TestCase):
 
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
     def test_denied_when_missing_external_identifier(self) -> None:
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
         )
@@ -353,7 +353,7 @@ class TestCodeReviewPreflightService(TestCase):
 
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
     def test_denied_when_contributor_does_not_exist(self) -> None:
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
         )
@@ -369,7 +369,7 @@ class TestCodeReviewPreflightService(TestCase):
     def test_denied_when_quota_check_fails(self, mock_check_quota: MagicMock) -> None:
         mock_check_quota.return_value = False
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
         )
@@ -399,7 +399,7 @@ class TestCodeReviewPreflightService(TestCase):
     ) -> None:
         mock_check_quota.return_value = True
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
             code_review_triggers=[CodeReviewTrigger.ON_NEW_COMMIT.value],

--- a/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from sentry.constants import ObjectStatus
-from sentry.models.repositorysettings import RepositorySettings
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.endpoints.organization_seer_onboarding_check import (
     has_supported_scm_integration,
@@ -70,7 +69,7 @@ class TestIsCodeReviewEnabled(TestCase):
     def test_code_review_enabled(self) -> None:
         repo = self.create_repo(project=self.project)
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )
@@ -80,7 +79,7 @@ class TestIsCodeReviewEnabled(TestCase):
     def test_code_review_disabled(self) -> None:
         repo = self.create_repo(project=self.project)
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=False,
         )
@@ -91,12 +90,12 @@ class TestIsCodeReviewEnabled(TestCase):
         repo1 = self.create_repo(project=self.project)
         repo2 = self.create_repo(project=self.project)
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo1,
             enabled_code_review=True,
         )
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo2,
             enabled_code_review=False,
         )
@@ -111,7 +110,7 @@ class TestIsCodeReviewEnabled(TestCase):
         repo.status = ObjectStatus.DISABLED
         repo.save()
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )
@@ -132,12 +131,12 @@ class TestIsCodeReviewEnabled(TestCase):
         repo1 = self.create_repo(project=project1)
         repo2 = self.create_repo(project=project2)
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo1,
             enabled_code_review=True,
         )
 
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo2,
             enabled_code_review=False,
         )
@@ -262,7 +261,7 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
         )
 
         repo = self.create_repo(project=self.project)
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )
@@ -301,7 +300,7 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
 
     def test_code_review_enabled_only(self) -> None:
         repo = self.create_repo(project=self.project)
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )
@@ -340,7 +339,7 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
         )
 
         repo = self.create_repo(project=self.project)
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )
@@ -379,7 +378,7 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
 
     def test_code_review_and_autofix_enabled(self) -> None:
         repo = self.create_repo(project=self.project)
-        RepositorySettings.objects.create(
+        self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
         )


### PR DESCRIPTION
Let's always create a RepositorySettings row even if the toggle for the org default is set to False. 

Tests need to be updated to use the factory helper as we otherwise will get duplicate key errors trying to insert a row that already exists for that repo.