### PR TITLE
ref(dashboards): Migrate logs dataset to useSeriesQuery/useTableQuery pattern

### DIFF
--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -1,8 +1,5 @@
 import pickBy from 'lodash/pickBy';
 
-import {doEventsRequest} from 'sentry/actionCreators/events';
-import type {Client} from 'sentry/api';
-import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
@@ -10,20 +7,11 @@ import type {
   MultiSeriesEventsStats,
   Organization,
 } from 'sentry/types/organization';
-import toArray from 'sentry/utils/array/toArray';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Aggregation, QueryFieldValue} from 'sentry/utils/discover/fields';
-import {
-  doDiscoverQuery,
-  type DiscoverQueryExtras,
-  type DiscoverQueryRequestParams,
-} from 'sentry/utils/discover/genericDiscoverQuery';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {AggregationKey} from 'sentry/utils/fields';
-import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
@@ -38,10 +26,12 @@ import {
   getTimeseriesSortOptions,
   transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
-import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
-import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
-import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
+import {DisplayType, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {transformEventsResponseToSeries} from 'sentry/views/dashboards/utils/transformEventsResponseToSeries';
+import {
+  useLogsSeriesQuery,
+  useLogsTableQuery,
+} from 'sentry/views/dashboards/widgetCard/hooks/useLogsWidgetQuery';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
@@ -53,7 +43,6 @@ import {
   useTraceItemAttributes,
   useTraceItemAttributesWithConfig,
 } from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import {LOG_AGGREGATES} from 'sentry/views/explore/logs/logsToolbar';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -208,33 +197,8 @@ export const LogsConfig: DatasetConfig<
     DisplayType.TABLE,
     DisplayType.TOP_N,
   ],
-  getTableRequest: (
-    api: Client,
-    _widget: Widget,
-    query: WidgetQuery,
-    organization: Organization,
-    pageFilters: PageFilters,
-    _onDemandControlContext?: OnDemandControlContext,
-    limit?: number,
-    cursor?: string,
-    referrer?: string,
-    _mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
-  ) => {
-    return getEventsRequest(
-      api,
-      query,
-      organization,
-      pageFilters,
-      limit,
-      cursor,
-      referrer,
-      undefined,
-      undefined,
-      samplingMode
-    );
-  },
-  getSeriesRequest,
+  useSeriesQuery: useLogsSeriesQuery,
+  useTableQuery: useLogsTableQuery,
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
   filterAggregateParams,
@@ -309,57 +273,6 @@ function filterYAxisOptions() {
   };
 }
 
-function getEventsRequest(
-  api: Client,
-  query: WidgetQuery,
-  organization: Organization,
-  pageFilters: PageFilters,
-  limit?: number,
-  cursor?: string,
-  referrer?: string,
-  _mepSetting?: MEPState | null,
-  queryExtras?: DiscoverQueryExtras,
-  samplingMode?: SamplingMode
-) {
-  const url = `/organizations/${organization.slug}/events/`;
-  const eventView = eventViewFromWidget('', query, pageFilters);
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
-  const params: DiscoverQueryRequestParams = {
-    per_page: limit,
-    cursor,
-    referrer,
-    dataset: DiscoverDatasets.OURLOGS,
-    ...queryExtras,
-  };
-
-  if (query.orderby) {
-    params.sort = toArray(query.orderby);
-  }
-
-  return doDiscoverQuery<EventsTableData>(
-    api,
-    url,
-    {
-      ...eventView.generateQueryStringObject(),
-      ...params,
-      ...(samplingMode ? {sampling: samplingMode} : {}),
-    },
-    // Tries events request up to 3 times on rate limit
-    {
-      retry: hasQueueFeature
-        ? // The queue will handle retries, so we don't need to retry here
-          undefined
-        : {
-            statusCodes: [429],
-            tries: 10,
-          },
-    }
-  );
-}
-
 function getGroupByFieldOptions(
   organization: Organization,
   tags?: TagCollection,
@@ -374,33 +287,6 @@ function getGroupByFieldOptions(
   const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);
 
   return pickBy(primaryFieldOptions, filterGroupByOptions);
-}
-
-function getSeriesRequest(
-  api: Client,
-  widget: Widget,
-  queryIndex: number,
-  organization: Organization,
-  pageFilters: PageFilters,
-  _onDemandControlContext?: OnDemandControlContext,
-  referrer?: string,
-  _mepSetting?: MEPState | null,
-  samplingMode?: SamplingMode
-) {
-  const requestData = getSeriesRequestData(
-    widget,
-    queryIndex,
-    organization,
-    pageFilters,
-    DiscoverDatasets.OURLOGS,
-    referrer
-  );
-
-  if (samplingMode) {
-    requestData.sampling = samplingMode;
-  }
-
-  return doEventsRequest<true>(api, requestData);
 }
 
 // Filters the primary options in the sort by selector

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
@@ -56,10 +56,7 @@ describe('useLogsSeriesQuery', () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: {
-        data: [
-          [1, [{count: 100}]],
-          [2, [{count: 200}]],
-        ],
+        data: [],
       },
     });
 
