### PR TITLE
ref(eslint) prevent color package imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -865,6 +865,22 @@ export default typescript.config([
       'no-restricted-imports': [
         'error',
         {
+          patterns: [
+            {
+              group: ['admin/*'],
+              message: 'Do not import gsAdmin into sentry',
+            },
+            {
+              group: ['getsentry/*'],
+              message: 'Do not import gsApp into sentry',
+            },
+            {
+              group: ['sentry/utils/theme*', 'sentry/utils/theme'],
+              importNames: ['lightTheme', 'darkTheme', 'default'],
+              message:
+                "Use 'useTheme' hook of withTheme HOC instead of importing theme directly. For tests, use ThemeFixture.",
+            },
+          ],
           // Allow color package only in the components/core directory
           paths: restrictedImportPaths.filter(({name}) => name !== 'color'),
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -143,6 +143,11 @@ const restrictedImportPaths = [
     message:
       'Do not use this directly in your view component, see https://sentry.sentry.io/stories/shared/views/dashboards/widgets/timeserieswidget/timeserieswidgetvisualization#deeplinking for more information',
   },
+  {
+    name: 'color',
+    message:
+      'Only @sentry/scraps is allowed to use color package, please use the values set on the team or reach out to design-engineering for help',
+  },
 ];
 
 // Used by both: `languageOptions` & `parserOptions`
@@ -849,6 +854,19 @@ export default typescript.config([
                 'sentry/views/insights/common/components/insightsTimeSeriesWidget',
               ].includes(name)
           ),
+        },
+      ],
+    },
+  },
+  {
+    name: 'files/components-core',
+    files: ['static/app/components/core/**/*.{js,mjs,ts,jsx,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          // Allow color package only in the components/core directory
+          paths: restrictedImportPaths.filter(({name}) => name !== 'color'),
         },
       ],
     },

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import {useReducedMotion} from 'framer-motion';
 

--- a/static/app/components/events/autofix/v2/autofixSidebarCtaButton.tsx
+++ b/static/app/components/events/autofix/v2/autofixSidebarCtaButton.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 
 import {Flex, Stack} from '@sentry/scraps/layout';

--- a/static/app/components/issues/suspect/suspectFlags.tsx
+++ b/static/app/components/issues/suspect/suspectFlags.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -126,7 +127,7 @@ const TagValueRow = styled('li')`
   font-variant-numeric: tabular-nums;
 
   &:nth-child(2n) {
-    background-color: ${p => Color(p.theme.colors.gray400).alpha(0.1).toString()};
+    background-color: ${p => color(p.theme.colors.gray400).alpha(0.1).toString()};
   }
 `;
 

--- a/static/app/components/metrics/chart/chart.tsx
+++ b/static/app/components/metrics/chart/chart.tsx
@@ -1,4 +1,5 @@
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import type {Series} from 'sentry/types/echarts';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -100,7 +101,7 @@ function createIngestionAreaSeries(series: Series, fogBucketCnt = 0) {
     data: series.data.slice(-fogBucketCnt - 1),
     lineStyle: {
       type: 'dotted' as const,
-      color: Color(series.color).lighten(0.3).string(),
+      color: color(series.color).lighten(0.3).string(),
     },
   };
 }

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -1,5 +1,6 @@
 import {css, type Theme} from '@emotion/react';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import type {SpanBarType} from './constants';
 import {getSpanBarColors} from './constants';
@@ -90,5 +91,5 @@ export const lightenBarColor = (
   theme: Theme
 ): string => {
   const barColor = pickBarColor(input, theme);
-  return Color(barColor).lighten(lightenRatio).string();
+  return color(barColor).lighten(lightenRatio).string();
 };

