### PR TITLE
chore(api): deprecate non-org-scoped group reprocessing endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -3,6 +3,8 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.tasks.reprocessing2 import reprocess_group
 
@@ -13,6 +15,7 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-reprocessing"])
     def post(self, request: Request, group) -> Response:
         """
         Reprocess a group

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -17,7 +17,9 @@ class GroupReprocessingTest(APITestCase):
             project_id=self.project.id,
         )
         self.group = event.group
-        self.url = f"/api/0/issues/{self.group.id}/reprocessing/"
+        self.url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/reprocessing/"
+        )
 
     def test_reprocess_without_admin_scope_and_delete_remaining_events(
         self, mock_reprocess: MagicMock


### PR DESCRIPTION
Add deprecation decorator to POST method of GroupReprocessingEndpoint and update tests to use org-scoped URL pattern.
