### PR TITLE
feat(copilot): add has_identity field to GitHub Copilot integration

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationEventPermission
 from sentry.constants import ObjectStatus
+from sentry.hybridcloud.rpc.service import RpcException
 from sentry.integrations.coding_agent.utils import get_coding_agent_providers
 from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
 from sentry.integrations.services.integration import integration_service
@@ -96,10 +97,20 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         if features.has("organizations:integrations-github-copilot-agent", organization):
             has_identity = False
             if request.user and request.user.id:
-                access_token = github_copilot_identity_service.get_access_token_for_user(
-                    user_id=request.user.id
-                )
-                has_identity = access_token is not None
+                try:
+                    access_token = github_copilot_identity_service.get_access_token_for_user(
+                        user_id=request.user.id
+                    )
+                    has_identity = access_token is not None
+                except RpcException:
+                    # If the identity service is unavailable, default to no identity
+                    # This ensures the endpoint remains functional even if the service is down
+                    logger.warning(
+                        "Failed to check GitHub Copilot identity",
+                        extra={"user_id": request.user.id},
+                        exc_info=True,
+                    )
+                    has_identity = False
 
             integrations_data.append(
                 {

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -15,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationEventPermission
 from sentry.constants import ObjectStatus
 from sentry.integrations.coding_agent.utils import get_coding_agent_providers
+from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.seer.autofix.coding_agent import launch_coding_agents_for_run
@@ -93,12 +94,20 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         ]
 
         if features.has("organizations:integrations-github-copilot-agent", organization):
+            has_identity = False
+            if request.user and request.user.id:
+                access_token = github_copilot_identity_service.get_access_token_for_user(
+                    user_id=request.user.id
+                )
+                has_identity = access_token is not None
+
             integrations_data.append(
                 {
                     "id": None,
                     "name": "GitHub Copilot",
                     "provider": "github_copilot",
                     "requires_identity": True,
+                    "has_identity": has_identity,
                 }
             )
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -367,6 +367,51 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
             assert integrations[0]["name"] == "GitHub Copilot"
             assert integrations[0]["provider"] == "github_copilot"
             assert integrations[0]["requires_identity"] is True
+            assert integrations[0]["has_identity"] is False
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.github_copilot_identity_service"
+    )
+    def test_github_copilot_has_identity_true_when_authenticated(self, mock_identity_service):
+        """Test GET endpoint returns has_identity: True when user has GitHub Copilot OAuth token."""
+        mock_identity_service.get_access_token_for_user.return_value = "mock-access-token"
+
+        with (
+            self.feature("organizations:seer-coding-agent-integrations"),
+            self.feature("organizations:integrations-github-copilot-agent"),
+            self.mock_integration_service_calls(integrations=[]),
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+            integrations = response.data["integrations"]
+            assert len(integrations) == 1
+            assert integrations[0]["provider"] == "github_copilot"
+            assert integrations[0]["has_identity"] is True
+            mock_identity_service.get_access_token_for_user.assert_called_once_with(
+                user_id=self.user.id
+            )
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.github_copilot_identity_service"
+    )
+    def test_github_copilot_has_identity_false_when_not_authenticated(self, mock_identity_service):
+        """Test GET endpoint returns has_identity: False when user doesn't have GitHub Copilot OAuth token."""
+        mock_identity_service.get_access_token_for_user.return_value = None
+
+        with (
+            self.feature("organizations:seer-coding-agent-integrations"),
+            self.feature("organizations:integrations-github-copilot-agent"),
+            self.mock_integration_service_calls(integrations=[]),
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+            integrations = response.data["integrations"]
+            assert len(integrations) == 1
+            assert integrations[0]["provider"] == "github_copilot"
+            assert integrations[0]["has_identity"] is False
+            mock_identity_service.get_access_token_for_user.assert_called_once_with(
+                user_id=self.user.id
+            )
 
     def test_github_copilot_not_shown_without_feature_flag(self):
         """Test GET endpoint does not show GitHub Copilot without feature flag."""

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -413,6 +413,34 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
                 user_id=self.user.id
             )
 
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.github_copilot_identity_service"
+    )
+    def test_github_copilot_handles_rpc_exception_gracefully(self, mock_identity_service):
+        """Test GET endpoint handles RPC exceptions gracefully when checking GitHub Copilot identity."""
+        from sentry.hybridcloud.rpc.service import RpcRemoteException
+
+        # Simulate RPC service failure
+        mock_identity_service.get_access_token_for_user.side_effect = RpcRemoteException(
+            "github_copilot_identity", "get_access_token_for_user", "Service unavailable"
+        )
+
+        with (
+            self.feature("organizations:seer-coding-agent-integrations"),
+            self.feature("organizations:integrations-github-copilot-agent"),
+            self.mock_integration_service_calls(integrations=[]),
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+            # Should still return successfully with has_identity set to False
+            integrations = response.data["integrations"]
+            assert len(integrations) == 1
+            assert integrations[0]["provider"] == "github_copilot"
+            assert integrations[0]["has_identity"] is False
+            mock_identity_service.get_access_token_for_user.assert_called_once_with(
+                user_id=self.user.id
+            )
+
     def test_github_copilot_not_shown_without_feature_flag(self):
         """Test GET endpoint does not show GitHub Copilot without feature flag."""
         with (


### PR DESCRIPTION
- Add `has_identity` field to GitHub Copilot integration in coding agents endpoint
- Check user's GitHub Copilot OAuth status via identity service

Used on frontend to show users "Set up Copilot" if they haven't authed yet.