### PR TITLE
fix(ai-conversations): use correct query params

### DIFF
--- a/static/app/views/insights/pages/conversations/hooks/useConversations.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversations.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import {getUtcDateString} from 'sentry/utils/dates';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeList} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -45,8 +45,6 @@ export function useConversations() {
     fields: {agent: decodeList},
   });
 
-  const {start, end, period, utc} = pageFilters.selection.datetime;
-
   const agentQuery =
     agentFilters.length > 0
       ? `${SpanFields.GEN_AI_AGENT_NAME}:[${agentFilters.map(a => `"${a}"`).join(',')}]`
@@ -67,10 +65,7 @@ export function useConversations() {
           query: combinedQuery,
           project: pageFilters.selection.projects,
           environment: pageFilters.selection.environments,
-          period,
-          start: start instanceof Date ? getUtcDateString(start) : start,
-          end: end instanceof Date ? getUtcDateString(end) : end,
-          utc,
+          ...normalizeDateTimeParams(pageFilters.selection.datetime),
         },
       },
     ],


### PR DESCRIPTION
We were using wrong query parameter so we ended up always querying 90d of data. Query param should have been `statsPeriod` instead of `period`