### PR TITLE
Deprecate product-owners-settings-integrations in favor of eco

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -379,8 +379,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 # End of Workflow Engine (ACI)
 
 ## Integrations
-/src/sentry/sentry_apps/                                             @getsentry/product-owners-settings-integrations @getsentry/ecosystem
-/tests/sentry/sentry_apps                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+/src/sentry/sentry_apps/                                             @getsentry/ecosystem
+/tests/sentry/sentry_apps                                            @getsentry/ecosystem
 /src/sentry/utils/sentry_apps/                                       @getsentry/ecosystem
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/alerts-notifications
 /src/sentry/api/serializers/models/rule.py                           @getsentry/alerts-notifications
@@ -388,7 +388,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/digests/                                                 @getsentry/alerts-notifications
 /src/sentry/identity/                                                @getsentry/enterprise
 
-/src/sentry/integrations/                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+/src/sentry/integrations/                                            @getsentry/ecosystem
 /src/sentry/integrations/api/endpoints/organization_code_mapping*.py                            @getsentry/issue-detection-backend
 /src/sentry/integrations/api/endpoints/organization_coding_agents.py                            @getsentry/machine-learning-ai
 /src/sentry/integrations/coding_agent/                                      @getsentry/machine-learning-ai
@@ -412,14 +412,14 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/user_report.py                                     @getsentry/alerts-notifications
 /src/sentry/tasks/summaries/weekly_reports.py                        @getsentry/alerts-notifications
 
-/src/sentry_plugins/                                                 @getsentry/product-owners-settings-integrations
+/src/sentry_plugins/                                                 @getsentry/ecosystem
 
 /tests/sentry_plugins/                                               @getsentry/ecosystem
 /tests/sentry/integrations/                                          @getsentry/ecosystem
 
 # To find matching files -> find . -name "*sentry_app*.py"
-*sentry_app*.py                                                      @getsentry/product-owners-settings-integrations @getsentry/ecosystem
-*sentryapp*.py                                                       @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+*sentry_app*.py                                                      @getsentry/ecosystem
+*sentryapp*.py                                                       @getsentry/ecosystem
 *doc_integration*.py                                                 @getsentry/ecosystem
 *docintegration*.py                                                  @getsentry/ecosystem
 


### PR DESCRIPTION
Per Athena. Ignoring the getsentry/enterprise errors cause Jeffrey is fixing that