### PR TITLE
fix(eap): Change timestamp search type to second

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -827,6 +827,14 @@ register("aws-lambda.host-region", default="us-east-2", flags=FLAG_AUTOMATOR_MOD
 # the number of threads we should use to install Lambdas
 register("aws-lambda.thread-count", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Controls the search_type for the timestamp column in EAP queries.
+register(
+    "eap.timestamp-search-type",
+    type=String,
+    default="string",
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Snuba
 register(
     "snuba.search.pre-snuba-candidates-optimizer",

--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -1,41 +1,52 @@
+from sentry import options
 from sentry.search.eap import constants
 from sentry.search.eap.columns import ResolvedAttribute, datetime_processor
 
-COMMON_COLUMNS = [
-    ResolvedAttribute(
-        public_alias="organization.id",
-        internal_name="sentry.organization_id",
-        internal_type=constants.INT,
-        search_type="string",
-    ),
-    ResolvedAttribute(
-        public_alias="project.id",
-        internal_name="sentry.project_id",
-        internal_type=constants.INT,
-        search_type="string",
-    ),
-    ResolvedAttribute(
-        public_alias="project_id",
-        internal_name="sentry.project_id",
-        search_type="integer",
-    ),
-    ResolvedAttribute(
-        public_alias="sentry.item_type",
-        search_type="integer",
-        internal_name="sentry.item_type",
-        private=True,
-    ),
-    ResolvedAttribute(
-        public_alias="sentry.organization_id",
-        search_type="integer",
-        internal_name="sentry.organization_id",
-        private=True,
-    ),
-    ResolvedAttribute(
-        public_alias=constants.TIMESTAMP_ALIAS,
-        internal_name="sentry.timestamp",
-        internal_type=constants.DOUBLE,
-        search_type="second",
-        processor=datetime_processor,
-    ),
-]
+
+def get_common_columns() -> list[ResolvedAttribute]:
+    """Returns common columns used across EAP attribute definitions.
+
+    The timestamp column's search_type is controlled by the 'eap.timestamp-search-type' option.
+    """
+    return [
+        ResolvedAttribute(
+            public_alias="organization.id",
+            internal_name="sentry.organization_id",
+            internal_type=constants.INT,
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="project.id",
+            internal_name="sentry.project_id",
+            internal_type=constants.INT,
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="project_id",
+            internal_name="sentry.project_id",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="sentry.item_type",
+            search_type="integer",
+            internal_name="sentry.item_type",
+            private=True,
+        ),
+        ResolvedAttribute(
+            public_alias="sentry.organization_id",
+            search_type="integer",
+            internal_name="sentry.organization_id",
+            private=True,
+        ),
+        ResolvedAttribute(
+            public_alias=constants.TIMESTAMP_ALIAS,
+            internal_name="sentry.timestamp",
+            internal_type=constants.DOUBLE,
+            search_type=options.get("eap.timestamp-search-type"),
+            processor=datetime_processor,
+        ),
+    ]
+
+
+# For backwards compatibility, evaluate once at module load time
+COMMON_COLUMNS = get_common_columns()

--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -35,7 +35,7 @@ COMMON_COLUMNS = [
         public_alias=constants.TIMESTAMP_ALIAS,
         internal_name="sentry.timestamp",
         internal_type=constants.DOUBLE,
-        search_type="string",
+        search_type="second",
         processor=datetime_processor,
     ),
 ]


### PR DESCRIPTION
Changes search type of `timestamp` attribute to make it possible to use in queries like `max(timestamp)`. Currently because it was of string type it couldn't have been used like that.

There is no easy way to make this a runtime aware change, so this option will be read only during the initial start of the process, so in case we need to act quick on this, we will need to do:
1. options update
2. ping SRE to restart containers so that option will be picked up


That's the fastest way we can do this, without a huge refactor. I have went through the code, and we don't relay in the frontend on the `search_type` and for the backend, it shouldn't change anything according to Will who built this.