### PR TITLE
 fix(ai-converations): details endpoint should always return all spans

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,3 +1,7 @@
+import dataclasses
+from datetime import timedelta
+
+from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -31,6 +35,11 @@ AI_CONVERSATION_ATTRIBUTES = [
     "gen_ai.conversation.id",
     "gen_ai.cost.total_tokens",
     "gen_ai.operation.type",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "gen_ai.agent.name",
+    "gen_ai.function.id",
+    "gen_ai.operation.name",
     "gen_ai.input.messages",
     "gen_ai.output.messages",
     "gen_ai.system_instructions",
@@ -60,6 +69,13 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
+
+        # Override date range to always return all spans in the conversation
+        snuba_params = dataclasses.replace(
+            snuba_params,
+            start=timezone.now() - timedelta(days=90),
+            end=timezone.now(),
+        )
 
         selected_columns = AI_CONVERSATION_ATTRIBUTES
 

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -191,6 +191,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             cost=0.0025,
             user_id="user-123",
             user_email="test@example.com",
+            model="gpt-4",
         )
 
         query = {
@@ -227,6 +228,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         # Verify user attributes are included
         assert span["user.id"] == "user-123"
         assert span["user.email"] == "test@example.com"
+        # Verify model attribute is included
+        assert span["gen_ai.request.model"] == "gpt-4"
 
     def test_pagination(self) -> None:
         """Test pagination works correctly"""
@@ -388,3 +391,83 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["span.op"] == "gen_ai.execute_tool"
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
+
+    def test_ignores_date_range_filter(self) -> None:
+        """Test that the endpoint ignores user-provided date range and returns all spans"""
+        now = before_now(days=10).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        # Create spans at different times - some outside the requested date range
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(days=30),  # 30 days ago
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(days=15),  # 15 days ago
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now,  # Recent
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        # Request with a very narrow date range that only includes the recent span
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        # Should return ALL 3 spans, not just the one in the narrow date range
+        assert len(response.data) == 3
+
+        # Verify all spans belong to the same conversation
+        for span in response.data:
+            assert span["gen_ai.conversation.id"] == conversation_id
+
+    def test_returns_model_attributes(self) -> None:
+        """Test that model-related attributes are included in the response"""
+        now = before_now(days=85).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id,
+            model="claude-3-opus",
+            response_model="claude-3-opus-20240229",
+            agent_name="CodeAssistant",
+            function_id="func-123",
+            operation_name="generate_code",
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+
+        span = response.data[0]
+        assert span["gen_ai.request.model"] == "claude-3-opus"
+        assert span["gen_ai.response.model"] == "claude-3-opus-20240229"
+        assert span["gen_ai.agent.name"] == "CodeAssistant"
+        assert span["gen_ai.function.id"] == "func-123"
+        assert span["gen_ai.operation.name"] == "generate_code"

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -38,6 +38,10 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         output_messages=None,
         system_instructions=None,
         tool_definitions=None,
+        model=None,
+        response_model=None,
+        function_id=None,
+        operation_name=None,
     ):
         """Create and store an AI span with the given attributes.
 
@@ -63,6 +67,10 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             output_messages: The gen_ai.output.messages (new format, will be JSON serialized)
             system_instructions: The gen_ai.system_instructions attribute
             tool_definitions: The gen_ai.tool.definitions (new format, will be JSON serialized)
+            model: The gen_ai.request.model attribute
+            response_model: The gen_ai.response.model attribute
+            function_id: The gen_ai.function.id attribute
+            operation_name: The gen_ai.operation.name attribute
 
         Returns:
             The created span object
@@ -92,6 +100,14 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             span_data["gen_ai.system_instructions"] = system_instructions
         if tool_definitions is not None:
             span_data["gen_ai.tool.definitions"] = json.dumps(tool_definitions)
+        if model is not None:
+            span_data["gen_ai.request.model"] = model
+        if response_model is not None:
+            span_data["gen_ai.response.model"] = response_model
+        if function_id is not None:
+            span_data["gen_ai.function.id"] = function_id
+        if operation_name is not None:
+            span_data["gen_ai.operation.name"] = operation_name
         # Store user data with sentry. prefix for EAP indexing
         if user_id is not None:
             span_data["sentry.user.id"] = user_id


### PR DESCRIPTION
closes [TET-1761: Conversation endpoint does not return conversation spans that are outside of the stats period](https://linear.app/getsentry/issue/TET-1761/conversation-endpoint-does-not-return-conversation-spans-that-are)