### PR TITLE
feat(perf-detectors): Make it possible to provide a Detector ID to a PerformanceDetector

### DIFF
--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -58,10 +58,18 @@ class PerformanceDetector(ABC):
 
     type: ClassVar[DetectorType]
 
-    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        settings: dict[DetectorType, Any],
+        event: dict[str, Any],
+        organization: Organization | None = None,
+        detector_id: int | None = None,
+    ) -> None:
         self.settings = settings[self.settings_key]
         self._event = event
         self.stored_problems: dict[str, PerformanceProblem] = {}
+        self.organization = organization
+        self.detector_id = detector_id
 
     def find_span_prefix(self, settings: dict[str, Any], span_op: str) -> str | bool:
         allowed_span_ops = settings.get("allowed_span_ops", [])

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -51,8 +51,14 @@ class HTTPOverheadDetector(PerformanceDetector):
     type = DetectorType.HTTP_OVERHEAD
     settings_key = DetectorType.HTTP_OVERHEAD
 
-    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
-        super().__init__(settings, event)
+    def __init__(
+        self,
+        settings: dict[DetectorType, Any],
+        event: dict[str, Any],
+        organization: Organization | None = None,
+        detector_id: int | None = None,
+    ) -> None:
+        super().__init__(settings, event, organization, detector_id)
 
         self.location_to_indicators: dict[str, list[list[ProblemIndicator]]] = defaultdict(list)
 
@@ -150,6 +156,19 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         location_span_ids = [span["span_id"] for span in location_spans]
 
