### PR TITLE
chore(api): deprecate non-org-scoped group hashes endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -8,8 +8,10 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
@@ -34,6 +36,7 @@ class GroupHashesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-hashes"])
     def get(self, request: Request, group: Group) -> Response:
         """
         List an Issue's Hashes
@@ -71,6 +74,7 @@ class GroupHashesEndpoint(GroupEndpoint):
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-hashes"])
     def put(self, request: Request, group: Group) -> Response:
         """
         Perform an unmerge by reassigning events with hash values corresponding to the given

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -38,7 +38,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         assert new_event.group_id == old_event.group_id
 
-        url = f"/api/0/issues/{new_event.group_id}/hashes/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{new_event.group_id}/hashes/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -78,7 +78,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         eventstream.end_merge(state)
 
-        url = f"/api/0/issues/{event1.group_id}/hashes/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group_id}/hashes/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -147,7 +147,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
         metadata2.seer_matched_grouphash = grouphash1
         metadata2.save()
 
-        url = f"/api/0/issues/{event1.group_id}/hashes/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group_id}/hashes/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -178,7 +178,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         url = "?".join(
             [
-                f"/api/0/issues/{group.id}/hashes/",
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/hashes/",
                 urlencode({"id": [h.hash for h in hashes]}, True),
             ]
         )
@@ -210,7 +210,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         url = "?".join(
             [
-                f"/api/0/issues/{group.id}/hashes/",
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/hashes/",
                 urlencode({"id": [h.hash for h in hashes]}, True),
             ]
         )
@@ -237,7 +237,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         url = "?".join(
             [
-                f"/api/0/issues/{group.id}/hashes/",
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/hashes/",
                 urlencode({"id": [h.hash for h in hashes]}, True),
             ]
         )


### PR DESCRIPTION
Add deprecation decorator to GET and PUT methods of GroupHashesEndpoint and update tests to use org-scoped URL pattern.