### PR TITLE
chore(api): deprecate non-org-scoped group external issues endpoint

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -5,10 +5,12 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializerResponse,
@@ -38,6 +40,7 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         },
         examples=SentryAppExamples.GET_PLATFORM_EXTERNAL_ISSUE,
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-external-issues"])
     def get(self, request: Request, group) -> Response:
         """
         Retrieve custom integration issue links for the given Sentry issue

--- a/tests/sentry/api/endpoints/test_group_external_issues.py
+++ b/tests/sentry/api/endpoints/test_group_external_issues.py
@@ -16,7 +16,7 @@ class GroupExternalIssuesEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        url = f"/api/0/issues/{group.id}/external-issues/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/external-issues/"
         response = self.client.get(url, format="json")
         external_issue = PlatformExternalIssue.objects.get()
         assert response.status_code == 200, response.content


### PR DESCRIPTION
Add deprecation decorator to GET method of GroupExternalIssuesEndpoint and update tests to use org-scoped URL pattern.
