### PR TITLE
Update frontend to use org-scoped attachments endpoint URLs

### DIFF
--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -88,7 +88,7 @@ describe('groupEvents', () => {
     });
 
     requests.attachments = MockApiClient.addMockResponse({
-      url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
+      url: '/api/0/organizations/org-slug/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
       body: [],
     });
 
@@ -272,7 +272,7 @@ describe('groupEvents', () => {
 
   it('displays minidumps', async () => {
     requests.attachments = MockApiClient.addMockResponse({
-      url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
+      url: '/api/0/organizations/org-slug/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
       body: [
         {
           id: 'id123',
@@ -300,7 +300,7 @@ describe('groupEvents', () => {
 
   it('does not display attachments but displays minidump', async () => {
     requests.attachments = MockApiClient.addMockResponse({
-      url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
+      url: '/api/0/organizations/org-slug/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
       body: [
         {
           id: 'id123',

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -487,7 +487,7 @@ export default function EventsTable({
       ].join('&');
 
       const res: IssueAttachment[] = await api.requestPromise(
-        `/api/0/issues/${issueId}/attachments/?${queries}`
+        `/api/0/organizations/${organization.slug}/issues/${issueId}/attachments/?${queries}`
       );
 
       let newHasMinidumps = false;
@@ -502,7 +502,7 @@ export default function EventsTable({
       setAttachments(res);
       setHasMinidumps(newHasMinidumps);
     },
-    [api, customColumns, issueId]
+    [api, customColumns, issueId, organization.slug]
   );
 
   const totalEventsView = eventView.clone();


### PR DESCRIPTION
Change API calls and mock URLs from /issues/{id}/attachments/ to /organizations/{org}/issues/{id}/attachments/ to use the org-scoped endpoint. Frontend PR for https://github.com/getsentry/sentry/pull/106687
