### PR TITLE
chore(api): Deprecate non-org-scoped group autofix endpoint

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -13,6 +13,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -23,6 +24,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.autofix_examples import AutofixExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
@@ -144,6 +146,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         },
         examples=AutofixExamples.AUTOFIX_POST_RESPONSE,
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
     def post(self, request: Request, group: Group) -> Response:
         """
         Trigger a Seer Issue Fix run for a specific issue.
@@ -233,6 +236,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         },
         examples=AutofixExamples.AUTOFIX_GET_RESPONSE,
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve the current detailed state of an issue fix process for a specific issue including:

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -21,7 +21,7 @@ pytestmark = [requires_snuba]
 @patch("sentry.seer.autofix.autofix.get_seer_org_acknowledgement", return_value=True)
 class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def _get_url(self, group_id: int) -> str:
-        return f"/api/0/issues/{group_id}/autofix/"
+        return f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/autofix/"
 
     def setUp(self) -> None:
         super().setUp()
@@ -862,7 +862,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
     """Tests for feature flag routing to Explorer-based autofix."""
 
     def _get_url(self, group_id: int, mode: str | None = None) -> str:
-        url = f"/api/0/issues/{group_id}/autofix/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/autofix/"
         if mode is not None:
             url = f"{url}?mode={mode}"
         return url
@@ -966,7 +966,7 @@ class GroupAutofixEndpointLegacyRoutingTest(APITestCase, SnubaTestCase):
     """Tests that endpoint routes to legacy when autofix-on-explorer flag is missing."""
 
     def _get_url(self, group_id: int) -> str:
-        return f"/api/0/issues/{group_id}/autofix/"
+        return f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/autofix/"
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Add @deprecated decorator to GroupAutofixEndpoint.get() and .post() targeting the non-org-scoped URL name. Update Python tests to use org-scoped URLs to match frontend code usage.


