### PR TITLE
chore(preprod): Fix size status check fail from size rules UI

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -576,23 +576,23 @@ def _compute_overall_status(
     states = {artifact.state for artifact in artifacts}
 
     if PreprodArtifact.ArtifactState.FAILED in states:
-        return StatusCheckStatus.FAILURE, triggered_rules
+        return StatusCheckStatus.FAILURE, []
     elif (
         PreprodArtifact.ArtifactState.UPLOADING in states
         or PreprodArtifact.ArtifactState.UPLOADED in states
     ):
-        return StatusCheckStatus.IN_PROGRESS, triggered_rules
+        return StatusCheckStatus.IN_PROGRESS, []
     elif all(state == PreprodArtifact.ArtifactState.PROCESSED for state in states):
         for artifact in artifacts:
             size_metrics_list = size_metrics_map.get(artifact.id, [])
             if size_metrics_list:
                 for size_metrics in size_metrics_list:
                     if size_metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED:
-                        return StatusCheckStatus.FAILURE, triggered_rules
+                        return StatusCheckStatus.FAILURE, []
                     elif (
                         size_metrics.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
                     ):
-                        return StatusCheckStatus.IN_PROGRESS, triggered_rules
+                        return StatusCheckStatus.IN_PROGRESS, []
 
         if rules:
             for artifact in artifacts:


### PR DESCRIPTION
We need to add extra handling to show the correct UI for the case where the builds succeeded but the status check should fail because of a rule they set in the settings

Before:
<img width="878" height="336" alt="image" src="https://github.com/user-attachments/assets/78cfb91b-f734-4b4d-88f0-ed58dfefc189" />

After:
<img width="1108" height="429" alt="image" src="https://github.com/user-attachments/assets/4ecaab80-8107-46f6-bb6b-516340673032" />
