### PR TITLE
feat(ACI): Add deprecation warning to old alerts API docs

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -103,7 +103,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     }
 
     @extend_schema(
-        operation_id="Retrieve an Issue Alert Rule for a Project",
+        operation_id="(DEPRECATED) Retrieve an Issue Alert Rule for a Project",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
@@ -119,6 +119,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     )
     def get(self, request: Request, project, rule) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Fetch an Alert](/api/monitors/fetch-an-alert) instead.
+
+
         Return details on an individual issue alert rule.
 
         An issue alert rule triggers whenever a new event is received for any issue in a project that matches the specified alert conditions. These conditions can include a resolved issue re-appearing or an issue affecting many users. Alert conditions have three parts:
@@ -149,7 +153,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         return Response(serialized_rule)
 
     @extend_schema(
-        operation_id="Update an Issue Alert Rule",
+        operation_id="(DEPRECATED) Update an Issue Alert Rule",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
@@ -166,6 +170,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     )
     def put(self, request: Request, project, rule) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Update an Alert by ID](/api/monitors/update-an-alert-by-id) instead.
+
+
         Updates an issue alert rule.
         > Warning: Calling this endpoint fully overwrites the specified issue alert.
 
@@ -350,7 +358,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @extend_schema(
-        operation_id="Delete an Issue Alert Rule",
+        operation_id="(DEPRECATED) Delete an Issue Alert Rule",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
@@ -365,12 +373,16 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     )
     def delete(self, request: Request, project, rule) -> Response:
         """
-        Delete a specific issue alert rule.
+        ## Deprecated
+         🚧 Use [Delete an Alert](/api/monitors/delete-an-alert) instead.
 
-        An issue alert rule triggers whenever a new event is received for any issue in a project that matches the specified alert conditions. These conditions can include a resolved issue re-appearing or an issue affecting many users. Alert conditions have three parts:
-        - Triggers: specify what type of activity you'd like monitored or when an alert should be triggered.
-        - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
-        - Actions: specify what should happen when the trigger conditions are met and the filters match.
+
+         Delete a specific issue alert rule.
+
+         An issue alert rule triggers whenever a new event is received for any issue in a project that matches the specified alert conditions. These conditions can include a resolved issue re-appearing or an issue affecting many users. Alert conditions have three parts:
+         - Triggers: specify what type of activity you'd like monitored or when an alert should be triggered.
+         - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
+         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         with transaction.atomic(router.db_for_write(Rule)):
             rule.update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -682,7 +682,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     @extend_schema(
-        operation_id="List a Project's Issue Alert Rules",
+        operation_id="(DEPRECATED) List a Project's Issue Alert Rules",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=None,
         responses={
@@ -695,6 +695,10 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     )
     def get(self, request: Request, project: Project) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Fetch an Organization's Monitors](/api/monitors/fetch-an-organizations-monitors) and [Fetch Alerts](/api/monitors/fetch-alerts) instead.
+
+
         Return a list of active issue alert rules bound to a project.
 
         An issue alert rule triggers whenever a new event is received for any issue in a project that matches the specified alert conditions. These conditions can include a resolved issue re-appearing or an issue affecting many users. Alert conditions have three parts:
@@ -719,7 +723,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         )
 
     @extend_schema(
-        operation_id="Create an Issue Alert Rule for a Project",
+        operation_id="(DEPRECATED) Create an Issue Alert Rule for a Project",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
@@ -735,6 +739,10 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     )
     def post(self, request: Request, project) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Create a Monitor for a Project](/api/monitors/create-a-monitor-for-a-project) and [Create an Alert for an Organization](/api/monitors/create-an-alert-for-an-organization) instead.
+
+
         Create a new issue alert rule for the given project.
 
         An issue alert rule triggers whenever a new event is received for any issue in a project that matches the specified alert conditions. These conditions can include a resolved issue re-appearing or an issue affecting many users. Alert conditions have three parts:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -366,7 +366,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
         ## Deprecated
-        🚧 Use [Fetch a Monitor](/api/alerts/fetch-a-monitor) instead.
+        🚧 Use [Fetch a Monitor](/api/monitors/fetch-a-monitor) and [Fetch an Alert](/api/monitors/fetch-an-alert) instead.
 
 
         Return details on an individual metric alert rule.
@@ -381,7 +381,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         return fetch_alert_rule(request, organization, alert_rule)
 
     @extend_schema(
-        operation_id="Update a Metric Alert Rule",
+        operation_id="(DEPRECATED) Update a Metric Alert Rule",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         request=OrganizationAlertRuleDetailsPutSerializer,
         responses={
@@ -396,6 +396,10 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     @_check_project_access
     def put(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Update a Monitor by ID](/api/monitors/update-a-monitor-by-id) and [Update an Alert by ID](/api/monitors/update-an-alert-by-id) instead.
+
+
         Updates a metric alert rule. See **Metric Alert Rule Types** under
         [Create a Metric Alert Rule for an Organization](/api/alerts/create-a-metric-alert-rule-for-an-organization/#metric-alert-rule-types)
         to see valid request body configurations for different types of metric alert rule types.
@@ -413,7 +417,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         return update_alert_rule(request, organization, alert_rule)
 
     @extend_schema(
-        operation_id="Delete a Metric Alert Rule",
+        operation_id="(DEPRECATED) Delete a Metric Alert Rule",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         responses={
             202: RESPONSE_ACCEPTED,
@@ -428,13 +432,16 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         self, request: Request, organization: Organization, alert_rule: AlertRule
     ) -> Response:
         """
