### PR TITLE
ref(aci): Rename _ensure_metric_detector

### DIFF
--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -9,7 +9,7 @@ from sentry.models.project import Project
 from sentry.signals import project_created
 from sentry.workflow_engine.processors.detector import (
     UnableToAcquireLockApiError,
-    _ensure_metric_detector,
+    ensure_default_anomaly_detector,
     ensure_default_detectors,
 )
 
@@ -75,7 +75,7 @@ def create_metric_detector_with_owner(project: Project, user=None, user_id=None,
         enabled = features.has(
             "organizations:anomaly-detection-alerts", project.organization, actor=user
         )
-        detector = _ensure_metric_detector(
+        detector = ensure_default_anomaly_detector(
             project, owner_team_id=owner_team.id if owner_team else None, enabled=enabled
         )
         if detector:
@@ -86,7 +86,7 @@ def create_metric_detector_with_owner(project: Project, user=None, user_id=None,
     except UnableToAcquireLockApiError as e:
         sentry_sdk.capture_exception(e)
     except Exception:
-        # Seer data send failed - detector was not created, already logged in _ensure_metric_detector
+        # Seer data send failed - detector was not created, already logged in ensure_default_anomaly_detector
         pass
 
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -115,7 +115,7 @@ def _ensure_detector(project: Project, type: str) -> Detector:
         raise UnableToAcquireLockApiError
 
 
-def _ensure_metric_detector(
+def ensure_default_anomaly_detector(
     project: Project, owner_team_id: int | None = None, enabled: bool = True
 ) -> Detector | None:
     """


### PR DESCRIPTION
It isn't private as the prefix implied, and made the name a bit more specific while we're renaming.