### PR TITLE
chore(api): deprecate non-org-scoped group-user-reports endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_user_reports.py
+++ b/src/sentry/issues/endpoints/group_user_reports.py
@@ -3,9 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environment
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.environment import Environment
 from sentry.models.userreport import UserReport
@@ -17,6 +19,7 @@ class GroupUserReportsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-user-reports"])
     def get(self, request: Request, group) -> Response:
         """
         List User Reports

--- a/tests/sentry/issues/endpoints/test_group_user_reports.py
+++ b/tests/sentry/issues/endpoints/test_group_user_reports.py
@@ -29,7 +29,9 @@ class GroupUserReport(APITestCase, SnubaTestCase):
 
     @cached_property
     def path(self) -> str:
-        return f"/api/0/groups/{self.group.id}/user-feedback/"
+        return (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/user-feedback/"
+        )
 
     def create_events_for_environment(self, environment: Any, num_events: int) -> list[Any]:
         return [

--- a/tests/sentry/issues/endpoints/test_group_user_reports.py
+++ b/tests/sentry/issues/endpoints/test_group_user_reports.py
@@ -29,7 +29,7 @@ class GroupUserReport(APITestCase, SnubaTestCase):
 
     @cached_property
     def path(self) -> str:
-        return f"/api/0/groups/{self.group.id}/user-feedback/"
+        return f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/user-reports/"
 
     def create_events_for_environment(self, environment: Any, num_events: int) -> list[Any]:
         return [


### PR DESCRIPTION
Mark the group user reports endpoint as deprecated and update Python test to use the org-scoped URL pattern.