-        Delete a specific metric alert rule.
+        ## Deprecated
+         🚧 Use [Delete a Monitor](/api/monitors/delete-a-monitor) and [Delete an Alert](/api/monitors/delete-an-alert) instead.
 
-        A metric alert rule is a configuration that defines the conditions for triggering an alert.
-        It specifies the metric type, function, time interval, and threshold
-        values that determine when an alert should be triggered. Metric alert rules are used to monitor
-        and notify you when certain metrics, like error count, latency, or failure rate, cross a
-        predefined threshold. These rules help you proactively identify and address issues in your
-        project.
+         Delete a specific metric alert rule.
+
+         A metric alert rule is a configuration that defines the conditions for triggering an alert.
+         It specifies the metric type, function, time interval, and threshold
+         values that determine when an alert should be triggered. Metric alert rules are used to monitor
+         and notify you when certain metrics, like error count, latency, or failure rate, cross a
+         predefined threshold. These rules help you proactively identify and address issues in your
+         project.
         """
         return remove_alert_rule(request, organization, alert_rule)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -351,7 +351,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     }
 
     @extend_schema(
-        operation_id="Retrieve a Metric Alert Rule for an Organization",
+        operation_id="(DEPRECATED) Retrieve a Metric Alert Rule for an Organization",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         responses={
             200: AlertRuleSerializer,
@@ -365,6 +365,10 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     @_check_project_access
     def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
+        ## Deprecated
+        🚧 Use [Fetch a Monitor](/api/alerts/fetch-a-monitor) instead.
+
+
         Return details on an individual metric alert rule.
 
         A metric alert rule is a configuration that defines the conditions for triggering an alert.

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -607,7 +607,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     permission_classes = (OrganizationAlertRulePermission,)
 
     @extend_schema(
-        operation_id="List an Organization's Metric Alert Rules",
+        operation_id="(DEPRECATED) List an Organization's Metric Alert Rules",
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=None,
         responses={
@@ -623,6 +623,10 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rules")
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
+        ## Deprecated
+        🚧 Use [Fetch an Organization's Monitors](/api/monitors/fetch-an-organizations-monitors) and [Fetch Alerts](/api/monitors/fetch-alerts) instead.
+
+
         Return a list of active metric alert rules bound to an organization.
 
         A metric alert rule is a configuration that defines the conditions for triggering an alert.
@@ -637,7 +641,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         return self.fetch_metric_alert(request, organization, alert_rules)
 
     @extend_schema(
-        operation_id="Create a Metric Alert Rule for an Organization",
+        operation_id="(DEPRECATED) Create a Metric Alert Rule for an Organization",
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=OrganizationAlertRuleIndexPostSerializer,
         responses={
@@ -651,6 +655,10 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     @track_alert_endpoint_execution("POST", "sentry-api-0-organization-alert-rules")
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
+        ## Deprecated
+        🚧 Use [Create a Monitor for a Project](/api/monitors/create-a-monitor-for-a-project) and [Create an Alert for an Organization](/api/monitors/create-an-alert-for-an-organization) instead.
+
+
         Create a new metric alert rule for the given organization.
 
         A metric alert rule is a configuration that defines the conditions for triggering an alert.


### PR DESCRIPTION
Add a deprecation warning to the old alert API docs with links to the new workflow engine endpoints to use instead.

<img width="986" height="823" alt="Screenshot 2026-01-21 at 11 22 17 AM" src="https://github.com/user-attachments/assets/4a0bbb8c-bfe7-4220-a23d-c98fa67e127b" />
<img width="1211" height="718" alt="Screenshot 2026-01-21 at 11 22 26 AM" src="https://github.com/user-attachments/assets/731131f4-e071-45d5-9cf0-949f41c1bffd" />