+        evidence_data = {
+            "parent_span_ids": [],
+            "cause_span_ids": [],
+            "offender_span_ids": location_span_ids,
+            "op": "http",
+            "transaction_name": self._event.get("transaction", ""),
+            "repeating_spans": get_span_evidence_value(example_span),
+            "repeating_spans_compact": get_span_evidence_value(example_span, include_op=False),
+            "num_repeating_spans": str(len(location_spans)),
+        }
+        if self.detector_id is not None:
+            evidence_data["detector_id"] = self.detector_id
+
         self.stored_problems[fingerprint] = PerformanceProblem(
             fingerprint,
             "http",
@@ -158,16 +177,7 @@ class HTTPOverheadDetector(PerformanceDetector):
             cause_span_ids=[],
             parent_span_ids=None,
             offender_span_ids=location_span_ids,
-            evidence_data={
-                "parent_span_ids": [],
-                "cause_span_ids": [],
-                "offender_span_ids": location_span_ids,
-                "op": "http",
-                "transaction_name": self._event.get("transaction", ""),
-                "repeating_spans": get_span_evidence_value(example_span),
-                "repeating_spans_compact": get_span_evidence_value(example_span, include_op=False),
-                "num_repeating_spans": str(len(location_spans)),
-            },
+            evidence_data=evidence_data,
             evidence_display=[
                 IssueEvidence(
                     name="Offending Spans",

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -417,11 +417,15 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
         self.state, performance_problem = self.state.next(span)
         if performance_problem:
             if self.detector_id is not None:
+                if performance_problem.evidence_data is None:
+                    performance_problem.evidence_data = {}
                 performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem
 
     def on_complete(self) -> None:
         if performance_problem := self.state.finish():
             if self.detector_id is not None:
+                if performance_problem.evidence_data is None:
+                    performance_problem.evidence_data = {}
                 performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -392,8 +392,14 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
     type = DetectorType.M_N_PLUS_ONE_DB
     settings_key = DetectorType.M_N_PLUS_ONE_DB
 
-    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
-        super().__init__(settings, event)
+    def __init__(
+        self,
+        settings: dict[DetectorType, Any],
+        event: dict[str, Any],
+        organization: Organization | None = None,
+        detector_id: int | None = None,
+    ) -> None:
+        super().__init__(settings, event, organization, detector_id)
 
         self.state: MNPlusOneState = SearchingForMNPlusOne(
             settings=self.settings,
@@ -410,8 +416,12 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
     def visit_span(self, span: Span) -> None:
         self.state, performance_problem = self.state.next(span)
         if performance_problem:
+            if self.detector_id is not None:
+                performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem
 
     def on_complete(self) -> None:
         if performance_problem := self.state.finish():
+            if self.detector_id is not None:
+                performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -56,8 +56,14 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
     type = DetectorType.N_PLUS_ONE_DB_QUERIES
     settings_key = DetectorType.N_PLUS_ONE_DB_QUERIES
 
-    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
-        super().__init__(settings, event)
+    def __init__(
+        self,
+        settings: dict[DetectorType, Any],
+        event: dict[str, Any],
+        organization: Organization | None = None,
+        detector_id: int | None = None,
+    ) -> None:
+        super().__init__(settings, event, organization, detector_id)
 
         self.potential_parents = {}
         self.previous_span: Span | None = None
@@ -195,6 +201,20 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 metrics.incr("performance.performance_issue.invalid_description")
                 return
 
+            evidence_data = {
+                "transaction_name": self._event.get("transaction", ""),
+                "op": "db",
+                "parent_span_ids": [parent_span_id],
+                "parent_span": get_span_evidence_value(parent_span),
+                "cause_span_ids": [self.source_span.get("span_id", None)],
+                "offender_span_ids": offender_span_ids,
+                "repeating_spans": f"{self.n_spans[0].get('op', 'db')} - {first_span_description}",
+                "repeating_spans_compact": first_span_description,
+                "num_repeating_spans": str(len(offender_span_ids)),
+            }
+            if self.detector_id is not None:
+                evidence_data["detector_id"] = self.detector_id
+
             self.stored_problems[fingerprint] = PerformanceProblem(
                 fingerprint=fingerprint,
                 op="db",
@@ -211,17 +231,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                         important=True,
                     )
                 ],
-                evidence_data={
-                    "transaction_name": self._event.get("transaction", ""),
-                    "op": "db",
-                    "parent_span_ids": [parent_span_id],
-                    "parent_span": get_span_evidence_value(parent_span),
-                    "cause_span_ids": [self.source_span.get("span_id", None)],
-                    "offender_span_ids": offender_span_ids,
-                    "repeating_spans": f"{self.n_spans[0].get('op', 'db')} - {first_span_description}",
-                    "repeating_spans_compact": first_span_description,
-                    "num_repeating_spans": str(len(offender_span_ids)),
-                },
+                evidence_data=evidence_data,
             )
 
     def _is_slower_than_threshold(self) -> bool:

--- a/src/sentry/issue_detection/detectors/slow_db_query_detector.py
+++ b/src/sentry/issue_detection/detectors/slow_db_query_detector.py
@@ -65,6 +65,21 @@ class SlowDBQueryDetector(PerformanceDetector):
             hash = span.get("hash", "")
             type = PerformanceSlowDBQueryGroupType
 
+            evidence_data = {
+                "op": op,
+                "cause_span_ids": [],
+                "parent_span_ids": [],
+                "offender_span_ids": spans_involved,
+                "transaction_name": self._event.get("description", ""),
+                "repeating_spans": get_span_evidence_value(span)[:MAX_EVIDENCE_VALUE_LENGTH],
+                "repeating_spans_compact": get_span_evidence_value(span, include_op=False)[
+                    :MAX_EVIDENCE_VALUE_LENGTH
+                ],
+                "num_repeating_spans": str(len(spans_involved)),
+            }
+            if self.detector_id is not None:
+                evidence_data["detector_id"] = self.detector_id
+
             self.stored_problems[fingerprint] = PerformanceProblem(
                 type=type,
                 fingerprint=self._fingerprint(hash),
@@ -73,18 +88,7 @@ class SlowDBQueryDetector(PerformanceDetector):
                 cause_span_ids=[],
                 parent_span_ids=[],
                 offender_span_ids=spans_involved,
-                evidence_data={
-                    "op": op,
-                    "cause_span_ids": [],
-                    "parent_span_ids": [],
-                    "offender_span_ids": spans_involved,
-                    "transaction_name": self._event.get("description", ""),
-                    "repeating_spans": get_span_evidence_value(span)[:MAX_EVIDENCE_VALUE_LENGTH],
-                    "repeating_spans_compact": get_span_evidence_value(span, include_op=False)[
-                        :MAX_EVIDENCE_VALUE_LENGTH
-                    ],
-                    "num_repeating_spans": str(len(spans_involved)),
-                },
+                evidence_data=evidence_data,
                 evidence_display=[
                     IssueEvidence(
                         name="Offending Spans",

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -305,7 +305,6 @@ def get_detection_settings(
             "payload_size_threshold": settings["large_http_payload_size_threshold"],
             "detection_enabled": settings["large_http_payload_detection_enabled"],
             "minimum_span_duration": 100,  # ms
-            "organization": organization,
             "filtered_paths": settings["large_http_payload_filtered_paths"],
         },
         DetectorType.HTTP_OVERHEAD: {
@@ -361,7 +360,7 @@ def _detect_performance_problems(
 
     with sentry_sdk.start_span(op="initialize", name="PerformanceDetector"):
         detectors: list[PerformanceDetector] = [
-            detector_class(detection_settings, data)
+            detector_class(detection_settings, data, organization)
             for detector_class in DETECTOR_CLASSES
             if detector_class.is_detection_allowed_for_system()
         ]

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -83,7 +83,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = LargeHTTPPayloadDetector(settings, event)
+        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -94,7 +94,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = LargeHTTPPayloadDetector(settings, event)
+        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
 
         assert not detector.is_creation_allowed_for_project(project)
 
@@ -328,7 +328,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event)
+        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
@@ -356,7 +356,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event)
+        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 1
 
@@ -375,6 +375,6 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event)
+        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0


### PR DESCRIPTION
We don't have corresponding workflow engine Detectors yet, but when we do, this will make it easy to wire them up.

While in the area, passed in Organization to enable flagpole gating in detector logic without abusing settings.
