### PR TITLE
Add audit logs only when priviledge access changes

### DIFF
--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -188,6 +188,33 @@ class SuperuserUserSerializer(BaseUserSerializer):
         model = User
         fields = ("name", "username", "is_active")
 
+    def update(self, instance: User, validated_data: dict[str, Any]) -> User:
+        request = self.context.get("request")
+        should_audit = False
+
+        if request:
+            privileged_fields = {"is_active", "is_staff", "is_superuser"}
+            changed_fields = {
+                field
+                for field in privileged_fields
+                if field in validated_data and getattr(instance, field) != validated_data[field]
+            }
+            should_audit = bool(changed_fields)
+
+        user = super().update(instance, validated_data)
+
+        if should_audit and request:
+            audit_logger.info(
+                "user.edit",
+                extra={
+                    "user_id": user.id,
+                    "actor_id": getattr(request.user, "id", None),
+                    "form_data": getattr(request, "data", None),
+                },
+            )
+
+        return user
+
 
 class PrivilegedUserSerializer(SuperuserUserSerializer):
     is_staff = serializers.BooleanField()
@@ -284,7 +311,9 @@ class UserDetailsEndpoint(UserEndpoint):
             serializer_cls = SuperuserUserSerializer
         else:
             serializer_cls = UserSerializer
-        serializer = serializer_cls(instance=user, data=request.data, partial=True)
+        serializer = serializer_cls(
+            instance=user, data=request.data, partial=True, context={"request": request}
+        )
 
         serializer_options = UserOptionsSerializer(
             data=request.data.get("options", {}), partial=True
@@ -315,16 +344,6 @@ class UserDetailsEndpoint(UserEndpoint):
 
         with transaction.atomic(using=router.db_for_write(User)):
             user = serializer.save()
-
-            if any(k in request.data for k in ("isStaff", "isSuperuser", "isActive")):
-                audit_logger.info(
-                    "user.edit",
-                    extra={
-                        "user_id": user.id,
-                        "actor_id": request.user.id,
-                        "form_data": request.data,
-                    },
-                )
 
         return Response(serialize(user, request.user, DetailedSelfUserSerializer()))
 

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -210,6 +210,7 @@ class SuperuserUserSerializer(BaseUserSerializer):
                     "user_id": user.id,
                     "actor_id": getattr(request.user, "id", None),
                     "form_data": getattr(request, "data", None),
+                    "changed_fields": changed_fields,
                 },
             )
 

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -344,6 +344,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
                 "form_data": {"isActive": "false"},
+                "changed_fields": {"is_active"},
             },
         )
 
@@ -364,6 +365,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
                 "form_data": {"isStaff": "true"},
+                "changed_fields": {"is_staff"},
             },
         )
 
@@ -384,6 +386,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
                 "form_data": {"isSuperuser": "true"},
+                "changed_fields": {"is_superuser"},
             },
         )
 
@@ -436,6 +439,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
                 "form_data": {"isActive": "false", "isStaff": "true"},
+                "changed_fields": {"is_active", "is_staff"},
             },
         )
 
@@ -574,6 +578,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
                 "form_data": {"isActive": "false"},
+                "changed_fields": {"is_active"},
             },
         )
 
@@ -594,6 +599,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
                 "form_data": {"isStaff": "true"},
+                "changed_fields": {"is_staff"},
             },
         )
 
@@ -614,6 +620,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
                 "form_data": {"isSuperuser": "true"},
+                "changed_fields": {"is_superuser"},
             },
         )
 

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from unittest.mock import patch
 
 from django.test import override_settings
 from pytest import fixture
