### PR TITLE
chore(issues): Update external issues URLs to use org-scoped endpoints

### DIFF
--- a/static/app/actionCreators/platformExternalIssues.tsx
+++ b/static/app/actionCreators/platformExternalIssues.tsx
@@ -2,11 +2,12 @@ import type {Client} from 'sentry/api';
 
 export async function deleteExternalIssue(
   api: Client,
+  orgSlug: string,
   groupId: string,
   externalIssueId: string
 ) {
   return await api.requestPromise(
-    `/issues/${groupId}/external-issues/${externalIssueId}/`,
+    `/organizations/${orgSlug}/issues/${groupId}/external-issues/${externalIssueId}/`,
     {method: 'DELETE'}
   );
 }

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -68,7 +68,7 @@ export function useSentryAppExternalIssues({
           : `${appDisplayName}: ${externalIssue.displayName}`,
         displayIcon,
         onUnlink: () => {
-          deleteExternalIssue(api, group.id, externalIssue.id)
+          deleteExternalIssue(api, organization.slug, group.id, externalIssue.id)
             .then(_data => {
               onDeleteExternalIssue(externalIssue);
               addSuccessMessage(t('Successfully unlinked issue.'));

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
@@ -101,7 +101,7 @@ describe('ExternalIssueSidebarList', () => {
     });
 
     const unlinkMock = MockApiClient.addMockResponse({
-      url: `/issues/1/external-issues/1/`,
+      url: `/organizations/${organization.slug}/issues/1/external-issues/1/`,
       method: 'DELETE',
     });
 


### PR DESCRIPTION
Update the deleteExternalIssue function and its callers to use the org-scoped URL pattern /organizations/{org}/issues/{id}/external-issues/{id}/ instead of the deprecated /issues/{id}/external-issues/{id}/ pattern.