### PR TITLE
feat(dynamic-sampling): use span metric for rebalancing transactions & option for activation

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -48,12 +48,13 @@ from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils import metrics
 from sentry.utils.snuba import raw_snql_query
 
 
@@ -100,26 +101,82 @@ def boost_low_volume_transactions() -> None:
 
     orgs_iterator = GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY, granularity=Granularity(60))
     for orgs in orgs_iterator:
-        # get the low and high transactions
-        totals_it = FetchProjectTransactionTotals(orgs)
-        small_transactions_it = FetchProjectTransactionVolumes(
-            orgs,
-            large_transactions=False,
-            max_transactions=num_small_trans,
+        span_metric_orgs, transaction_metric_orgs = _partition_orgs_by_span_metric_option(orgs)
+
+        metrics.incr(
+            "dynamic_sampling.boost_low_volume_transactions.orgs_partitioned",
+            tags={"metric_type": "span"},
+            amount=len(span_metric_orgs),
         )
-        big_transactions_it = FetchProjectTransactionVolumes(
-            orgs,
-            large_transactions=True,
-            max_transactions=num_big_trans,
+        metrics.incr(
+            "dynamic_sampling.boost_low_volume_transactions.orgs_partitioned",
+            tags={"metric_type": "transaction"},
+            amount=len(transaction_metric_orgs),
         )
 
-        for project_transactions in transactions_zip(
-            totals_it, big_transactions_it, small_transactions_it
-        ):
-            boost_low_volume_transactions_of_project.apply_async(
-                kwargs={"project_transactions": project_transactions},
-                headers={"sentry-propagate-traces": False},
-            )
+        _process_orgs_for_boost_low_volume_transactions(
+            span_metric_orgs, num_big_trans, num_small_trans, use_span_metric=True
+        )
+
+        _process_orgs_for_boost_low_volume_transactions(
+            transaction_metric_orgs, num_big_trans, num_small_trans, use_span_metric=False
+        )
+
+
+def _partition_orgs_by_span_metric_option(
+    org_ids: list[int],
+) -> tuple[list[int], list[int]]:
+    """
+    Partition organizations by whether they are in the span-metric-orgs option.
+    Returns (span_metric_orgs, transaction_metric_orgs).
+    """
+    span_metric_org_ids = set(options.get("dynamic-sampling.transactions.span-metric-orgs") or [])
+
+    span_metric_orgs = []
+    transaction_metric_orgs = []
+
+    for org_id in org_ids:
+        if org_id in span_metric_org_ids:
+            span_metric_orgs.append(org_id)
+        else:
+            transaction_metric_orgs.append(org_id)
+
+    return span_metric_orgs, transaction_metric_orgs
+
+
+def _process_orgs_for_boost_low_volume_transactions(
+    orgs: list[int],
+    num_big_trans: int,
+    num_small_trans: int,
+    use_span_metric: bool,
+) -> None:
+    """
+    Process a batch of organizations for boost low volume transactions.
+    """
+    if not orgs:
+        return
+
+    totals_it = FetchProjectTransactionTotals(orgs, use_span_metric=use_span_metric)
+    small_transactions_it = FetchProjectTransactionVolumes(
+        orgs,
+        large_transactions=False,
+        max_transactions=num_small_trans,
+        use_span_metric=use_span_metric,
+    )
+    big_transactions_it = FetchProjectTransactionVolumes(
+        orgs,
+        large_transactions=True,
+        max_transactions=num_big_trans,
+        use_span_metric=use_span_metric,
+    )
+
+    for project_transactions in transactions_zip(
+        totals_it, big_transactions_it, small_transactions_it
+    ):
+        boost_low_volume_transactions_of_project.apply_async(
+            kwargs={"project_transactions": project_transactions},
+            headers={"sentry-propagate-traces": False},
+        )
 
 
 @instrumented_task(
@@ -239,12 +296,23 @@ class FetchProjectTransactionTotals:
     project in the given organizations
     """
 
-    def __init__(self, orgs: Sequence[int]):
+    def __init__(self, orgs: Sequence[int], use_span_metric: bool = False):
         transaction_string_id = indexer.resolve_shared_org("transaction")
         self.transaction_tag = f"tags_raw[{transaction_string_id}]"
-        self.metric_id = indexer.resolve_shared_org(
-            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
-        )
+
+        self.use_span_metric = use_span_metric
+        self.is_segment_tag: str | None
+        if self.use_span_metric:
+            is_segment_string_id = indexer.resolve_shared_org("is_segment")
+            self.is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+            self.metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+            self.use_case_id = UseCaseID.SPANS
+        else:
+            self.is_segment_tag = None
+            self.metric_id = indexer.resolve_shared_org(
+                str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+            )
+            self.use_case_id = UseCaseID.TRANSACTIONS
 
         self.org_ids = list(orgs)
         self.offset = 0
@@ -262,6 +330,19 @@ class FetchProjectTransactionTotals:
         granularity = Granularity(60)
 
         if self.has_more_results:
+            where_conditions = [
+                Condition(
+                    Column("timestamp"),
+                    Op.GTE,
+                    datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
+                ),
+                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("metric_id"), Op.EQ, self.metric_id),
+                Condition(Column("org_id"), Op.IN, self.org_ids),
+            ]
+            if self.use_span_metric and self.is_segment_tag:
+                where_conditions.append(Condition(Column(self.is_segment_tag), Op.EQ, "true"))
+
             query = (
                 Query(
                     match=Entity(EntityKey.GenericOrgMetricsCounters.value),
@@ -275,16 +356,7 @@ class FetchProjectTransactionTotals:
                         Column("org_id"),
                         Column("project_id"),
                     ],
-                    where=[
-                        Condition(
-                            Column("timestamp"),
-                            Op.GTE,
-                            datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
-                        ),
-                        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
-                        Condition(Column("metric_id"), Op.EQ, self.metric_id),
-                        Condition(Column("org_id"), Op.IN, self.org_ids),
-                    ],
+                    where=where_conditions,
                     granularity=granularity,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
@@ -298,12 +370,19 @@ class FetchProjectTransactionTotals:
                 dataset=Dataset.PerformanceMetrics.value,
                 app_id="dynamic_sampling",
                 query=query,
-                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value, "cross_org_query": 1},
+                tenant_ids={"use_case_id": self.use_case_id.value, "cross_org_query": 1},
             )
             data = raw_snql_query(
                 request,
                 referrer=Referrer.DYNAMIC_SAMPLING_COUNTERS_FETCH_PROJECTS_WITH_TRANSACTION_TOTALS.value,
             )["data"]
+
+            metric_type = "span" if self.use_span_metric else "transaction"
+            metrics.incr(
+                "dynamic_sampling.boost_low_volume_transactions.query",
+                tags={"query_type": "totals", "metric_type": metric_type},
+            )
+
             count = len(data)
             self.has_more_results = count > CHUNK_SIZE
             self.offset += CHUNK_SIZE
@@ -349,6 +428,8 @@ class FetchProjectTransactionVolumes:
                         if False it returns transactions with the smallest count
 
     max_transactions: maximum number of transactions to return
+
+    use_span_metric: if True, use span count per root metric with is_segment filter
     """
 
     def __init__(
@@ -356,6 +437,7 @@ class FetchProjectTransactionVolumes:
         orgs: list[int],
         large_transactions: bool,
         max_transactions: int,
+        use_span_metric: bool = False,
     ):
         self.large_transactions = large_transactions
         self.max_transactions = max_transactions
@@ -363,9 +445,21 @@ class FetchProjectTransactionVolumes:
         self.offset = 0
         transaction_string_id = indexer.resolve_shared_org("transaction")
         self.transaction_tag = f"tags_raw[{transaction_string_id}]"
-        self.metric_id = indexer.resolve_shared_org(
-            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
-        )
+
+        self.use_span_metric = use_span_metric
+        self.is_segment_tag: str | None
+        if self.use_span_metric:
+            is_segment_string_id = indexer.resolve_shared_org("is_segment")
+            self.is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+            self.metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+            self.use_case_id = UseCaseID.SPANS
+        else:
+            self.is_segment_tag = None
+            self.metric_id = indexer.resolve_shared_org(
+                str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+            )
+            self.use_case_id = UseCaseID.TRANSACTIONS
+
         self.has_more_results = True
         self.cache: list[ProjectTransactions] = []
 
@@ -390,6 +484,19 @@ class FetchProjectTransactionVolumes:
 
         if self.has_more_results:
             # still data in the db, load cache
+            where_conditions = [
+                Condition(
+                    Column("timestamp"),
+                    Op.GTE,
+                    datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
+                ),
+                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("metric_id"), Op.EQ, self.metric_id),
+                Condition(Column("org_id"), Op.IN, self.org_ids),
+            ]
+            if self.use_span_metric and self.is_segment_tag:
+                where_conditions.append(Condition(Column(self.is_segment_tag), Op.EQ, "true"))
+
             query = (
                 Query(
                     match=Entity(EntityKey.GenericOrgMetricsCounters.value),
@@ -404,16 +511,7 @@ class FetchProjectTransactionVolumes:
                         Column("project_id"),
                         AliasedExpression(Column(self.transaction_tag), "transaction_name"),
                     ],
-                    where=[
-                        Condition(
-                            Column("timestamp"),
-                            Op.GTE,
-                            datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
-                        ),
-                        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
-                        Condition(Column("metric_id"), Op.EQ, self.metric_id),
-                        Condition(Column("org_id"), Op.IN, self.org_ids),
-                    ],
+                    where=where_conditions,
                     granularity=granularity,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
@@ -434,12 +532,23 @@ class FetchProjectTransactionVolumes:
                 dataset=Dataset.PerformanceMetrics.value,
                 app_id="dynamic_sampling",
                 query=query,
-                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value, "cross_org_query": 1},
+                tenant_ids={"use_case_id": self.use_case_id.value, "cross_org_query": 1},
             )
             data = raw_snql_query(
                 request,
                 referrer=Referrer.DYNAMIC_SAMPLING_COUNTERS_FETCH_PROJECTS_WITH_COUNT_PER_TRANSACTION.value,
             )["data"]
+
+            metric_type = "span" if self.use_span_metric else "transaction"
+            volume_type = "large" if self.large_transactions else "small"
+            metrics.incr(
+                "dynamic_sampling.boost_low_volume_transactions.query",
+                tags={
+                    "query_type": "volumes",
+                    "metric_type": metric_type,
+                    "volume_type": volume_type,
+                },
+            )
 
             count = len(data)
             self.has_more_results = count > CHUNK_SIZE

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2268,6 +2268,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# List of organization IDs that should be using span metrics for boost low volume transactions.
+register(
+    "dynamic-sampling.transactions.span-metric-orgs",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # === Hybrid cloud subsystem options ===
 # UI rollout

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -15,7 +16,8 @@ from sentry.dynamic_sampling.tasks.boost_low_volume_transactions import (
     transactions_zip,
 )
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgs
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.sentry_metrics import indexer
+from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.testutils.cases import BaseMetricsLayerTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -50,6 +52,14 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
                     self.store_performance_metric(
                         name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
                         tags={"transaction": name},
+                        minutes_before_now=30,
+                        value=num_transactions,
+                        project_id=p.id,
+                        org_id=org.id,
+                    )
+                    self.store_performance_metric(
+                        name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                        tags={"transaction": name, "is_segment": "true"},
                         minutes_before_now=30,
                         value=num_transactions,
                         project_id=p.id,
@@ -138,6 +148,174 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
             total_counts, num_classes = self.get_total_counts_for_project(idx)
             assert totals["total_num_transactions"] == total_counts
             assert totals["total_num_classes"] == num_classes
+
+    def test_fetch_project_transaction_totals_uses_transaction_metric_by_default(self) -> None:
+        """
+        Verify that FetchProjectTransactionTotals uses the transaction count per root metric
+        by default (when use_span_metric=False).
+        """
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionTotals(orgs, use_span_metric=False)
+
+        expected_metric_id = indexer.resolve_shared_org(
+            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+        )
+        assert fetcher.metric_id == expected_metric_id
+        assert fetcher.use_span_metric is False
+        assert fetcher.is_segment_tag is None
+
+    def test_fetch_project_transaction_volumes_uses_transaction_metric_by_default(self) -> None:
+        """
+        Verify that FetchProjectTransactionVolumes uses the transaction count per root metric
+        by default (when use_span_metric=False).
+        """
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionVolumes(
+            orgs, large_transactions=True, max_transactions=3, use_span_metric=False
+        )
+
+        expected_metric_id = indexer.resolve_shared_org(
+            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+        )
+        assert fetcher.metric_id == expected_metric_id
+        assert fetcher.use_span_metric is False
+        assert fetcher.is_segment_tag is None
+
+    def test_fetch_project_transaction_totals_uses_span_metric_when_enabled(self) -> None:
+        """
+        Verify that FetchProjectTransactionTotals uses the span count per root metric
+        with is_segment tag when use_span_metric=True.
+        """
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionTotals(orgs, use_span_metric=True)
+
+        expected_metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+        assert fetcher.metric_id == expected_metric_id
+        assert fetcher.use_span_metric is True
+
+        is_segment_string_id = indexer.resolve_shared_org("is_segment")
+        expected_is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+        assert fetcher.is_segment_tag == expected_is_segment_tag
+
+    def test_fetch_project_transaction_volumes_uses_span_metric_when_enabled(self) -> None:
+        """
+        Verify that FetchProjectTransactionVolumes uses the span count per root metric
+        with is_segment tag when use_span_metric=True.
+        """
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionVolumes(
+            orgs, large_transactions=True, max_transactions=3, use_span_metric=True
+        )
+
+        expected_metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+        assert fetcher.metric_id == expected_metric_id
+        assert fetcher.use_span_metric is True
+
+        is_segment_string_id = indexer.resolve_shared_org("is_segment")
+        expected_is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+        assert fetcher.is_segment_tag == expected_is_segment_tag
+
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_transactions.raw_snql_query")
+    def test_fetch_project_transaction_totals_query_includes_is_segment_filter_when_enabled(
+        self, mock_raw_snql_query
+    ) -> None:
+        """
+        Verify that the query sent to Snuba includes the is_segment=true filter when enabled.
+        """
+        mock_raw_snql_query.return_value = {"data": []}
+
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionTotals(orgs, use_span_metric=True)
+        try:
+            next(fetcher)
+        except StopIteration:
+            pass
+
+        assert mock_raw_snql_query.called
+        call_args = mock_raw_snql_query.call_args
+        request = call_args[0][0]
+
+        query_str = str(request.query)
+        is_segment_id = indexer.resolve_shared_org("is_segment")
+        assert f"tags_raw[{is_segment_id}]" in query_str
+        assert "'true'" in query_str
+
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_transactions.raw_snql_query")
+    def test_fetch_project_transaction_totals_query_excludes_is_segment_filter_when_disabled(
+        self, mock_raw_snql_query
+    ) -> None:
+        """
+        Verify that the query sent to Snuba excludes the is_segment filter when disabled.
+        """
+        mock_raw_snql_query.return_value = {"data": []}
+
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionTotals(orgs, use_span_metric=False)
+        try:
+            next(fetcher)
+        except StopIteration:
+            pass
+
+        assert mock_raw_snql_query.called
+        call_args = mock_raw_snql_query.call_args
+        request = call_args[0][0]
+
+        query_str = str(request.query)
+        is_segment_id = indexer.resolve_shared_org("is_segment")
+        assert f"tags_raw[{is_segment_id}]" not in query_str
+
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_transactions.raw_snql_query")
+    def test_fetch_project_transaction_volumes_query_includes_is_segment_filter_when_enabled(
+        self, mock_raw_snql_query
+    ) -> None:
+        """
+        Verify that the query sent to Snuba includes the is_segment=true filter when enabled.
+        """
+        mock_raw_snql_query.return_value = {"data": []}
+
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionVolumes(
+            orgs, large_transactions=True, max_transactions=3, use_span_metric=True
+        )
+        try:
+            next(fetcher)
+        except StopIteration:
+            pass
+
+        assert mock_raw_snql_query.called
+        call_args = mock_raw_snql_query.call_args
+        request = call_args[0][0]
+
+        query_str = str(request.query)
+        is_segment_id = indexer.resolve_shared_org("is_segment")
+        assert f"tags_raw[{is_segment_id}]" in query_str
+        assert "'true'" in query_str
+
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_transactions.raw_snql_query")
+    def test_fetch_project_transaction_volumes_query_excludes_is_segment_filter_when_disabled(
+        self, mock_raw_snql_query
+    ) -> None:
+        """
+        Verify that the query sent to Snuba excludes the is_segment filter when disabled.
+        """
+        mock_raw_snql_query.return_value = {"data": []}
+
+        orgs = self.org_ids
+        fetcher = FetchProjectTransactionVolumes(
+            orgs, large_transactions=True, max_transactions=3, use_span_metric=False
+        )
+        try:
+            next(fetcher)
+        except StopIteration:
+            pass
+
+        assert mock_raw_snql_query.called
+        call_args = mock_raw_snql_query.call_args
+        request = call_args[0][0]
+
+        query_str = str(request.query)
+        is_segment_id = indexer.resolve_shared_org("is_segment")
+        assert f"tags_raw[{is_segment_id}]" not in query_str
 
 
 def test_merge_transactions_full() -> None:

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -350,6 +350,14 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
                         project_id=p.id,
                         org_id=org.id,
                     )
+                    self.store_performance_metric(
+                        name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                        tags={"transaction": name, "is_segment": "true"},
+                        minutes_before_now=30,
+                        value=num_transactions,
+                        project_id=p.id,
+                        org_id=org.id,
+                    )
         self.org_ids = [org["org_id"] for org in self.orgs_info]
 
     def get_count_for_transaction(self, idx: int, name: str):


### PR DESCRIPTION
- Instead of feature checks, use a sequence of org ids in an option to speed up the checks
- Previous tries were too slow with a) single feature checking and b) batch feature checking