@@ -105,7 +102,7 @@ describe('useLogsSeriesQuery', () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: {
-        data: [[1, [{count: 100}]]],
+        data: [],
       },
     });
 
@@ -164,7 +161,7 @@ describe('useLogsTableQuery', () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
-        data: [{message: 'Test log message', 'count()': 100}],
+        data: [],
       },
     });
 
@@ -209,7 +206,7 @@ describe('useLogsTableQuery', () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
-        data: [{message: 'Test log message', 'count()': 100}],
+        data: [],
       },
     });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
@@ -1,0 +1,241 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import {DisplayType} from 'sentry/views/dashboards/types';
+
+import {useLogsSeriesQuery, useLogsTableQuery} from './useLogsWidgetQuery';
+
+jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
+  useWidgetQueryQueue: () => ({queue: null}),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({children}: {children: React.ReactNode}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useLogsSeriesQuery', () => {
+  const organization = OrganizationFixture();
+  const pageFilters = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(pageFilters);
+  });
+
+  it('makes a request to the events-stats endpoint', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1, [{count: 100}]],
+          [2, [{count: 200}]],
+        ],
+      },
+    });
+
+    renderHook(
+      () =>
+        useLogsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['count()'],
+            dataset: 'ourlogs',
+          }),
+        })
+      );
+    });
+  });
+
+  it('applies dashboard filters to widget query', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'level:error',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [[1, [{count: 100}]]],
+      },
+    });
+
+    renderHook(
+      () =>
+        useLogsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          dashboardFilters: {
+            release: ['1.0.0'],
+          },
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: expect.stringContaining('release:"1.0.0"'),
+          }),
+        })
+      );
+    });
+  });
+});
+
+describe('useLogsTableQuery', () => {
+  const organization = OrganizationFixture();
+  const pageFilters = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(pageFilters);
+  });
+
+  it('makes a request to the events endpoint', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['message', 'count()'],
+          aggregates: ['count()'],
+          columns: ['message'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{message: 'Test log message', 'count()': 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useLogsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'ourlogs',
+          }),
+        })
+      );
+    });
+  });
+
+  it('handles pagination parameters', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['message', 'count()'],
+          aggregates: ['count()'],
+          columns: ['message'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{message: 'Test log message', 'count()': 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useLogsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          limit: 50,
+          cursor: 'test-cursor',
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            per_page: 50,
+            cursor: 'test-cursor',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -1,0 +1,447 @@
+import {useCallback, useMemo, useRef} from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+import type {ApiResult} from 'sentry/api';
+import type {Series} from 'sentry/types/echarts';
+import type {
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+} from 'sentry/types/organization';
+import toArray from 'sentry/utils/array/toArray';
+import {getUtcDateString} from 'sentry/utils/dates';
+import type {
+  EventsTableData,
+  TableData,
+  TableDataWithTitle,
+} from 'sentry/utils/discover/discoverQuery';
+import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useQueries} from 'sentry/utils/queryClient';
+import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
+import {LogsConfig} from 'sentry/views/dashboards/datasetConfig/logs';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {
+  dashboardFiltersToString,
+  eventViewFromWidget,
+} from 'sentry/views/dashboards/utils';
+import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {
+  cleanWidgetForRequest,
+  getReferrer,
+} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+
+type LogsSeriesResponse =
+  | EventsStats
+  | MultiSeriesEventsStats
+  | GroupedMultiSeriesEventsStats;
+type LogsTableResponse = TableData | EventsTableData;
+
+/**
+ * Helper to apply dashboard filters and clean widget for API request
+ */
+function applyDashboardFilters(
+  widget: Widget,
+  dashboardFilters?: DashboardFilters,
+  skipParens?: boolean
+): Widget {
+  let processedWidget = widget;
+
+  // Apply dashboard filters if provided
+  if (dashboardFilters) {
+    const filtered = cloneDeep(widget);
+    const dashboardFilterConditions = dashboardFiltersToString(
+      dashboardFilters,
+      filtered.widgetType
+    );
+
+    filtered.queries.forEach(query => {
+      if (dashboardFilterConditions) {
+        // If there is no base query, there's no need to add parens
+        if (query.conditions && !skipParens) {
+          query.conditions = `(${query.conditions})`;
+        }
+        query.conditions = query.conditions + ` ${dashboardFilterConditions}`;
+      }
+    });
+
+    processedWidget = filtered;
+  }
+
+  // Clean widget to remove empty/invalid fields before API request
+  return cleanWidgetForRequest(processedWidget);
+}
+
+// Stable empty array to prevent infinite rerenders
+const EMPTY_ARRAY: any[] = [];
+
+/**
+ * Hook for fetching Logs widget series data (charts) using React Query.
+ * Queries are disabled by default - use refetch() to trigger fetching.
+ * This allows genericWidgetQueries to control timing with queue/callbacks.
+ */
+export function useLogsSeriesQuery(
+  params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled = true,
+    samplingMode,
+    dashboardFilters,
+    skipDashboardFilterParens,
+  } = params;
+
+  const {queue} = useWidgetQueryQueue();
+  const prevRawDataRef = useRef<LogsSeriesResponse[] | undefined>(undefined);
+
+  // Apply dashboard filters
+  const filteredWidget = useMemo(
+    () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  // Build query keys for all widget queries
+  const queryKeys = useMemo(() => {
+    const keys = filteredWidget.queries.map((_, queryIndex) => {
+      const requestData = getSeriesRequestData(
+        filteredWidget,
+        queryIndex,
+        organization,
+        pageFilters,
+        DiscoverDatasets.OURLOGS,
+        getReferrer(filteredWidget.displayType)
+      );
+
+      // Add sampling mode if provided
+      if (samplingMode) {
+        requestData.sampling = samplingMode;
+      }
+
+      // Transform requestData into proper query params
+      const {
+        organization: _org,
+        includeAllArgs: _includeAllArgs,
+        includePrevious: _includePrevious,
+        generatePathname: _generatePathname,
+        period,
+        ...restParams
+      } = requestData;
+
+      const queryParams = {
+        ...restParams,
+        ...(period ? {statsPeriod: period} : {}),
+      };
+
+      if (queryParams.start) {
+        queryParams.start = getUtcDateString(queryParams.start);
+      }
+      if (queryParams.end) {
+        queryParams.end = getUtcDateString(queryParams.end);
+      }
+
+      // Build the API query key for events-stats endpoint
+      return [
+        `/organizations/${organization.slug}/events-stats/`,
+        {
+          method: 'GET' as const,
+          query: queryParams,
+        },
+      ] satisfies ApiQueryKey;
+    });
+    return keys;
+  }, [filteredWidget, organization, pageFilters, samplingMode]);
+
+  // Create stable queryFn that uses queue
+  const createQueryFn = useCallback(
+    () =>
+      async (context: any): Promise<ApiResult<LogsSeriesResponse>> => {
+        if (queue) {
+          return new Promise((resolve, reject) => {
+            const fetchFnRef = {
+              current: async () => {
+                try {
+                  const result = await fetchDataQuery<LogsSeriesResponse>(context);
+                  resolve(result);
+                } catch (error) {
+                  reject(error);
+                }
+              },
+            };
+            queue.addItem({fetchDataRef: fetchFnRef});
+          });
+        }
+
+        // Fallback: call directly if queue not available
+        return fetchDataQuery<LogsSeriesResponse>(context);
+      },
+    [queue]
+  );
+
+  // Check if organization has the async queue feature
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const queryResults = useQueries({
+    queries: queryKeys.map(queryKey => ({
+      queryKey,
+      queryFn: createQueryFn(),
+      staleTime: 0,
+      enabled,
+      // Retry on 429 status codes up to 10 times, unless queue handles it
+      retry: hasQueueFeature
+        ? false
+        : (failureCount: number, error: any) => {
+            // Retry up to 10 times on rate limit errors
+            if (error?.status === 429 && failureCount < 10) {
+              return true;
+            }
+            return false;
+          },
+      placeholderData: (previousData: unknown) => previousData,
+    })),
+  });
+
+  const transformedData = (() => {
+    const isFetching = queryResults.some(q => q?.isFetching);
+    const allHaveData = queryResults.every(q => q?.data?.[0]);
+    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+
+    if (!allHaveData || isFetching) {
+      const loading = isFetching || !errorMessage;
+      return {
+        loading,
+        errorMessage,
+        rawData: EMPTY_ARRAY,
+      };
+    }
+
+    const timeseriesResults: Series[] = [];
+    const rawData: LogsSeriesResponse[] = [];
+
+    queryResults.forEach((q, requestIndex) => {
+      if (!q?.data?.[0]) {
+        return;
+      }
+
+      const responseData = q.data[0];
+      rawData[requestIndex] = responseData;
+
+      const transformedResult = LogsConfig.transformSeries!(
+        responseData,
+        filteredWidget.queries[requestIndex]!,
+        organization
+      );
+
+      // Maintain color consistency
+      transformedResult.forEach((result: Series, resultIndex: number) => {
+        timeseriesResults[requestIndex * transformedResult.length + resultIndex] = result;
+      });
+    });
+
+    // Check if rawData is the same as before to prevent unnecessary rerenders
+    let finalRawData = rawData;
+    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+      const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
+      if (allSame) {
+        finalRawData = prevRawDataRef.current;
+      }
+    }
+
+    // Store current rawData for next comparison
+    if (finalRawData !== prevRawDataRef.current) {
+      prevRawDataRef.current = finalRawData;
+    }
+
+    return {
+      loading: false,
+      errorMessage: undefined,
+      timeseriesResults,
+      rawData: finalRawData,
+    };
+  })();
+
+  return transformedData;
+}
+
+/**
+ * Hook for fetching Logs widget table data using React Query.
+ * Queries are disabled by default - use refetch() to trigger fetching.
+ * This allows genericWidgetQueries to control timing with queue/callbacks.
+ */
+export function useLogsTableQuery(
+  params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled = true,
+    samplingMode,
+    cursor,
+    limit,
+    dashboardFilters,
+    skipDashboardFilterParens,
+  } = params;
+
+  const {queue} = useWidgetQueryQueue();
+  const prevRawDataRef = useRef<LogsTableResponse[] | undefined>(undefined);
+
+  const filteredWidget = useMemo(
+    () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  const queryKeys = useMemo(() => {
+    return filteredWidget.queries.map(query => {
+      const eventView = eventViewFromWidget('', query, pageFilters);
+
+      const requestParams: DiscoverQueryRequestParams = {
+        per_page: limit,
+        cursor,
+        referrer: getReferrer(filteredWidget.displayType),
+        dataset: DiscoverDatasets.OURLOGS,
+      };
+
+      if (query.orderby) {
+        requestParams.sort = toArray(query.orderby);
+      }
+
+      const queryParams = {
+        ...eventView.generateQueryStringObject(),
+        ...requestParams,
+        ...(samplingMode ? {sampling: samplingMode} : {}),
+      };
+
+      const baseQueryKey: ApiQueryKey = [
+        `/organizations/${organization.slug}/events/`,
+        {
+          method: 'GET' as const,
+          query: queryParams,
+        },
+      ];
+
+      return baseQueryKey;
+    });
+  }, [filteredWidget, organization, pageFilters, samplingMode, cursor, limit]);
+
+  const createQueryFnTable = useCallback(
+    () =>
+      async (context: any): Promise<ApiResult<LogsTableResponse>> => {
+        if (queue) {
+          return new Promise((resolve, reject) => {
+            const fetchFnRef = {
+              current: async () => {
+                try {
+                  const result = await fetchDataQuery<LogsTableResponse>(context);
+                  resolve(result);
+                } catch (error) {
+                  reject(error);
+                }
+              },
+            };
+            queue.addItem({fetchDataRef: fetchFnRef});
+          });
+        }
+        return fetchDataQuery<LogsTableResponse>(context);
+      },
+    [queue]
+  );
+
+  // Check if organization has the async queue feature
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const queryResults = useQueries({
+    queries: queryKeys.map(queryKey => ({
+      queryKey,
+      queryFn: createQueryFnTable(),
+      staleTime: 0,
+      enabled,
+      // Retry on 429 status codes up to 10 times, unless queue handles it
+      retry: hasQueueFeature
+        ? false
+        : (failureCount: number, error: any) => {
+            // Retry up to 10 times on rate limit errors
+            if (error?.status === 429 && failureCount < 10) {
+              return true;
+            }
+            return false;
+          },
+    })),
+  });
+
+  const transformedData = (() => {
+    const isFetching = queryResults.some(q => q?.isFetching);
+    const allHaveData = queryResults.every(q => q?.data?.[0]);
+    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+
+    if (!allHaveData || isFetching) {
+      const loading = isFetching || !errorMessage;
+      return {
+        loading,
+        errorMessage,
+        rawData: EMPTY_ARRAY,
+      };
+    }
+
+    const tableResults: TableDataWithTitle[] = [];
+    const rawData: LogsTableResponse[] = [];
+    let responsePageLinks: string | undefined;
+
+    queryResults.forEach((q, i) => {
+      if (!q?.data?.[0]) {
+        return;
+      }
+
+      const responseData = q.data[0];
+      const responseMeta = q.data[2];
+      rawData[i] = responseData;
+
+      const transformedDataItem: TableDataWithTitle = {
+        ...LogsConfig.transformTable(
+          responseData,
+          filteredWidget.queries[i]!,
+          organization,
+          pageFilters
+        ),
+        title: filteredWidget.queries[i]?.name ?? '',
+      };
+
+      tableResults.push(transformedDataItem);
+
+      // Get page links from response meta
+      responsePageLinks = responseMeta?.getResponseHeader('Link') ?? undefined;
+    });
+
+    // Check if rawData is the same as before to prevent unnecessary rerenders
+    let finalRawData = rawData;
+    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+      const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
+      if (allSame) {
+        finalRawData = prevRawDataRef.current;
+      }
+    }
+
+    // Store current rawData for next comparison
+    if (finalRawData !== prevRawDataRef.current) {
+      prevRawDataRef.current = finalRawData;
+    }
+
+    return {
+      loading: false,
+      errorMessage: undefined,
+      tableResults,
+      pageLinks: responsePageLinks,
+      rawData: finalRawData,
+    };
+  })();
+
+  return transformedData;
+}


### PR DESCRIPTION
This PR migrates the logs dataset from the legacy request pattern to use the modern React Query hooks pattern (`useSeriesQuery` and `useTableQuery`) similar to https://github.com/getsentry/sentry/pull/106779