### PR TITLE
ref(integrations): Create separate traces for GitHub webhook events

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -10,6 +10,7 @@ from datetime import timezone
 from typing import Any, Protocol
 
 import orjson
+import sentry_sdk
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest, HttpResponse
@@ -1108,10 +1109,19 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
 
         event_handler = handler()
 
-        with IntegrationWebhookEvent(
-            interaction_type=event_handler.event_type,
-            domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            provider_key=event_handler.provider,
-        ).capture():
-            event_handler(event, github_event=github_event)
+        # Create a new transaction for each webhook event to ensure separate traces
+        transaction_name = f"github.webhook.{github_event.value}"
+        with sentry_sdk.start_transaction(
+            op="webhook",
+            name=transaction_name,
+            source="component",
+        ) as transaction:
+            transaction.set_tag("github_event", github_event.value)
+
+            with IntegrationWebhookEvent(
+                interaction_type=event_handler.event_type,
+                domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+                provider_key=event_handler.provider,
+            ).capture():
+                event_handler(event, github_event=github_event)
         return HttpResponse(status=204)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -290,12 +290,22 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             return HttpResponse(MALFORMED_SIGNATURE_ERROR, status=400)
 
         event_handler = handler()
-        with IntegrationWebhookEvent(
-            interaction_type=event_handler.event_type,
-            domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            provider_key=event_handler.provider,
-        ).capture():
-            event_handler(event, host=host, github_event=github_event)
+
+        # Create a new transaction for each webhook event to ensure separate traces
+        transaction_name = f"github_enterprise.webhook.{github_event}"
+        with sentry_sdk.start_transaction(
+            op="webhook",
+            name=transaction_name,
+            source="component",
+        ) as transaction:
+            transaction.set_tag("github_event", github_event)
+
+            with IntegrationWebhookEvent(
+                interaction_type=event_handler.event_type,
+                domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+                provider_key=event_handler.provider,
+            ).capture():
+                event_handler(event, host=host, github_event=github_event)
 
         return HttpResponse(status=204)
 


### PR DESCRIPTION
## Summary

Creates separate traces for each GitHub webhook event instead of sharing a single HTTP request trace across all webhook events.

I was looking at some traces in Sentry and it looked pretty bad coalescing all different events.

If this works well, we can expand it to other integrations.

## Problem

Previously, all GitHub webhook events (push, pull_request, installation, etc.) were processed within a single HTTP request transaction, causing them to share the same trace ID. This made it difficult to:
- Isolate and monitor individual webhook events
- Track performance per webhook event type
- Debug specific webhook failures
- Understand webhook processing patterns

## Solution

Wraps each webhook event handler with `sentry_sdk.start_transaction()` to create a unique trace per webhook event. Each transaction is:
- Named descriptively (e.g., `github.webhook.push`, `github.webhook.pull_request`)
- Tagged with `github_event` for filtering by event type
- Maintains existing `IntegrationWebhookEvent` metrics tracking

## Benefits

- **Performance monitoring**: Track latency per webhook event type
- **Error attribution**: Clearly identify which webhook events are failing
- **Debugging**: Isolate traces for specific webhook types
- **Observability**: Better visibility into webhook processing pipeline

## Changes

- Modified `src/sentry/integrations/github/webhook.py`
- Modified `src/sentry/integrations/github_enterprise/webhook.py`

## Testing

Existing tests should continue to work as the changes wrap the existing webhook handling logic without modifying its behavior.