### PR TITLE
chore(ai-insights): remove new badge from agents

### DIFF
--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo} from 'react';
 import partition from 'lodash/partition';
 
 import Feature from 'sentry/components/acl/feature';
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -87,7 +86,6 @@ export function InsightsSecondaryNav() {
           <SecondaryNav.Item
             to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
             analyticsItemName="insights_agents"
-            trailingItems={<FeatureBadge type="new" />}
           >
             {AGENTS_SIDEBAR_LABEL}
           </SecondaryNav.Item>


### PR DESCRIPTION
<!-- Describe your PR here. -->
Removes the "new" badge from the Agents menu item in the Insights secondary navigation. Fixes [TET-1776: Remove new badge in Agents menu item](https://linear.app/getsentry/issue/TET-1776/remove-new-badge-in-agents-menu-item)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C047YNXDDA7/p1769075476302339?thread_ts=1769075476.302339&cid=C047YNXDDA7)

<a href="https://cursor.com/background-agent?bcId=bc-41404a23-d0b5-4573-b87e-53843e22e0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41404a23-d0b5-4573-b87e-53843e22e0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

