### PR TITLE
chore(api): deprecate non-org-scoped group integration details endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -12,7 +12,9 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.api.serializers.models.integration import IntegrationSerializer
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.mixins.issues import IssueBasicIntegration
@@ -79,6 +81,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         "DELETE": ApiPublishStatus.UNKNOWN,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
     def get(self, request: Request, group, integration_id) -> Response:
         """
         Retrieves the config needed to either link or create an external issue for a group.
@@ -131,6 +134,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             )
         )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
     def post(self, request: Request, group, integration_id) -> Response:
         """
         Creates a new external issue and links it to a group.
@@ -233,6 +237,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
     def put(self, request: Request, group, integration_id) -> Response:
         """
         Links an existing external issue to a group.
@@ -336,6 +341,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
     def delete(self, request: Request, group, integration_id) -> Response:
         """
         Deletes a link between a group and an external issue.

--- a/tests/sentry/issues/endpoints/test_group_integration_details.py
+++ b/tests/sentry/issues/endpoints/test_group_integration_details.py
@@ -73,7 +73,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=link"
+        path = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/integrations/{integration.id}/?action=link"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -116,7 +116,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         )
         group = self.group
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=create"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -183,7 +183,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=create"
+        path = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature("organizations:integrations-issue-basic"):
             with mock.patch.object(
@@ -201,7 +201,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=create"
+        path = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature(
             {
@@ -249,7 +249,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.put(path, data={"externalIssue": "APP-123"})
 
@@ -271,7 +271,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             # Test with IntegrationFormError
             mock_get_issue.side_effect = raise_integration_form_error
@@ -303,7 +303,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.put(path, data={"externalIssue": "APP-123"})
 
@@ -331,7 +331,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             # Test with IntegrationFormError
             mock_after_link_issue.side_effect = raise_integration_form_error
@@ -359,7 +359,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature(
             {
@@ -380,7 +380,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.post(path, data={})
@@ -437,7 +437,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             mock_create_issue.side_effect = raise_integration_error
             response = self.client.post(path, data={})
@@ -471,7 +471,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             mock_create_issue.side_effect = raise_integration_installation_configuration_error
 
@@ -492,7 +492,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             organization=org, provider="example", name="Example", external_id="example:1"
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature(
             {
@@ -524,7 +524,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.delete(path)
@@ -553,7 +553,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
 
         with self.feature(
             {
@@ -598,8 +598,8 @@ class GroupIntegrationDetailsTest(APITestCase):
             external_id="example:1",
             oi_params={"config": {"project_issue_defaults": {group.project_id: {"project": "2"}}}},
         )
-        create_path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=create"
-        link_path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=link"
+        create_path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/?action=create"
+        link_path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/{integration.id}/?action=link"
         project_field = {
             "name": "project",
             "label": "Project",


### PR DESCRIPTION
Add deprecation decorator to GET, POST, PUT, and DELETE methods of GroupIntegrationDetailsEndpoint and update tests to use org-scoped URL pattern.