### PR TITLE
fix(context): Redirect the user to the right page when a project was renamed

### DIFF
--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -66,24 +66,25 @@ class RedirectToProjectModal extends Component<Props, State> {
         <Header>{t('Redirecting to New Project...')}</Header>
 
         <Body>
-          <div>
-            <Text>{t('The project slug has been changed.')}</Text>
-
-            <Text>
-              {tct(
-                'You will be redirected to the new project [project] in [timer] seconds...',
-                {
-                  project: <strong>{slug}</strong>,
-                  timer: `${this.state.timer}`,
-                }
-              )}
-            </Text>
+          <Flex direction="column" gap="lg">
+            <Flex direction="column" gap="sm">
+              <Text>{t('The project slug has been changed.')}</Text>
+              <Text variant="muted">
+                {tct(
+                  'You will be redirected to the new project [project] in [timer] seconds...',
+                  {
+                    project: <strong>{slug}</strong>,
+                    timer: `${this.state.timer}`,
+                  }
+                )}
+              </Text>
+            </Flex>
             <Flex justify="end">
               <LinkButton priority="primary" href={this.newPath}>
                 {t('Continue to %s', slug)}
               </LinkButton>
             </Flex>
-          </div>
+          </Flex>
         </Body>
       </Fragment>
     );

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -2,6 +2,7 @@ import {Component, createContext} from 'react';
 import styled from '@emotion/styled';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
+import {redirectToProject} from 'sentry/actionCreators/redirectToProject';
 import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -213,9 +214,26 @@ class ProjectContextProvider extends Component<Props, State> {
     // *does not exist* or the project has not yet been added to the store.
     // Either way, make a request to check for existence of the project.
     try {
-      await this.props.api.requestPromise(
+      const project = await this.props.api.requestPromise(
         `/projects/${organization.slug}/${projectSlug}/`
       );
+
+      // Check if the returned project slug matches the requested slug.
+      // If it doesn't match, the project was likely renamed and the API
+      // followed a redirect to the new slug. In this case, redirect the
+      // user to the correct URL with the new project slug.
+      if (project?.slug && project.slug !== projectSlug) {
+        redirectToProject(project.slug);
+        return;
+      }
+
+      // Project exists but wasn't in store - this shouldn't normally happen
+      // but handle gracefully by showing not found error
+      this.setState({
+        loading: false,
+        error: true,
+        errorType: ErrorTypes.PROJECT_NOT_FOUND,
+      });
     } catch (error) {
       this.setState({
         loading: false,


### PR DESCRIPTION
Fixes [ID-1231](https://linear.app/getsentry/issue/ID-1231/project-ownership-settings-infinite-loading).

[Slack thread for context](https://sentry.slack.com/archives/CQDHVRS2W/p1768517227023729)

We were seeing a bug where the ownership rules page could show an infinite loading spinner when the old slug for a project that was renamed is provided. The API actually follows the redirect and gives us the up-to-date project slug, but we weren't following it. This PR updates the `ProjectContextProvider` component to redirect the user to the right page path in this case.

[Here's](https://drive.google.com/file/d/1cWEAGBMb3_h5oEVyKZ7XE31ZZHvgEUjY/view?usp=sharing) a screen recording of the redirect experience.

Image of the redirect modal:
<img width="719" height="267" alt="image" src="https://github.com/user-attachments/assets/0385ca2b-e718-4c24-85a5-4de62495c8ed" />