### PR TITLE
chore(integrations): reduce noisy logging across integrations

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -341,7 +341,7 @@ class AwsLambdaCloudFormationPipelineView:
                 # if we have a configuration error, we should blow up the pipeline
                 raise
             except Exception as e:
-                logger.exception(
+                logger.warning(
                     "AwsLambdaCloudFormationPipelineView.unexpected_error",
                     extra={"error": str(e)},
                 )

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -189,7 +189,7 @@ class BitbucketWebhookEndpoint(Endpoint):
 
         body = bytes(request.body)
         if not body:
-            logger.error(
+            logger.warning(
                 "%s.webhook.missing-body", PROVIDER_NAME, extra={"organization_id": organization.id}
             )
             return HttpResponse(status=400)
@@ -197,7 +197,7 @@ class BitbucketWebhookEndpoint(Endpoint):
         try:
             handler = self.get_handler(request.META["HTTP_X_EVENT_KEY"])
         except KeyError:
-            logger.exception(
+            logger.warning(
                 "%s.webhook.missing-event",
                 PROVIDER_NAME,
                 extra={"organization_id": organization.id},
@@ -216,7 +216,7 @@ class BitbucketWebhookEndpoint(Endpoint):
                 break
 
         if not valid_ip and address_string not in BITBUCKET_IPS:
-            logger.error(
+            logger.warning(
                 "%s.webhook.invalid-ip-range",
                 PROVIDER_NAME,
                 extra={"organization_id": organization.id},
@@ -226,7 +226,7 @@ class BitbucketWebhookEndpoint(Endpoint):
         try:
             event = orjson.loads(body)
         except orjson.JSONDecodeError:
-            logger.exception(
+            logger.warning(
                 "%s.webhook.invalid-json",
                 PROVIDER_NAME,
                 extra={"organization_id": organization.id},

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -171,7 +171,7 @@ class BitbucketServerWebhookEndpoint(Endpoint):
         try:
             organization: Organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:
-            logger.exception(
+            logger.warning(
                 "%s.webhook.invalid-organization",
                 PROVIDER_NAME,
                 extra={"organization_id": organization_id, "integration_id": integration_id},
@@ -180,7 +180,7 @@ class BitbucketServerWebhookEndpoint(Endpoint):
 
         body = bytes(request.body)
         if not body:
-            logger.error(
+            logger.warning(
                 "%s.webhook.missing-body", PROVIDER_NAME, extra={"organization_id": organization.id}
             )
             return HttpResponse(status=400)
@@ -188,7 +188,7 @@ class BitbucketServerWebhookEndpoint(Endpoint):
         try:
             handler = self.get_handler(request.META["HTTP_X_EVENT_KEY"])
         except KeyError:
-            logger.exception(
+            logger.warning(
                 "%s.webhook.missing-event",
                 PROVIDER_NAME,
                 extra={"organization_id": organization.id, "integration_id": integration_id},
@@ -201,7 +201,7 @@ class BitbucketServerWebhookEndpoint(Endpoint):
         try:
             event = orjson.loads(body)
         except orjson.JSONDecodeError:
-            logger.exception(
+            logger.warning(
                 "%s.webhook.invalid-json",
                 PROVIDER_NAME,
                 extra={"organization_id": organization.id, "integration_id": integration_id},

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -76,13 +76,13 @@ class CursorWebhookEndpoint(Endpoint):
         )
 
         if not integrations:
-            logger.error(
+            logger.warning(
                 "cursor_webhook.no_integrations", extra={"organization_id": organization_id}
             )
             return None
 
         if len(integrations) > 1:
-            logger.error(
+            logger.warning(
                 "cursor_webhook.multiple_integrations",
                 extra={
                     "organization_id": organization_id,
@@ -94,7 +94,7 @@ class CursorWebhookEndpoint(Endpoint):
         installation = integrations[0].get_installation(organization_id)
 
         if not isinstance(installation, CursorAgentIntegration):
-            logger.error(
+            logger.warning(
                 "cursor_webhook.unexpected_installation_type",
                 extra={
                     "integration_id": integrations[0].id,
@@ -147,7 +147,7 @@ class CursorWebhookEndpoint(Endpoint):
 
     def _handle_unknown_event(self, payload: dict[str, Any]) -> None:
         """Handle unknown event types."""
-        logger.error("cursor_webhook.unknown_event", extra=payload)
+        logger.warning("cursor_webhook.unknown_event", extra=payload)
 
     def _handle_status_change(self, payload: dict[str, Any]) -> None:
         """Handle status change events."""
@@ -160,7 +160,7 @@ class CursorWebhookEndpoint(Endpoint):
         summary = payload.get("summary")
 
         if not agent_id or not cursor_status:
-            logger.error(
+            logger.warning(
                 "cursor_webhook.status_change_missing_data",
                 extra={"agent_id": agent_id, "status": cursor_status},
             )
@@ -168,7 +168,7 @@ class CursorWebhookEndpoint(Endpoint):
 
         status = CodingAgentStatus.from_cursor_status(cursor_status)
         if not status:
-            logger.error(
+            logger.warning(
                 "cursor_webhook.unknown_status",
                 extra={"cursor_status": cursor_status, "agent_id": agent_id},
             )
@@ -187,7 +187,7 @@ class CursorWebhookEndpoint(Endpoint):
 
         repo_url = source.get("repository", None)
         if not repo_url:
-            logger.error(
+            logger.warning(
                 "cursor_webhook.repo_not_found",
                 extra={"agent_id": agent_id, "source": source},
             )
@@ -199,7 +199,7 @@ class CursorWebhookEndpoint(Endpoint):
 
         parsed = urlparse(repo_url)
         if parsed.netloc != "github.com":
-            logger.error(
+            logger.warning(
                 "cursor_webhook.not_github_repo",
                 extra={"agent_id": agent_id, "repo": repo_url},
             )
@@ -211,7 +211,7 @@ class CursorWebhookEndpoint(Endpoint):
         # If the repo isn't in the owner/repo format we can't work with it
         # Allow dots in the repository name segment (owner.repo is common)
         if not re.match(r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$", repo_full_name):
-            logger.error(
+            logger.warning(
                 "cursor_webhook.repo_format_invalid",
                 extra={"agent_id": agent_id, "source": source},
             )
@@ -254,7 +254,7 @@ class CursorWebhookEndpoint(Endpoint):
                 },
             )
         except SeerApiError:
-            logger.exception(
+            logger.warning(
                 "cursor_webhook.seer_update_error",
                 extra={
                     "agent_id": agent_id,

--- a/src/sentry/integrations/data_forwarding/segment/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/segment/forwarder.py
@@ -102,7 +102,7 @@ class SegmentForwarder(BaseDataForwarder):
                 )
                 response.raise_for_status()
         except Exception:
-            logger.exception(
+            logger.warning(
                 "segment.send_payload.error",
                 extra={"event_id": event.event_id, "project_id": event.project_id},
             )

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -123,7 +123,7 @@ class DiscordIntegration(IntegrationInstallation, IntegrationNotificationClient)
             # The bot failed to leave the guild for some other reason, but
             # this doesn't need to interrupt the uninstall. Just means the
             # bot will persist on the server until removed manually.
-            logger.error(
+            logger.warning(
                 "discord.uninstall.failed_to_leave_guild",
                 extra={"discord_guild_id": self.model.external_id, "status": e.code},
             )
@@ -210,7 +210,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
         try:
             return self.client.has_application_commands()
         except ApiError as e:
-            logger.error(
+            logger.warning(
                 "discord.fail.setup.get_application_commands",
                 extra={
                     "status": e.code,
@@ -232,7 +232,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
                 for command in COMMANDS:
                     self.client.set_application_command(command)
             except ApiError as e:
-                logger.error(
+                logger.warning(
                     "discord.fail.setup.set_application_command",
                     extra={
                         "status": e.code,
@@ -284,7 +284,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
             (self.application_id, self.public_key, self.bot_token, self.client_secret)
         )
         if not has_credentials:
-            logger.error(
+            logger.warning(
                 "discord.install.fail.credentials_exist",
                 extra={
                     "application_id": self.application_id,

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -245,7 +245,7 @@ class DiscordRequest:
         logger.info(key, extra=extra)
 
     def _error(self, key: str) -> None:
-        logger.error(key, extra={**self.logging_data})
+        logger.warning(key, extra={**self.logging_data})
 
     def is_ping(self) -> bool:
         return self._data.get("type", 0) == DiscordRequestTypes.PING

--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -79,7 +79,7 @@ class DiscordInteractionsEndpoint(Endpoint):
         except DiscordRequestError as e:
             if SiloMode.get_current_mode() != SiloMode.MONOLITH:
                 sentry_sdk.capture_exception(e)
-            logger.exception(
+            logger.warning(
                 "discord.request.error",
                 extra={
                     "error": str(e),
@@ -88,7 +88,7 @@ class DiscordInteractionsEndpoint(Endpoint):
             )
             return self.respond(status=e.status)
         except Exception as e:
-            logger.exception(
+            logger.warning(
                 "discord.request.unexpected_error",
                 extra={
                     "error": str(e),

--- a/src/sentry/integrations/github/blame.py
+++ b/src/sentry/integrations/github/blame.py
@@ -88,7 +88,7 @@ def create_blame_query(
         try:
             [repo_owner, repo_name] = full_repo_name.split("/", maxsplit=1)
         except ValueError:
-            logger.exception(
+            logger.warning(
                 "get_blame_for_files.create_blame_query.invalid_repo_name",
                 extra={**extra, "repo_name": full_repo_name},
             )
@@ -161,7 +161,7 @@ def extract_commits_from_blame_response(
                     f"blame{file_path_index}"
                 )
                 if not blame:
-                    logger.error(
+                    logger.warning(
                         "get_blame_for_files.extract_commits_from_blame.missing_file_blame",
                         extra={
                             **extra,
@@ -220,7 +220,7 @@ def _get_matching_file_blame(
 
     commit: GitHubFileBlameCommit | None = matching_blame_range.get("commit", None)
     if not commit:
-        logger.error(
+        logger.warning(
             "get_blame_for_files.extract_commits_from_blame.no_commit_data",
             extra=extra,
         )
@@ -230,7 +230,7 @@ def _get_matching_file_blame(
     commit_id = commit.get("oid")
 
     if not commit_id:
-        logger.error(
+        logger.warning(
             "get_blame_for_files.extract_commits_from_blame.invalid_commit_response",
             extra={
                 **extra,
@@ -239,7 +239,7 @@ def _get_matching_file_blame(
         )
         return None
     if not committed_date_str:
-        logger.error(
+        logger.warning(
             "get_blame_for_files.extract_commits_from_blame.invalid_commit_response",
             extra={
                 **extra,
@@ -252,7 +252,7 @@ def _get_matching_file_blame(
     try:
         committed_date = datetime.fromisoformat(committed_date_str).astimezone(timezone.utc)
     except Exception:
-        logger.exception(
+        logger.warning(
             "get_blame_for_files.extract_commits_from_blame.invalid_commit_response",
             extra={
                 **extra,

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -692,7 +692,7 @@ class GitHubBaseClient(
                 metrics.incr(
                     "integrations.github.get_blame_for_files.not_enough_requests_remaining"
                 )
-                logger.error(
+                logger.warning(
                     "sentry.integrations.github.get_blame_for_files.rate_limit",
                     extra={
                         "provider": IntegrationProviderSlug.GITHUB,
@@ -723,7 +723,7 @@ class GitHubBaseClient(
                     allow_text=False,
                 )
             except ValueError as e:
-                logger.exception(str(e), log_info)
+                logger.warning(str(e), log_info)
                 return []
             else:
                 self.set_cache(cache_key, response, 60)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -197,7 +197,7 @@ def error(
         org_id = None
     else:
         org_id = org.organization.id
-    logger.error(
+    logger.warning(
         "github.installation_error",
         extra={"org_id": org_id, "error_short": error_short},
     )

--- a/src/sentry/integrations/github/issue_sync.py
+++ b/src/sentry/integrations/github/issue_sync.py
@@ -46,7 +46,7 @@ class GitHubIssueSyncSpec(IssueSyncIntegration):
             repo_id, issue_num = external_issue_key.split("#")
             return repo_id, issue_num
         except ValueError:
-            logger.exception(
+            logger.warning(
                 "assignee-outbound.invalid-key",
                 extra={
                     "external_issue_key": external_issue_key,
@@ -71,7 +71,7 @@ class GitHubIssueSyncSpec(IssueSyncIntegration):
         repo_id, issue_num = self.split_external_issue_key(external_issue.key)
 
         if not repo_id or not issue_num:
-            logger.error(
+            logger.warning(
                 "assignee-outbound.invalid-key",
                 extra={
                     "provider": self.model.provider,
@@ -131,7 +131,7 @@ class GitHubIssueSyncSpec(IssueSyncIntegration):
         repo_id, issue_num = self.split_external_issue_key(external_issue.key)
 
         if not repo_id or not issue_num:
-            logger.error(
+            logger.warning(
                 "status-outbound.invalid-key",
                 extra={
                     "external_issue_key": external_issue.key,

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -164,7 +164,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             if not host:
                 raise MissingRequiredHeaderError()
         except MissingRequiredHeaderError as e:
-            logger.exception("github_enterprise.webhook.missing-enterprise-host")
+            logger.warning("github_enterprise.webhook.missing-enterprise-host")
             sentry_sdk.capture_exception(e)
             return HttpResponse(MISSING_GITHUB_ENTERPRISE_HOST_ERROR, status=400)
 
@@ -187,9 +187,8 @@ class GitHubEnterpriseWebhookBase(Endpoint):
                 raise MissingRequiredHeaderError()
 
             handler = self.get_handler(github_event)
-        except MissingRequiredHeaderError as e:
-            logger.exception("github_enterprise.webhook.missing-event", extra=extra)
-            sentry_sdk.capture_exception(e)
+        except MissingRequiredHeaderError:
+            logger.warning("github_enterprise.webhook.missing-event", extra=extra)
             return HttpResponse(MISSING_GITHUB_EVENT_HEADER_ERROR, status=400)
 
         if not handler:
@@ -205,7 +204,6 @@ class GitHubEnterpriseWebhookBase(Endpoint):
                 extra=extra,
                 exc_info=True,
             )
-            logger.exception("Invalid JSON.")
             return HttpResponse(status=400)
 
         secret = self.get_secret(event, host)
@@ -252,7 +250,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         except UnsupportedSignatureAlgorithmError as e:
             # we should never end up here with the regex checks above on the signature format,
             # but just in case
-            logger.exception(
+            logger.warning(
                 "github-enterprise-app.webhook.unsupported-signature-algorithm",
                 extra=extra,
             )

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -192,5 +192,5 @@ def _create_commit_from_blame(
             committedDate=datetime.fromisoformat(committed_date).replace(tzinfo=timezone.utc),
         )
     except Exception:
-        logger.exception("get_blame_for_files.invalid_commit_response", extra=extra)
+        logger.warning("get_blame_for_files.invalid_commit_response", extra=extra)
         return None

--- a/src/sentry/integrations/issue_alert_image_builder.py
+++ b/src/sentry/integrations/issue_alert_image_builder.py
@@ -73,7 +73,7 @@ class IssueAlertImageBuilder:
                     extra={"group_id": self.group.id},
                 )
         except Exception as e:
-            logger.exception(
+            logger.warning(
                 "issue_alert_chartcuterie_image.failed",
                 extra={"exception": e, "group_id": self.group.id},
             )

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -101,13 +101,13 @@ class JiraWebhookBase(Endpoint, abc.ABC):
                     exc.text = f"Gateway timeout when connecting to {jira_api_endpoint}"
                 else:  # generic ApiError
                     exc.text = f"Unknown error when requesting {jira_api_endpoint}"
-                    logger.error("Unclear JIRA exception")
+                    logger.warning("Unclear JIRA exception")
 
         # OperationalErrors are errors talking to our postgres DB
         elif isinstance(exc, OperationalError):
             pass  # No processing needed and these are known errors
         else:
-            logger.error("Unclear JIRA exception")
+            logger.warning("Unclear JIRA exception")
 
         # This will log the error locally, capture the exception and send it to Sentry, and create a
         # generic 500/Internal Error response

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -100,7 +100,6 @@ class JiraServerIssueUpdatedWebhook(Endpoint):
         except (ApiError, ObjectDoesNotExist) as err:
             extra.update({"token": token, "error": str(err)})
             logger.info("sync-failed", extra=extra)
-            logger.exception("Invalid token.")
             return self.respond(status=400)
         else:
             return self.respond()

--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -154,7 +154,7 @@ class IdentityLinkageView(LinkageView, ABC):
                     self.provider, request.user, integration_id=integration_id
                 )
         except Http404:
-            logger.exception("get_identity_error", extra={"integration_id": integration_id})
+            logger.warning("get_identity_error", extra={"integration_id": integration_id})
             self.capture_metric("failure.get_identity")
             return self.render_error_page(
                 request,
@@ -196,7 +196,7 @@ class IdentityLinkageView(LinkageView, ABC):
             external_id: str = params_dict[self.external_id_parameter]
         except KeyError as e:
             event = self.capture_metric("failure.post.missing_params", tags={"error": str(e)})
-            logger.exception(event)
+            logger.warning(event)
             return self.render_error_page(
                 request,
                 status=400,
@@ -284,7 +284,7 @@ class LinkIdentityView(IdentityLinkageView, ABC):
             Identity.objects.link_identity(user=request.user, idp=idp, external_id=external_id)
         except IntegrityError:
             event = self.capture_metric("failure.integrity_error")
-            logger.exception(event)
+            logger.warning(event)
             raise Http404
 
 
@@ -323,7 +323,7 @@ class UnlinkIdentityView(IdentityLinkageView, ABC):
             identities.delete()
         except IntegrityError:
             tag = f"{self.provider_slug}.unlink.integrity-error"
-            logger.exception(tag)
+            logger.warning(tag)
             raise Http404
         return None
 

--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -127,7 +127,7 @@ def send_notification_as_msteams(
 
                         notification.record_notification_sent(recipient, ExternalProviders.MSTEAMS)
                     except Exception:
-                        logger.exception("Exception occurred while trying to send the notification")
+                        logger.warning("Exception occurred while trying to send the notification")
 
     metrics.incr(
         f"{notification.metrics_key}.notifications.sent",

--- a/src/sentry/integrations/opsgenie/actions/notification.py
+++ b/src/sentry/integrations/opsgenie/actions/notification.py
@@ -46,12 +46,12 @@ class OpsgenieNotifyTeamAction(IntegrationEventAction):
     def after(self, event, notification_uuid: str | None = None):
         integration = self.get_integration()
         if not integration:
-            logger.error("Integration removed, but the rule still refers to it")
+            logger.warning("Integration removed, but the rule still refers to it")
             return
 
         org_integration = self.get_organization_integration()
         if not org_integration:
-            logger.error("No associated org integration.")
+            logger.warning("No associated org integration.")
             return
 
         team = get_team(self.get_option("team"), org_integration)
@@ -61,7 +61,7 @@ class OpsgenieNotifyTeamAction(IntegrationEventAction):
         )
 
         if not team:
-            logger.error(
+            logger.warning(
                 "The Opsgenie team no longer exists, or the team does not belong to the selected account."
             )
             return

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -291,7 +291,7 @@ class OpsgenieIntegrationProvider(IntegrationProvider):
                 )
 
             except OrganizationIntegration.DoesNotExist:
-                logger.exception("The Opsgenie post_install step failed.")
+                logger.warning("The Opsgenie post_install step failed.")
                 return
 
             key = integration.metadata["api_key"]

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -212,7 +212,7 @@ class PagerDutyIntegrationProvider(IntegrationProvider):
                     integration=integration, organization_id=organization.id
                 )
             except OrganizationIntegration.DoesNotExist:
-                logger.exception("The PagerDuty post_install step failed.")
+                logger.warning("The PagerDuty post_install step failed.")
                 return
 
             with transaction.atomic(router.db_for_write(OrganizationIntegration)):

--- a/src/sentry/integrations/perforce/repository.py
+++ b/src/sentry/integrations/perforce/repository.py
@@ -87,7 +87,7 @@ class PerforceRepositoryProvider(IntegrationRepositoryProvider):
         except Exception as e:
             # Log and re-raise connection/P4 errors
             # We cannot create a repository if we can't validate the depot exists
-            logger.exception(
+            logger.warning(
                 "perforce.get_repository_data.depot_validation_failed",
                 extra={"depot_path": depot_path.path},
             )
@@ -250,7 +250,7 @@ class PerforceRepositoryProvider(IntegrationRepositoryProvider):
 
         except (ValueError, TypeError) as e:
             # Log conversion errors for debugging
-            logger.exception(
+            logger.warning(
                 "perforce.compare_commits.invalid_changelist",
                 extra={
                     "start_sha": start_sha,
@@ -262,7 +262,7 @@ class PerforceRepositoryProvider(IntegrationRepositoryProvider):
             )
             return []
         except Exception as e:
-            logger.exception(
+            logger.warning(
                 "perforce.compare_commits.failed",
                 extra={
                     "start_sha": start_sha,

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -87,12 +87,12 @@ def is_violating_region_restriction(organization_id: int, integration_id: int):
     )
 
     if len(region_names) > 1:
-        logger.error("region_violation", extra={"regions": region_names, **logger_extra})
+        logger.warning("region_violation", extra={"regions": region_names, **logger_extra})
 
     try:
         mapping = OrganizationMapping.objects.get(organization_id=organization_id)
     except OrganizationMapping.DoesNotExist:
-        logger.exception("mapping_missing", extra=logger_extra)
+        logger.warning("mapping_missing", extra=logger_extra)
         return True
 
     return mapping.region_name not in region_names

--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -130,7 +130,7 @@ class IssueAlertNotificationMessageRepository:
         except NotificationMessage.DoesNotExist:
             return None
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "Failed to get parent notification for issue rule",
                 exc_info=e,
                 extra={
@@ -159,7 +159,7 @@ class IssueAlertNotificationMessageRepository:
             )
             return IssueAlertNotificationMessage.from_model(instance=new_instance)
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "failed to create new issue alert notification alert",
                 exc_info=e,
                 extra=data.__dict__,
@@ -193,7 +193,7 @@ class IssueAlertNotificationMessageRepository:
             for instance in query:
                 yield IssueAlertNotificationMessage.from_model(instance=instance)
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "Failed to get parent notifications on filters",
                 exc_info=e,
                 extra=filter.__dict__,

--- a/src/sentry/integrations/repository/metric_alert.py
+++ b/src/sentry/integrations/repository/metric_alert.py
@@ -106,7 +106,7 @@ class MetricAlertNotificationMessageRepository:
         except NotificationMessage.DoesNotExist:
             return None
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "Failed to get parent notification for metric rule",
                 exc_info=e,
                 extra={
@@ -134,7 +134,7 @@ class MetricAlertNotificationMessageRepository:
             )
             return MetricAlertNotificationMessage.from_model(instance=new_instance)
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "failed to create new metric alert notification alert",
                 exc_info=e,
                 extra=data.__dict__,

--- a/src/sentry/integrations/repository/notification_action.py
+++ b/src/sentry/integrations/repository/notification_action.py
@@ -125,7 +125,7 @@ class NotificationActionNotificationMessageRepository:
         except NotificationMessage.DoesNotExist:
             return None
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "Failed to get parent notification for issue rule",
                 exc_info=e,
                 extra={
@@ -153,7 +153,7 @@ class NotificationActionNotificationMessageRepository:
             )
             return NotificationActionNotificationMessage.from_model(instance=instance)
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "failed to create new notification action notification message",
                 exc_info=e,
                 extra=data.__dict__,
@@ -187,7 +187,7 @@ class NotificationActionNotificationMessageRepository:
             for instance in query:
                 yield NotificationActionNotificationMessage.from_model(instance=instance)
         except Exception as e:
-            self._logger.exception(
+            self._logger.warning(
                 "Failed to get parent notifications on filters",
                 exc_info=e,
                 extra=filter.__dict__,

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -228,7 +228,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
             return sdk_response.get("team")
         except SlackApiError:
-            _logger.exception("slack.install.team-info.error")
+            _logger.warning("slack.install.team-info.error")
             raise IntegrationError("Could not retrieve Slack team information.")
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -283,7 +283,7 @@ def get_suggested_assignees(
     except (Release.DoesNotExist, Commit.DoesNotExist):
         logger.info("Skipping suspect committers because release does not exist.")
     except Exception:
-        logger.exception("Could not get suspect committers. Continuing execution.")
+        logger.warning("Could not get suspect committers. Continuing execution.")
 
     if suggested_assignees:
         suggested_assignees = dedupe_suggested_assignees(suggested_assignees)

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -239,7 +239,7 @@ class SlackRequest:
         self._info("slack.request")
 
     def _error(self, key: str) -> None:
-        _logger.error(key, extra={**self.logging_data})
+        _logger.warning(key, extra={**self.logging_data})
 
     def _info(self, key: str) -> None:
         _logger.info(key, extra={**self.logging_data})

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -329,10 +329,7 @@ class SlackService:
                         lifecycle.record_failure(err)
 
         if use_open_period_start and parent_notification_count > 1:
-            sentry_sdk.capture_message(
-                f"slack.notify_all_threads_for_activity.multiple_parent_notifications_for_single_open_period Activity: {activity.id}, Group: {group.id}, Project: {activity.project.id}, Integration: {client.integration_id}, Parent Notification Count: {parent_notification_count}"
-            )
-            self._logger.error(
+            self._logger.warning(
                 "multiple parent notifications found for single open period",
                 extra={
                     "activity_id": activity.id,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -333,6 +333,9 @@ class SlackService:
                 "multiple parent notifications found for single open period",
                 extra={
                     "activity_id": activity.id,
+                    "group_id": group.id,
+                    "project_id": activity.project.id,
+                    "integration_id": client.integration_id,
                     "parent_notification_count": parent_notification_count,
                 },
             )

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -37,7 +37,7 @@ def link_slack_user_identities(
     organization_context = organization_service.get_organization_by_id(id=organization_id)
     organization = organization_context.organization if organization_context else None
     if organization is None or integration is None:
-        logger.error(
+        logger.warning(
             "slack.post_install.link_identities.invalid_params",
             extra={
                 "organization_id": organization_id,

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -165,7 +165,7 @@ def _unfurl_discover(
                 )
 
             except Exception:
-                _logger.exception("Failed to load saved query for unfurl")
+                _logger.warning("Failed to load saved query for unfurl")
             else:
                 saved_query = response.data
 
@@ -278,7 +278,7 @@ def _unfurl_discover(
                 params=params,
             )
         except Exception:
-            _logger.exception("Failed to load %s for unfurl", endpoint)
+            _logger.warning("Failed to load %s for unfurl", endpoint)
             continue
 
         chart_data = {"seriesName": params.get("yAxis"), "stats": resp.data}
@@ -288,7 +288,7 @@ def _unfurl_discover(
         try:
             url = charts.generate_chart(style, chart_data)
         except RuntimeError:
-            _logger.exception("Failed to generate chart for discover unfurl")
+            _logger.warning("Failed to generate chart for discover unfurl")
             continue
 
         unfurls[link.url] = SlackDiscoverMessageBuilder(

--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -115,7 +115,7 @@ def validate_user_id(*, input_name: str, input_user_id: str, integration_id: int
         results = client.users_info(user=input_user_id).data
 
     except SlackApiError as e:
-        _logger.exception(
+        _logger.warning(
             "rule.slack.user_info_failed",
             extra={
                 "integration_id": integration_id,
@@ -171,7 +171,7 @@ def validate_channel_id(name: str, integration_id: int, input_channel_id: str) -
             sample_rate=1.0,
             tags={"type": "conversations_info"},
         )
-        _logger.exception(
+        _logger.warning(
             "rule.slack.conversation_info_failed",
             extra={
                 "integration_id": integration_id,
@@ -228,7 +228,7 @@ def get_channel_id_with_timeout(
         _channel_id = check_for_channel(client, name)
         _prefix = "#"
     except SlackApiError:
-        _logger.exception("rule.slack.channel_check_error", extra=logger_params)
+        _logger.warning("rule.slack.channel_check_error", extra=logger_params)
         return SlackChannelIdData(prefix=_prefix, channel_id=None, timed_out=False)
 
     if _channel_id is not None:
@@ -297,7 +297,7 @@ def check_user_with_timeout(
                 )
                 return SlackChannelIdData(prefix=_prefix, channel_id=None, timed_out=True)
     except SlackApiError as e:
-        _logger.exception("rule.slack.user_check_error", extra=logger_params)
+        _logger.warning("rule.slack.user_check_error", extra=logger_params)
         if unpack_slack_api_error(e) == RATE_LIMITED:
             metrics.incr(
                 SLACK_UTILS_CHANNEL_FAILURE_DATADOG_METRIC,
@@ -344,7 +344,7 @@ def check_for_channel(
             "channel": name,
             "post_at": int(time.time() + 500),
         }
-        _logger.exception("slack.chat_scheduleMessage.error", extra=logger_params)
+        _logger.warning("slack.chat_scheduleMessage.error", extra=logger_params)
         if unpack_slack_api_error(e) == CHANNEL_NOT_FOUND:
             return None
         else:
@@ -378,5 +378,5 @@ def check_for_channel(
             "channel_id": msg_response.get("channel"),
             "scheduled_message_id": msg_response.get("scheduled_message_id"),
         }
-        _logger.exception("slack.chat_deleteScheduledMessage.error", extra=logger_params)
+        _logger.warning("slack.chat_deleteScheduledMessage.error", extra=logger_params)
         raise

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -114,7 +114,7 @@ def update_group(
 
     resp = update_groups(request=request, groups=[group], user=user, data=data)
     if resp.status_code != 200:
-        _logger.error(
+        _logger.warning(
             "slack.action.update-group-error",
             extra={
                 "group_id": group.id,
@@ -556,7 +556,7 @@ class SlackActionEndpoint(Endpoint):
         try:
             requests_.post(slack_request.response_url, json=payload)
         except ApiError:
-            _logger.exception("slack.action.response-error")
+            _logger.warning("slack.action.response-error")
             return self.respond(status=403)
 
         return self.respond()
@@ -771,7 +771,7 @@ class SlackActionEndpoint(Endpoint):
                 member.reject_member_invitation(identity_user)
         except Exception:
             # shouldn't error but if it does, respond to the user
-            _logger.exception(
+            _logger.warning(
                 "slack.action.member-invitation-error",
                 extra={
                     "organization_id": organization.id,

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -76,7 +76,7 @@ class SlackDMEndpoint(Endpoint, abc.ABC):
             )
 
         if not (slack_request.integration and slack_request.user_id and slack_request.channel_id):
-            logger.error(".link-user.bad_request.error", extra={"slack_request": slack_request})
+            logger.warning(".link-user.bad_request.error", extra={"slack_request": slack_request})
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 
         associate_url = build_linking_url(

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -110,7 +110,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         client = SlackSdkClient(integration_id=slack_request.integration.id)
         if slack_request.user_id is None:
-            _logger.error("prompt_link.post-ephemeral-error", extra=logger_params)
+            _logger.warning("prompt_link.post-ephemeral-error", extra=logger_params)
         else:
             try:
                 client.chat_postEphemeral(
@@ -120,7 +120,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                     **SlackPromptLinkMessageBuilder(associate_url).as_payload(),
                 )
             except SlackApiError:
-                _logger.exception("prompt_link.post-ephemeral-error", extra=logger_params)
+                _logger.warning("prompt_link.post-ephemeral-error", extra=logger_params)
 
     def on_message(self, request: Request, slack_request: SlackDMRequest) -> Response:
         command = request.data.get("event", {}).get("text", "").lower()
@@ -145,7 +145,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         client = SlackSdkClient(integration_id=slack_request.integration.id)
         if slack_request.channel_id is None:
-            _logger.error("on_message.post-message-error", extra=logger_params)
+            _logger.warning("on_message.post-message-error", extra=logger_params)
         else:
             try:
                 client.chat_postMessage(
@@ -156,7 +156,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                     ).as_payload(),
                 )
             except SlackApiError:
-                _logger.exception("on_message.post-message-error", extra=logger_params)
+                _logger.warning("on_message.post-message-error", extra=logger_params)
 
         return self.respond()
 

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -100,7 +100,7 @@ class SlackOptionsLoadEndpoint(Endpoint):
         )
 
         if not group:
-            _logger.error(
+            _logger.warning(
                 "slack.options_load.request-error",
                 extra={
                     "group_id": slack_request.group_id,

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -547,7 +547,7 @@ class PRCommentWorkflow(ABC):
                 for row in result["data"]
             ]
         except Exception:
-            logger.exception(
+            logger.warning(
                 "Fetching top 5 issues by count from EAP failed",
                 extra={
                     "issue_ids": issue_ids,

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -153,7 +153,7 @@ class RepoTreesIntegration(ABC):
                     connection_error_count += 1
             except Exception:
                 # Report for investigation but do not stop processing
-                logger.exception(
+                logger.warning(
                     "Failed to populate_tree. Investigate. Contining execution.", extra=extra
                 )
 
@@ -261,7 +261,7 @@ def filter_source_code_files(files: list[str]) -> list[str]:
             if should_include(file_path):
                 supported_files.append(file_path)
         except Exception:
-            logger.exception("We've failed to store the file path.")
+            logger.warning("We've failed to store the file path.")
 
     return supported_files
 

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -315,19 +315,19 @@ def _get_blames_from_all_integrations(
                     )
                 else:
                     if e.code == 429:
-                        logger.exception(
+                        logger.warning(
                             "process_commit_context_all_frames.get_commit_context_all_frames.rate_limit",
                             extra={**log_info, "error_message": e.text},
                         )
                     else:
-                        logger.exception(
+                        logger.warning(
                             "process_commit_context_all_frames.get_commit_context_all_frames.api_error",
                             extra={**log_info, "code": e.code, "error_message": e.text},
                         )
                     # Rate limit and other API errors should be raised to the task to trigger a retry
                     raise
             except Exception:
-                logger.exception(
+                logger.warning(
                     "process_commit_context_all_frames.get_commit_context_all_frames.unknown_error",
                     extra=log_info,
                 )

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -62,5 +62,5 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     except concurrent.futures.TimeoutError:
         return None
     except Exception as e:
-        logger.exception("Error generating issue summary: %s", e)
+        logger.warning("Error generating issue summary: %s", e)
         return None

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -200,7 +200,7 @@ class EventLifecycle:
 
     @staticmethod
     def _report_flow_error(message) -> None:
-        logger.error("EventLifecycle flow error: %s", message)
+        logger.warning("EventLifecycle flow error: %s", message)
 
     def _terminate(
         self,

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -94,7 +94,7 @@ def bind_org_context_from_integration(
         if org is not None:
             bind_organization_context(org.organization)
         else:
-            logger.error(
+            logger.warning(
                 "Unable to call organization_service.get_organization_by_id with organization id=%s.",
                 org_integration.organization_id,
                 extra=extra,

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -245,7 +245,7 @@ class VercelIntegration(IntegrationInstallation):
         for configuration_id, data in self.metadata["configurations"].items():
             if data["organization_id"] == self.organization_id:
                 return configuration_id
-        logger.error(
+        logger.warning(
             "could not find matching org",
             extra={"organization_id": self.organization_id, "integration_id": self.model.id},
         )

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -162,11 +162,11 @@ class VercelWebhookEndpoint(Endpoint):
 
     def post(self, request: Request) -> Response | None:
         if not request.META.get("HTTP_X_VERCEL_SIGNATURE"):
-            logger.error("vercel.webhook.missing-signature")
+            logger.warning("vercel.webhook.missing-signature")
             return self.respond(status=401)
         is_valid = verify_signature(request)
         if not is_valid:
-            logger.error("vercel.webhook.invalid-signature")
+            logger.warning("vercel.webhook.invalid-signature")
             return self.respond(status=401)
 
         # Vercel's webhook allows you to subscribe to different events,
@@ -389,7 +389,7 @@ class VercelWebhookEndpoint(Endpoint):
                         resp.raise_for_status()
                     except RequestException as e:
                         # errors here should be uncommon but we should be aware of them
-                        logger.exception(
+                        logger.warning(
                             "Error creating release: %s - %s",
                             e,
                             json_error,

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -56,7 +56,7 @@ class GitlabRequestParser(BaseRequestParser):
                 self._METRIC_CONTROL_PATH_FAILURE_KEY,
                 tags={"integration": self.provider, "error": str(e)},
             )
-            logger.exception("Failed to get integration from request")
+            logger.warning("Failed to get integration from request")
 
         return None
 

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -178,7 +178,7 @@ class SlackRequestParser(BaseRequestParser):
             if self.action_option in CONTROL_RESPONSE_ACTIONS:
                 CONTROL_RESPONSE_ACTIONS[self.action_option](self.request, self.action_option)
         except ValueError:
-            logger.exception(
+            logger.warning(
                 "slack.control.response.error",
                 extra={
                     "integration_id": integration and integration.id,

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -79,7 +79,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                 else AutofixStoppingPoint.ROOT_CAUSE
             )
         except ValueError:
-            logger.exception(
+            logger.warning(
                 "invalid_autofix_stopping_point",
                 extra={
                     "stopping_point": action.value,
@@ -123,7 +123,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                 message_ts=self.thread_ts,
             )
         except (IntegrationError, TypeError, KeyError):
-            logger.exception(
+            logger.warning(
                 "slack.autofix.update_message_failed",
                 extra={
                     "channel_id": self.channel_id,
@@ -163,7 +163,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             status=ObjectStatus.ACTIVE,
         )
         if not integration:
-            logger.error("integration_not_found", extra=logging_ctx)
+            logger.warning("integration_not_found", extra=logging_ctx)
             return
 
         install = SlackIntegration(

--- a/tests/sentry/integrations/discord/test_uninstall.py
+++ b/tests/sentry/integrations/discord/test_uninstall.py
@@ -89,12 +89,12 @@ class DiscordUninstallTest(APITestCase):
         self.assert_leave_guild_api_call_count(1)
 
     @responses.activate
-    @mock.patch("sentry.integrations.discord.integration.logger.error")
-    def test_uninstall_unexpected_failure(self, mock_log_error: mock.MagicMock) -> None:
+    @mock.patch("sentry.integrations.discord.integration.logger.warning")
+    def test_uninstall_unexpected_failure(self, mock_log_warning: mock.MagicMock) -> None:
         self.mock_discord_guild_leave(status=500)
         self.uninstall()
         self.assert_leave_guild_api_call_count(1)
-        assert mock_log_error.call_count == 1
+        assert mock_log_warning.call_count == 1
 
     @responses.activate
     def test_uninstall_multiple_orgs(self) -> None:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1645,10 +1645,10 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             ],
         )
 
-    @mock.patch("sentry.integrations.github.client.logger.error")
+    @mock.patch("sentry.integrations.github.client.logger.warning")
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_get_blame_for_files_invalid_commit(self, get_jwt, mock_logger_error) -> None:
+    def test_get_blame_for_files_invalid_commit(self, get_jwt, mock_logger_warning) -> None:
         """
         Tests commits that have invalid data are skipped and logged
         """
@@ -1717,7 +1717,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
         response = self.github_client.get_blame_for_files([file1, file2], extra={})
         self.assertEqual(response, [])
 
-        mock_logger_error.assert_has_calls(
+        mock_logger_warning.assert_has_calls(
             [
                 mock.call(
                     "get_blame_for_files.extract_commits_from_blame.invalid_commit_response",
@@ -1789,13 +1789,13 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
             content_type="application/json",
         )
 
-    @mock.patch("sentry.integrations.github.client.logger.error")
+    @mock.patch("sentry.integrations.github.client.logger.warning")
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_rate_limit_exceeded(self, get_jwt, mock_logger_error) -> None:
+    def test_rate_limit_exceeded(self, get_jwt, mock_logger_warning) -> None:
         with pytest.raises(ApiRateLimitedError):
             self.github_client.get_blame_for_files([self.file], extra={})
-        mock_logger_error.assert_called_with(
+        mock_logger_warning.assert_called_with(
             "sentry.integrations.github.get_blame_for_files.rate_limit",
             extra={
                 "provider": "github",

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -70,7 +70,7 @@ class WebhookTest(GitLabTestCase):
         assert response.status_code == 400
         assert (
             response.reason_phrase
-            == "The customer has edited the webhook in Gitlab to include other types of events."
+            == "The customer has edited the webhook in Gitlab to include other types of events. We only support these kinds of events: Merge Request Hook, Push Hook"
         )
 
     def test_invalid_token(self) -> None:

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -356,4 +356,4 @@ class JiraWebhookBaseTest(TestCase):
 
             assert mock_super_handle_exception.call_args.args[1] == unknown_error
             assert str(unknown_error) == expected_error_message
-            assert mock_logger.error.call_args.args[0] == "Unclear JIRA exception"
+            assert mock_logger.warning.call_args.args[0] == "Unclear JIRA exception"

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -244,7 +244,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         results = list(rule.after(event=event))
         assert len(results) == 0
         assert (
-            mock_logger.error.call_args.args[0]
+            mock_logger.warning.call_args.args[0]
             == "The Opsgenie team no longer exists, or the team does not belong to the selected account."
         )
 
@@ -259,7 +259,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         results = list(rule.after(event=event))
         assert len(results) == 0
         assert (
-            mock_logger.error.call_args.args[0]
+            mock_logger.warning.call_args.args[0]
             == "Integration removed, but the rule still refers to it"
         )
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -835,7 +835,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
         mock_process_suspect_commits.assert_not_called()
 
-    @patch("sentry.integrations.utils.commit_context.logger.exception")
+    @patch("sentry.integrations.utils.commit_context.logger.warning")
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
@@ -845,7 +845,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         self,
         mock_get_commit_context,
         mock_process_suspect_commits,
-        mock_logger_exception,
+        mock_logger_warning,
     ):
         """
         A failure case where the integration returned an API error.
@@ -866,7 +866,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
         mock_process_suspect_commits.assert_not_called()
 
-        mock_logger_exception.assert_any_call(
+        mock_logger_warning.assert_any_call(
             "process_commit_context_all_frames.get_commit_context_all_frames.unknown_error",
             extra={
                 "organization": self.organization.id,


### PR DESCRIPTION
downgrade logger.error and logger.exception calls to logger.warning for expected error conditions across all integrations. these errors are typically caused by external factors (invalid webhooks, api errors, missing data, auth failures) and don't need to create sentry issues.

this reduces noise in our error tracking and helps us focus on actual bugs rather than expected failure modes from external services.