### PR TITLE
feat(copilot): add has_identity support to explorer autofix

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -356,7 +356,7 @@ function getErrorMessage(error: RequestError, agentName: string): string {
   return t('Failed to launch %s', agentName);
 }
 
-function needsGitHubAuth(error: RequestError): boolean {
+export function needsGitHubAuth(error: RequestError): boolean {
   const detail = error.responseJSON?.detail;
   return (
     typeof detail === 'string' &&

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -1,7 +1,10 @@
 import {useCallback, useState} from 'react';
 
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
-import {needsGitHubAuth} from 'sentry/components/events/autofix/useAutofix';
+import {
+  needsGitHubAuth,
+  type CodingAgentIntegration,
+} from 'sentry/components/events/autofix/useAutofix';
 import {
   setApiQueryData,
   useApiQuery,
@@ -408,7 +411,7 @@ export function useExplorerAutofix(
    * Trigger coding agent handoff for an existing run.
    */
   const triggerCodingAgentHandoff = useCallback(
-    async (runId: number, integration: {id: string | null; provider: string}) => {
+    async (runId: number, integration: CodingAgentIntegration) => {
       setWaitingForResponse(true);
 
       addLoadingMessage('Launching coding agent...');

--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -10,6 +10,7 @@ import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {Button, ButtonBar} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
+import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {
   hasCodeChanges as checkHasCodeChanges,
   getArtifactsFromBlocks,
@@ -206,9 +207,9 @@ export function ExplorerSeerDrawer({
   }, [runState?.run_id]);
 
   const handleCodingAgentHandoff = useCallback(
-    async (integrationId: number) => {
+    async (integration: CodingAgentIntegration) => {
       if (runState?.run_id) {
-        await triggerCodingAgentHandoff(runState.run_id, integrationId);
+        await triggerCodingAgentHandoff(runState.run_id, integration);
       }
     },
     [triggerCodingAgentHandoff, runState?.run_id]

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -10,7 +10,10 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Text} from 'sentry/components/core/text';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import {
+  useCodingAgentIntegrations,
+  type CodingAgentIntegration,
+} from 'sentry/components/events/autofix/useAutofix';
 import type {AutofixExplorerStep} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {cardAnimationProps} from 'sentry/components/events/autofix/v2/utils';
 import {IconChat, IconChevron} from 'sentry/icons';
@@ -54,7 +57,7 @@ interface ExplorerNextStepsProps {
   /**
    * Callback when a coding agent handoff is requested.
    */
-  onCodingAgentHandoff?: (integrationId: number) => void;
+  onCodingAgentHandoff?: (integration: CodingAgentIntegration) => void;
   /**
    * Callback when the open chat button is clicked.
    */
@@ -121,10 +124,9 @@ function StepButton({
   isBusy: boolean;
   onStepClick: () => void;
   step: AutofixExplorerStep;
-  // TODO(autofix): Handle GitHub Copilot in explore autofix
-  codingAgentIntegrations?: Array<{id: string | null; name: string; provider: string}>;
+  codingAgentIntegrations?: CodingAgentIntegration[];
   isLoading?: boolean;
-  onCodingAgentHandoff?: (integrationId: number) => void;
+  onCodingAgentHandoff?: (integration: CodingAgentIntegration) => void;
 }) {
   const priority = index === 0 ? 'primary' : 'default';
 
@@ -142,19 +144,32 @@ function StepButton({
     );
   }
 
-  // Build dropdown items for coding agent integrations (filter out those without IDs for now)
-  const dropdownItems = codingAgentIntegrations
-    .filter(integration => integration.id !== null)
-    .map(integration => ({
-      key: `agent:${integration.id}`,
+  // Build dropdown items for coding agent integrations
+  const dropdownItems = codingAgentIntegrations.map(integration => {
+    const needsSetup = integration.requires_identity && !integration.has_identity;
+    const actionLabel = needsSetup
+      ? t('Setup %s', integration.name)
+      : t('Send to %s', integration.name);
+
+    return {
+      key: `agent:${integration.id ?? integration.provider}`,
       label: (
         <Flex gap="md" align="center">
-          <PluginIcon pluginId="cursor" size={16} />
-          <span>{t('Send to %s', integration.name)}</span>
+          <PluginIcon pluginId={integration.provider} size={16} />
+          <span>{actionLabel}</span>
         </Flex>
       ),
-      onAction: () => onCodingAgentHandoff?.(parseInt(integration.id!, 10)),
-    }));
+      onAction: () => {
+        // OAuth redirect for integrations without identity
+        if (needsSetup) {
+          const currentUrl = window.location.href;
+          window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+          return;
+        }
+        onCodingAgentHandoff?.(integration);
+      },
+    };
+  });
 
   return (
     <ButtonBar merged gap="0">

--- a/static/app/views/issueDetails/streamline/instrumentationFixSection.tsx
+++ b/static/app/views/issueDetails/streamline/instrumentationFixSection.tsx
@@ -4,6 +4,7 @@ import {AnimatePresence} from 'framer-motion';
 import {Flex} from '@sentry/scraps/layout';
 
 import {Button} from 'sentry/components/core/button';
+import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {
   hasCodeChanges as checkHasCodeChanges,
   getArtifactsFromBlocks,
@@ -94,9 +95,9 @@ export function InstrumentationFixSection({group}: InstrumentationFixSectionProp
   }, [runState?.run_id]);
 
   const handleCodingAgentHandoff = useCallback(
-    async (integrationId: number) => {
+    async (integration: CodingAgentIntegration) => {
       if (runState?.run_id) {
-        await triggerCodingAgentHandoff(runState.run_id, integrationId);
+        await triggerCodingAgentHandoff(runState.run_id, integration);
       }
     },
     [triggerCodingAgentHandoff, runState?.run_id]


### PR DESCRIPTION
## Summary

Extends the GitHub Copilot `has_identity` feature (already implemented in legacy autofix) to the explorer autofix (v2) components. This allows the UI to show "Setup GitHub Copilot" vs "Send to GitHub Copilot" based on whether the user has authenticated with GitHub Copilot OAuth.

**Changes:**
- Export `needsGitHubAuth` helper from `useAutofix.tsx` for reuse
- Update `nextSteps.tsx` to show "Setup" vs "Send to" labels based on `has_identity`/`requires_identity` fields
- Update `useExplorerAutofix.tsx` to support `provider` param (for GitHub Copilot which has no integration ID) and OAuth error handling with redirect
- Update `explorerSeerDrawer.tsx` and `instrumentationFixSection.tsx` callbacks to pass full integration object

**Behavior:**
- When a user hasn't authenticated with GitHub Copilot, dropdown shows "Setup GitHub Copilot" and redirects to OAuth on click
- When a user has authenticated, dropdown shows "Send to GitHub Copilot" and triggers the handoff
- Backend already supports the `provider` parameter (from legacy autofix PR)

Depends on: #106785 (backend `has_identity` support)