### PR TITLE
chore(cells): deprecate group-event-details endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -13,6 +13,7 @@ from snuba_sdk.legacy import is_condition, parse_condition
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import parse_and_convert_issue_search_query
 from sentry.api.helpers.group_index.validators import ValidationError
@@ -27,6 +28,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.endpoints.project_event_details import (
@@ -153,6 +155,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         },
         examples=EventExamples.GROUP_EVENT_DETAILS,
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-event-details"])
     def get(self, request: Request, group: Group, event_id: str) -> Response:
         """
         Retrieves the details of an issue event.

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -56,7 +56,7 @@ class GroupEventDetailsEndpointTestBase(APITestCase, SnubaTestCase):
 
 class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCase, SnubaTestCase):
     def test_get_simple_latest(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/latest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -65,7 +65,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] is None
 
     def test_get_simple_oldest(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/oldest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -74,7 +74,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] == str(self.event_b.event_id)
 
     def test_get_simple_event_id(self) -> None:
-        url = f"/api/0/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -83,7 +83,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] == str(self.event_c.event_id)
 
     def test_get_with_environment_latest(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/latest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200, response.content
@@ -92,7 +92,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] is None
 
     def test_get_with_environment_oldest(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/oldest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/oldest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200, response.content
@@ -101,7 +101,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] is None
 
     def test_collapse_stacktrace_only(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/latest/"
         response = self.client.get(url, format="json", data={"collapse": ["stacktraceOnly"]})
 
         assert response.status_code == 200, response.content
@@ -110,7 +110,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert "nextEventID" not in response.data
 
     def test_collapse_full_release(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/latest/"
         response_no_collapse = self.client.get(
             url, format="json", data={"environment": ["production"]}
         )
@@ -135,7 +135,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         )
 
     def test_prev_filtered(self) -> None:
-        url = f"/api/0/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
         response = self.client.get(
             url,
             {
@@ -150,7 +150,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["nextEventID"] == str(self.event_c.event_id)
 
     def test_next_filtered(self) -> None:
-        url = f"/api/0/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
         response = self.client.get(
             url,
             {
@@ -187,7 +187,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             },
             project_id=self.project_1.id,
         )
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -223,7 +223,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             },
             project_id=self.project_1.id,
         )
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -271,7 +271,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             project_id=self.project_1.id,
         )
 
-        url = f"/api/0/issues/{self.event_d.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_d.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -280,7 +280,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] == str(self.event_f.event_id)
 
     def test_with_empty_query(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": ""}, format="json")
 
         assert response.status_code == 200, response.content
@@ -289,7 +289,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_issue_filter_query_ignored(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": "is:unresolved"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -298,7 +298,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_event_release_query(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f"release:{self.release_version}"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -322,7 +322,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert release.version == "test@1.2.3"
         assert release.is_semver_release
 
-        url = f"/api/0/issues/{event_g.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_g.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f"{SEMVER_ALIAS}:1.2.3"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -331,7 +331,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_has_environment(self) -> None:
-        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": "has:environment"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -374,7 +374,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         group.substatus = None
         group.save(update_fields=["status", "substatus"])
 
-        url = f"/api/0/issues/{group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
         response = self.client.get(url, {"query": "is:unresolved has:environment"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -395,7 +395,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             project_id=self.project_1.id,
         )
 
-        url = f"/api/0/issues/{event_e.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_e.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f'title:"{title}"'}, format="json")
 
         assert response.status_code == 200, response.content
@@ -415,7 +415,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             project_id=self.project_1.id,
         )
 
-        url = f"/api/0/issues/{event_e.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event_e.group.id}/events/recommended/"
         response = self.client.get(url, {"query": '!title:["*value1*", "*value2*"]'}, format="json")
 
         assert response.status_code == 200, response.content
@@ -429,7 +429,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         )
 
         assert group_info is not None
-        url = f"/api/0/issues/{group_info.group.id}/events/recommended/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group_info.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f'title:"{issue_title}"'}, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -35,62 +35,62 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         self.group = Group.objects.first()
 
     def test_snuba_no_environment_latest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event2.event_id)
 
     def test_snuba_no_environment_oldest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/oldest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event1.event_id)
 
     def test_snuba_no_environment_event_id(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/{self.event1.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/{self.event1.event_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event1.event_id)
 
     def test_snuba_environment_latest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event2.event_id)
 
     def test_snuba_environment_oldest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/oldest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event2.event_id)
 
     def test_snuba_environment_event_id(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/{self.event2.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/{self.event2.event_id}/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event2.event_id)
 
     def test_simple_latest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/latest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == str(self.event2.event_id)
 
     def test_simple_oldest(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/oldest/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.event1.event_id)
 
     def test_simple_event_id(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/events/{self.event1.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/{self.event1.event_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -99,7 +99,9 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
     def test_perf_issue_latest(self) -> None:
         event = self.create_performance_issue()
         assert event.group is not None
-        url = f"/api/0/issues/{event.group.id}/events/latest/"
+        url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/latest/"
+        )
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == event.event_id
@@ -107,7 +109,9 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
     def test_perf_issue_oldest(self) -> None:
         event = self.create_performance_issue()
         assert event.group is not None
-        url = f"/api/0/issues/{event.group.id}/events/oldest/"
+        url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/oldest/"
+        )
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == event.event_id
@@ -115,7 +119,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
     def test_perf_issue_event_id(self) -> None:
         event = self.create_performance_issue()
         assert event.group is not None
-        url = f"/api/0/issues/{event.group.id}/events/{event.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/{event.event_id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == event.event_id
@@ -123,6 +127,6 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
     def test_invalid_query(self) -> None:
         event = self.create_performance_issue()
         assert event.group is not None
-        url = f"/api/0/issues/{event.group.id}/events/{event.event_id}/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/{event.event_id}/"
         response = self.client.get(url, format="json", data={"query": "release.version:foobar"})
         assert response.status_code == 400


### PR DESCRIPTION
Add deprecation decorators to GroupEventDetailsEndpoint and update tests to use the org-scoped variant's URL pattern.