### PR TITLE
chore(api): Deprecate non-org-scoped group autofix update endpoint

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_update.py
+++ b/src/sentry/seer/endpoints/group_autofix_update.py
@@ -12,6 +12,8 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
@@ -29,6 +31,7 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
     }
     owner = ApiOwner.ML_AI
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix-update"])
     def post(self, request: Request, group: Group) -> Response:
         """
         Send an update event to autofix for a given group.

--- a/tests/sentry/seer/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_update.py
@@ -14,7 +14,9 @@ class TestGroupAutofixUpdate(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
         self.group = self.create_group()
-        self.url = f"/api/0/issues/{self.group.id}/autofix/update/"
+        self.url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/autofix/update/"
+        )
 
     @patch(
         "sentry.seer.endpoints.group_autofix_update.get_seer_org_acknowledgement", return_value=True


### PR DESCRIPTION
Add @deprecated decorator targeting the non-org-scoped URL name. Update Python test to use org-scoped URL to match frontend code usage.
