### PR TITLE
chore: Include seer billing flags check for explorer index

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1255,6 +1255,12 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.explorer-index.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -76,19 +76,16 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
                 org_key = f"organization:{project.organization.id}"
                 org_features = batch_result.get(org_key, {})
 
-                # Check required flags (AND logic)
                 has_required_features = org_features.get(
                     "organizations:gen-ai-features", False
                 ) and org_features.get("organizations:seer-explorer-index", False)
 
-                # Check billing plan flags (OR logic)
                 has_seer_plan = org_features.get(
                     "organizations:seat-based-seer-enabled", False
                 ) or org_features.get("organizations:seer-added", False)
 
                 has_all_features = has_required_features and has_seer_plan
             else:
-                # Fallback to individual checks
                 has_required_features = features.has(
                     "organizations:gen-ai-features", project.organization
                 ) and features.has("organizations:seer-explorer-index", project.organization)

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -77,9 +77,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
             if batch_result:
                 org_key = f"organization:{project.organization.id}"
                 org_features = batch_result.get(org_key, {})
-
                 has_gen_ai = org_features.get("organizations:gen-ai-features", False)
-
                 has_explorer_index = org_features.get("organizations:seer-explorer-index", False)
 
                 if has_explorer_index and has_gen_ai:

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -13,6 +13,7 @@ from django.utils import timezone as django_timezone
 from sentry import features, options
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
+from sentry.options.rollout import in_rollout_group
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.tasks.base import instrumented_task
@@ -69,6 +70,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
         if bool(project.organization.get_option("sentry:hide_ai_features")):
             continue
 
+        is_eligible = False
         with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):
             batch_result = features.batch_has(FEATURE_NAMES, organization=project.organization)
 
@@ -76,27 +78,39 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
                 org_key = f"organization:{project.organization.id}"
                 org_features = batch_result.get(org_key, {})
 
-                has_required_features = org_features.get(
-                    "organizations:gen-ai-features", False
-                ) and org_features.get("organizations:seer-explorer-index", False)
+                has_gen_ai = org_features.get("organizations:gen-ai-features", False)
+
+                has_explorer_index = org_features.get("organizations:seer-explorer-index", False)
+
+                if has_explorer_index and has_gen_ai:
+                    is_eligible = True
 
                 has_seer_plan = org_features.get(
                     "organizations:seat-based-seer-enabled", False
                 ) or org_features.get("organizations:seer-added", False)
 
-                has_all_features = has_required_features and has_seer_plan
+                if has_seer_plan and has_gen_ai:
+                    if in_rollout_group("seer.explorer-index.rollout", project.organization_id):
+                        is_eligible = True
+
             else:
-                has_required_features = features.has(
-                    "organizations:gen-ai-features", project.organization
-                ) and features.has("organizations:seer-explorer-index", project.organization)
+                has_gen_ai = features.has("organizations:gen-ai-features", project.organization)
+                has_explorer_index = features.has(
+                    "organizations:seer-explorer-index", project.organization
+                )
+
+                if has_explorer_index and has_gen_ai:
+                    is_eligible = True
 
                 has_seer_plan = features.has(
                     "organizations:seat-based-seer-enabled", project.organization
                 ) or features.has("organizations:seer-added", project.organization)
 
-                has_all_features = has_required_features and has_seer_plan
+                if has_seer_plan and has_gen_ai:
+                    if in_rollout_group("seer.explorer-index.rollout", project.organization_id):
+                        is_eligible = True
 
-            has_feature = has_all_features and get_seer_org_acknowledgement(project.organization)
+            has_feature = is_eligible and get_seer_org_acknowledgement(project.organization)
 
         if not has_feature:
             continue

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -83,7 +83,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
 @instrumented_task(
     name="sentry.tasks.seer_explorer_index.schedule_explorer_index",
     namespace=seer_tasks,
-    processing_deadline_duration=10 * 60,
+    processing_deadline_duration=15 * 60,
 )
 def schedule_explorer_index() -> None:
     """

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -105,6 +105,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             assert active_project.id in project_ids
         assert inactive_project.id not in project_ids
 
+    @freeze_time("2024-01-15 12:00:00")
     def test_returns_empty_without_feature_flag(self):
         org = self.create_organization()
         project = self.create_project(organization=org)

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -253,7 +253,6 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         with self.feature(
             {
                 "organizations:gen-ai-features": [org.slug],
-                "organizations:seer-explorer-index": [org.slug],
             }
         ):
             result = list(get_seer_explorer_enabled_projects())


### PR DESCRIPTION
- Checks seat or legacy seer billing
- Checks open team membership
- Moving org flag check up so we can skip early

Avg for this task is about 7.5 min, but we've exceeded deadline twice in the last 24h, so
also just want to give it some more room.