### PR TITLE
chore(api): deprecate non-org-scoped similar-issues-embeddings endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -11,7 +11,9 @@ from sentry.api.analytics import GroupSimilarIssuesEmbeddingsCountEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
@@ -79,6 +81,9 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         return [(serialized_groups[group_id], group_data[group_id]) for group_id in group_data]
 
+    @deprecated(
+        CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-similar-issues-embeddings"]
+    )
     def get(self, request: Request, group: Group) -> Response:
         if killswitch_enabled(group.project.id, ReferrerOptions.SIMILAR_ISSUES_TAB):
             return Response([])

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -79,7 +79,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         self.event = self.store_event(data=self.base_error_trace, project_id=self.project)
         self.group = self.event.group
         assert self.group
-        self.path = f"/api/0/issues/{self.group.id}/similar-issues-embeddings/"
+        self.path = f"/api/0/organizations/{self.org.slug}/issues/{self.group.id}/similar-issues-embeddings/"
         self.similar_event = self.store_event(
             data={"message": "Dogs are great!"}, project_id=self.project
         )
@@ -219,7 +219,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         assert event.group
-        path = f"/api/0/issues/{event.group.id}/similar-issues-embeddings/"
+        path = f"/api/0/organizations/{self.org.slug}/issues/{event.group.id}/similar-issues-embeddings/"
         response = self.client.get(path, data={"k": "1", "threshold": "0.01"})
 
         assert self.similar_event.group_id is not None
@@ -554,7 +554,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         assert group_no_contributing_exception
 
         response = self.client.get(
-            f"/api/0/issues/{group_no_contributing_exception.id}/similar-issues-embeddings/",
+            f"/api/0/organizations/{self.org.slug}/issues/{group_no_contributing_exception.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.98"},
         )
 
@@ -565,7 +565,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         group_no_exception = event_no_exception.group
         assert group_no_exception
         response = self.client.get(
-            f"/api/0/issues/{group_no_exception.id}/similar-issues-embeddings/",
+            f"/api/0/organizations/{self.org.slug}/issues/{group_no_exception.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.98"},
         )
 
@@ -576,7 +576,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_get_latest_event.return_value = None
 
         response = self.client.get(
-            f"/api/0/issues/{self.group.id}/similar-issues-embeddings/",
+            f"/api/0/organizations/{self.org.slug}/issues/{self.group.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.98"},
         )
 
@@ -587,7 +587,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_get_stacktrace_string.return_value = ""
 
         response = self.client.get(
-            f"/api/0/issues/{self.group.id}/similar-issues-embeddings/",
+            f"/api/0/organizations/{self.org.slug}/issues/{self.group.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.98"},
         )
 
@@ -745,7 +745,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         new_event = self.store_event(data=error_data, project_id=self.project)
         assert new_event.group
         response = self.client.get(
-            path=f"/api/0/issues/{new_event.group.id}/similar-issues-embeddings/",
+            path=f"/api/0/organizations/{self.org.slug}/issues/{new_event.group.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.01"},
         )
         assert response.data == []
@@ -777,7 +777,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         new_event = self.store_event(data=error_data, project_id=self.project)
         assert new_event.group
         response = self.client.get(
-            path=f"/api/0/issues/{new_event.group.id}/similar-issues-embeddings/",
+            path=f"/api/0/organizations/{self.org.slug}/issues/{new_event.group.id}/similar-issues-embeddings/",
             data={"k": "1", "threshold": "0.01"},
         )
         assert response.data == []


### PR DESCRIPTION
Mark the group similar issues embeddings endpoint as deprecated and update tests to use the org-scoped URL pattern instead.