### PR TITLE
fix(detector-schedule-preview): Shouldn't overlay higher z-index comp…

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -250,6 +250,10 @@ const commonTheme = {
     initial: 1,
     truncationFullValue: 10,
 
+    monitorCreationForms: {
+      schedulePreview: 2,
+    },
+
     // @TODO(jonasbadalic) This should exist on traceView component
     traceView: {
       spanTreeToggler: 900,

--- a/static/app/views/detectors/components/forms/common/schedulePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/schedulePreview.tsx
@@ -247,7 +247,7 @@ const OpenPeriodCountLabel = styled('div')`
 
 const StyledContainer = styled(Container)`
   top: 8px;
-  z-index: ${p => p.theme.zIndex.dropdown};
+  z-index: ${p => p.theme.zIndex.monitorCreationForms.schedulePreview};
   /*
     * Prevent seeing content beneath in the uncovered strip above the sticky element.
     * Use a solid, zero-blur shadow so we don't paint over the border.


### PR DESCRIPTION
…onents like dropdowns and drawers
<img width="663" height="377" alt="Screenshot 2026-01-21 at 7 09 33 PM" src="https://github.com/user-attachments/assets/3fb1d9b0-2a1b-400a-a035-372fa4d0fb13" />
