### PR TITLE
ref(agent): Create onboarding for client-side only

### DIFF
--- a/static/app/gettingStartedDocs/javascript-angular/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/angular',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-angular/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock, platformOptions, type PlatformOptions } from './utils';
 
 const docs: Docs<PlatformOptions> = {
   onboarding,
@@ -33,7 +33,9 @@ const docs: Docs<PlatformOptions> = {
     docsPlatform: 'angular',
     packageName: '@sentry/angular',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/angular',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-angular/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock, platformOptions, type PlatformOptions } from './utils';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
 
 const docs: Docs<PlatformOptions> = {
   onboarding,

--- a/static/app/gettingStartedDocs/javascript-ember/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/ember',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-ember/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock } from './utils';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock} from './utils';
 
 const docs: Docs = {
   onboarding,

--- a/static/app/gettingStartedDocs/javascript-ember/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock } from './utils';
 
 const docs: Docs = {
   onboarding,
@@ -32,7 +32,9 @@ const docs: Docs = {
     docsPlatform: 'ember',
     packageName: '@sentry/ember',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/ember',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-gatsby/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/gatsby',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock } from './utils';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
 const docs: Docs = {
   onboarding,
@@ -32,7 +32,9 @@ const docs: Docs = {
     docsPlatform: 'gatsby',
     packageName: '@sentry/gatsby',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/gatsby',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock } from './utils';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock} from './utils';
 
 const docs: Docs = {
   onboarding,

--- a/static/app/gettingStartedDocs/javascript-react/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/react',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/index.tsx
@@ -1,16 +1,16 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { performance } from './performance';
-import { replay } from './replay';
-import { installSnippetBlock } from './utils';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {performance} from './performance';
+import {replay} from './replay';
+import {installSnippetBlock} from './utils';
 
 const docs: Docs = {
   onboarding,

--- a/static/app/gettingStartedDocs/javascript-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/index.tsx
@@ -1,16 +1,16 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {performance} from './performance';
-import {replay} from './replay';
-import {installSnippetBlock} from './utils';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { performance } from './performance';
+import { replay } from './replay';
+import { installSnippetBlock } from './utils';
 
 const docs: Docs = {
   onboarding,
@@ -34,7 +34,9 @@ const docs: Docs = {
     docsPlatform: 'react',
     packageName: '@sentry/react',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/react',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-solid/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/solid',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-solid/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock } from './utils';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
 const docs: Docs = {
   onboarding,
@@ -32,7 +32,9 @@ const docs: Docs = {
     docsPlatform: 'solid',
     packageName: '@sentry/solid',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/solid',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-solid/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock } from './utils';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock} from './utils';
 
 const docs: Docs = {
   onboarding,

--- a/static/app/gettingStartedDocs/javascript-svelte/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/svelte',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-svelte/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock } from './utils';
 
 const docs: Docs = {
   onboarding,
@@ -32,7 +32,9 @@ const docs: Docs = {
     docsPlatform: 'svelte',
     packageName: '@sentry/svelte',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/svelte',
+  })
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-svelte/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock } from './utils';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock} from './utils';
 
 const docs: Docs = {
   onboarding,
@@ -34,7 +34,7 @@ const docs: Docs = {
   }),
   agentMonitoringOnboarding: agentMonitoring({
     packageName: '@sentry/svelte',
-  })
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-vue/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/agentMonitoring.tsx
@@ -1,6 +1,0 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
-
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/vue',
-  importMode: 'esm-only',
-});

--- a/static/app/gettingStartedDocs/javascript-vue/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/index.tsx
@@ -1,15 +1,15 @@
-import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
-import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
-import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
+import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
+import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import {agentMonitoring} from './agentMonitoring';
-import {crashReport} from './crashReport';
-import {feedback} from './feedback';
-import {onboarding} from './onboarding';
-import {replay} from './replay';
-import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
+import { crashReport } from './crashReport';
+import { feedback } from './feedback';
+import { onboarding } from './onboarding';
+import { replay } from './replay';
+import { installSnippetBlock, platformOptions, type PlatformOptions } from './utils';
+import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 
 const docs: Docs<PlatformOptions> = {
   onboarding,
@@ -33,7 +33,9 @@ const docs: Docs<PlatformOptions> = {
     docsPlatform: 'vue',
     packageName: '@sentry/vue',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring({
+    packageName: '@sentry/vue',
+  })
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-vue/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/index.tsx
@@ -1,15 +1,15 @@
-import type { Docs } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { featureFlag } from 'sentry/gettingStartedDocs/javascript/featureFlag';
-import { logs } from 'sentry/gettingStartedDocs/javascript/logs';
-import { metrics } from 'sentry/gettingStartedDocs/javascript/metrics';
-import { profiling } from 'sentry/gettingStartedDocs/javascript/profiling';
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/javascript/logs';
+import {metrics} from 'sentry/gettingStartedDocs/javascript/metrics';
+import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
 
-import { crashReport } from './crashReport';
-import { feedback } from './feedback';
-import { onboarding } from './onboarding';
-import { replay } from './replay';
-import { installSnippetBlock, platformOptions, type PlatformOptions } from './utils';
-import { agentMonitoring } from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {replay} from './replay';
+import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
 
 const docs: Docs<PlatformOptions> = {
   onboarding,
@@ -35,7 +35,7 @@ const docs: Docs<PlatformOptions> = {
   }),
   agentMonitoringOnboarding: agentMonitoring({
     packageName: '@sentry/vue',
-  })
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -1,21 +1,18 @@
-import { ExternalLink } from '@sentry/scraps/link';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import type {
   ContentBlock,
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { StepType } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   getAgentMonitoringInstallStep,
   getAgentMonitoringManualConfigStep,
   getImport,
 } from 'sentry/gettingStartedDocs/node/utils';
-import { t, tct } from 'sentry/locale';
-import {
-  AgentIntegration,
-} from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
-
+import {t, tct} from 'sentry/locale';
+import {AgentIntegration} from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
 function getClientSideAgentMonitoringOnboardingConfig({
   integration,
@@ -26,8 +23,6 @@ function getClientSideAgentMonitoringOnboardingConfig({
   params: DocsParams;
   sentryImport: string;
 }): ContentBlock[] {
-
-
   const initConfig: ContentBlock[] = [
     {
       type: 'text',
@@ -306,9 +301,10 @@ export function agentMonitoring({
   packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig {
   return {
-    install: params => getAgentMonitoringInstallStep(params, {
-      packageName,
-    }),
+    install: params =>
+      getAgentMonitoringInstallStep(params, {
+        packageName,
+      }),
     configure: params => {
       const selected =
         (params.platformOptions as any)?.integration ?? AgentIntegration.VERCEL_AI;
@@ -322,7 +318,6 @@ export function agentMonitoring({
         });
       }
 
-
       return [
         {
           title: t('Configure'),
@@ -334,18 +329,16 @@ export function agentMonitoring({
         },
       ];
     },
-    verify: () => (
-      [
-        {
-          type: StepType.VERIFY,
-          content: [
-            {
-              type: 'text',
-              text: t('Verify that your instrumentation works by simply calling your LLM.'),
-            }
-          ],
-        },
-      ]
-    )
+    verify: () => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t('Verify that your instrumentation works by simply calling your LLM.'),
+          },
+        ],
+      },
+    ],
   };
 }

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -1,8 +1,351 @@
-import {getNodeAgentMonitoringOnboarding} from 'sentry/gettingStartedDocs/node/utils';
+import { ExternalLink } from '@sentry/scraps/link';
 
-export const getBrowserAgentMonitoringOnboarding = getNodeAgentMonitoringOnboarding;
+import type {
+  ContentBlock,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import { StepType } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getAgentMonitoringInstallStep,
+  getAgentMonitoringManualConfigStep,
+  getImport,
+} from 'sentry/gettingStartedDocs/node/utils';
+import { t, tct } from 'sentry/locale';
+import {
+  AgentIntegration,
+} from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
-export const agentMonitoring = getNodeAgentMonitoringOnboarding({
-  packageName: '@sentry/browser',
-  importMode: 'esm-only',
+
+function getClientSideAgentMonitoringOnboardingConfig({
+  integration,
+  params,
+  sentryImport,
+}: {
+  integration: AgentIntegration;
+  params: DocsParams;
+  sentryImport: string;
+}): ContentBlock[] {
+
+
+  const initConfig: ContentBlock[] = [
+    {
+      type: 'text',
+      text: t('Import and initialize the Sentry SDK:'),
+    },
+    {
+      type: 'code',
+      tabs: [
+        {
+          label: 'JavaScript',
+          language: 'javascript',
+          code: `${sentryImport}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  // Tracing must be enabled for agent monitoring to work
+  tracesSampleRate: 1.0,
+  // Add data like inputs and responses to/from LLMs and tools;
+  // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
+  sendDefaultPii: true,
+});`,
+        },
+      ],
+    },
+  ];
+
+  if (integration === AgentIntegration.LANGGRAPH) {
+    return [
+      ...initConfig,
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [manualSpanCreationDoc:manual custom spans] to instrument your AI calls, or use the [code:instrumentLangGraph] helper:',
+          {
+            manualSpanCreationDoc: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module-browser/#manual-span-creation" />
+            ),
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${sentryImport}
+import { ChatOpenAI } from "@langchain/openai";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+
+const llm = new ChatOpenAI({
+  modelName: "gpt-4o",
+  // WARNING: Never expose API keys in browser code
+  apiKey: "OPENAI_API_KEY",
 });
+
+const agent = createReactAgent({ llm, tools: [] });
+
+Sentry.instrumentLangGraph(agent, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const result = await agent.invoke({
+  messages: [
+    new SystemMessage("You are a helpful assistant."),
+    new HumanMessage("Tell me a joke")
+  ],
+});
+
+const messages = result.messages;
+const lastMessage = messages[messages.length - 1];
+const text = lastMessage.content;
+            `,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (integration === AgentIntegration.LANGCHAIN) {
+    return [
+      ...initConfig,
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [manualSpanCreationDoc:manual custom spans] to instrument your AI calls, or use the [code:createLangChainCallbackHandler] helper:',
+          {
+            manualSpanCreationDoc: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module-browser/#manual-span-creation" />
+            ),
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${sentryImport}
+import { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+
+
+// Create a LangChain callback handler
+const callbackHandler = Sentry.createLangChainCallbackHandler({
+  recordInputs: true, // Optional: record input prompts/messages
+  recordOutputs: true, // Optional: record output responses
+});
+
+const chatModel = new ChatOpenAI({
+  modelName: "gpt-4o",
+  // WARNING: Never expose API keys in browser code
+  apiKey: "OPENAI_API_KEY",
+});
+
+const messages = [
+  new SystemMessage("You are a helpful assistant."),
+  new HumanMessage("Tell me a joke"),
+];
+
+const response = await chatModel.invoke(messages, {
+  callbacks: [callbackHandler],
+});
+const text = response.content;
+            `,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (integration === AgentIntegration.GOOGLE_GENAI) {
+    return [
+      ...initConfig,
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [manualSpanCreationDoc:manual custom spans] to instrument your AI calls, or use the [code:instrumentGoogleGenAIClient] helper:',
+          {
+            manualSpanCreationDoc: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module-browser/#manual-span-creation" />
+            ),
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${sentryImport}
+import { GoogleGenAI } from "@google/genai";
+
+// WARNING: Never expose API keys in browser code
+const genAI = new GoogleGenAI({apiKey: "GEMINI_API_KEY"});
+
+const client = Sentry.instrumentGoogleGenAIClient(genAI, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const response = await client.models.generateContent({
+  model: 'gemini-2.0-flash-001',
+  contents: 'Why is the sky blue?',
+});
+            `,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (integration === AgentIntegration.ANTHROPIC) {
+    return [
+      ...initConfig,
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [manualSpanCreationDoc:manual custom spans] to instrument your AI calls, or use the [code:instrumentAnthropicAiClient] helper:',
+          {
+            manualSpanCreationDoc: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module-browser/#manual-span-creation" />
+            ),
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${sentryImport}
+import Anthropic from "@anthropic-ai/sdk";
+
+// WARNING: Never expose API keys in browser code
+const anthropic = new Anthropic({apiKey: "ANTHROPIC_API_KEY"});
+
+const client = Sentry.instrumentAnthropicAiClient(anthropic, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const msg = await client.messages.create({
+ model: "claude-3-5-sonnet",
+ messages: [{role: "user", content: "Tell me a joke"}],
+});
+            `,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (integration === AgentIntegration.OPENAI) {
+    return [
+      ...initConfig,
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [manualSpanCreationDoc:manual custom spans] to instrument your AI calls, or use the [code:instrumentOpenAiClient] helper:',
+          {
+            manualSpanCreationDoc: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module-browser/#manual-span-creation" />
+            ),
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${sentryImport}
+import OpenAI from "openai";
+
+// WARNING: Never expose API keys in browser code
+const openai = new OpenAI({apiKey: "OPENAI_API_KEY"});
+
+const client = Sentry.instrumentOpenAiClient(openai, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const response = await client.responses.create({
+  model: "gpt-4o-mini",
+  input: "Tell me a joke",
+});
+            `,
+          },
+        ],
+      },
+    ];
+  }
+
+  return initConfig;
+}
+
+/**
+ * Browser-only agent monitoring configuration.
+ * Use this for pure browser platforms like React, Vue, Angular, Svelte, etc.
+ */
+export function agentMonitoring({
+  packageName = '@sentry/browser',
+}: {
+  packageName?: `@sentry/${string}`;
+} = {}): OnboardingConfig {
+  return {
+    install: params => getAgentMonitoringInstallStep(params, {
+      packageName,
+    }),
+    configure: params => {
+      const selected =
+        (params.platformOptions as any)?.integration ?? AgentIntegration.VERCEL_AI;
+
+      const importMode = 'esm-only';
+
+      if (selected === AgentIntegration.MANUAL) {
+        return getAgentMonitoringManualConfigStep(params, {
+          packageName,
+          importMode,
+        });
+      }
+
+
+      return [
+        {
+          title: t('Configure'),
+          content: getClientSideAgentMonitoringOnboardingConfig({
+            integration: selected,
+            sentryImport: getImport(packageName, importMode).join('\n'),
+            params,
+          }),
+        },
+      ];
+    },
+    verify: () => (
+      [
+        {
+          type: StepType.VERIFY,
+          content: [
+            {
+              type: 'text',
+              text: t('Verify that your instrumentation works by simply calling your LLM.'),
+            }
+          ],
+        },
+      ]
+    )
+  };
+}

--- a/static/app/gettingStartedDocs/javascript/index.tsx
+++ b/static/app/gettingStartedDocs/javascript/index.tsx
@@ -40,7 +40,7 @@ const docs: Docs<PlatformOptions> = {
     docsPlatform: 'javascript',
     packageName: '@sentry/browser',
   }),
-  agentMonitoringOnboarding: agentMonitoring,
+  agentMonitoringOnboarding: agentMonitoring(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -111,7 +111,6 @@ export function getAgentMonitoringInstallStep(
         text: tct(
           'To enable agent monitoring, you need to install the Sentry SDK with a minimum version of [minVersion].',
           {
-            code: <code />,
             minVersion: <code>{minVersion}</code>,
           }
         ),

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'sentry/components/core/link';
+import {ExternalLink} from 'sentry/components/core/link';
 import type {
   BasePlatformOptions,
   ContentBlock,
@@ -6,10 +6,10 @@ import type {
   OnboardingConfig,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { StepType } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import { javascriptMetaFrameworks } from 'sentry/data/platformCategories';
-import { t, tct } from 'sentry/locale';
-import { CopyLLMPromptButton } from 'sentry/views/insights/pages/agents/llmOnboardingInstructions';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {javascriptMetaFrameworks} from 'sentry/data/platformCategories';
+import {t, tct} from 'sentry/locale';
+import {CopyLLMPromptButton} from 'sentry/views/insights/pages/agents/llmOnboardingInstructions';
 import {
   AGENT_INTEGRATION_LABELS,
   AgentIntegration,
@@ -103,25 +103,26 @@ export function getAgentMonitoringInstallStep(
     packageName?: `@sentry/${string}`;
   } = {}
 ): OnboardingStep[] {
-  return [{
-    type: StepType.INSTALL,
-    content: [
-      {
-        type: 'text',
-        text: tct(
-          'To enable agent monitoring, you need to install the Sentry SDK with a minimum version of [minVersion].',
-          {
-            minVersion: <code>{minVersion}</code>,
-          }
-        ),
-      },
-      getInstallCodeBlock(params, {
-        packageName,
-      }),
-    ],
-  }];
+  return [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To enable agent monitoring, you need to install the Sentry SDK with a minimum version of [minVersion].',
+            {
+              minVersion: <code>{minVersion}</code>,
+            }
+          ),
+        },
+        getInstallCodeBlock(params, {
+          packageName,
+        }),
+      ],
+    },
+  ];
 }
-
 
 export function getAgentMonitoringManualConfigStep(
   params: DocsParams,
@@ -133,22 +134,21 @@ export function getAgentMonitoringManualConfigStep(
     packageName?: `@sentry/${string}`;
   } = {}
 ): OnboardingStep[] {
-  return [{
-    title: t('Configure'),
-    content: [
-      {
-        type: 'text',
-        text: t(
-          'Initialize the Sentry SDK in the entry point of your application.'
-        ),
-      },
-      {
-        type: 'code',
-        tabs: [
-          {
-            label: 'JavaScript',
-            language: 'javascript',
-            code: `${getImport(packageName, importMode).join('\n')}
+  return [
+    {
+      title: t('Configure'),
+      content: [
+        {
+          type: 'text',
+          text: t('Initialize the Sentry SDK in the entry point of your application.'),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `${getImport(packageName, importMode).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -158,26 +158,27 @@ Sentry.init({
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
   sendDefaultPii: true,
 });`,
-          },
-        ],
-      },
-      {
-        type: 'text',
-        text: tct(
-          'Then follow the [link:manual instrumentation guide] to instrument your AI calls, or use an AI coding agent to do it for you.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
-            ),
-          }
-        ),
-      },
-      {
-        type: 'custom',
-        content: <CopyLLMPromptButton />,
-      },
-    ],
-  }];
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Then follow the [link:manual instrumentation guide] to instrument your AI calls, or use an AI coding agent to do it for you.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'custom',
+          content: <CopyLLMPromptButton />,
+        },
+      ],
+    },
+  ];
 }
 
 export function getImport(
@@ -189,13 +190,13 @@ export function getImport(
   }
   return importMode === 'esm'
     ? [
-      `// Import with \`const Sentry = require("${packageName}");\` if you are using CJS`,
-      `import * as Sentry from "${packageName}"`,
-    ]
+        `// Import with \`const Sentry = require("${packageName}");\` if you are using CJS`,
+        `import * as Sentry from "${packageName}"`,
+      ]
     : [
-      `// Import with \`import * as Sentry from "${packageName}"\` if you are using ESM`,
-      `const Sentry = require("${packageName}");`,
-    ];
+        `// Import with \`import * as Sentry from "${packageName}"\` if you are using ESM`,
+        `const Sentry = require("${packageName}");`,
+      ];
 }
 
 function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
@@ -309,33 +310,35 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
     nodeProfilingIntegration(),
-  ],${params.profilingOptions?.defaultProfilingMode === 'continuous'
-                  ? profilingLifecycle === 'trace'
-                    ? `
+  ],${
+    params.profilingOptions?.defaultProfilingMode === 'continuous'
+      ? profilingLifecycle === 'trace'
+        ? `
   // Tracing must be enabled for profiling to work
   tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profileSessionSampleRate: 1.0,
   // Trace lifecycle automatically enables profiling during active traces
   profileLifecycle: 'trace',`
-                    : `
+        : `
   // Tracing is not required for profiling to work
   // but for the best experience we recommend enabling it
   tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profileSessionSampleRate: 1.0,`
-                  : `
+      : `
   // Tracing must be enabled for profiling to work
   tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profilesSampleRate: 1.0,`
-                }
+  }
 
   // Setting this option to true will send default PII data to Sentry.
   // For example, automatic IP address collection on events
   sendDefaultPii: true,
-});${params.profilingOptions?.defaultProfilingMode === 'continuous' &&
-                  profilingLifecycle === 'trace'
+});${
+                params.profilingOptions?.defaultProfilingMode === 'continuous' &&
+                profilingLifecycle === 'trace'
                   ? `
 
 // Profiling happens automatically after setting it up with \`Sentry.init()\`.
@@ -346,8 +349,9 @@ Sentry.startSpan({
   // The code executed here will be profiled
 });`
                   : ''
-                }${params.profilingOptions?.defaultProfilingMode === 'continuous' &&
-                  profilingLifecycle === 'manual'
+              }${
+                params.profilingOptions?.defaultProfilingMode === 'continuous' &&
+                profilingLifecycle === 'manual'
                   ? `
 
 Sentry.profiler.startProfiler();
@@ -355,7 +359,7 @@ Sentry.profiler.startProfiler();
 Sentry.profiler.stopProfiler();
                   `
                   : ''
-                }`,
+              }`,
             },
           ],
         },
@@ -658,9 +662,10 @@ export const getNodeAgentMonitoringOnboarding = ({
   importMode?: 'esm' | 'cjs' | 'esm-only';
   packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
-  install: params => getAgentMonitoringInstallStep(params, {
-    packageName,
-  }),
+  install: params =>
+    getAgentMonitoringInstallStep(params, {
+      packageName,
+    }),
   configure: params => {
     const selected =
       (params.platformOptions as any)?.integration ?? AgentIntegration.VERCEL_AI;
@@ -717,12 +722,12 @@ const result = await generateText({
         type: 'text',
         text: isNodeOrMetaPlatform
           ? tct(
-            'Import and initialize the Sentry SDK - the [integration] will be enabled automatically:',
-            {
-              integration:
-                AGENT_INTEGRATION_LABELS[selected as AgentIntegration] ?? selected,
-            }
-          )
+              'Import and initialize the Sentry SDK - the [integration] will be enabled automatically:',
+              {
+                integration:
+                  AGENT_INTEGRATION_LABELS[selected as AgentIntegration] ?? selected,
+              }
+            )
           : t('Import and initialize the Sentry SDK:'),
       },
       {
@@ -753,13 +758,13 @@ Sentry.init({
         content: isNodeOrMetaPlatform
           ? nonManualContent
           : [
-            ...nonManualContent,
-            ...getBrowserAgentMonitoringOnboardingConfiguration({
-              integration: selected,
-              packageName,
-              importMode,
-            }),
-          ],
+              ...nonManualContent,
+              ...getBrowserAgentMonitoringOnboardingConfiguration({
+                integration: selected,
+                packageName,
+                importMode,
+              }),
+            ],
       },
     ];
   },
@@ -1096,7 +1101,7 @@ export const getNodeLogsOnboarding = <
             }
           ),
         },
-        getInstallCodeBlock(params, { packageName }),
+        getInstallCodeBlock(params, {packageName}),
         {
           type: 'text',
           text: tct(
@@ -1121,7 +1126,7 @@ export const getNodeLogsOnboarding = <
           type: 'text',
           text: tct(
             'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
-            { code: <code /> }
+            {code: <code />}
           ),
         },
         generateConfigureSnippet(params, packageName),
@@ -1165,46 +1170,52 @@ export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null,
   defaultMode?: 'esm' | 'cjs'
-) => `${getDefaultNodeImports({ params, sdkImport, defaultMode })}
+) => `${getDefaultNodeImports({params, sdkImport, defaultMode})}
 
 Sentry.init({
-  dsn: "${params.dsn.public}",${params.isProfilingSelected
-    ? `integrations: [
+  dsn: "${params.dsn.public}",${
+    params.isProfilingSelected
+      ? `integrations: [
     nodeProfilingIntegration(),
   ],`
-    : ''
-  }${params.isLogsSelected
-    ? `
+      : ''
+  }${
+    params.isLogsSelected
+      ? `
 
   // Send structured logs to Sentry
   enableLogs: true,`
-    : ''
-  }${params.isPerformanceSelected
-    ? `
+      : ''
+  }${
+    params.isPerformanceSelected
+      ? `
       // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-  }${params.isProfilingSelected &&
+      : ''
+  }${
+    params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode !== 'continuous'
-    ? `
+      ? `
     // Set sampling rate for profiling - this is evaluated only once per SDK.init call
     profilesSampleRate: 1.0,`
-    : ''
-  }${params.isProfilingSelected &&
+      : ''
+  }${
+    params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode === 'continuous'
-    ? `
+      ? `
     // Set sampling rate for profiling - this is evaluated only once per SDK.init call
     profileSessionSampleRate: 1.0,
     // Trace lifecycle automatically enables profiling during active traces
     profileLifecycle: 'trace',`
-    : ''
+      : ''
   }
   // Setting this option to true will send default PII data to Sentry.
   // For example, automatic IP address collection on events
   sendDefaultPii: true,
-  });${params.isProfilingSelected &&
+  });${
+    params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode === 'continuous'
-    ? `
+      ? `
 
 // Profiling happens automatically after setting it up with \`Sentry.init()\`.
 // All spans (unless those discarded by sampling) will have profiling data attached to them.
@@ -1213,5 +1224,5 @@ Sentry.startSpan({
 }, () => {
   // The code executed here will be profiled
 });`
-    : ''
+      : ''
   }`;


### PR DESCRIPTION
All JavaScript platforms currently use the [agentMonitoring](https://github.com/getsentry/sentry/blob/09d75973b9da642307ea0135ced5966c991ebf38/static/app/gettingStartedDocs/node/utils.tsx#L564) function from node/utils.tsx. Over time, this function has become difficult to follow, as it now handles multiple platform-specific behaviors: rendering one set of content for Node.js, another for browser environments, and (eventually) combined browser and server content for Meta frameworks (which is not yet supported, but we should and will).

This PR is part one of a broader refactor to improve this situation by beginning to separate these concerns.

In a follow-up, we will introduce a dedicated function for Meta platforms, followed by a cleanup of node/utils.tsx.

Contributes to https://linear.app/getsentry/issue/TET-1759/split-agent-monitoring-onboarding-into-separate-node-and-browser