### PR TITLE
feat(seer): Remove "Next Button" on Connect GitHub step

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
@@ -5,7 +5,6 @@ import connectGithubImg from 'sentry-images/spot/seer-config-connect-1.svg';
 
 import {Text} from '@sentry/scraps/text';
 
-import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 
@@ -33,9 +32,6 @@ export function ConnectGithubStep() {
                 analyticsView="seer_onboarding_github"
               />
             </ActionSection>
-            <GuidedSteps.ButtonWrapper>
-              <GuidedSteps.NextButton size="md" />
-            </GuidedSteps.ButtonWrapper>
           </PanelBody>
         </MaxWidthPanel>
       </StepContentWithBackground>


### PR DESCRIPTION
Removes "Next Button" on Connect GitHub step because connecting to GitHub is required and users should not be able to skip the step. (It will auto-advance when GitHub is added)
