### PR TITLE
chore(issues): Update autofix tests to use org-scoped url

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -336,7 +336,7 @@ const mockGroupApis = (
     }),
   });
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/autofix/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
     body: {
       steps: [],
     },

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -322,7 +322,7 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/autofix/setup/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
     method: 'GET',
     body: AutofixSetupFixture({
       integration: {


### PR DESCRIPTION
Change mock URL from /issues/{id}/autofix/setup/ to /organizations/{org}/issues/{id}/autofix/setup/ to match actual frontend usage. Front end change for https://github.com/getsentry/sentry/pull/106663