### PR TITLE
Add PreprodSearchBar

### DIFF
--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,0 +1,86 @@
+import {useMemo} from 'react';
+
+import type {TagCollection} from 'sentry/types/group';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+interface PreprodSearchBarProps {
+  initialQuery: string;
+  /**
+   * Optional list of attribute keys to show. If not provided, all attributes are shown.
+   */
+  allowedKeys?: string[];
+  onChange?: (query: string, state: {queryIsValid: boolean}) => void;
+  onSearch?: (query: string) => void;
+  portalTarget?: HTMLElement | null;
+  searchSource?: string;
+}
+
+function filterAttributes(
+  attributes: TagCollection,
+  allowedKeys?: string[]
+): TagCollection {
+  if (!allowedKeys) {
+    return attributes;
+  }
+  const allowedSet = new Set(allowedKeys);
+  return Object.fromEntries(
+    Object.entries(attributes).filter(([key]) => allowedSet.has(key))
+  );
+}
+
+/**
+ * A reusable search bar component for preprod/mobile build data.
+ * Automatically fetches available attributes from the EAP /attribute endpoint.
+ */
+export function PreprodSearchBar({
+  initialQuery,
+  allowedKeys,
+  onChange,
+  onSearch,
+  portalTarget,
+  searchSource = 'preprod',
+}: PreprodSearchBarProps) {
+  const organization = useOrganization();
+  const {
+    selection: {projects},
+  } = usePageFilters();
+
+  const traceItemAttributeConfig = {
+    traceItemType: TraceItemDataset.PREPROD,
+    enabled: organization.features.includes('preprod-app-size-dashboard'),
+  };
+
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+
+  const filteredStringAttributes = useMemo(
+    () => filterAttributes(stringAttributes, allowedKeys),
+    [stringAttributes, allowedKeys]
+  );
+  const filteredNumberAttributes = useMemo(
+    () => filterAttributes(numberAttributes, allowedKeys),
+    [numberAttributes, allowedKeys]
+  );
+
+  return (
+    <TraceItemSearchQueryBuilder
+      initialQuery={initialQuery}
+      onSearch={onSearch}
+      onChange={onChange}
+      itemType={TraceItemDataset.PREPROD}
+      numberAttributes={filteredNumberAttributes}
+      stringAttributes={filteredStringAttributes}
+      numberSecondaryAliases={stringSecondaryAliases}
+      stringSecondaryAliases={numberSecondaryAliases}
+      searchSource={searchSource}
+      projects={projects}
+      portalTarget={portalTarget}
+    />
+  );
+}

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -14,7 +14,15 @@ interface PreprodSearchBarProps {
    * Optional list of attribute keys to show. If not provided, all attributes are shown.
    */
   allowedKeys?: string[];
-  disableHas?: boolean;
+  /**
+   * When true, free text will be marked as invalid.
+   */
+  disallowFreeText?: boolean;
+  disallowHas?: boolean;
+  /**
+   * When true, parens and logical operators (AND, OR) will be marked as invalid.
+   */
+  disallowLogicalOperators?: boolean;
   /**
    * List of attribute keys to hide from the search bar. Defaults to HIDDEN_PREPROD_ATTRIBUTES.
    */
@@ -49,7 +57,9 @@ export function PreprodSearchBar({
   onChange,
   onSearch,
   portalTarget,
-  disableHas,
+  disallowFreeText,
+  disallowHas,
+  disallowLogicalOperators,
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
   const organization = useOrganization();
@@ -89,7 +99,9 @@ export function PreprodSearchBar({
       searchSource={searchSource}
       projects={projects}
       portalTarget={portalTarget}
-      disableHas={disableHas}
+      disallowFreeText={disallowFreeText}
+      disallowHas={disallowHas}
+      disallowLogicalOperators={disallowLogicalOperators}
     />
   );
 }

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -76,8 +76,8 @@ export function PreprodSearchBar({
       itemType={TraceItemDataset.PREPROD}
       numberAttributes={filteredNumberAttributes}
       stringAttributes={filteredStringAttributes}
-      numberSecondaryAliases={stringSecondaryAliases}
-      stringSecondaryAliases={numberSecondaryAliases}
+      numberSecondaryAliases={numberSecondaryAliases}
+      stringSecondaryAliases={stringSecondaryAliases}
       searchSource={searchSource}
       projects={projects}
       portalTarget={portalTarget}

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -4,6 +4,7 @@ import type {TagCollection} from 'sentry/types/group';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -13,6 +14,10 @@ interface PreprodSearchBarProps {
    * Optional list of attribute keys to show. If not provided, all attributes are shown.
    */
   allowedKeys?: string[];
+  /**
+   * List of attribute keys to hide from the search bar. Defaults to HIDDEN_PREPROD_ATTRIBUTES.
+   */
+  hiddenKeys?: string[];
   onChange?: (query: string, state: {queryIsValid: boolean}) => void;
   onSearch?: (query: string) => void;
   portalTarget?: HTMLElement | null;
@@ -39,6 +44,7 @@ function filterAttributes(
 export function PreprodSearchBar({
   initialQuery,
   allowedKeys,
+  hiddenKeys = HIDDEN_PREPROD_ATTRIBUTES,
   onChange,
   onSearch,
   portalTarget,
@@ -55,9 +61,9 @@ export function PreprodSearchBar({
   };
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string', hiddenKeys);
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number', hiddenKeys);
 
   const filteredStringAttributes = useMemo(
     () => filterAttributes(stringAttributes, allowedKeys),

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -14,6 +14,7 @@ interface PreprodSearchBarProps {
    * Optional list of attribute keys to show. If not provided, all attributes are shown.
    */
   allowedKeys?: string[];
+  disableHas?: boolean;
   /**
    * List of attribute keys to hide from the search bar. Defaults to HIDDEN_PREPROD_ATTRIBUTES.
    */
@@ -48,6 +49,7 @@ export function PreprodSearchBar({
   onChange,
   onSearch,
   portalTarget,
+  disableHas,
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
   const organization = useOrganization();
@@ -87,6 +89,7 @@ export function PreprodSearchBar({
       searchSource={searchSource}
       projects={projects}
       portalTarget={portalTarget}
+      disableHas={disableHas}
     />
   );
 }

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3353,6 +3353,7 @@ export const getFieldDefinition = (
     | 'replay'
     | 'replay_click'
     | 'feedback'
+    | 'preprod'
     | 'span'
     | 'log'
     | 'uptime'
@@ -3386,6 +3387,7 @@ export const getFieldDefinition = (
         return EVENT_FIELD_DEFINITIONS[key as FieldKey];
       }
       return null;
+    case 'preprod':
     case 'span':
       if (SPAN_FIELD_DEFINITIONS[key]) {
         return SPAN_FIELD_DEFINITIONS[key];

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -1,5 +1,6 @@
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
+import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
@@ -26,10 +27,7 @@ import {isEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
-import {
-  TraceItemSearchQueryBuilder,
-  useTraceItemSearchQueryBuilderProps,
-} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {useTraceItemSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -171,27 +169,12 @@ function MobileAppSizeSearchBar({
   WidgetBuilderSearchBarProps,
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
-  const {
-    selection: {projects},
-  } = usePageFilters();
-
-  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    useTraceItemAttributes('string', HIDDEN_PREPROD_ATTRIBUTES);
-  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    useTraceItemAttributes('number', HIDDEN_PREPROD_ATTRIBUTES);
-
   return (
-    <TraceItemSearchQueryBuilder
+    <PreprodSearchBar
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
-      itemType={TraceItemDataset.PREPROD}
-      numberAttributes={numberAttributes}
-      stringAttributes={stringAttributes}
-      numberSecondaryAliases={numberSecondaryAliases}
-      stringSecondaryAliases={stringSecondaryAliases}
-      searchSource="dashboards"
-      projects={projects}
       portalTarget={portalTarget}
+      searchSource="dashboards"
       onChange={(query, state) => {
         onClose?.(query, {validSearch: state.queryIsValid});
       }}

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -25,6 +25,7 @@ export type TraceItemSearchQueryBuilderProps = {
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
   caseInsensitive?: CaseInsensitive;
+  disableHas?: boolean;
   disabled?: boolean;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
@@ -90,11 +91,17 @@ export function useTraceItemSearchQueryBuilderProps({
   matchKeySuggestions,
   caseInsensitive,
   onCaseInsensitiveClick,
+  disableHas,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
   const filterKeySections = useFilterKeySections(itemType, stringAttributes);
-  const filterTags = useFilterTags(numberAttributes, stringAttributes, functionTags);
+  const filterTags = useFilterTags(
+    numberAttributes,
+    stringAttributes,
+    functionTags,
+    disableHas
+  );
 
   const getTraceItemAttributeValues = useGetTraceItemAttributeValues({
     traceItemType: itemType,
@@ -180,6 +187,7 @@ export function TraceItemSearchQueryBuilder({
   onCaseInsensitiveClick,
   matchKeySuggestions,
   replaceRawSearchKeys,
+  disableHas,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -201,6 +209,7 @@ export function TraceItemSearchQueryBuilder({
     onCaseInsensitiveClick,
     matchKeySuggestions,
     replaceRawSearchKeys,
+    disableHas,
   });
 
   return (
@@ -227,7 +236,8 @@ function useFunctionTags(
 function useFilterTags(
   numberAttributes: TagCollection,
   stringAttributes: TagCollection,
-  functionTags: TagCollection
+  functionTags: TagCollection,
+  disableHas: boolean
 ) {
   return useMemo(() => {
     const tags: TagCollection = {
@@ -235,12 +245,15 @@ function useFilterTags(
       ...numberAttributes,
       ...stringAttributes,
     };
-    tags.has = getHasTag({
-      ...numberAttributes,
-      ...stringAttributes,
-    });
+
+    if (!disableHas) {
+      tags.has = getHasTag({
+        ...numberAttributes,
+        ...stringAttributes,
+      });
+    }
     return tags;
-  }, [numberAttributes, stringAttributes, functionTags]);
+  }, [numberAttributes, stringAttributes, functionTags, disableHas]);
 }
 
 function useFilterKeySections(

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -55,6 +55,8 @@ const typeMap: Partial<
   [TraceItemDataset.UPTIME_RESULTS]: 'uptime',
   [TraceItemDataset.TRACEMETRICS]: 'tracemetric',
   [TraceItemDataset.REPLAYS]: 'replay',
+  // PREPROD uses 'span' type for field definitions since both have dynamic tags from the backend
+  [TraceItemDataset.PREPROD]: 'span',
 };
 
 function getTraceItemFieldDefinitionFunction(

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -48,15 +48,17 @@ const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
 };
 
 const typeMap: Partial<
-  Record<TraceItemDataset, 'span' | 'log' | 'uptime' | 'tracemetric' | 'replay'>
+  Record<
+    TraceItemDataset,
+    'span' | 'log' | 'uptime' | 'tracemetric' | 'replay' | 'preprod'
+  >
 > = {
   [TraceItemDataset.SPANS]: 'span',
   [TraceItemDataset.LOGS]: 'log',
   [TraceItemDataset.UPTIME_RESULTS]: 'uptime',
   [TraceItemDataset.TRACEMETRICS]: 'tracemetric',
   [TraceItemDataset.REPLAYS]: 'replay',
-  // PREPROD uses 'span' type for field definitions since both have dynamic tags from the backend
-  [TraceItemDataset.PREPROD]: 'span',
+  [TraceItemDataset.PREPROD]: 'preprod',
 };
 
 function getTraceItemFieldDefinitionFunction(

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -25,8 +25,10 @@ export type TraceItemSearchQueryBuilderProps = {
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
   caseInsensitive?: CaseInsensitive;
-  disableHas?: boolean;
   disabled?: boolean;
+  disallowFreeText?: boolean;
+  disallowHas?: boolean;
+  disallowLogicalOperators?: boolean;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
   onCaseInsensitiveClick?: SearchQueryBuilderProps['onCaseInsensitiveClick'];
@@ -91,7 +93,9 @@ export function useTraceItemSearchQueryBuilderProps({
   matchKeySuggestions,
   caseInsensitive,
   onCaseInsensitiveClick,
-  disableHas,
+  disallowHas,
+  disallowFreeText,
+  disallowLogicalOperators,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
@@ -100,7 +104,7 @@ export function useTraceItemSearchQueryBuilderProps({
     numberAttributes,
     stringAttributes,
     functionTags,
-    disableHas
+    disallowHas ?? false
   );
 
   const getTraceItemAttributeValues = useGetTraceItemAttributeValues({
@@ -129,6 +133,8 @@ export function useTraceItemSearchQueryBuilderProps({
       getSuggestedFilterKey: getSuggestedAttribute,
       getTagValues: getTraceItemAttributeValues,
       disallowUnsupportedFilters: true,
+      disallowFreeText,
+      disallowLogicalOperators,
       recentSearches: itemTypeToRecentSearches(itemType),
       namespace,
       showUnsubmittedIndicator: true,
@@ -141,6 +147,8 @@ export function useTraceItemSearchQueryBuilderProps({
     }),
     [
       caseInsensitive,
+      disallowFreeText,
+      disallowLogicalOperators,
       filterKeySections,
       filterTags,
       getFilterTokenWarning,
@@ -187,7 +195,9 @@ export function TraceItemSearchQueryBuilder({
   onCaseInsensitiveClick,
   matchKeySuggestions,
   replaceRawSearchKeys,
-  disableHas,
+  disallowHas,
+  disallowFreeText,
+  disallowLogicalOperators,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -209,7 +219,9 @@ export function TraceItemSearchQueryBuilder({
     onCaseInsensitiveClick,
     matchKeySuggestions,
     replaceRawSearchKeys,
-    disableHas,
+    disallowHas,
+    disallowFreeText,
+    disallowLogicalOperators,
   });
 
   return (
@@ -237,7 +249,7 @@ function useFilterTags(
   numberAttributes: TagCollection,
   stringAttributes: TagCollection,
   functionTags: TagCollection,
-  disableHas: boolean
+  disallowHas: boolean
 ) {
   return useMemo(() => {
     const tags: TagCollection = {
@@ -246,14 +258,14 @@ function useFilterTags(
       ...stringAttributes,
     };
 
-    if (!disableHas) {
+    if (!disallowHas) {
       tags.has = getHasTag({
         ...numberAttributes,
         ...stringAttributes,
       });
     }
     return tags;
-  }, [numberAttributes, stringAttributes, functionTags, disableHas]);
+  }, [numberAttributes, stringAttributes, functionTags, disallowHas]);
 }
 
 function useFilterKeySections(

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -109,6 +109,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
           onChange={(query, _state) => handleQueryChange(query)}
           searchSource="preprod_status_check_filters"
           portalTarget={document.body}
+          disableHas
           allowedKeys={[
             'app_id',
             'git_head_ref',

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -7,9 +7,8 @@ import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {NumberInput} from 'sentry/components/core/input/numberInput';
 import {Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
-import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
 
 import {SectionLabel} from './statusCheckSharedComponents';
 import type {StatusCheckRule} from './types';
@@ -28,26 +27,6 @@ interface Props {
   onSave: (rule: StatusCheckRule) => void;
   rule: StatusCheckRule;
 }
-
-const FILTER_KEYS: TagCollection = {
-  platform: {key: 'platform', name: 'Platform'},
-  app_id: {key: 'app_id', name: 'App ID'},
-  build_configuration: {
-    key: 'build_configuration',
-    name: 'Build Configuration',
-  },
-  git_head_ref: {key: 'git_head_ref', name: 'Branch'},
-};
-
-const getTagValues = (
-  tag: {key: string; name: string},
-  _searchQuery: string
-): Promise<string[]> => {
-  if (tag.key === 'platform') {
-    return Promise.resolve(['android', 'ios']);
-  }
-  return Promise.resolve([]);
-};
 
 export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
   const [metric, setMetric] = useState(rule.metric);
@@ -125,16 +104,17 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
 
       <Stack gap="sm">
         <SectionLabel>{t('For')}</SectionLabel>
-        <SearchQueryBuilder
-          filterKeys={FILTER_KEYS}
-          getTagValues={getTagValues}
+        <PreprodSearchBar
           initialQuery={filterQuery}
-          onChange={handleQueryChange}
+          onChange={(query, _state) => handleQueryChange(query)}
           searchSource="preprod_status_check_filters"
-          disallowFreeText
-          disallowLogicalOperators
-          placeholder={t('Add build filters...')}
           portalTarget={document.body}
+          allowedKeys={[
+            'app_id',
+            'git_head_ref',
+            'build_configuration_name',
+            'platform_name',
+          ]}
         />
       </Stack>
 

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -109,7 +109,9 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
           onChange={(query, _state) => handleQueryChange(query)}
           searchSource="preprod_status_check_filters"
           portalTarget={document.body}
-          disableHas
+          disallowFreeText
+          disallowHas
+          disallowLogicalOperators
           allowedKeys={[
             'app_id',
             'git_head_ref',


### PR DESCRIPTION
This extracts a common `PreprodSearchBar` based on `TraceItemSearchQueryBuilder`.

Co-authored-by: Trevor Elkins <trevor.elkins@sentry.io>