### PR TITLE
Rate limit API requests if it's an impersonated session

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1625,6 +1625,10 @@ ENFORCE_CONCURRENT_RATE_LIMITS = False
 SENTRY_CONCURRENT_RATE_LIMIT_GROUP_CLI = 999
 SENTRY_RATELIMITER_GROUP_CLI = 999
 
+# Impersonation Rate Limiting
+# Fixed rate limit applied during impersonation sessions (requests per second)
+SENTRY_IMPERSONATION_RATE_LIMIT = 30
+
 # The default value for project-level quotas
 SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = "90%"
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -84,12 +84,7 @@ class RatelimitMiddleware:
                     min_limit = impersonation_limit
 
                 if api_rate_limit.concurrent_limit:
-                    min_concurrent_limit = _normalize_and_min_limit(
-                        api_rate_limit.concurrent_limit,
-                        api_rate_limit.window,
-                        impersonation_limit,
-                        1,
-                    )
+                    min_concurrent_limit = min(api_rate_limit.concurrent_limit, impersonation_limit)
                 else:
                     min_concurrent_limit = impersonation_limit
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -68,10 +68,9 @@ class RatelimitMiddleware:
                     impersonation_limit,
                     api_rate_limit.concurrent_limit or impersonation_limit,
                 )
-                # Preserve the API's window value
                 method_limits[category] = RateLimit(
                     limit=min_limit,
-                    window=api_rate_limit.window,
+                    window=1,  # Impersonation rate limits are always 1 second
                     concurrent_limit=min_concurrent_limit,
                 )
             limit_overrides[method] = method_limits

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable
+from math import ceil
 
 import orjson
 import sentry_sdk
@@ -37,7 +38,9 @@ def _normalize_and_min_limit(a_limit: int, a_window: int, b_limit: int, b_window
     """Normalize two (limit, window) pairs and return the minimum of the two normalized values."""
     norm_a = a_limit / a_window if a_window and a_window >= 1 else a_limit
     norm_b = b_limit / b_window if b_window and b_window >= 1 else b_limit
-    return min(int(norm_a), int(norm_b))
+
+    # Take the ceiling of the normalized values to ensure that the values are at least 1
+    return min(ceil(norm_a), ceil(norm_b))
 
 
 class RatelimitMiddleware:

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -76,6 +76,13 @@ def get_rate_limit_key(
     )
     request_user = getattr(request, "user", None)
 
+    # During impersonation, use the actual_user (the impersonator) for rate limiting
+    # This ensures rate limits are applied to the staff member doing the impersonation,
+    # not the user being impersonated
+    actual_user = getattr(request, "actual_user", None)
+    if actual_user is not None:
+        request_user = actual_user
+
     from django.contrib.auth.models import AnonymousUser
 
     from sentry.auth.system import is_system_auth

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -157,7 +157,7 @@ def get_rate_limit_config(
     view_cls: type[object],
     view_args: Any = None,
     view_kwargs: Any = None,
-) -> RateLimitConfig | None:
+) -> RateLimitConfig:
     """Read the rate limit config from the view to be used for the rate limit check.
 
     If there is no rate limit defined on the view_cls, use the rate limit defined for the group

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -346,7 +346,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         assert (
             user_limit.concurrent_limit == 3
         ), "Should use API's smaller concurrent_limit (3) instead of impersonation_limit (10)"
-        assert user_limit.window == 30, "Should preserve API's window value"
+        assert user_limit.window == 1, "Should always be one second"
 
         # Should use impersonation limit (10) since it's smaller
         ip_limit = result.get_rate_limit("POST", RateLimitCategory.IP)
@@ -354,7 +354,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         assert (
             ip_limit.concurrent_limit == 10
         ), "Should use impersonation limit (10) since it's smaller"
-        assert ip_limit.window == 60, "Should preserve API's window value"
+        assert ip_limit.window == 1, "Should always be one second"
 
 
 @override_settings(SENTRY_SELF_HOSTED=False)


### PR DESCRIPTION
If the request is an impersonated session, we will want to make sure that we rate limit these requests. This is to prevent a hijacked or stolen privileged sessions from doing too much damage for an account.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
