### PR TITLE
fix(aci): Don't treat deleted Detector as an error

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -226,10 +226,6 @@ def ensure_default_detectors(project: Project) -> tuple[Detector, Detector]:
     )
 
 
-class SpecificDetectorNotFound(Exception):
-    pass
-
-
 @dataclass(frozen=True)
 class EventDetectors:
     issue_stream_detector: Detector | None = None
@@ -291,49 +287,28 @@ def get_detectors_for_event_data(
         )
 
     if detector is None and isinstance(event_data.event, GroupEvent):
-        try:
-            detector = _get_detector_for_event(event_data.event)
-        except (Detector.DoesNotExist, SpecificDetectorNotFound):
-            pass
-
+        detector = _get_detector_for_event(event_data.event)
     try:
         return EventDetectors(issue_stream_detector=issue_stream_detector, event_detector=detector)
     except ValueError:
         return None
 
 
-def _get_detector_for_event(event: GroupEvent) -> Detector:
+def _get_detector_for_event(event: GroupEvent) -> Detector | None:
     """
-    Returns the detector from the GroupEvent in event_data.
+    Returns the detector from the GroupEvent in event_data, or None if no detector is found.
     """
-
     issue_occurrence = event.occurrence
-
     try:
         if issue_occurrence is not None:
             detector_id = issue_occurrence.evidence_data.get("detector_id")
             if detector_id is None:
-                raise SpecificDetectorNotFound
-            detector = Detector.objects.get(id=detector_id)
+                return None
+            return Detector.objects.get(id=detector_id)
         else:
-            detector = Detector.get_error_detector_for_project(event.group.project_id)
+            return Detector.get_error_detector_for_project(event.group.project_id)
     except Detector.DoesNotExist:
-        metrics.incr("workflow_engine.detectors.error")
-        detector_id = (
-            issue_occurrence.evidence_data.get("detector_id") if issue_occurrence else None
-        )
-
-        logger.exception(
-            "Detector not found for event",
-            extra={
-                "event_id": event.event_id,
-                "group_id": event.group_id,
-                "detector_id": detector_id,
-            },
-        )
-        raise Detector.DoesNotExist("Detector not found for event")
-
-    return detector
+        return None
 
 
 def _get_detector_for_group(group: Group) -> Detector:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -944,7 +944,7 @@ class TestGetDetectorsForEvent(TestCase):
         assert result.detectors == {self.issue_stream_detector}
 
         # assert no exception is logged
-        mock_logger.exception.assert_called_once()
+        mock_logger.exception.assert_not_called()
 
     def test_no_detectors(self) -> None:
         self.issue_stream_detector.delete()


### PR DESCRIPTION
Fixes the main cause of SENTRY-5D9J, and I think returns us back to intended behavior.
