### PR TITLE
fix(uptime): Fix cURL snippet background leaking in alert form

### DIFF
--- a/static/app/views/alerts/rules/uptime/httpSnippet.tsx
+++ b/static/app/views/alerts/rules/uptime/httpSnippet.tsx
@@ -78,6 +78,7 @@ export function HTTPSnippet({body, headers, method, url, traceSampling}: Props) 
 }
 
 const MaxSizedSnippet = styled(CodeBlock)`
+  height: auto;
   pre {
     overflow-y: auto;
     max-height: 400px;


### PR DESCRIPTION
## Summary
- Fixed the cURL/HTTP snippet background visually extending beyond its content in the uptime alert create/edit form
- Added `height: auto` to the `MaxSizedSnippet` styled component to override the inherited `height: 100%` from `CodeBlock`

Fixes NEW-710