### PR TITLE
meta: Add .claude/plans to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ ngrok.yml
 package-lock.json
 yarn.lock
 .claude/settings.local.json
+.claude/plans


### PR DESCRIPTION
This is a good place to put plans that are relevant locally. For sharing work across the team and org and with open-source we still have all the existing methods of gathering feedback, tracking execution, and communicating outwards.
