### PR TITLE
fix(preprod): temporarily hardcode to neutral status checks

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -45,8 +45,8 @@ BUILD_1 = {
     "build_number": 42,
     "build_configuration": "Debug",  # Head build configuration
     "base_build_configuration": "Release",  # Base build configuration (test different configs!)
-    "state": "processed_with_metrics",  # uploading, uploaded, failed, processed_no_metrics, processed_with_metrics, metrics_pending
-    "create_base_artifacts": True,  # Create base artifacts for size comparison
+    "state": "uploading",  # TEST: This triggers IN_PROGRESS status, so completed_at will be None
+    "create_base_artifacts": False,  # Not needed for this test
     "create_multiple_metrics": False,  # Create watch/dynamic feature metrics in addition to main
     "error_message": None,  # Only used if state is "failed"
 }
@@ -604,6 +604,12 @@ def main() -> None:
 
             # Create the preprod artifact
             preprod_artifact = PreprodArtifact.objects.create(**artifact_data)
+            PreprodArtifactMobileAppInfo.objects.create(
+                preprod_artifact=preprod_artifact,
+                app_name=build_config["app_name"],
+                build_version=build_config["build_version"],
+                build_number=build_config["build_number"],
+            )
             created_artifacts.append(preprod_artifact)
             logger.info(
                 "  ✓ Created artifact: %s (state: %s, build_config: %s)",
@@ -622,7 +628,7 @@ def main() -> None:
 
             # Simulate processing time by backdating the creation timestamp
             # This ensures completed_at != started_at in the status check
-            preprod_artifact.date_added = preprod_artifact.date_added - timedelta(minutes=5)
+            preprod_artifact.date_added = preprod_artifact.date_added - timedelta(minutes=7)
             preprod_artifact.save(update_fields=["date_added"])
             logger.info("  ✓ Backdated artifact creation by 5 minutes (simulating processing time)")
 

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -618,14 +618,6 @@ def main() -> None:
                 head_build_config.name if head_build_config else "None",
             )
 
-            # Create mobile app info with version details
-            PreprodArtifactMobileAppInfo.objects.create(
-                preprod_artifact=preprod_artifact,
-                app_name=build_config["app_name"],
-                build_version=build_config["build_version"],
-                build_number=build_config["build_number"],
-            )
-
             # Simulate processing time by backdating the creation timestamp
             # This ensures completed_at != started_at in the status check
             preprod_artifact.date_added = preprod_artifact.date_added - timedelta(minutes=7)

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -858,6 +858,13 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
                         extra={"target_url": target_url},
                     )
 
+            # GitHub rejects completed_at=null when status is "completed" with a 422
+            if "completed_at" in check_data and check_data["completed_at"] is None:
+                raise ValueError(
+                    "GitHub API rejects completed_at=null when status is 'completed'. "
+                    "Omit completed_at entirely instead of setting it to None."
+                )
+
             try:
                 response = self.client.create_check_run(repo=repo, data=check_data)
                 check_id = response.get("id")

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -181,15 +181,15 @@ def create_preprod_status_check_task(
         all_artifacts, size_metrics_map, status, preprod_artifact.project, triggered_rules
     )
 
-    # Temporarily hardcode neutral status to avoid GitHub rate limiting issues
-    # leaving checks stuck in "in progress" state
-    status = StatusCheckStatus.NEUTRAL
-
     target_url = get_preprod_artifact_url(preprod_artifact)
 
     completed_at: datetime | None = None
     if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
         completed_at = preprod_artifact.date_updated
+
+    # Temporarily hardcode neutral status to avoid GitHub rate limiting issues
+    # leaving checks stuck in "in progress" state
+    status = StatusCheckStatus.NEUTRAL
 
     try:
         check_id = provider.create_status_check(

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -862,7 +862,11 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
                     )
 
             # GitHub rejects completed_at=null when status is "completed" with a 422
-            if "completed_at" in check_data and check_data["completed_at"] is None:
+            if (
+                mapped_status == GitHubCheckStatus.COMPLETED
+                and "completed_at" in check_data
+                and check_data["completed_at"] is None
+            ):
                 raise ValueError(
                     "GitHub API rejects completed_at=null when status is 'completed'. "
                     "Omit completed_at entirely instead of setting it to None."

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -862,11 +862,7 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
                     )
 
             # GitHub rejects completed_at=null when status is "completed" with a 422
-            if (
-                mapped_status == GitHubCheckStatus.COMPLETED
-                and "completed_at" in check_data
-                and check_data["completed_at"] is None
-            ):
+            if mapped_status == GitHubCheckStatus.COMPLETED and completed_at is None:
                 raise ValueError(
                     "GitHub API rejects completed_at=null when status is 'completed'. "
                     "Omit completed_at entirely instead of setting it to None."

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -181,6 +181,10 @@ def create_preprod_status_check_task(
         all_artifacts, size_metrics_map, status, preprod_artifact.project, triggered_rules
     )
 
+    # Temporarily hardcode neutral status to avoid GitHub rate limiting issues
+    # leaving checks stuck in "in progress" state
+    status = StatusCheckStatus.NEUTRAL
+
     target_url = get_preprod_artifact_url(preprod_artifact)
 
     completed_at: datetime | None = None


### PR DESCRIPTION
While we sort out some of the rate limiting issues going on, we can hardcode this to always be a neutral result for now which won't block PR merging. Eventually this will be user configurable.