### PR TITLE
feat(llm-detection): Add create_issue_occurrence RPC method for async LLM detection

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -100,6 +100,7 @@ from sentry.seer.explorer.tools import (
     rpc_get_trace_waterfall,
 )
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
+from sentry.seer.issue_detection import create_issue_occurrence
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.silo.base import SiloMode
@@ -1060,6 +1061,9 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     # Replays
     "get_replay_summary_logs": rpc_get_replay_summary_logs,
     "get_replay_metadata": get_replay_metadata,
+    #
+    # Issue Detection
+    "create_issue_occurrence": create_issue_occurrence,
 }
 
 

--- a/src/sentry/seer/issue_detection.py
+++ b/src/sentry/seer/issue_detection.py
@@ -1,0 +1,50 @@
+import logging
+
+from sentry.models.project import Project
+from sentry.tasks.llm_issue_detection.detection import (
+    DetectedIssue,
+    create_issue_occurrence_from_detection,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_issue_occurrence(
+    *,
+    organization_id: int,
+    project_id: int,
+    detected_issue: dict,
+) -> dict:
+    """
+    Create an issue occurrence from Seer detection data.
+
+    Called by Seer after async LLM analysis completes, see analyze_issue_endpoint.
+    Currently used for LLM-detected performance issues, could be expanded to support other detection types.
+
+    Args:
+        organization_id: The organization ID
+        project_id: The project ID where the issue should be created
+        detected_issue: Dict containing DetectedIssue fields (title, explanation,
+            impact, evidence, offender_span_ids, trace_id, transaction_name, etc.)
+
+    Returns:
+        Dict with "success": True on successful issue creation
+    """
+    project = Project.objects.get(id=project_id, organization_id=organization_id)  # IDOR check
+
+    issue = DetectedIssue.parse_obj(detected_issue)
+    create_issue_occurrence_from_detection(detected_issue=issue, project=project)
+
+    logger.info(
+        "seer_rpc.create_issue_occurrence.success",
+        extra={
+            "organization_id": organization_id,
+            "title": issue.title,
+            "trace_id": issue.trace_id,
+            "project_id": project_id,
+            "category": issue.category,
+            "subcategory": issue.subcategory,
+        },
+    )
+
+    return {"success": True}

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -119,7 +119,9 @@ def create_issue_occurrence_from_detection(
     """
     Create and produce an IssueOccurrence from an LLM-detected issue.
     """
-    if not project:
+    if project is None:
+        if project_id is None:
+            raise ValueError("Either project or project_id must be provided")
         project = Project.objects.get_from_cache(id=project_id)
 
     event_id = uuid4().hex
@@ -149,7 +151,7 @@ def create_issue_occurrence_from_detection(
     occurrence = IssueOccurrence(
         id=occurrence_id,
         event_id=event_id,
-        project_id=project_id,
+        project_id=project.id,
         fingerprint=fingerprint,
         issue_title=detected_issue.title,
         subtitle=detected_issue.explanation[:200],  # Truncate for subtitle
@@ -166,7 +168,7 @@ def create_issue_occurrence_from_detection(
 
     event_data = {
         "event_id": event_id,
-        "project_id": project_id,
+        "project_id": project.id,
         "platform": platform,
         "received": detection_time.isoformat(),
         "timestamp": detection_time.isoformat(),

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import sentry_sdk
 from django.conf import settings
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from urllib3.exceptions import TimeoutError
 
 from sentry import features, options
@@ -35,6 +35,10 @@ START_TIME_DELTA_MINUTES = 60
 TRANSACTION_BATCH_SIZE = 50
 NUM_TRANSACTIONS_TO_PROCESS = 10
 TRACE_PROCESSING_TTL_SECONDS = 7200
+# Character limit for LLM-generated fields to protect against abuse.
+# Word limits are enforced by Seer's prompt (see seer/automation/issue_detection/analyze.py).
+# This limit prevents excessively long outputs from malicious or malfunctioning LLMs.
+MAX_LLM_FIELD_LENGTH = 2000
 
 
 seer_issue_detection_connection_pool = connection_from_url(
@@ -58,15 +62,15 @@ def mark_trace_as_processed(trace_id: str) -> bool:
 
 class DetectedIssue(BaseModel):
     # LLM generated fields
-    explanation: str
-    impact: str
-    evidence: str
-    missing_telemetry: str | None = None
+    explanation: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    impact: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    evidence: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    missing_telemetry: str | None = Field(None, max_length=MAX_LLM_FIELD_LENGTH)
     offender_span_ids: list[str]
-    title: str
-    subcategory: str
-    category: str
-    verification_reason: str
+    title: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    subcategory: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    category: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    verification_reason: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     # context fields, not LLM generated
     trace_id: str
     transaction_name: str
@@ -109,15 +113,18 @@ def get_base_platform(platform: str | None) -> str | None:
 
 def create_issue_occurrence_from_detection(
     detected_issue: DetectedIssue,
-    project_id: int,
+    project_id: int | None = None,
+    project: Project | None = None,
 ) -> None:
     """
     Create and produce an IssueOccurrence from an LLM-detected issue.
     """
+    if not project:
+        project = Project.objects.get_from_cache(id=project_id)
+
     event_id = uuid4().hex
     occurrence_id = uuid4().hex
     detection_time = datetime.now(UTC)
-    project = Project.objects.get_from_cache(id=project_id)
     trace_id = detected_issue.trace_id
     transaction_name = detected_issue.transaction_name
     title = detected_issue.title.lower().replace(" ", "-")

--- a/tests/sentry/seer/test_issue_detection.py
+++ b/tests/sentry/seer/test_issue_detection.py
@@ -1,0 +1,106 @@
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from sentry.models.project import Project
+from sentry.seer.issue_detection import create_issue_occurrence
+from sentry.testutils.cases import TestCase
+
+
+class TestCreateIssueOccurrence(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    @patch("sentry.seer.issue_detection.create_issue_occurrence_from_detection")
+    def test_create_issue_occurrence_success(self, mock_create: Any) -> None:
+        detected_issue = {
+            "explanation": "Test explanation",
+            "impact": "Test impact",
+            "evidence": "Test evidence",
+            "missing_telemetry": None,
+            "offender_span_ids": ["span1", "span2"],
+            "title": "Test Issue",
+            "subcategory": "test",
+            "category": "performance",
+            "verification_reason": "test reason",
+            "trace_id": "abc123",
+            "transaction_name": "/api/test",
+        }
+
+        result = create_issue_occurrence(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            detected_issue=detected_issue,
+        )
+
+        assert result == {"success": True}
+        mock_create.assert_called_once()
+        call_args = mock_create.call_args
+        assert call_args.kwargs["project"] == self.project
+        assert call_args.kwargs["detected_issue"].title == "Test Issue"
+
+    def test_create_issue_occurrence_invalid_data(self) -> None:
+        with pytest.raises(ValidationError):
+            create_issue_occurrence(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                detected_issue={"invalid": "data"},
+            )
+
+    def test_create_issue_occurrence_project_not_in_organization(self) -> None:
+        other_project = self.create_project(organization=self.create_organization(owner=self.user))
+
+        detected_issue = {
+            "explanation": "Test explanation",
+            "impact": "Test impact",
+            "evidence": "Test evidence",
+            "missing_telemetry": None,
+            "offender_span_ids": ["span1", "span2"],
+            "title": "Test Issue",
+            "subcategory": "test",
+            "category": "performance",
+            "verification_reason": "test reason",
+            "trace_id": "abc123",
+            "transaction_name": "/api/test",
+        }
+
+        with pytest.raises(Project.DoesNotExist):
+            create_issue_occurrence(
+                organization_id=self.organization.id,
+                project_id=other_project.id,
+                detected_issue=detected_issue,
+            )
+
+    @patch("sentry.seer.issue_detection.logger")
+    @patch("sentry.seer.issue_detection.create_issue_occurrence_from_detection")
+    def test_create_issue_occurrence_creation_fails(
+        self, mock_create: Any, mock_logger: Any
+    ) -> None:
+        detected_issue = {
+            "explanation": "Test explanation",
+            "impact": "Test impact",
+            "evidence": "Test evidence",
+            "missing_telemetry": None,
+            "offender_span_ids": ["span1", "span2"],
+            "title": "Test Issue",
+            "subcategory": "test",
+            "category": "performance",
+            "verification_reason": "test reason",
+            "trace_id": "abc123",
+            "transaction_name": "/api/test",
+        }
+
+        mock_create.side_effect = Exception("Failed to create occurrence")
+
+        with pytest.raises(Exception, match="Failed to create occurrence"):
+            create_issue_occurrence(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                detected_issue=detected_issue,
+            )
+
+        mock_logger.info.assert_not_called()


### PR DESCRIPTION
Adds an RPC endpoint for Seer to create issue occurrences - first step in converting LLM issue detection from sync to async request-response. Full tech spec [here](https://www.notion.so/sentry/Add-Create-Issue-Occurrence-Endpoint-2e78b10e4b5d8021a518c43e2090769b?source=copy_link)

**New RPC method** (`src/sentry/seer/issue_detection.py`)
- `create_issue_occurrence` registered in `seer_method_registry`
- Pydantic validation via `DetectedIssue.parse_obj()`
- Uses pre-existing function to create issue occurrence

**LLM field length limits** (`src/sentry/tasks/llm_issue_detection/detection.py`)
- Added `MAX_LLM_FIELD_LENGTH = 2000` for all LLM-generated fields
- the `/find-bugs` skill recommended this change, it's not related to the async changes but it is nice to have

**Refactor**
- `create_issue_occurrence_from_detection` now accepts `project` object directly (avoids redundant lookup when caller already has it)
- can remove `project_id` as an input when we cut over to async