### PR TITLE
chore(cells): deprecate group-events endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -14,6 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.events import get_direct_hit_response, get_query_builder_for_group
 from sentry.api.paginator import GenericOffsetPaginator
@@ -29,6 +30,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.search.events.types import SnubaParams
@@ -82,6 +84,7 @@ class GroupEventsEndpoint(GroupEndpoint):
         },
         examples=EventExamples.GROUP_EVENTS_SIMPLE,
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-events"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Return a list of error events bound to an issue

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -47,7 +47,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event_1.group.id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -79,7 +79,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event_1.group.id}/events/?full=false"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/?full=false"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -110,7 +110,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event_1.group.id}/events/?full=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/?full=true"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -139,7 +139,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             },
             project_id=self.project.id,
         )
-        url = f"/api/0/issues/{event_1.group.id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/"
         response = self.do_request(url + "?query=foo:baz")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -203,7 +203,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             },
             project_id=self.project.id,
         )
-        url = f"/api/0/issues/{event_1.group.id}/events/?query={event_1.event_id}"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/?query={event_1.event_id}"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -238,7 +238,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         query_2 = "hello+world"
 
         # Single Word Query
-        url = f"/api/0/issues/{group.id}/events/?query={query_1}"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query={query_1}"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -246,7 +246,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert response.data[0]["eventID"] == event_1.event_id
 
         # Multiple Word Query
-        url = f"/api/0/issues/{group.id}/events/?query={query_2}"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query={query_2}"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -267,7 +267,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             },
             project_id=self.project.id,
         )
-        url = f"/api/0/issues/{event_1.group.id}/events/?query=release:latest"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/?query=release:latest"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -291,7 +291,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         # Asserts that all are in the same group
         (group_id,) = {e.group.id for e in events.values()}
 
-        url = f"/api/0/issues/{group_id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/events/"
         response = self.do_request(url + "?environment=production")
 
         assert response.status_code == 200, response.content
@@ -332,7 +332,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         group = event_2.group
 
         with self.options({"system.event-retention-days": 1}):
-            response = self.client.get(f"/api/0/issues/{group.id}/events/")
+            response = self.client.get(
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/"
+            )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -349,7 +351,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        response = self.client.get(f"/api/0/issues/{event.group.id}/events/")
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
+        )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -369,7 +373,10 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         group = event_1.group
         assert group == event_2.group
 
-        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "6d"})
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/",
+            data={"statsPeriod": "6d"},
+        )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -377,7 +384,10 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
-        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "2d"})
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/",
+            data={"statsPeriod": "2d"},
+        )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -387,7 +397,10 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         self.login_as(user=self.user)
         first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
-        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "lol"})
+        response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/",
+            data={"statsPeriod": "lol"},
+        )
         assert response.status_code == 400
 
     def test_invalid_query(self) -> None:
@@ -395,7 +408,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
         response = self.client.get(
-            f"/api/0/issues/{group.id}/events/",
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/",
             data={"statsPeriod": "7d", "query": "foo(bar"},
         )
         assert response.status_code == 400
@@ -423,7 +436,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         )
 
         for event in (event_1, event_2):
-            url = f"/api/0/issues/{event.group.id}/events/"
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
             response = self.do_request(url)
             assert response.status_code == 200, response.content
             assert len(response.data) == 1, response.data
@@ -443,7 +456,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
                 project_id=self.project.id,
             )
 
-        url = f"/api/0/issues/{event.group.id}/events/?per_page=1"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/?per_page=1"
         response = self.do_request(url)
         links = self._parse_links(response["Link"])
         assert response.status_code == 200, response.content
@@ -473,7 +486,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event.group.id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
         response = self.do_request(url)
         assert len(response.data) == 2
         assert response.data[0]["eventID"] == "a" * 32
@@ -486,7 +499,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event_1.group.id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_1.group.id}/events/"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -513,7 +526,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group_info.group.id}/events/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group_info.group.id}/events/"
         response = self.do_request(url)
 
         assert response.status_code == 200, response.content
@@ -544,6 +557,6 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             project_id=self.project.id,
         )
 
-        url = f"/api/0/issues/{event.group.id}/events/?sample=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/?sample=true"
         response = self.do_request(url)
         assert len(response.data) == 2


### PR DESCRIPTION
Add deprecation decorators to GroupEventsEndpoint and update tests to use the org-scoped variant's URL pattern.