### PR TITLE
feat(seer): Add feedback buttons to the top of Seer settings pages

### DIFF
--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
@@ -2,10 +2,12 @@ import {useEffect} from 'react';
 
 import {Alert} from '@sentry/scraps/alert/alert';
 import {LinkButton} from '@sentry/scraps/button/linkButton';
+import {Flex} from '@sentry/scraps/layout/flex';
 import {Stack} from '@sentry/scraps/layout/stack';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import Feature from 'sentry/components/acl/feature';
+import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {NoAccess} from 'sentry/components/noAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -67,12 +69,23 @@ export default function SeerSettingsPageWrapper({children}: Props) {
           }
         )}
         action={
-          <LinkButton
-            href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities"
-            external
-          >
-            {t('Read the docs')}
-          </LinkButton>
+          <Flex gap="lg">
+            <FeedbackButton
+              size="md"
+              feedbackOptions={{
+                messagePlaceholder: t('How can we make Seer better for you?'),
+                tags: {
+                  ['feedback.source']: 'seer-org-settings',
+                },
+              }}
+            />
+            <LinkButton
+              href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities"
+              external
+            >
+              {t('Read the docs')}
+            </LinkButton>
+          </Flex>
         }
       />
 

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
@@ -75,7 +75,8 @@ export default function SeerSettingsPageWrapper({children}: Props) {
               feedbackOptions={{
                 messagePlaceholder: t('How can we make Seer better for you?'),
                 tags: {
-                  ['feedback.source']: 'seer-org-settings',
+                  ['feedback.source']: 'seer-settings-org',
+                  ['feedback.owner']: 'coding-workflows',
                 },
               }}
             />

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert/alert';
 
+import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import Placeholder from 'sentry/components/placeholder';
@@ -71,6 +72,18 @@ export default function SeerOnboardingSeatBased() {
         subtitle={t(
           'Follow these steps to configure Seer for your organization. Seer helps automatically analyze, fix, and prevent issues in your codebase.'
         )}
+        action={
+          <FeedbackButton
+            size="md"
+            feedbackOptions={{
+              messagePlaceholder: t('How can we make Seer better for you?'),
+              tags: {
+                ['feedback.source']: 'seer-settings-wizard',
+                ['feedback.owner']: 'coding-workflows',
+              },
+            }}
+          />
+        }
       />
 
       <NoProjectMessage organization={organization}>

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -76,7 +76,8 @@ function SeerProjectDetails() {
               feedbackOptions={{
                 messagePlaceholder: t('How can we make Seer better for you?'),
                 tags: {
-                  ['feedback.source']: 'seer-project-details',
+                  ['feedback.source']: 'seer-settings-project-details',
+                  ['feedback.owner']: 'coding-workflows',
                 },
               }}
             />

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -61,7 +61,7 @@ function SeerProjectDetails() {
       <SettingsPageHeader
         title={tct('Seer Settings for [projectName]', {
           projectName: (
-            <Text as="code" monospace>
+            <Text as="span" monospace>
               {project.slug}
             </Text>
           ),

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -2,12 +2,15 @@ import {Fragment} from 'react';
 
 import {Alert} from '@sentry/scraps/alert/alert';
 import {LinkButton} from '@sentry/scraps/button/linkButton';
+import {Flex} from '@sentry/scraps/layout/flex';
 import {Stack} from '@sentry/scraps/layout/stack';
+import {Text} from '@sentry/scraps/text/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
+import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -57,18 +60,33 @@ function SeerProjectDetails() {
       />
       <SettingsPageHeader
         title={tct('Seer Settings for [projectName]', {
-          projectName: <code>{project.slug}</code>,
+          projectName: (
+            <Text as="code" monospace>
+              {project.slug}
+            </Text>
+          ),
         })}
         subtitle={t(
           'Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them.'
         )}
         action={
-          <LinkButton
-            href="https://docs.sentry.io/product/ai-in-sentry/seer/issue-fix/"
-            external
-          >
-            {t('Read the docs')}
-          </LinkButton>
+          <Flex gap="lg">
+            <FeedbackButton
+              size="md"
+              feedbackOptions={{
+                messagePlaceholder: t('How can we make Seer better for you?'),
+                tags: {
+                  ['feedback.source']: 'seer-project-details',
+                },
+              }}
+            />
+            <LinkButton
+              href="https://docs.sentry.io/product/ai-in-sentry/seer/issue-fix/"
+              external
+            >
+              {t('Read the docs')}
+            </LinkButton>
+          </Flex>
         }
       />
       {canWrite ? null : (


### PR DESCRIPTION
<img width="990" height="207" alt="SCR-20260120-tbxl" src="https://github.com/user-attachments/assets/8f827fcd-d11c-484c-9e8d-e3350080c9bb" />

Fixes https://linear.app/getsentry/issue/CW-650/add-give-feedback-buttons-to-seer-wizard-and-settings
