### PR TITLE
fix(alerts): Support AssignedToFilter in issue alert preview

### DIFF
--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from django import forms
 
 from sentry.mail.forms.assigned_to import AssignedToForm
+from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.team import Team
 from sentry.notifications.types import ASSIGNEE_CHOICES, AssigneeTargetType
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
 from sentry.services.eventstore.models import GroupEvent
+from sentry.types.condition_activity import ConditionActivity
 from sentry.users.services.user.service import user_service
 from sentry.utils.cache import cache
-
-if TYPE_CHECKING:
-    from sentry.models.group import Group
 
 
 class AssignedToFilter(EventFilter):
@@ -33,23 +32,36 @@ class AssignedToFilter(EventFilter):
             cache.set(cache_key, assignee_list, 60)
         return assignee_list
 
-    def passes(self, event: GroupEvent, state: EventState) -> bool:
+    def _passes(self, group: Group) -> bool:
         target_type = AssigneeTargetType(self.get_option("targetType"))
 
         if target_type == AssigneeTargetType.UNASSIGNED:
-            return len(self.get_assignees(event.group)) == 0
-        else:
-            target_id = self.get_option("targetIdentifier", None)
+            return len(self.get_assignees(group)) == 0
 
-            if target_type == AssigneeTargetType.TEAM:
-                for assignee in self.get_assignees(event.group):
-                    if assignee.team_id and assignee.team_id == target_id:
-                        return True
-            elif target_type == AssigneeTargetType.MEMBER:
-                for assignee in self.get_assignees(event.group):
-                    if assignee.user_id and assignee.user_id == target_id:
-                        return True
+        target_id = self.get_option("targetIdentifier", None)
+
+        if target_type == AssigneeTargetType.TEAM:
+            for assignee in self.get_assignees(group):
+                if assignee.team_id and assignee.team_id == target_id:
+                    return True
+        elif target_type == AssigneeTargetType.MEMBER:
+            for assignee in self.get_assignees(group):
+                if assignee.user_id and assignee.user_id == target_id:
+                    return True
+        return False
+
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
+        return self._passes(event.group)
+
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: dict[str, Any]
+    ) -> bool:
+        try:
+            group = Group.objects.get_from_cache(id=condition_activity.group_id)
+        except Group.DoesNotExist:
             return False
+
+        return self._passes(group)
 
     def get_form_instance(self) -> forms.Form:
         return AssignedToForm(self.project, self.data)


### PR DESCRIPTION
the issue alert preview was returning no results when the "assigned to" filter was applied because `AssignedToFilter` didn't implement `passes_activity()`. now it does, so you can preview alerts that filter by team/member assignment! 🎉

Fixes #78754