### PR TITLE
fix(infra): Fix bug with changed file detection

### DIFF
--- a/.github/workflows/backend-selective.yml
+++ b/.github/workflows/backend-selective.yml
@@ -133,7 +133,9 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | tr '\n' ' ')
+          # Use triple-dot syntax to find the merge-base first, so we only get
+          # changes introduced in this PR, not changes merged to master since branching
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | tr '\n' ' ')
           echo "Changed files: $CHANGED_FILES"
           echo "files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
I noticed a relatively simple PR (https://github.com/getsentry/sentry/pull/106699) was triggering almost all tests to run in our backend selective testing workflow. Upon investigation, I noticed the changed file detection was listing files changed from both the base and head vs the tip of master:
```
› git diff --name-only 18441e1b7bd613fda807ce15e317520417511ebd 733a049fb59d4ab22c9bf8380abb004c546a5bad
bin/preprod/trigger_size_status_check
src/sentry/preprod/vcs/status_checks/size/tasks.py
src/sentry/sentry_apps/services/region/impl.py
src/sentry/sentry_apps/services/region/model.py
src/sentry/sentry_apps/services/region/serial.py
src/sentry/sentry_apps/services/region/service.py
src/sentry/testutils/factories.py
src/sentry/testutils/fixtures.py
src/sentry/workflow_engine/processors/detector.py
tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
tests/sentry/sentry_apps/services/test_region_service.py
tests/sentry/workflow_engine/processors/test_detector.py
```

When it should only list 3 files:
```
bin/preprod/trigger_size_status_check
src/sentry/preprod/vcs/status_checks/size/tasks.py
tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
```

Upon further investigation, this is because we're not getting the diff for just changes introduced in the PR (from the common ancestor to HEAD), rather we're getting all changes that were merged to master in the meantime on top of the base sha. Adding the commit range (`...`) between the shas gives us the diff only between the two shas, which is what we want in this case:
```
› git diff --name-only 18441e1b7bd613fda807ce15e317520417511ebd...733a049fb59d4ab22c9bf8380abb004c546a5bad
bin/preprod/trigger_size_status_check
src/sentry/preprod/vcs/status_checks/size/tasks.py
tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
```