### PR TITLE
perf(code review): reorder contributor seat check to avoid unnecessary seat-based-seer-enabled calls

### DIFF
--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -140,18 +140,14 @@ def should_create_or_increment_contributor_seat(
     Determines if we should create or increment an OrganizationContributor record
     and potentially assign a new seat.
 
-    Logic:
-    1. Require seat-based Seer to be enabled for the organization
-    2. Require code review OR autofix to be enabled for the repo
-    3. Check Seer quota (returns True if contributor has seat OR quota available)
+    Require repo integration, code review OR autofix enabled for the repo,
+    and seat-based Seer enabled for the organization.
     """
-    if not features.has("organizations:seat-based-seer-enabled", organization):
-        return False
-
-    if not _has_code_review_or_autofix_enabled(organization.id, repo.id):
-        return False
-
-    if repo.integration_id is None:
+    if (
+        repo.integration_id is None
+        or not _has_code_review_or_autofix_enabled(organization.id, repo.id)
+        or not features.has("organizations:seat-based-seer-enabled", organization)
+    ):
         return False
 
     return quotas.backend.check_seer_quota(

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -70,6 +70,18 @@ class ShouldCreateOrIncrementContributorSeatTest(TestCase):
             assert result is True
             mock_quota.assert_called_once()
 
+    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=True)
+    def test_returns_true_when_autofix_enabled_and_quota_available(self, mock_quota):
+        self.create_code_mapping(project=self.project, repo=self.repo)
+        self.project.update_option("sentry:autofix_automation_tuning", "medium")
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_create_or_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is True
+            mock_quota.assert_called_once()
+
     @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=False)
     def test_returns_false_when_quota_not_available(self, mock_quota):
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
@@ -79,17 +91,6 @@ class ShouldCreateOrIncrementContributorSeatTest(TestCase):
                 self.organization, self.repo, self.contributor
             )
             assert result is False
-
-    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=True)
-    def test_returns_true_when_autofix_enabled(self, mock_quota):
-        self.create_code_mapping(project=self.project, repo=self.repo)
-        self.project.update_option("sentry:autofix_automation_tuning", "medium")
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_create_or_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
inc-1590

Reorder the logic so that we only check for `seat-based-seer-enabled` if necessary.