### PR TITLE
chore(ACI): Use serializer responses as serialize response type

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -308,8 +308,6 @@ class WorkflowEngineExamples:
                 },
                 "config": {"detectionType": "static"},
                 "enabled": True,
-                "alertRuleId": None,
-                "ruleId": None,
                 "latestGroup": {
                     "id": "123456789",
                     "title": "Test monitor",

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -93,9 +93,6 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
-
-    # TODO: We probably need a specific permission for detectors. Possibly specific detectors have different perms
-    # too?
     permission_classes = (OrganizationDetectorPermission,)
 
     @extend_schema(

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -39,7 +39,7 @@ class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     projectId: str
     name: str
     type: str
-    workflowIds: list[str]
+    workflowIds: list[str] | None
     dateCreated: datetime
     dateUpdated: datetime
     dataSources: list[dict] | None
@@ -172,7 +172,9 @@ class DetectorSerializer(Serializer):
 
         return attrs
 
-    def serialize(self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
+    def serialize(
+        self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs
+    ) -> DetectorSerializerResponse:
         alert_rule_mapping = attrs.get("alert_rule_mapping", {})
         return {
             "id": str(obj.id),

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -14,7 +14,7 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
 
 
-class ActionSerializerResponse(TypedDict):
+class ActionSerializerResponse(TypedDict, total=False):
     id: str
     type: str
     integrationId: str | None
@@ -26,11 +26,11 @@ class ActionSerializerResponse(TypedDict):
 class ConditionSerializerResponse(TypedDict):
     id: str
     type: str
-    comparison: bool
+    comparison: bool | int
     conditionResult: bool
 
 
-class TriggerSerializerResponse(TypedDict):
+class TriggerSerializerResponse(TypedDict, total=False):
     id: str
     organizationId: str
     logicType: str

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -46,7 +46,7 @@ class WorkflowSerializerResponse(TypedDict):
     dateCreated: datetime
     dateUpdated: datetime
     triggers: TriggerSerializerResponse | None
-    actionFilters: list[TriggerSerializerResponse]
+    actionFilters: list[TriggerSerializerResponse] | None
     environment: str | None
     config: dict[str, Any]
     detectorIds: list[str] | None
@@ -102,7 +102,9 @@ class WorkflowSerializer(Serializer):
             attrs[item]["lastTriggered"] = last_triggered_map.get(item.id)
         return attrs
 
-    def serialize(self, obj: Workflow, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
+    def serialize(
+        self, obj: Workflow, attrs: Mapping[str, Any], user, **kwargs
+    ) -> WorkflowSerializerResponse:
         return {
             "id": str(obj.id),
             "name": str(obj.name),

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -19,17 +19,6 @@ from .organization_workflow_group_history import OrganizationWorkflowGroupHistor
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
 from .organization_workflow_stats import OrganizationWorkflowStatsEndpoint
 
-# TODO @saponifi3d - Add the remaining API endpoints
-
-# Remaining Detector Endpoints
-#   - GET /detector w/ filters
-
-# Remaining Workflows Endpoints
-# - GET /workflow w/ filters
-# - POST /workflow
-# - PUT /workflow/:id
-# - DELETE /workflow/:id
-
 organization_urlpatterns = [
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/detectors/(?P<detector_id>\d+)/$",


### PR DESCRIPTION
As part of the API publication I ended up making serializer response typed dicts, but they weren't actually being used by the serializers as the response type yet. This PR adds them there and cleans up some old comments.

Closes https://linear.app/getsentry/issue/ISWF-872/