### PR TITLE
fix(tests): Fix boolean conversion in scalar_to_any_value

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3337,12 +3337,12 @@ class _OptionalOurLogData(TypedDict, total=False):
 def scalar_to_any_value(value: Any) -> AnyValue:
     if isinstance(value, str):
         return AnyValue(string_value=value)
+    if isinstance(value, bool):
+        return AnyValue(bool_value=value)
     if isinstance(value, int):
         return AnyValue(int_value=value)
     if isinstance(value, float):
         return AnyValue(double_value=value)
-    if isinstance(value, bool):
-        return AnyValue(bool_value=value)
     if isinstance(value, dict):
         return AnyValue(**value)
     raise Exception(f"cannot convert {value} of type {type(value)} to AnyValue")


### PR DESCRIPTION
## Summary
- Fix boolean type check order in `scalar_to_any_value` function

In Python, `bool` is a subclass of `int`, so `isinstance(True, int)` returns `True`. The previous code checked for `int` before `bool`, causing booleans to be incorrectly converted to `int_value` (1/0) instead of `bool_value` (true/false).

This fix moves the `bool` check before the `int` check to ensure booleans are properly converted to protobuf boolean values.

## Test plan
- [x] Verified the change matches the pattern used in other similar functions in the codebase (e.g., `_anyvalue` in `convert.py`, `rpc_utils.py`, `write.py`)
- [ ] Existing tests should pass