### PR TITLE
chore(api): deprecate non-org-scoped group-similar endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_similar_issues.py
+++ b/src/sentry/issues/endpoints/group_similar_issues.py
@@ -6,7 +6,9 @@ from rest_framework.response import Response
 from sentry import similarity
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 
@@ -30,6 +32,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-similar"])
     def get(self, request: Request, group: Group) -> Response:
         # Any project using embeddings-based grouping will not work with this endpoint
         if group.project.get_option("sentry:similarity_backfill_completed"):


### PR DESCRIPTION
Mark the group similar issues endpoint as deprecated