### PR TITLE
feat(uptime): Add default status code assertion for verifications

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
@@ -2,7 +2,11 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import Form from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
-import type {Assertion} from 'sentry/views/alerts/rules/uptime/types';
+import type {
+  AndOp,
+  Assertion,
+  StatusCodeOp,
+} from 'sentry/views/alerts/rules/uptime/types';
 
 import {normalizeAssertion, UptimeAssertionsField} from './field';
 
@@ -399,8 +403,8 @@ describe('normalizeAssertion', () => {
       value: 700,
     };
 
-    expect(normalizeAssertion(tooLow).value).toBe(100);
-    expect(normalizeAssertion(tooHigh).value).toBe(599);
+    expect((normalizeAssertion(tooLow) as StatusCodeOp).value).toBe(100);
+    expect((normalizeAssertion(tooHigh) as StatusCodeOp).value).toBe(599);
   });
 
   it('preserves valid status code values', () => {
@@ -411,7 +415,7 @@ describe('normalizeAssertion', () => {
       value: 404,
     };
 
-    expect(normalizeAssertion(valid).value).toBe(404);
+    expect((normalizeAssertion(valid) as StatusCodeOp).value).toBe(404);
   });
 
   it('recursively normalizes nested assertions in and/or groups', () => {
@@ -434,8 +438,8 @@ describe('normalizeAssertion', () => {
       ],
     };
 
-    const result = normalizeAssertion(nested);
-    expect(result.children[0]?.value).toBe(200);
-    expect(result.children[1]?.value).toBe(599);
+    const result = normalizeAssertion(nested) as AndOp;
+    expect((result.children[0] as StatusCodeOp).value).toBe(200);
+    expect((result.children[1] as StatusCodeOp).value).toBe(599);
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
@@ -224,7 +224,7 @@ describe('UptimeAssertionsField', () => {
     });
   });
 
-  it('shows empty UI when editing monitor with empty assertion children', async () => {
+  it('shows empty UI when editing monitor with empty assertion children', () => {
     // When editing a monitor that previously had assertions removed,
     // the backend may return an assertion structure with empty children
     const emptyAssertion: Assertion = {

--- a/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
@@ -435,7 +435,7 @@ describe('normalizeAssertion', () => {
     };
 
     const result = normalizeAssertion(nested);
-    expect(result.children[0].value).toBe(200);
-    expect(result.children[1].value).toBe(599);
+    expect(result.children[0]?.value).toBe(200);
+    expect(result.children[1]?.value).toBe(599);
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -52,10 +52,36 @@ function UptimeAssertionsControl({onChange, onBlur, value}: any) {
   );
 }
 
+/**
+ * Creates a default assertion that validates 2xx status codes (>199 AND <300)
+ */
+function createDefaultAssertion(): Assertion {
+  return {
+    root: {
+      op: 'and',
+      id: uniqueId(),
+      children: [
+        {
+          op: 'status_code_check',
+          id: uniqueId(),
+          operator: {cmp: 'greater_than'},
+          value: 199,
+        },
+        {
+          op: 'status_code_check',
+          id: uniqueId(),
+          operator: {cmp: 'less_than'},
+          value: 300,
+        },
+      ],
+    },
+  };
+}
+
 export function UptimeAssertionsField(props: Omit<FormFieldProps, 'children'>) {
   return (
     <FormField
-      defaultValue={{root: {op: 'and', children: [], id: uniqueId()}}}
+      defaultValue={createDefaultAssertion()}
       {...props}
       flexibleControlStateSize
       // Use getValue (not getData) to transform field value at submission time.

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -34,6 +34,19 @@ export function normalizeAssertion(op: Op): Op {
 }
 
 /**
+ * Creates an empty assertion root with no children.
+ * Used when editing monitors that have no assertions - empty children signals
+ * "edit with no assertions" vs the default assertions for new monitors.
+ */
+export function createEmptyAssertionRoot(): AndOp {
+  return {
+    op: 'and',
+    id: uniqueId(),
+    children: [],
+  };
+}
+
+/**
  * Creates a default assertion root that validates 2xx status codes (>199 AND <300)
  */
 function createDefaultAssertionRoot(): AndOp {

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -9,7 +9,7 @@ import {AssertionOpGroup} from './opGroup';
  * Recursively normalizes assertion values to ensure they are valid before submission.
  * Handles NaN values (from cleared inputs) and clamps to valid HTTP status code range.
  */
-export function normalizeAssertion(op: Op): Op {
+export function normalizeAssertion<T extends Op>(op: T): T {
   switch (op.op) {
     case 'status_code_check':
       return {

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -9,7 +9,7 @@ import {AssertionOpGroup} from './opGroup';
  * Recursively normalizes assertion values to ensure they are valid before submission.
  * Handles NaN values (from cleared inputs) and clamps to valid HTTP status code range.
  */
-export function normalizeAssertion<T extends Op>(op: T): T {
+export function normalizeAssertion(op: Op): Op {
   switch (op.op) {
     case 'status_code_check':
       return {

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -103,6 +103,10 @@ export function UptimeAssertionsField(props: Omit<FormFieldProps, 'children'>) {
       // getData only works for save-on-blur; getValue is used by getTransformedData()
       // which is called during full form submission via saveForm().
       getValue={(value: Assertion) => {
+        // Handle edge cases where FormField may pass undefined/null/empty string
+        if (!value?.root) {
+          return null;
+        }
         // Empty children = user deleted all assertions or editing monitor with no assertions
         if (value.root.children.length === 0) {
           return null;

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -62,6 +62,10 @@ export enum CheckStatusReason {
   TLS_ERROR = 'tls_error',
   CONNECTION_ERROR = 'connection_error',
   REDIRECT_ERROR = 'redirect_error',
+  MISS_PRODUCED = 'miss_produced',
+  MISS_BACKFILL = 'miss_backfill',
+  ASSERTION_COMPILATION_ERROR = 'assertion_compilation_error',
+  ASSERTION_EVALUATION_ERROR = 'assertion_evaluation_error',
 }
 
 export enum CheckStatus {

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -523,82 +523,48 @@ describe('Uptime Alert Form', () => {
       })
     );
   });
-});
 
-describe('normalizeAssertion', () => {
-  // Import the function directly for unit testing
-  const {
-    normalizeAssertion,
-  } = require('sentry/views/alerts/rules/uptime/assertions/field');
-
-  it('handles NaN status code value by defaulting to 200', () => {
-    const op = {
-      id: 'test-1',
-      op: 'status_code_check' as const,
-      operator: {cmp: 'equals' as const},
-      value: NaN,
-    };
-
-    expect(normalizeAssertion(op)).toEqual({
-      id: 'test-1',
-      op: 'status_code_check',
-      operator: {cmp: 'equals'},
-      value: 200,
+  it('preserves null assertion when editing rule without assertions', async () => {
+    const orgWithAssertions = OrganizationFixture({
+      features: ['uptime-runtime-assertions'],
     });
-  });
+    OrganizationStore.onUpdate(orgWithAssertions);
 
-  it('clamps status code values to valid HTTP range', () => {
-    const tooLow = {
-      id: 'test-1',
-      op: 'status_code_check' as const,
-      operator: {cmp: 'equals' as const},
-      value: 50,
-    };
+    // Rule with no assertions (assertion: null from API)
+    const rule = UptimeRuleFixture({
+      name: 'Rule without Assertion',
+      projectSlug: project.slug,
+      url: 'https://existing-url.com',
+      owner: ActorFixture(),
+      assertion: null,
+    });
 
-    const tooHigh = {
-      id: 'test-2',
-      op: 'status_code_check' as const,
-      operator: {cmp: 'equals' as const},
-      value: 700,
-    };
+    render(<UptimeAlertForm rule={rule} />, {organization: orgWithAssertions});
+    await screen.findByText('Verification');
 
-    expect(normalizeAssertion(tooLow).value).toBe(100);
-    expect(normalizeAssertion(tooHigh).value).toBe(599);
-  });
+    // Should show empty UI - Add Assertion button but no assertion inputs
+    expect(screen.getByRole('button', {name: 'Add Assertion'})).toBeInTheDocument();
+    // The assertion field should not have any status code inputs (which would indicate defaults were applied)
+    const assertionSection = screen.getByText('Verification').closest('section');
+    expect(
+      assertionSection?.querySelectorAll('input[type="text"]').length ?? 0
+    ).toBeLessThanOrEqual(0);
 
-  it('preserves valid status code values', () => {
-    const valid = {
-      id: 'test-1',
-      op: 'status_code_check' as const,
-      operator: {cmp: 'equals' as const},
-      value: 404,
-    };
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/projects/${orgWithAssertions.slug}/${project.slug}/uptime/${rule.id}/`,
+      method: 'PUT',
+    });
 
-    expect(normalizeAssertion(valid).value).toBe(404);
-  });
+    await userEvent.click(screen.getByRole('button', {name: 'Save Rule'}));
 
-  it('recursively normalizes nested assertions in and/or groups', () => {
-    const nested = {
-      id: 'group-1',
-      op: 'and' as const,
-      children: [
-        {
-          id: 'test-1',
-          op: 'status_code_check' as const,
-          operator: {cmp: 'equals' as const},
-          value: NaN,
-        },
-        {
-          id: 'test-2',
-          op: 'status_code_check' as const,
-          operator: {cmp: 'equals' as const},
-          value: 800,
-        },
-      ],
-    };
-
-    const result = normalizeAssertion(nested);
-    expect(result.children[0].value).toBe(200);
-    expect(result.children[1].value).toBe(599);
+    // Should submit null, not default assertions
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          assertion: null,
+        }),
+      })
+    );
   });
 });

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -437,7 +437,26 @@ describe('Uptime Alert Form', () => {
         data: expect.objectContaining({
           name: 'Rule with Assertion',
           url: 'http://example.com',
-          assertion: {root: {op: 'and', children: [], id: expect.any(String)}},
+          assertion: {
+            root: {
+              op: 'and',
+              id: expect.any(String),
+              children: [
+                {
+                  op: 'status_code_check',
+                  id: expect.any(String),
+                  operator: {cmp: 'greater_than'},
+                  value: 199,
+                },
+                {
+                  op: 'status_code_check',
+                  id: expect.any(String),
+                  operator: {cmp: 'less_than'},
+                  value: 300,
+                },
+              ],
+            },
+          },
         }),
       })
     );

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -28,6 +28,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {uniqueId} from 'sentry/utils/guid';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -82,7 +83,9 @@ function getFormDataFromRule(rule: UptimeRule) {
     owner: rule.owner ? `${rule.owner.type}:${rule.owner.id}` : null,
     recoveryThreshold: rule.recoveryThreshold,
     downtimeThreshold: rule.downtimeThreshold,
-    assertion: rule.assertion,
+    // Use empty assertion structure for null - FormField converts null to '' which
+    // we can't distinguish from "new form". Empty children signals "edit with no assertions".
+    assertion: rule.assertion ?? {root: {op: 'and', children: [], id: uniqueId()}},
   };
 }
 

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -28,7 +28,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {uniqueId} from 'sentry/utils/guid';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -37,7 +36,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 
-import {UptimeAssertionsField} from './assertions/field';
+import {createEmptyAssertionRoot, UptimeAssertionsField} from './assertions/field';
 import {HTTPSnippet} from './httpSnippet';
 import {UptimeHeadersField} from './uptimeHeadersField';
 
@@ -85,7 +84,7 @@ function getFormDataFromRule(rule: UptimeRule) {
     downtimeThreshold: rule.downtimeThreshold,
     // Use empty assertion structure for null - FormField converts null to '' which
     // we can't distinguish from "new form". Empty children signals "edit with no assertions".
-    assertion: rule.assertion ?? {root: {op: 'and', children: [], id: uniqueId()}},
+    assertion: rule.assertion ?? {root: createEmptyAssertionRoot()},
   };
 }
 

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -235,7 +235,10 @@ describe('uptimeSavedDetectorToFormData', () => {
     expect(formData.assertion).toEqual(assertion);
   });
 
-  it('sets assertion to null when not present in data source', () => {
+  it('returns empty assertion structure when not present in data source', () => {
+    // When editing a monitor with no assertions, we return an empty assertion structure
+    // rather than null, because FormField converts null to '' which we can't distinguish
+    // from "new form". Empty children signals "edit with no assertions" to the UI.
     const detector = UptimeDetectorFixture({
       dataSources: [
         {
@@ -250,7 +253,13 @@ describe('uptimeSavedDetectorToFormData', () => {
 
     const formData = uptimeSavedDetectorToFormData(detector);
 
-    expect(formData.assertion).toBeNull();
+    expect(formData.assertion).toMatchObject({
+      root: {
+        op: 'and',
+        children: [],
+        id: expect.any(String),
+      },
+    });
   });
 
   it('uses default values when data source is missing', () => {

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -277,7 +277,15 @@ describe('uptimeSavedDetectorToFormData', () => {
       url: 'https://example.com',
       headers: [],
       body: '',
-      assertion: null,
+      // Uses empty assertion structure (not null) for consistency with the main case.
+      // null would cause a crash in getValue when accessing value.root.children.length
+      assertion: {
+        root: {
+          op: 'and',
+          children: [],
+          id: expect.any(String),
+        },
+      },
     });
   });
 

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -146,7 +146,9 @@ export function uptimeSavedDetectorToFormData(
     url: 'https://example.com',
     headers: DEFAULT_UPTIME_DETECTOR_FORM_DATA_MAP.headers,
     body: DEFAULT_UPTIME_DETECTOR_FORM_DATA_MAP.body,
-    assertion: DEFAULT_UPTIME_DETECTOR_FORM_DATA_MAP.assertion,
+    // Use empty assertion structure for consistency with the main case above.
+    // null would cause a crash in getValue when accessing value.root.children.length
+    assertion: {root: createEmptyAssertionRoot()},
     workflowIds: detector.workflowIds,
   };
 }

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -4,7 +4,7 @@ import type {
   UptimeDetectorUpdatePayload,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
-import {uniqueId} from 'sentry/utils/guid';
+import {createEmptyAssertionRoot} from 'sentry/views/alerts/rules/uptime/assertions/field';
 import type {Assertion} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
 import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
@@ -132,9 +132,7 @@ export function uptimeSavedDetectorToFormData(
       body: dataSource.queryObj.body ?? '',
       // Use empty assertion structure for null - FormField converts null to '' which
       // we can't distinguish from "new form". Empty children signals "edit with no assertions".
-      assertion: dataSource.queryObj.assertion ?? {
-        root: {op: 'and', children: [], id: uniqueId()},
-      },
+      assertion: dataSource.queryObj.assertion ?? {root: createEmptyAssertionRoot()},
       workflowIds: detector.workflowIds,
     };
   }

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -4,6 +4,7 @@ import type {
   UptimeDetectorUpdatePayload,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
+import {uniqueId} from 'sentry/utils/guid';
 import type {Assertion} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
 import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
@@ -129,7 +130,11 @@ export function uptimeSavedDetectorToFormData(
       url: dataSource.queryObj.url,
       headers: dataSource.queryObj.headers,
       body: dataSource.queryObj.body ?? '',
-      assertion: dataSource.queryObj.assertion ?? null,
+      // Use empty assertion structure for null - FormField converts null to '' which
+      // we can't distinguish from "new form". Empty children signals "edit with no assertions".
+      assertion: dataSource.queryObj.assertion ?? {
+        root: {op: 'and', children: [], id: uniqueId()},
+      },
       workflowIds: detector.workflowIds,
     };
   }

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -35,6 +35,10 @@ export const reasonToText: Record<
   [CheckStatusReason.TLS_ERROR]: _ => t('TLS Connection Error'),
   [CheckStatusReason.CONNECTION_ERROR]: _ => t('Connection Error'),
   [CheckStatusReason.REDIRECT_ERROR]: _ => t('Too Many Redirects'),
+  [CheckStatusReason.MISS_PRODUCED]: _ => t('No Result Produced'),
+  [CheckStatusReason.MISS_BACKFILL]: _ => t('Backfilled'),
+  [CheckStatusReason.ASSERTION_COMPILATION_ERROR]: _ => t('Invalid Assertion'),
+  [CheckStatusReason.ASSERTION_EVALUATION_ERROR]: _ => t('Assertion Error'),
 };
 
 export const tickStyle: TickStyle<CheckStatus> = theme => ({


### PR DESCRIPTION
## Summary
- Adds a default assertion that validates 2xx status codes (>199 AND <300) when creating new uptime monitors
- This provides a sensible default that users can modify or extend as needed
- Fixes fallback case in detector form to use empty assertion structure instead of null (prevents crash)
- Adds missing CheckStatusReason values from uptime-checker (miss_produced, miss_backfill, assertion errors)

Fixes NEW-709

## Test plan

### Automated tests
- [x] Updated existing tests to verify default assertion structure
- [x] Verified default renders two status code checks (>199 and <300)
- [x] Updated test for fallback case with empty assertion structure

### Manual testing - Old Uptime Alert Form (`/alerts/new/uptime/`)

#### Creating new monitors
- [x] Navigate to `/organizations/{org}/alerts/new/uptime/`
- [x] Verify default assertions appear (Status Code > 199 AND Status Code < 300)
- [x] Verify you can add additional assertions
- [x] Verify you can delete all assertions (should submit with null)
- [x] Verify you can modify the default assertions
- [x] Save the monitor and verify assertions persist

#### Editing existing monitors
- [x] Edit a monitor that has assertions - verify they load correctly
- [x] Edit a monitor that has NO assertions - verify form shows empty (no assertions), not defaults
- [x] Modify assertions on existing monitor and save - verify changes persist
- [x] Delete all assertions on existing monitor and save - verify null is saved

### Manual testing - New Detector Form (`/monitors/create/?type=uptime`)

#### Creating new monitors
- [x] Navigate to `/organizations/{org}/monitors/create/?type=uptime`
- [x] Verify default assertions appear (Status Code > 199 AND Status Code < 300)
- [x] Verify you can add additional assertions
- [x] Verify you can delete all assertions
- [x] Verify you can modify the default assertions
- [x] Save the monitor and verify assertions persist

#### Editing existing monitors
- [x] Edit a detector that has assertions - verify they load correctly
- [x] Edit a detector that has NO assertions - verify form shows empty (no assertions), not defaults
- [ ] Edit a detector with missing data source (edge case) - verify no crash, form shows empty assertions
- [x] Modify assertions on existing detector and save - verify changes persist
- [x] Delete all assertions on existing detector and save - verify null is saved

### Check status reasons
- [ ] Verify uptime check grid displays all reason types without console warnings
- [ ] Test with checks that have assertion-related failures (if available in test env)