### PR TITLE
chore(api): deprecate legacy ai summary endpoint URL

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_summary.py
+++ b/src/sentry/seer/endpoints/group_ai_summary.py
@@ -9,6 +9,8 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
@@ -36,6 +38,7 @@ class GroupAiSummaryEndpoint(GroupAiEndpoint):
         }
     )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-ai-summary"])
     def post(self, request: Request, group: Group) -> Response:
         data = orjson.loads(request.body) if request.body else {}
         force_event_id = data.get("event_id", None)

--- a/tests/sentry/seer/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_summary.py
@@ -17,7 +17,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
     def _get_url(self, group_id: int) -> str:
-        return f"/api/0/issues/{group_id}/summarize/"
+        return f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/summarize/"
 
     @patch("sentry.seer.endpoints.group_ai_summary.get_issue_summary")
     def test_endpoint_calls_get_issue_summary(self, mock_get_issue_summary: MagicMock) -> None:


### PR DESCRIPTION
Add deprecation decorator to GroupNotesEndpoint for cellularization and updates the tests. Frontend already uses the correct org scoped url
