### PR TITLE
fix(seer): Disable default code-review triggers before the user has setup Seer

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -723,11 +723,10 @@ ENABLE_SEER_CODING_DEFAULT = True
 AUTO_OPEN_PRS_DEFAULT = False
 # Seer Org level setting to automatically enable code review for all new GitHub repo's that become connected
 AUTO_ENABLE_CODE_REVIEW = False
-# Seer Org level default for code review triggers
-DEFAULT_CODE_REVIEW_TRIGGERS: list[str] = [
-    "on_ready_for_review",
-    "on_new_commit",
-]
+# Seer Org level default for code review triggers, users need to set defaults themselves.
+# The `@sentry review` command will always be a valid trigger.
+DEFAULT_CODE_REVIEW_TRIGGERS: list[str] = []
+
 # Org level setting to allow/disallow Projects to delegate Seer scanner automation to other LLMS
 ALLOW_BACKGROUND_AGENT_DELEGATION = True
 ENABLED_CONSOLE_PLATFORMS_DEFAULT: list[str] = []


### PR DESCRIPTION
We need to nuke this default value.

When there's a value in here, what happens is:

1. There's no SCM configured, so we show the wizard
2. People configure github, import some repos
3. Repos get imported, and default values are set, using this array!
4. Now we have satisfied this condition: `has_scm_integration and (code_review_enabled or autofix_enabled)` (see: [organization_seer_onboarding_check.py](https://github.com/getsentry/sentry/blob/master/src/sentry/seer/endpoints/organization_seer_onboarding_check.py#L89)) therefore the [wizard will be skipped](https://github.com/getsentry/sentry/blob/master/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx#L30-L37).
5. The user is redirected back to sentry from github, straight to the main settings pages.

If we make this an empty array then at step 5 the user will come back into the wizard.
The condition in 4) above will probably be satisfied as the user moves through the wizard, if it is then the wizard is never shown again. At the end of the wizard steps they can set their own defaults for the next time that repos are added.

Fixes https://linear.app/getsentry/issue/CW-656/seer-setup-wizard-redirects-to-settings-after-gh-install