@@ -327,6 +328,117 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         user = User.objects.get(id=self.user.id)
         assert user.is_staff
 
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_is_active_changed(self, mock_audit_logger) -> None:
+        self.user.update(is_active=True)
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.get_success_response(
+            self.user.id,
+            isActive="false",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.superuser.id,
+                "form_data": {"isActive": "false"},
+            },
+        )
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_is_staff_changed(self, mock_audit_logger) -> None:
+        self.user.update(is_staff=False)
+        UserPermission.objects.create(user=self.superuser, permission="users.admin")
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.get_success_response(
+            self.user.id,
+            isStaff="true",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.superuser.id,
+                "form_data": {"isStaff": "true"},
+            },
+        )
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_is_superuser_changed(self, mock_audit_logger) -> None:
+        self.user.update(is_superuser=False)
+        UserPermission.objects.create(user=self.superuser, permission="users.admin")
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.get_success_response(
+            self.user.id,
+            isSuperuser="true",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.superuser.id,
+                "form_data": {"isSuperuser": "true"},
+            },
+        )
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_not_emitted_when_is_active_unchanged(self, mock_audit_logger) -> None:
+        self.user.update(is_active=True)
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.get_success_response(
+            self.user.id,
+            isActive="true",  # Same as current value
+        )
+
+        mock_audit_logger.info.assert_not_called()
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_not_emitted_for_non_privileged_fields(self, mock_audit_logger) -> None:
+        self.login_as(user=self.superuser, superuser=True)
+
+        # Only change name, not any privileged fields
+        self.get_success_response(
+            self.user.id,
+            name="New Name",
+        )
+
+        # Verify name was updated
+        user = User.objects.get(id=self.user.id)
+        assert user.name == "New Name"
+
+        # Audit log should NOT be called for non-privileged field changes
+        mock_audit_logger.info.assert_not_called()
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_multiple_privileged_fields_changed(
+        self, mock_audit_logger
+    ) -> None:
+        self.user.update(is_active=True, is_staff=False)
+        UserPermission.objects.create(user=self.superuser, permission="users.admin")
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.get_success_response(
+            self.user.id,
+            isActive="false",
+            isStaff="true",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.superuser.id,
+                "form_data": {"isActive": "false", "isStaff": "true"},
+            },
+        )
+
 
 @control_silo_test
 class UserDetailsStaffUpdateTest(UserDetailsTest):
@@ -445,6 +557,65 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
 
         user = User.objects.get(id=self.user.id)
         assert user.is_staff
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_staff_changes_is_active(self, mock_audit_logger) -> None:
+        self.user.update(is_active=True)
+        self.login_as(user=self.staff_user, staff=True)
+
+        self.get_success_response(
+            self.user.id,
+            isActive="false",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.staff_user.id,
+                "form_data": {"isActive": "false"},
+            },
+        )
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_staff_changes_is_staff(self, mock_audit_logger) -> None:
+        self.user.update(is_staff=False)
+        UserPermission.objects.create(user=self.staff_user, permission="users.admin")
+        self.login_as(user=self.staff_user, staff=True)
+
+        self.get_success_response(
+            self.user.id,
+            isStaff="true",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.staff_user.id,
+                "form_data": {"isStaff": "true"},
+            },
+        )
+
+    @patch("sentry.users.api.endpoints.user_details.audit_logger")
+    def test_audit_log_emitted_when_staff_changes_is_superuser(self, mock_audit_logger) -> None:
+        self.user.update(is_superuser=False)
+        UserPermission.objects.create(user=self.staff_user, permission="users.admin")
+        self.login_as(user=self.staff_user, staff=True)
+
+        self.get_success_response(
+            self.user.id,
+            isSuperuser="true",
+        )
+
+        mock_audit_logger.info.assert_called_once_with(
+            "user.edit",
+            extra={
+                "user_id": self.user.id,
+                "actor_id": self.staff_user.id,
+                "form_data": {"isSuperuser": "true"},
+            },
+        )
 
 
 @control_silo_test


### PR DESCRIPTION
This change ensures that we only emit the audit log if the priviledged access (i.e. superuser, admin, staff) modes have changed. If they haven't changed, then do not emit an audit log.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
