### PR TITLE
chore(api): deprecate non-org-scoped group-current-release endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_current_release.py
+++ b/src/sentry/issues/endpoints/group_current_release.py
@@ -4,9 +4,11 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.grouprelease import GroupReleaseWithStatsSerializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.releaseenvironment import ReleaseEnvironment
@@ -47,6 +49,7 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint):
         except IndexError:
             return None
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-current-release"])
     def get(self, request: Request, group) -> Response:
         """Get the current release in the group's project.
 

--- a/tests/sentry/issues/endpoints/test_group_current_release.py
+++ b/tests/sentry/issues/endpoints/test_group_current_release.py
@@ -85,7 +85,7 @@ class GroupCurrentReleaseTest(APITestCase):
         target_group, target_releases = self._set_up_current_release(group_seen_on_latest_release)
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{target_group.id}/current-release/"
+        url = f"/api/0/organizations/{target_group.project.organization.slug}/issues/{target_group.id}/current-release/"
         response = self.client.get(url, {"environment": environments_to_query}, format="json")
         assert response.status_code == 200
         return response.data["currentRelease"], target_releases


### PR DESCRIPTION
Mark the group current release endpoint as deprecated and update Python test to use the org-scoped URL pattern.
