### PR TITLE
fix(preprod): Show correct message on no size analysis

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -74,6 +74,17 @@ export default function BuildDetails() {
       ],
       {
         staleTime: 0,
+        retry: (failureCount, apiError: RequestError) => {
+          // By default we retry 404s 3 times which causes
+          // latency when loading the page if there is no size-analysis
+          // (which is legitimate if size was not run on this artifact).
+          // Instead don't retry 404s:
+          if (apiError?.status === 404) {
+            return false;
+          }
+          // Keep default behaviour otherwise:
+          return failureCount < 2;
+        },
         enabled: !!projectId && !!artifactId,
       }
     );

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -116,9 +116,9 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
 
   const sizeInfo = buildDetailsData?.size_info;
   const isLoadingRequests = isAppSizeLoading || isBuildDetailsPending;
-  const isSizeNotStarted = sizeInfo === undefined;
+  const isSizeStarted = sizeInfo !== undefined && sizeInfo !== null;
   const isSizeFailed = sizeInfo?.state === BuildDetailsSizeAnalysisState.FAILED;
-  const showNoSizeRequested = !isLoadingRequests && isSizeNotStarted;
+  const showNoSizeRequested = !isLoadingRequests && !isSizeStarted;
 
   if (isLoadingRequests) {
     return (


### PR DESCRIPTION
This fixes a bug where we did not handle null.
Also disable retries on legitimate 404s.
