### PR TITLE
bug(preprod): Ensure we're also selecting mobile_app_info to avoid n+1 queries

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
@@ -67,9 +67,9 @@ class PreprodArtifactAdminBatchDeleteEndpoint(Endpoint):
 
         # Get all artifacts to be deleted
         artifacts_to_delete = list(
-            PreprodArtifact.objects.select_related("project", "project__organization").filter(
-                id__in=preprod_artifact_ids
-            )
+            PreprodArtifact.objects.select_related(
+                "project", "project__organization", "mobile_app_info"
+            ).filter(id__in=preprod_artifact_ids)
         )
 
         if not artifacts_to_delete:

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -93,14 +93,14 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact")
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact")
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
@@ -151,14 +151,14 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact")
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact")
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -400,7 +400,7 @@ def _assemble_preprod_artifact_size_analysis(
 
     preprod_artifact = None
     try:
-        preprod_artifact = PreprodArtifact.objects.get(
+        preprod_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
             project=project,
             id=artifact_id,
         )
@@ -703,7 +703,7 @@ def _assemble_preprod_artifact_installable_app(
     assemble_result: AssembleResult, project: Project, artifact_id: int, org_id: int
 ) -> None:
     try:
-        preprod_artifact = PreprodArtifact.objects.get(
+        preprod_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
             project=project,
             id=artifact_id,
         )

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -83,9 +83,9 @@ def create_preprod_status_check_task(
     preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
 ) -> None:
     try:
-        preprod_artifact: PreprodArtifact | None = PreprodArtifact.objects.get(
-            id=preprod_artifact_id
-        )
+        preprod_artifact: PreprodArtifact | None = PreprodArtifact.objects.select_related(
+            "mobile_app_info"
+        ).get(id=preprod_artifact_id)
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.status_checks.create.artifact_not_found",


### PR DESCRIPTION
A quick pass of preprod code resulted in these suggested select_related additions to ensure we don't have n+1 queries in the future.