--- a/static/app/components/scrollCarousel.tsx
+++ b/static/app/components/scrollCarousel.tsx
@@ -1,7 +1,8 @@
 import {useCallback, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
@@ -235,11 +236,11 @@ const LeftMask = styled('div')<{transparentMask: boolean}>`
   left: 0;
   background: ${p =>
     p.transparentMask
-      ? `linear-gradient(to left, ${Color(p.theme.tokens.background.primary).alpha(0).rgb().string()}, ${p.theme.tokens.background.primary})`
+      ? `linear-gradient(to left, ${color(p.theme.tokens.background.primary).alpha(0).rgb().string()}, ${p.theme.tokens.background.primary})`
       : `linear-gradient(
     90deg,
     ${p.theme.tokens.background.primary} 50%,
-    ${Color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
+    ${color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
   )`};
 `;
 
@@ -252,7 +253,7 @@ const RightMask = styled('div')<{transparentMask: boolean}>`
       : `linear-gradient(
     270deg,
     ${p.theme.tokens.background.primary} 50%,
-    ${Color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
+    ${color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
   )`};
 `;
 
@@ -270,11 +271,11 @@ const TopMask = styled('div')<{transparentMask: boolean}>`
   top: 0;
   background: ${p =>
     p.transparentMask
-      ? `linear-gradient(to top, ${Color(p.theme.tokens.background.primary).alpha(0).rgb().string()}, ${p.theme.tokens.background.primary})`
+      ? `linear-gradient(to top, ${color(p.theme.tokens.background.primary).alpha(0).rgb().string()}, ${p.theme.tokens.background.primary})`
       : `linear-gradient(
     180deg,
     ${p.theme.tokens.background.primary} 50%,
-    ${Color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
+    ${color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
   )`};
 `;
 
@@ -287,7 +288,7 @@ const BottomMask = styled('div')<{transparentMask: boolean}>`
       : `linear-gradient(
     0deg,
     ${p.theme.tokens.background.primary} 50%,
-    ${Color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
+    ${color(p.theme.tokens.background.primary).alpha(0.09).rgb().string()} 100%
   )`};
 `;
 

--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
 import {css, keyframes, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import modifyColor from 'color';
 import {useReducedMotion} from 'framer-motion';
 

--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import sortBy from 'lodash/sortBy';
 import startCase from 'lodash/startCase';

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useMemo} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {LineSeriesOption, TooltipComponentOption} from 'echarts';
 import moment from 'moment-timezone';

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -1,4 +1,5 @@
 import type {Theme} from '@emotion/react';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {YAXisComponentOption} from 'echarts';
 import moment from 'moment-timezone';

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -1,5 +1,6 @@
 import {PureComponent} from 'react';
 import type {Theme} from '@emotion/react';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {LineSeriesOption, TooltipComponentFormatterCallbackParams} from 'echarts';
 

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 
 import {Button} from 'sentry/components/core/button';

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 import type {BarSeriesOption, LineSeriesOption} from 'echarts';
 
 import BarSeries from 'sentry/components/charts/series/barSeries';
@@ -41,8 +42,8 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
   ): Array<BarSeriesOption | LineSeriesOption> {
     const {config = {}} = this;
 
-    const color = plottingOptions.color ?? config.color ?? undefined;
-    const colorObject = Color(color);
+    const colorValue = plottingOptions.color ?? config.color ?? undefined;
+    const colorObject = color(colorValue);
     const scaledTimeSeries = this.scaleToUnit(plottingOptions.unit);
 
     return [
@@ -50,7 +51,7 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
         name: this.name,
         stack: config.stack,
         yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
-        color,
+        color: colorValue,
         emphasis: {
           itemStyle: {
             color:
@@ -64,7 +65,7 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
           color: params => {
             const datum = scaledTimeSeries.values[params.dataIndex]!;
 
-            return datum.incomplete ? colorObject.alpha(0.5).string() : color;
+            return datum.incomplete ? colorObject.alpha(0.5).string() : colorValue;
           },
           opacity: 1.0,
         },

--- a/static/app/views/detectors/components/details/metric/charts/metricDetectorChartOptions.tsx
+++ b/static/app/views/detectors/components/details/metric/charts/metricDetectorChartOptions.tsx
@@ -1,4 +1,5 @@
 import type {Theme} from '@emotion/react';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {YAXisComponentOption} from 'echarts';
 import moment from 'moment-timezone';

--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {LineSeriesOption} from 'echarts';
 

--- a/static/app/views/insights/crons/components/serviceIncidents.tsx
+++ b/static/app/views/insights/crons/components/serviceIncidents.tsx
@@ -1,7 +1,8 @@
 import {Fragment, useCallback} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 import moment, {type Moment} from 'moment-timezone';
 
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
@@ -141,7 +142,7 @@ const IncidentOverlay = styled('div')`
   left: var(--incidentOverlayStart);
   width: calc(var(--incidentOverlayEnd) - var(--incidentOverlayStart));
   pointer-events: none;
-  background: ${p => Color(p.theme.colors.yellow100).alpha(0.05).toString()};
+  background: ${p => color(p.theme.colors.yellow100).alpha(0.05).toString()};
   border-left: 1px solid ${p => p.theme.colors.yellow200};
   border-right: 1px solid ${p => p.theme.colors.yellow200};
   z-index: 2;

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -171,7 +172,7 @@ const TagBarPlaceholder = styled('div')`
   width: 100%;
   border-radius: 3px;
   box-shadow: inset 0 0 0 1px ${p => p.theme.tokens.border.transparent.neutral.muted};
-  background: ${p => Color(p.theme.colors.gray400).alpha(0.1).toString()};
+  background: ${p => color(p.theme.colors.gray400).alpha(0.1).toString()};
   overflow: hidden;
 `;
 
@@ -186,7 +187,7 @@ const TagBarContainer = styled('div')`
     inset: 0;
     content: '';
     background: ${p =>
-      `linear-gradient(to right, ${Color(p.theme.colors.gray400).alpha(0.5).toString()} 0px, ${Color(p.theme.colors.gray400).alpha(0.7).toString()} ${progressBarWidth})`};
+      `linear-gradient(to right, ${color(p.theme.colors.gray400).alpha(0.5).toString()} 0px, ${color(p.theme.colors.gray400).alpha(0.7).toString()} ${progressBarWidth})`};
     width: 100%;
   }
 `;

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -1,7 +1,8 @@
 import {Fragment, useCallback, useMemo, type CSSProperties} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
@@ -260,7 +261,7 @@ const JsonLinkWrapper = styled('div')`
 const JsonLink = styled(ExternalLink)`
   color: ${p => p.theme.tokens.content.secondary};
   text-decoration: underline;
-  text-decoration-color: ${p => Color(p.theme.colors.gray400).alpha(0.5).string()};
+  text-decoration-color: ${p => color(p.theme.colors.gray400).alpha(0.5).string()};
 
   :hover {
     color: ${p => p.theme.tokens.content.secondary};
@@ -272,7 +273,7 @@ const JsonLink = styled(ExternalLink)`
 const MarkdownButton = styled(Button)`
   color: ${p => p.theme.tokens.content.secondary};
   text-decoration: underline;
-  text-decoration-color: ${p => Color(p.theme.colors.gray400).alpha(0.5).string()};
+  text-decoration-color: ${p => color(p.theme.colors.gray400).alpha(0.5).string()};
   font-size: inherit;
   font-weight: normal;
   cursor: pointer;

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Tag} from 'sentry/components/core/badge/tag';
@@ -364,7 +365,7 @@ const ActionBar = styled('div')<{isComplete: boolean}>`
     background: linear-gradient(
       to right,
       ${p => p.theme.tokens.background.primary},
-      ${p => Color(p.theme.tokens.content.success).lighten(0.5).alpha(0.15).string()}
+      ${p => color(p.theme.tokens.content.success).lighten(0.5).alpha(0.15).string()}
     );
   }
   &:after {

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -2,7 +2,8 @@ import type React from 'react';
 import {Fragment, useMemo, useState} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
@@ -54,7 +55,7 @@ type Segment = {
 };
 
 const bgColor = (index: number, theme: Theme) =>
-  Color(theme.chart.getColorPalette(4).at(index)).alpha(0.8).toString();
+  color(theme.chart.getColorPalette(4).at(index)).alpha(0.8).toString();
 const getRoundedPercentage = (percentage: number) =>
   percentage < 0.5 ? '<1%' : `${Math.round(percentage)}%`;
 
@@ -357,7 +358,7 @@ const TagBarPlaceholder = styled('div')`
   width: 100%;
   border-radius: 3px;
   box-shadow: inset 0 0 0 1px ${p => p.theme.tokens.border.transparent.neutral.muted};
-  background: ${p => Color(p.theme.colors.gray400).alpha(0.1).toString()};
+  background: ${p => color(p.theme.colors.gray400).alpha(0.1).toString()};
   overflow: hidden;
 `;
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 
 import {Tooltip} from 'sentry/components/core/tooltip';

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 import type {LocationDescriptor} from 'history';
 import * as qs from 'query-string';
 
@@ -195,6 +196,6 @@ const IssuesTraceOverlayContainer = styled(Link)`
   pointer-events: auto;
 
   &:hover {
-    background: ${p => Color(p.theme.colors.gray400).alpha(0.1).toString()};
+    background: ${p => color(p.theme.colors.gray400).alpha(0.1).toString()};
   }
 `;

--- a/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.ts
@@ -1,4 +1,5 @@
 import type {Theme} from '@emotion/react';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 
 import {t} from 'sentry/locale';

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {Location} from 'history';
 import partition from 'lodash/partition';

--- a/static/gsApp/views/amCheckout/components/cartDiff.tsx
+++ b/static/gsApp/views/amCheckout/components/cartDiff.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 import isEqual from 'lodash/isEqual';
 
 import {Button} from 'sentry/components/core/button';
@@ -639,7 +640,7 @@ const Added = styled(Change)<{prefersDarkMode?: boolean}>`
   span {
     background: ${p =>
       p.prefersDarkMode
-        ? Color(p.theme.colors.green500).lighten(0.08).alpha(0.5).string()
+        ? color(p.theme.colors.green500).lighten(0.08).alpha(0.5).string()
         : '#a8ecaa'};
   }
 `;

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import styled from '@emotion/styled';
-import Color from 'color';
+// eslint-disable-next-line no-restricted-imports
+import color from 'color';
 import {motion} from 'framer-motion';
 import moment from 'moment-timezone';
 
@@ -665,7 +666,7 @@ const ReceiptSlot = styled('div')`
   border-radius: ${p => p.theme.radius.md};
   background: ${p => p.theme.colors.gray200};
   box-shadow: 0px 2px 4px 0px
-    ${p => Color(p.theme.colors.black).lighten(0.08).alpha(0.15).toString()} inset;
+    ${p => color(p.theme.colors.black).lighten(0.08).alpha(0.15).toString()} inset;
 `;
 
 const ReceiptPaperContainer = styled('div')`
@@ -683,7 +684,7 @@ const ReceiptPaperShadow = styled('div')`
   width: 320px;
   height: 7px;
   box-shadow: inset 0 10px 6px -6px
-    ${p => Color(p.theme.colors.black).lighten(0.05).alpha(0.15).toString()};
+    ${p => color(p.theme.colors.black).lighten(0.05).alpha(0.15).toString()};
 `;
 
 const ReceiptPaper = styled(Container)`


### PR DESCRIPTION
Deter folks from making their own colors by forbidding the color package imports outside of `@sentry/scraps`. 