### PR TITLE
chore(anomaly thresholds): Add tip when anomaly thresholds out of chart bounds

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -1,7 +1,13 @@
 import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {DetectorPriorityLevel} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  AlertRuleSensitivity,
+  AlertRuleThresholdType,
+} from 'sentry/views/alerts/rules/metric/types';
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
 
 describe('MetricDetectorDetailsChart', () => {
@@ -29,5 +35,73 @@ describe('MetricDetectorDetailsChart', () => {
 
     expect(await screen.findByText('Invalid query: xyz')).toBeInTheDocument();
     expect(screen.getByText('Error loading chart data')).toBeInTheDocument();
+  });
+
+  describe('anomaly threshold cutoff message', () => {
+    const organization = OrganizationFixture({
+      features: ['anomaly-detection-threshold-data', 'visibility-explore-view'],
+    });
+
+    const anomalyDetector = MetricDetectorFixture({
+      config: {detectionType: 'dynamic'},
+      conditionGroup: {
+        id: '1',
+        logicType: 'any',
+        conditions: [
+          {
+            id: '1',
+            type: 'anomaly_detection',
+            comparison: {
+              sensitivity: AlertRuleSensitivity.HIGH,
+              seasonality: 'auto',
+              thresholdType: AlertRuleThresholdType.ABOVE_AND_BELOW,
+            },
+            conditionResult: DetectorPriorityLevel.HIGH,
+          },
+        ],
+      },
+    });
+
+    const baseTimestamp = Date.now() / 1000;
+    const CUTOFF_MESSAGE = 'Some anomaly thresholds are outside the chart area';
+
+    function mockChartData() {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        body: {data: [[baseTimestamp, [{count: 100}]]]},
+      });
+    }
+
+    function mockAnomalyData(yhatUpper: number) {
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/detectors/${anomalyDetector.id}/anomaly-data/`,
+        body: {
+          data: [
+            {timestamp: baseTimestamp, value: 50, yhat_upper: yhatUpper, yhat_lower: 10},
+          ],
+        },
+      });
+    }
+
+    it('does not show cutoff message when thresholds are within chart bounds', async () => {
+      mockChartData();
+      mockAnomalyData(105); // Within bounds (max 100 + 10% padding = 110)
+
+      render(<MetricDetectorDetailsChart detector={anomalyDetector} />, {organization});
+
+      expect(
+        await screen.findByRole('button', {name: 'Open in Discover'})
+      ).toBeInTheDocument();
+      expect(screen.queryByText(CUTOFF_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it('shows cutoff message when thresholds exceed chart bounds', async () => {
+      mockChartData();
+      mockAnomalyData(500); // Exceeds bounds
+
+      render(<MetricDetectorDetailsChart detector={anomalyDetector} />, {organization});
+
+      expect(await screen.findByText(CUTOFF_MESSAGE)).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -3,7 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {DetectorPriorityLevel} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
@@ -46,11 +50,11 @@ describe('MetricDetectorDetailsChart', () => {
       config: {detectionType: 'dynamic'},
       conditionGroup: {
         id: '1',
-        logicType: 'any',
+        logicType: DataConditionGroupLogicType.ANY,
         conditions: [
           {
             id: '1',
-            type: 'anomaly_detection',
+            type: DataConditionType.ANOMALY_DETECTION,
             comparison: {
               sensitivity: AlertRuleSensitivity.HIGH,
               seasonality: 'auto',
@@ -61,6 +65,7 @@ describe('MetricDetectorDetailsChart', () => {
         ],
       },
     });
+    const anomalySnubaQuery = anomalyDetector.dataSources[0].queryObj.snubaQuery;
 
     const baseTimestamp = Date.now() / 1000;
     const CUTOFF_MESSAGE = 'Some anomaly thresholds are outside the chart area';
@@ -87,7 +92,13 @@ describe('MetricDetectorDetailsChart', () => {
       mockChartData();
       mockAnomalyData(105); // Within bounds (max 100 + 10% padding = 110)
 
-      render(<MetricDetectorDetailsChart detector={anomalyDetector} />, {organization});
+      render(
+        <MetricDetectorDetailsChart
+          detector={anomalyDetector}
+          snubaQuery={anomalySnubaQuery}
+        />,
+        {organization}
+      );
 
       expect(
         await screen.findByRole('button', {name: 'Open in Discover'})
@@ -99,7 +110,13 @@ describe('MetricDetectorDetailsChart', () => {
       mockChartData();
       mockAnomalyData(500); // Exceeds bounds
 
-      render(<MetricDetectorDetailsChart detector={anomalyDetector} />, {organization});
+      render(
+        <MetricDetectorDetailsChart
+          detector={anomalyDetector}
+          snubaQuery={anomalySnubaQuery}
+        />,
+        {organization}
+      );
 
       expect(await screen.findByText(CUTOFF_MESSAGE)).toBeInTheDocument();
     });

--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -82,7 +82,12 @@ describe('MetricDetectorDetailsChart', () => {
         url: `/organizations/org-slug/detectors/${anomalyDetector.id}/anomaly-data/`,
         body: {
           data: [
-            {timestamp: baseTimestamp, value: 50, yhat_upper: yhatUpper, yhat_lower: 10},
+            {
+              timestamp: baseTimestamp,
+              value: 50,
+              yhat_upper: yhatUpper,
+              yhat_lower: 10,
+            },
           ],
         },
       });
@@ -108,7 +113,7 @@ describe('MetricDetectorDetailsChart', () => {
 
     it('shows cutoff message when thresholds exceed chart bounds', async () => {
       mockChartData();
-      mockAnomalyData(500); // Exceeds bounds
+      mockAnomalyData(500); // yhat_upper exceeds bounds (max ~110)
 
       render(
         <MetricDetectorDetailsChart

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -271,23 +271,16 @@ export function useMetricDetectorChart({
   // Check if any anomaly threshold values exceed the chart bounds
   // Only check against maxValue when it's used (maxValue > 0), otherwise chart auto-scales
   const isAnomalyThresholdCutOff = useMemo(() => {
-    if (filteredAnomalyThresholdSeries.length === 0) {
-      return false;
-    }
-
-    for (const seriesItem of filteredAnomalyThresholdSeries) {
+    return filteredAnomalyThresholdSeries.some(seriesItem => {
       const data = (seriesItem as {data?: Array<[number, number]>}).data;
       if (!data) {
-        continue;
+        return false;
       }
-      for (const [, value] of data) {
+      return data.some(([, value]) => {
         const exceedsMax = maxValue > 0 && value > maxValue;
-        if (exceedsMax || value < minValue) {
-          return true;
-        }
-      }
-    }
-    return false;
+        return exceedsMax || value < minValue;
+      });
+    });
   }, [filteredAnomalyThresholdSeries, maxValue, minValue]);
 
   const additionalSeries = useMemo(() => {

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -268,20 +268,19 @@ export function useMetricDetectorChart({
     aggregate,
   });
 
-  // Check if any anomaly threshold values exceed the chart bounds
-  // Only check against maxValue when it's used (maxValue > 0), otherwise chart auto-scales
+  // Check if any anomaly threshold values exceed the chart's upper bound
   const isAnomalyThresholdCutOff = useMemo(() => {
+    if (maxValue <= 0) {
+      return false;
+    }
     return filteredAnomalyThresholdSeries.some(seriesItem => {
       const data = (seriesItem as {data?: Array<[number, number]>}).data;
       if (!data) {
         return false;
       }
-      return data.some(([, value]) => {
-        const exceedsMax = maxValue > 0 && value > maxValue;
-        return exceedsMax || value < minValue;
-      });
+      return data.some(([, value]) => value > maxValue);
     });
-  }, [filteredAnomalyThresholdSeries, maxValue, minValue]);
+  }, [filteredAnomalyThresholdSeries, maxValue]);
 
   const additionalSeries = useMemo(() => {
     const baseSeries = [...thresholdAdditionalSeries, ...filteredAnomalyThresholdSeries];

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -10,9 +10,10 @@ import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
-import {IconWarning} from 'sentry/icons';
+import {IconInfo, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {GroupOpenPeriod} from 'sentry/types/group';
@@ -153,9 +154,19 @@ function createOpenPeriodMarkerData({
 }
 
 type UseMetricDetectorChartResult =
-  | {chartProps: AreaChartProps; error: null; isLoading: false}
-  | {chartProps: null; error: null; isLoading: true}
-  | {chartProps: null; error: RequestError; isLoading: false};
+  | {
+      chartProps: AreaChartProps;
+      error: null;
+      isAnomalyThresholdCutOff: boolean;
+      isLoading: false;
+    }
+  | {chartProps: null; error: null; isAnomalyThresholdCutOff: false; isLoading: true}
+  | {
+      chartProps: null;
+      error: RequestError;
+      isAnomalyThresholdCutOff: false;
+      isLoading: false;
+    };
 
 export function useMetricDetectorChart({
   statsPeriod,
@@ -256,6 +267,28 @@ export function useMetricDetectorChart({
     thresholdMaxValue,
     aggregate,
   });
+
+  // Check if any anomaly threshold values exceed the chart bounds
+  // Only check against maxValue when it's used (maxValue > 0), otherwise chart auto-scales
+  const isAnomalyThresholdCutOff = useMemo(() => {
+    if (filteredAnomalyThresholdSeries.length === 0) {
+      return false;
+    }
+
+    for (const seriesItem of filteredAnomalyThresholdSeries) {
+      const data = (seriesItem as {data?: Array<[number, number]>}).data;
+      if (!data) {
+        continue;
+      }
+      for (const [, value] of data) {
+        const exceedsMax = maxValue > 0 && value > maxValue;
+        if (exceedsMax || value < minValue) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }, [filteredAnomalyThresholdSeries, maxValue, minValue]);
 
   const additionalSeries = useMemo(() => {
     const baseSeries = [...thresholdAdditionalSeries, ...filteredAnomalyThresholdSeries];
@@ -378,6 +411,7 @@ export function useMetricDetectorChart({
     return {
       chartProps,
       error: null,
+      isAnomalyThresholdCutOff,
       isLoading: false,
     };
   }
@@ -386,6 +420,7 @@ export function useMetricDetectorChart({
     return {
       chartProps: null,
       error,
+      isAnomalyThresholdCutOff: false,
       isLoading: false,
     };
   }
@@ -393,6 +428,7 @@ export function useMetricDetectorChart({
   return {
     isLoading: true,
     error: null,
+    isAnomalyThresholdCutOff: false,
     chartProps: null,
   };
 }
@@ -467,9 +503,25 @@ function ChartBody({children}: {children: React.ReactNode}) {
   return <Container padding="lg">{children}</Container>;
 }
 
-function ChartFooter({detector}: {detector: MetricDetector}) {
+function ChartFooter({
+  detector,
+  isAnomalyThresholdCutOff,
+}: {
+  detector: MetricDetector;
+  isAnomalyThresholdCutOff?: boolean;
+}) {
   return (
-    <Flex justify="end" padding="lg" borderTop="muted">
+    <Flex justify="between" align="center" padding="lg" borderTop="muted">
+      {isAnomalyThresholdCutOff ? (
+        <Flex align="center" gap="xs">
+          <IconInfo size="xs" variant="muted" />
+          <Text size="sm" variant="muted">
+            {t('Some anomaly thresholds are outside the chart area')}
+          </Text>
+        </Flex>
+      ) : (
+        <div />
+      )}
       <OpenInButton detector={detector} />
     </Flex>
   );
@@ -498,12 +550,14 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
     ...dateParams,
   });
 
-  const {chartProps, isLoading, error} = useMetricDetectorChart({
-    detector,
-    openPeriods,
-    height: CHART_HEIGHT,
-    ...dateParams,
-  });
+  const {chartProps, isLoading, error, isAnomalyThresholdCutOff} = useMetricDetectorChart(
+    {
+      detector,
+      openPeriods,
+      height: CHART_HEIGHT,
+      ...dateParams,
+    }
+  );
 
   if (isLoading) {
     return (
@@ -545,7 +599,12 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
       <ChartBody>
         <AreaChart {...chartProps} />
       </ChartBody>
-      {destination && <ChartFooter detector={detector} />}
+      {destination && (
+        <ChartFooter
+          detector={detector}
+          isAnomalyThresholdCutOff={isAnomalyThresholdCutOff}
+        />
+      )}
     </ChartContainer>
   );
 }


### PR DESCRIPTION
If a monitor has low error volume and high thresholds, the upper bound can be cut off from the graph making it seem like there are no bounds. Adds tip explaining “Some anomaly thresholds are outside the chart area” if anomaly thresholds are cut off from chart. Will follow up with a PR to add this to alerts. 

<img width="1054" height="341" alt="image" src="https://github.com/user-attachments/assets/f40dc338-dce2-4e5c-832a-d4a782dbb579" />
