### PR TITLE
feat(copilot): add has_identity field support for Setup button

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -314,6 +314,7 @@ export type CodingAgentIntegration = {
   id: string | null;
   name: string;
   provider: string;
+  has_identity?: boolean;
   requires_identity?: boolean;
 };
 
@@ -418,12 +419,9 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
     },
     onError: (error, params) => {
       if (needsGitHubAuth(error)) {
-        addErrorMessage(
-          t('Please connect your GitHub account. Redirecting to authorization...')
-        );
-        setTimeout(() => {
-          window.open('/remote/github-copilot/oauth/', '_blank');
-        }, 1000);
+        const currentUrl = window.location.href;
+        const oauthUrl = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+        window.location.href = oauthUrl;
         return;
       }
       const message = getErrorMessage(error, params.agentName);


### PR DESCRIPTION
## Summary
- Add `has_identity` field to CodingAgentIntegration type
- Show "Setup <Agent>" vs "Send to <Agent>" based on identity status
- Redirect to OAuth flow when clicking Setup
<img width="236" height="65" alt="Screenshot 2026-01-22 at 11 08 08 AM" src="https://github.com/user-attachments/assets/d0fcf75e-db04-4007-85e4-f05db51dc025" />

