### PR TITLE
chore(api): Update frontend test to use org-scoped similar endpoint URLs

### DIFF
--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -301,7 +301,9 @@ describe('Grouping Store', () => {
       GroupingStore.init();
       mergeList = [];
       mergeState = new Map();
-      GroupingStore.onFetch([{dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'}]);
+      GroupingStore.onFetch([
+        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
+      ]);
     });
 
     describe('onToggleMerge (checkbox state)', () => {

--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -58,7 +58,7 @@ describe('Grouping Store', () => {
       ],
     });
     MockApiClient.addMockResponse({
-      url: '/issues/groupId/similar/',
+      url: '/organizations/org-slug/issues/groupId/similar/',
       body: [
         [
           {
@@ -130,7 +130,7 @@ describe('Grouping Store', () => {
 
     it('fetches list of similar items', async () => {
       await GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/issues/groupId/similar/'},
+        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
       ]);
 
       expect(trigger).toHaveBeenCalled();
@@ -179,13 +179,13 @@ describe('Grouping Store', () => {
     it('unsuccessfully fetches list of similar items', () => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
-        url: '/issues/groupId/similar/',
+        url: '/organizations/org-slug/issues/groupId/similar/',
         statusCode: 500,
         body: {message: 'failed'},
       });
 
       const promise = GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/issues/groupId/similar/'},
+        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
       ]);
 
       expect(trigger).toHaveBeenCalled();
@@ -204,7 +204,7 @@ describe('Grouping Store', () => {
 
     it('ignores null scores in aggregate', async () => {
       await GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/issues/groupId/similar/'},
+        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
       ]);
 
       expect(trigger).toHaveBeenCalled();
@@ -301,7 +301,7 @@ describe('Grouping Store', () => {
       GroupingStore.init();
       mergeList = [];
       mergeState = new Map();
-      GroupingStore.onFetch([{dataKey: 'similar', endpoint: '/issues/groupId/similar/'}]);
+      GroupingStore.onFetch([{dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'}]);
     });
 
     describe('onToggleMerge (checkbox state)', () => {


### PR DESCRIPTION
Change mock URLs from /issues/{id}/similar/ to
/organizations/{org}/issues/{id}/similar/ to match actual frontend usage. Frontend PR for https://github.com/getsentry/sentry/pull/106684