### PR TITLE
Fix N+1 query in transform_preprod_artifact_to_build_details

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -127,7 +127,11 @@ def queryset_for_query(
     Raises:
         InvalidSearchQuery: If the query string is invalid
     """
-    queryset = PreprodArtifact.objects.get_queryset()
+    queryset = (
+        PreprodArtifact.objects.get_queryset()
+        .select_related("project", "build_configuration", "commit_comparison", "mobile_app_info")
+        .prefetch_related("preprodartifactsizemetrics_set")
+    )
     queryset = queryset.annotate_download_count()
     queryset = queryset.annotate_installable()
     queryset = queryset.annotate_main_size_metrics()

--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -313,7 +313,10 @@ class BuildsEndpoint(OrganizationEndpoint):
             )
 
         on_results = lambda artifacts: [
-            transform_preprod_artifact_to_build_details(artifact).dict() for artifact in artifacts
+            transform_preprod_artifact_to_build_details(
+                artifact, include_base_artifact=False
+            ).dict()
+            for artifact in artifacts
         ]
         paginate = lambda queryset: self.paginate(
             order_by="-date_added",

--- a/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
@@ -172,7 +172,10 @@ class OrganizationPreprodListBuildsEndpoint(OrganizationEndpoint):
             build_details_list = []
             for artifact in results:
                 try:
-                    build_details = transform_preprod_artifact_to_build_details(artifact)
+                    # Skip base artifact fetching in list view to avoid N+1 queries
+                    build_details = transform_preprod_artifact_to_build_details(
+                        artifact, include_base_artifact=False
+                    )
                     build_details_list.append(build_details.dict())
                 except Exception as e:
                     logger.warning("Failed to transform artifact %s: %s", artifact.id, str(e))

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -270,30 +270,57 @@ def to_size_info(
 
 def transform_preprod_artifact_to_build_details(
     artifact: PreprodArtifact,
+    include_base_artifact: bool = True,
+    size_metrics_list: list[PreprodArtifactSizeMetrics] | None = None,
 ) -> BuildDetailsApiResponse:
+    """
+    Transform a PreprodArtifact to a BuildDetailsApiResponse.
 
-    size_metrics_list = list(artifact.preprodartifactsizemetrics_set.all())
+    Args:
+        artifact: The PreprodArtifact to transform
+        include_base_artifact: If True, fetch and include base artifact data.
+            Set to False for list endpoints to avoid N+1 queries.
+        size_metrics_list: Optional pre-fetched size metrics. If not provided,
+            will be fetched from artifact.preprodartifactsizemetrics_set.
+    """
+    if size_metrics_list is None:
+        size_metrics_list = list(artifact.preprodartifactsizemetrics_set.all())
 
     base_size_metrics_list: list[PreprodArtifactSizeMetrics] = []
-    base_artifact = (
-        artifact.get_base_artifact_for_commit().select_related("build_configuration").first()
-    )
+    base_artifact = None
     base_build_info = None
-    if base_artifact:
-        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact=base_artifact,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+
+    if include_base_artifact:
+        base_artifact = (
+            artifact.get_base_artifact_for_commit()
+            .select_related("build_configuration", "mobile_app_info")
+            .first()
         )
-        base_size_metrics_list = list(base_size_metrics_qs)
-        base_build_info = create_build_details_app_info(base_artifact)
+        if base_artifact:
+            base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact=base_artifact,
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            )
+            base_size_metrics_list = list(base_size_metrics_qs)
+            base_build_info = create_build_details_app_info(base_artifact)
 
     size_info = to_size_info(size_metrics_list, base_size_metrics_list)
 
     app_info = create_build_details_app_info(artifact)
     is_installable = is_installable_artifact(artifact)
+
+    # Use annotated download_count if available, otherwise query for it
+    download_count = 0
+    if is_installable:
+        annotated_count = getattr(artifact, "download_count", None)
+        if annotated_count is not None:
+            download_count = int(annotated_count)
+        else:
+            download_count = get_download_count_for_artifact(artifact)
+
     distribution_info = DistributionInfo(
         is_installable=is_installable,
-        download_count=(get_download_count_for_artifact(artifact) if is_installable else 0),
+        download_count=download_count,
         release_notes=(artifact.extras.get("release_notes") if artifact.extras else None),
     )
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
