### PR TITLE
chore(cells): deprecate group-tags endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -8,9 +8,11 @@ from rest_framework.response import Response
 from sentry import tagstore
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.utils import DEVICE_CLASS
@@ -37,6 +39,7 @@ class GroupTagsEndpoint(GroupEndpoint):
         }
     )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tags"])
     def get(self, request: Request, group: Group) -> Response:
 
         if request.GET.get("useFlagsBackend") == "1":

--- a/tests/sentry/issues/endpoints/test_group_tags.py
+++ b/tests/sentry/issues/endpoints/test_group_tags.py
@@ -34,7 +34,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event1.group.id}/tags/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 4
@@ -55,7 +55,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         assert len(data[3]["topValues"]) == 1
 
         # Use the key= queryparam to grab results for specific tags
-        url = f"/api/0/issues/{event1.group.id}/tags/?key=foo&key=sentry:release"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?key=foo&key=sentry:release"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -84,7 +84,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
 
@@ -109,7 +109,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         assert len(data[11]["topValues"]) == 1
 
         # Use the key= queryparam to grab results for specific tags
-        url = f"/api/0/issues/{event.group.id}/tags/?key=foo&key=sentry:release"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?key=foo&key=sentry:release"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
 
@@ -125,7 +125,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
     def test_invalid_env(self) -> None:
         this_group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{this_group.id}/tags/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{this_group.id}/tags/"
         response = self.client.get(url, {"environment": "notreal"}, format="json")
         assert response.status_code == 404
 
@@ -141,7 +141,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         group = event.group
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/tags/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/"
         response = self.client.get(url, {"environment": "prod"}, format="json")
         assert response.status_code == 200
         assert len(response.data) == 4
@@ -171,7 +171,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         )
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{event2.group.id}/tags/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event2.group.id}/tags/"
         response = self.client.get(
             f"{url}?environment={env.name}&environment={env2.name}", format="json"
         )
@@ -206,7 +206,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event1.group.id}/tags/?readable=true&key=device"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?readable=true&key=device"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -252,7 +252,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/?limit=2&key=os"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?limit=2&key=os"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -295,7 +295,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/?limit=3&key=device.class"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?limit=3&key=device.class"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -330,7 +330,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/?key=foo"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?key=foo"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -359,7 +359,9 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         )
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{event.group.id}/tags/?limit=10"
+        url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?limit=10"
+        )
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -428,7 +430,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event1.group.id}/tags/?useFlagsBackend=1"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?useFlagsBackend=1"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 3
@@ -454,7 +456,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         assert data[2]["totalValues"] == sum(counts.values())
 
         # Use the key= queryparam to grab results for specific tags
-        url = f"/api/0/issues/{event1.group.id}/tags/?key=hello&key=world&useFlagsBackend=1"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?key=hello&key=world&useFlagsBackend=1"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -524,7 +526,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
             )
 
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{event.group.id}/tags/?useFlagsBackend=1&limit=3"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/?useFlagsBackend=1&limit=3"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -554,12 +556,12 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event1.group.id}/tags/?useFlagsBackend=1&key=sentry:release"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?useFlagsBackend=1&key=sentry:release"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
 
-        url = f"/api/0/issues/{event1.group.id}/tags/?useFlagsBackend=1&key=release"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event1.group.id}/tags/?useFlagsBackend=1&key=release"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1


### PR DESCRIPTION
Add deprecation decorators to GroupTagsEndpoint and update tests to use the org-scoped variant's URL pattern.