### PR TITLE
fix(middleware): Skip OAuth endpoints in AI agent middleware

### DIFF
--- a/src/sentry/middleware/ai_agent.py
+++ b/src/sentry/middleware/ai_agent.py
@@ -83,7 +83,7 @@ class AIAgentMiddleware:
     and returns helpful markdown guidance instead of HTML.
 
     Detection criteria:
-    1. Request path does NOT start with /api/ (frontend routes only)
+    1. Request path does NOT start with /api/ or /oauth/ (frontend routes only)
     2. Accept header contains text/markdown or text/x-markdown
     3. Request is anonymous (no authenticated user, no auth token)
     """
@@ -94,6 +94,10 @@ class AIAgentMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponse:
         # Skip API routes - only intercept frontend UI routes
         if request.path.startswith("/api/"):
+            return self.get_response(request)
+
+        # Skip OAuth routes - legitimate machine-to-machine endpoints
+        if request.path.startswith("/oauth/"):
             return self.get_response(request)
 
         if not _accepts_markdown(request):

--- a/tests/sentry/middleware/test_ai_agent.py
+++ b/tests/sentry/middleware/test_ai_agent.py
@@ -100,6 +100,11 @@ class AIAgentMiddlewareTest(TestCase):
 
         assert self.middleware(request).status_code == 401
 
+    def test_oauth_path_passes_through(self):
+        request = self.make_anonymous_request("/oauth/token/", HTTP_ACCEPT="text/markdown")
+
+        assert self.middleware(request).status_code == 401
+
     @patch("sentry.middleware.ai_agent.logger.info")
     def test_logs_request(self, mock_logger: MagicMock):
         request = self.make_anonymous_request(


### PR DESCRIPTION
## Summary
- Exclude `/oauth/` paths from the AI agent markdown response middleware
- These are legitimate machine-to-machine endpoints (device authorization, token exchange) that should work normally

## Test plan
- [x] Added test case `test_oauth_path_passes_through` to verify OAuth paths are not intercepted
- [x] All existing tests pass

Addresses feedback from https://github.com/getsentry/sentry/pull/106485#discussion_r2714337214