### PR TITLE
chore(api): deprecate non-org-scoped group external issue details endpoint

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
@@ -5,6 +5,8 @@ from sentry import deletions
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 
@@ -16,6 +18,7 @@ class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-external-issues-details"])
     def delete(self, request: Request, external_issue_id, group) -> Response:
         try:
             external_issue = PlatformExternalIssue.objects.get(

--- a/tests/sentry/sentry_apps/api/endpoints/test_group_external_issue_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_group_external_issue_details.py
@@ -14,7 +14,7 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        self.url = f"/api/0/issues/{self.group.id}/external-issues/{self.external_issue.id}/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/external-issues/{self.external_issue.id}/"
 
     def test_deletes_external_issue(self) -> None:
         response = self.client.delete(self.url, format="json")
@@ -23,7 +23,7 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
         assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
 
     def test_handles_non_existing_external_issue(self) -> None:
-        url = f"/api/0/issues/{self.group.id}/external-issues/99999/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/external-issues/99999/"
 
         response = self.client.delete(url, format="json")
 
@@ -45,7 +45,7 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        url = f"/api/0/issues/{group.id}/external-issues/{external_issue.id}/"
+        url = f"/api/0/organizations/{group.project.organization.slug}/issues/{group.id}/external-issues/{external_issue.id}/"
 
         response = self.client.delete(url, format="json")
 


### PR DESCRIPTION
Add deprecation decorator to DELETE method of GroupExternalIssueDetailsEndpoint and update tests to use org-scoped URL pattern.
