### PR TITLE
chore(api): deprecate non-org-scoped group integrations endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_integrations.py
+++ b/src/sentry/issues/endpoints/group_integrations.py
@@ -12,7 +12,9 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.hybridcloud.rpc.pagination import RpcPaginationArgs
 from sentry.integrations.api.serializers.models.integration import IntegrationSerializer
 from sentry.integrations.base import IntegrationFeatures
@@ -88,6 +90,7 @@ class GroupIntegrationsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integrations"])
     def get(self, request: Request, group) -> Response:
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", group.organization, actor=request.user

--- a/tests/sentry/issues/endpoints/test_group_integrations.py
+++ b/tests/sentry/issues/endpoints/test_group_integrations.py
@@ -19,7 +19,7 @@ class GroupIntegrationsTest(APITestCase):
             title="this is an example title",
             description="this is an example description",
         )
-        path = f"/api/0/issues/{group.id}/integrations/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -70,7 +70,7 @@ class GroupIntegrationsTest(APITestCase):
             description="this is an example description",
         )
 
-        path = f"/api/0/issues/{group.id}/integrations/"
+        path = f"/api/0/organizations/{org.slug}/issues/{group.id}/integrations/"
 
         with self.feature(
             {


### PR DESCRIPTION
Add deprecation decorator to GET method of GroupIntegrationsEndpoint and update tests to use org-scoped URL pattern.
