### PR TITLE
chore(api): deprecate legacy autofix setup endpoint URL 

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -11,7 +11,8 @@ from sentry import quotas
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.constants import DataCategory, ObjectStatus
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE, DataCategory, ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
@@ -119,6 +120,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         }
     )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix-setup"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Checks if we are able to run Autofix on the given group.

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -146,7 +146,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -190,7 +190,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -224,7 +224,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -259,7 +259,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -303,7 +303,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -322,7 +322,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -336,7 +336,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -348,7 +348,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         for setting in [None] + list(AutofixAutomationTuningSettings):
             self.project.update_option("sentry:autofix_automation_tuning", setting)
             group = self.create_group()
-            url = f"/api/0/issues/{group.id}/autofix/setup/"
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
             response = self.client.get(url, format="json")
 
             assert response.status_code == 200
@@ -361,7 +361,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         for setting in [None, AutofixAutomationTuningSettings.OFF]:
             self.project.update_option("sentry:autofix_automation_tuning", setting)
             group = self.create_group()
-            url = f"/api/0/issues/{group.id}/autofix/setup/"
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
             response = self.client.get(url, format="json")
 
             assert response.status_code == 200
@@ -378,7 +378,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         ]:
             self.project.update_option("sentry:autofix_automation_tuning", setting)
             group = self.create_group()
-            url = f"/api/0/issues/{group.id}/autofix/setup/"
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
             response = self.client.get(url, format="json")
 
             assert response.status_code == 200
@@ -399,7 +399,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -440,7 +440,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -479,7 +479,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200


### PR DESCRIPTION
Adds @deprecated decorator targeting the non-org-scoped URL name. Update Python tests to use org-scoped URLs to match frontend code usage.
