### PR TITLE
feat(hybridcloud): Preserve Content-Encoding header for Objectstore

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -124,6 +124,8 @@ def proxy_region_request(
 ) -> StreamingHttpResponse:
     """Take a django request object and proxy it to a region silo"""
     target_url = urljoin(region.address, request.path)
+
+    content_encoding = request.headers.get("Content-Encoding")
     header_dict = clean_proxy_headers(request.headers)
     header_dict[PROXY_APIGATEWAY_HEADER] = "true"
 
@@ -140,6 +142,8 @@ def proxy_region_request(
 
     data: bytes | Generator[bytes] | ChunkedEncodingDecoder | BodyWithLength | None = None
     if url_name == "sentry-api-0-organization-objectstore":
+        if content_encoding:
+            header_dict["Content-Encoding"] = content_encoding
         data = get_raw_body(request)
     else:
         data = BodyWithLength(request)


### PR DESCRIPTION
By default, Objectstore clients compress request bodies using `zstd`, and the Objectstore server correctly handles such requests by using the standard HTTP header `Content-Encoding` to tell whether it should decompress payloads.

The function `clean_proxy_headers` in the hybrid cloud module drops some HTTP headers, including `Content-Encoding` (I assume because no other endpoint expected compressed requests so far).
For the Objectstore endpoint this doesn't work, we need to keep that header intact.

This changes the `proxy_region_request` in a minimal way to make this compatible with Objectstore and adds a test that verifies the correct behavior after the patch.

In general, if any other endpoint that similarly supported compressed requests were introduced, I would assume the same issues would be observed.
I'm not sure why Content-Encoding is being dropped in the first place, but for the sake of avoiding the introduction of undesired side effects to other code paths, I'm scoping this change to affect only our endpoint.