### PR TITLE
ref(scraps):remove chartcolors

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -404,7 +404,7 @@ function BaseChart({
     resolveColors ||
     (series.length
       ? theme.chart.getColorPalette(series.length)
-      : theme.chart.getColorPalette(theme.chart.colors.length));
+      : theme.chart.getColorPalette('all'));
 
   const resolvedSeries = useMemo(() => {
     const previousPeriodColors =

--- a/static/app/components/performance/waterfall/utils.spec.tsx
+++ b/static/app/components/performance/waterfall/utils.spec.tsx
@@ -1,26 +1,27 @@
 import {ThemeFixture} from 'sentry-fixture/theme';
 
-import {makeBarColors, pickBarColor} from 'sentry/components/performance/waterfall/utils';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 
 const theme = ThemeFixture();
 
 describe('pickBarColor()', () => {
-  it('returns blue when undefined', () => {
-    expect(pickBarColor(undefined, theme)).toEqual(makeBarColors(theme).default);
+  it('returns magenta when undefined', () => {
+    expect(pickBarColor(undefined, theme)).toBe('#C81792');
   });
 
   it('returns the predefined color when available', () => {
-    expect(pickBarColor('transaction', theme)).toEqual(makeBarColors(theme).transaction);
+    expect(pickBarColor('transaction', theme)).toBe('#FFCF00');
   });
 
-  it('returns blue when the string is too short', () => {
-    expect(pickBarColor('', theme)).toEqual(makeBarColors(theme).default);
-    expect(pickBarColor('c', theme)).toEqual(makeBarColors(theme).default);
+  it('returns magenta when the string is too short', () => {
+    expect(pickBarColor('', theme)).toBe('#C81792');
+    expect(pickBarColor('c', theme)).toBe('#C81792');
   });
 
   it('returns a random color when no predefined option is available', () => {
-    const colorsAsArray = Object.keys(theme.chart.colors).map(
-      key => theme.chart.colors[17][key as keyof typeof theme.chart.colors]
+    const palette = theme.chart.getColorPalette(17);
+    const colorsAsArray = Object.keys(palette).map(
+      key => palette[key as keyof typeof palette]
     );
 
     let randomColor = pickBarColor('a normal string', theme);

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -51,29 +51,25 @@ const getLetterIndex = (letter: string): number => {
   return index === -1 ? 0 : index;
 };
 
-export const makeBarColors = (theme: Theme) => ({
-  default: theme.chart.colors[17][4],
-  transaction: theme.chart.colors[17][8],
-  http: theme.chart.colors[17][10],
-  db: theme.chart.colors[17][17],
-});
-
 export const pickBarColor = (input: string | undefined, theme: Theme): string => {
-  // We pick the color for span bars using the first three letters of the op name.
-  // That way colors stay consistent between transactions.
-  const barColors = makeBarColors(theme);
+  const palette = theme.chart.getColorPalette(17);
 
   if (!input || input.length < 3) {
-    const colors = theme.chart.getColorPalette(17);
-    return colors[4];
+    return palette[4];
   }
-
+  const barColors = {
+    default: palette[4],
+    transaction: palette[8],
+    http: palette[10],
+    db: palette[17],
+  };
   if (input in barColors) {
     return barColors[input as keyof typeof barColors];
   }
 
-  const colorsAsArray = Object.values(theme.chart.colors[17]);
-
+  const colorsAsArray = Object.values(palette);
+  // We pick the color for span bars using the first three letters of the op name.
+  // That way colors stay consistent between transactions.
   const letterIndex1 = getLetterIndex(input[0]!);
   const letterIndex2 = getLetterIndex(input[1]!);
   const letterIndex3 = getLetterIndex(input[2]!);

--- a/static/app/utils/theme/theme.spec.tsx
+++ b/static/app/utils/theme/theme.spec.tsx
@@ -7,15 +7,22 @@ describe('theme', () => {
   describe('getColorPalette', () => {
     it('should return correct amount of colors', () => {
       const {result} = renderHookWithProviders(useTheme);
-
       const theme = result.current;
 
       expect(theme.chart.getColorPalette(2)).toHaveLength(3);
     });
 
+    it('should return all colors when all is passed', () => {
+      const {result} = renderHookWithProviders(useTheme);
+      const theme = result.current;
+
+      const colors = theme.chart.getColorPalette('all');
+
+      expect(colors).toHaveLength(18);
+    });
+
     it('should have strict types', () => {
       const {result} = renderHookWithProviders(useTheme);
-
       const theme = result.current;
 
       const colors = theme.chart.getColorPalette(2);

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -308,7 +308,6 @@ const commonTheme = {
 export interface SentryTheme
   extends Omit<typeof lightThemeDefinition, 'chart' | 'tokens'> {
   chart: {
-    colors: typeof CHART_PALETTE_LIGHT | typeof CHART_PALETTE_DARK;
     getColorPalette: ReturnType<typeof makeChartColorPalette>;
     neutral: string;
   };
@@ -689,10 +688,13 @@ type ValidLengthArgument = TupleOf<ColorLength>[number];
  */
 function makeChartColorPalette<T extends ChartColorPalette>(
   palette: T
-): <Length extends ValidLengthArgument>(length: Length | number) => T[Length] {
+): <Length extends ValidLengthArgument>(length: Length | number | 'all') => T[Length] {
   return function getChartColorPalette<Length extends ValidLengthArgument>(
-    length: Length | number
+    length: Length | number | 'all'
   ): T[Length] {
+    if (length === 'all') {
+      return palette.at(-1) as T[Length];
+    }
     // @TODO(jonasbadalic) we guarantee type safety and sort of guarantee runtime safety by clamping and
     // the palette is not sparse, but we should probably add a runtime check here as well.
     const index = Math.max(0, Math.min(palette.length - 1, length));
@@ -869,7 +871,6 @@ const lightThemeDefinition = {
 
   chart: {
     neutral: baseLightTheme.tokens.dataviz.semantic.neutral,
-    colors: CHART_PALETTE_LIGHT,
     getColorPalette: makeChartColorPalette(CHART_PALETTE_LIGHT),
   },
 
@@ -899,7 +900,6 @@ export const darkTheme: SentryTheme = {
 
   chart: {
     neutral: baseDarkTheme.tokens.dataviz.semantic.neutral,
-    colors: CHART_PALETTE_DARK,
     getColorPalette: makeChartColorPalette(CHART_PALETTE_DARK),
   },
 


### PR DESCRIPTION
`chartColors` should be consumed with `theme.chart.getColorPalette`, there were only a few places that used `theme.chart.colors` directly.

The only real usage was `theme.chart.colors[17]`, which is  the same as `theme.chart.getColorPalette(17)`.