### PR TITLE
add auth checks in detector workflow

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -99,7 +99,9 @@ def can_edit_detector_workflow_connections(detector: Detector, request: Request)
     Anyone with alert write access to the project can connect/disconnect detectors of any type,
     which is slightly different from full edit access which differs by detector type.
     """
-    return request.access.has_scope("alerts:write")
+    return request.access.has_any_project_scope(
+        detector.project, USER_CREATED_DETECTOR_REQUIRED_SCOPES
+    )
 
 
 def validate_detectors_exist_and_have_permissions(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -439,6 +439,119 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         assert "Some detectors do not exist" in str(response.data)
 
+    def test_update_detectors_permission_denied_cross_project_idor(self) -> None:
+        """
+        Test that a user cannot connect a detector from a project they don't have access to.
+        This is a regression test for an IDOR vulnerability where users with alerts:write scope
+        in one project could manipulate detector-workflow connections for detectors in other
+        projects they don't have access to.
+        """
+        # Disable Open Membership - this is the key condition
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create two teams: one for Alice, one for Bob
+        team_alice = self.create_team(organization=self.organization, name="team-alice")
+        team_bob = self.create_team(organization=self.organization, name="team-bob")
+
+        # Create two projects, each owned by a different team
+        self.create_project(organization=self.organization, teams=[team_alice], name="proj-alice")
+        project_bob = self.create_project(
+            organization=self.organization, teams=[team_bob], name="proj-bob"
+        )
+
+        # Create user Alice - member of team_alice only (has access to project_alice)
+        alice = self.create_user(is_superuser=False)
+        self.create_member(
+            user=alice,
+            organization=self.organization,
+            role="member",
+            teams=[team_alice],
+        )
+
+        # Create a detector in Bob's project (Alice should NOT have access to this)
+        bob_detector = self.create_detector(project=project_bob, name="Bob's Detector")
+
+        # Create Alice's workflow
+        alice_workflow = self.create_workflow(organization_id=self.organization.id)
+
+        # Login as Alice
+        self.login_as(alice)
+
+        # Alice attempts to connect Bob's detector to her workflow
+        # This should fail because Alice doesn't have access to project_bob
+        data = {
+            **self.valid_workflow,
+            "detectorIds": [bob_detector.id],
+        }
+
+        self.get_error_response(
+            self.organization.slug,
+            alice_workflow.id,
+            raw_data=data,
+            status_code=403,  # Should be permission denied
+        )
+
+        # Verify the detector-workflow connection was NOT created
+        assert (
+            DetectorWorkflow.objects.filter(workflow=alice_workflow, detector=bob_detector).count()
+            == 0
+        )
+
+    def test_update_detectors_permission_allowed_when_user_has_project_access(self) -> None:
+        """
+        Test that a user CAN connect a detector from a project they have access to.
+        Companion test to test_update_detectors_permission_denied_cross_project_idor.
+        """
+        # Disable Open Membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create a team and project for the user
+        user_team = self.create_team(organization=self.organization, name="user-team")
+        user_project = self.create_project(
+            organization=self.organization, teams=[user_team], name="user-proj"
+        )
+
+        # Create user with team access
+        user_with_access = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_access,
+            organization=self.organization,
+            role="member",
+            teams=[user_team],
+        )
+
+        # Create a detector in the user's project
+        user_detector = self.create_detector(project=user_project, name="User's Detector")
+
+        # Create the user's workflow
+        user_workflow = self.create_workflow(organization_id=self.organization.id)
+
+        # Login as the user
+        self.login_as(user_with_access)
+
+        # User connects their own detector - this SHOULD succeed
+        data = {
+            **self.valid_workflow,
+            "detectorIds": [user_detector.id],
+        }
+
+        with outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                user_workflow.id,
+                raw_data=data,
+            )
+
+        assert response.status_code == 200
+
+        # Verify the detector-workflow connection WAS created
+        assert (
+            DetectorWorkflow.objects.filter(workflow=user_workflow, detector=user_detector).count()
+            == 1
+        )
+
     def test_update_detectors_transaction_rollback_on_validation_failure(self) -> None:
         """Test that workflow updates are rolled back when detector validation fails"""
         existing_detector = self.create_detector(project=self.project)
@@ -718,3 +831,174 @@ class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         with outbox_runner():
             response = self.get_error_response(self.organization.slug, workflow.id)
             assert response.status_code == 404
+
+
+@region_silo_test
+class OrganizationWorkflowDetailsProjectAccessTest(APITestCase):
+    """
+    Security tests to verify that project-level access is enforced when
+    accessing individual workflows via the details endpoint.
+
+    These tests ensure that users cannot access workflows connected to projects
+    they don't have access to, even when specifying the workflow ID directly.
+    This is a regression test for an IDOR vulnerability.
+    """
+
+    endpoint = "sentry-api-0-organization-workflow-details"
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Disable Open Membership - this is the key condition for testing project access
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create two teams: one for the user, one for someone else
+        self.user_team = self.create_team(organization=self.organization, name="user-team")
+        self.other_team = self.create_team(organization=self.organization, name="other-team")
+
+        # Create two projects, each owned by a different team
+        self.user_project = self.create_project(
+            organization=self.organization, teams=[self.user_team], name="user-proj"
+        )
+        self.other_project = self.create_project(
+            organization=self.organization, teams=[self.other_team], name="other-proj"
+        )
+
+        # Create a user who is only a member of user_team (has access to user_project only)
+        self.limited_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=self.limited_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.user_team],
+        )
+
+        # Create workflows with different project connections
+        self.user_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="User's Workflow"
+        )
+        self.other_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="Other's Workflow"
+        )
+        self.unattached_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="Unattached Workflow"
+        )
+
+        # Create detectors in each project
+        self.user_detector = self.create_detector(project=self.user_project)
+        self.other_detector = self.create_detector(project=self.other_project)
+
+        # Connect workflows to detectors
+        DetectorWorkflow.objects.create(workflow=self.user_workflow, detector=self.user_detector)
+        DetectorWorkflow.objects.create(workflow=self.other_workflow, detector=self.other_detector)
+        # unattached_workflow has no detectors connected
+
+    def test_get_cannot_access_workflow_from_inaccessible_project(self) -> None:
+        """
+        Test that users cannot GET workflows connected only to projects they don't have access to.
+        This is a regression test for an IDOR vulnerability.
+        """
+        self.login_as(self.limited_user)
+
+        # User should NOT be able to get the other workflow
+        self.get_error_response(
+            self.organization.slug,
+            self.other_workflow.id,
+            status_code=403,
+        )
+
+    def test_get_can_access_workflow_from_accessible_project(self) -> None:
+        """
+        Test that users CAN GET workflows connected to projects they have access to.
+        """
+        self.login_as(self.limited_user)
+
+        # User SHOULD be able to get their own workflow
+        response = self.get_success_response(
+            self.organization.slug,
+            self.user_workflow.id,
+        )
+        assert response.data["id"] == str(self.user_workflow.id)
+
+    def test_get_can_access_unattached_workflow(self) -> None:
+        """
+        Test that users can access workflows with no detector connections (org-level workflows).
+        """
+        self.login_as(self.limited_user)
+
+        # User SHOULD be able to get unattached workflows
+        response = self.get_success_response(
+            self.organization.slug,
+            self.unattached_workflow.id,
+        )
+        assert response.data["id"] == str(self.unattached_workflow.id)
+
+    def test_put_cannot_modify_workflow_from_inaccessible_project(self) -> None:
+        """
+        Test that users cannot PUT (modify) workflows connected only to projects
+        they don't have access to.
+        """
+        self.login_as(self.limited_user)
+
+        # User should NOT be able to modify the other workflow
+        self.get_error_response(
+            self.organization.slug,
+            self.other_workflow.id,
+            method="PUT",
+            raw_data={
+                "name": "Hacked Workflow",
+                "enabled": True,
+                "config": {},
+                "triggers": {"logicType": "any", "conditions": []},
+                "actionFilters": [],
+            },
+            status_code=403,
+        )
+
+        # Verify the workflow was NOT modified
+        self.other_workflow.refresh_from_db()
+        assert self.other_workflow.name == "Other's Workflow"
+
+    def test_delete_cannot_delete_workflow_from_inaccessible_project(self) -> None:
+        """
+        Test that users cannot DELETE workflows connected only to projects
+        they don't have access to.
+        """
+        self.login_as(self.limited_user)
+
+        # User should NOT be able to delete the other workflow
+        self.get_error_response(
+            self.organization.slug,
+            self.other_workflow.id,
+            method="DELETE",
+            status_code=403,
+        )
+
+        # Verify the workflow was NOT deleted
+        self.other_workflow.refresh_from_db()
+        assert self.other_workflow.status != ObjectStatus.PENDING_DELETION
+
+    def test_access_workflow_connected_to_multiple_projects_with_partial_access(self) -> None:
+        """
+        Test that users CAN access a workflow if they have access to at least one
+        of its connected projects, even if they don't have access to all of them.
+        """
+        self.login_as(self.limited_user)
+
+        # Create a workflow connected to BOTH projects
+        multi_project_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="Multi-Project Workflow"
+        )
+        DetectorWorkflow.objects.create(
+            workflow=multi_project_workflow, detector=self.user_detector
+        )
+        DetectorWorkflow.objects.create(
+            workflow=multi_project_workflow, detector=self.other_detector
+        )
+
+        # User has access to one of the projects, so should be able to access the workflow
+        response = self.get_success_response(
+            self.organization.slug,
+            multi_project_workflow.id,
+        )
+        assert response.data["id"] == str(multi_project_workflow.id)

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -385,7 +385,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         return sentry_app, installation
 
 
-class ProjectAccessTestMixin:
+class ProjectAccessTestMixin(TestCase):
     """
     Mixin that provides common setup for testing project-level access controls.
 

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -383,3 +383,65 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             slug=sentry_app.slug, organization=self.organization
         )
         return sentry_app, installation
+
+
+class ProjectAccessTestMixin:
+    """
+    Mixin that provides common setup for testing project-level access controls.
+
+    Sets up an organization with open membership disabled, two teams with separate
+    projects, a limited user with access to only one team/project, and workflows
+    connected to detectors in each project.
+
+    Use this mixin for testing IDOR vulnerabilities and project-level access filtering.
+    """
+
+    def setup_project_access_test_data(self) -> None:
+        """
+        Set up common test data for project access tests.
+        Call this from setUp() after calling super().setUp().
+        """
+        # Disable Open Membership - this is the key condition for testing project access
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create two teams: one for the user, one for someone else
+        self.user_team = self.create_team(organization=self.organization, name="user-team")
+        self.other_team = self.create_team(organization=self.organization, name="other-team")
+
+        # Create two projects, each owned by a different team
+        self.user_project = self.create_project(
+            organization=self.organization, teams=[self.user_team], name="user-proj"
+        )
+        self.other_project = self.create_project(
+            organization=self.organization, teams=[self.other_team], name="other-proj"
+        )
+
+        # Create a user who is only a member of user_team (has access to user_project only)
+        self.limited_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=self.limited_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.user_team],
+        )
+
+        # Create workflows with different project connections
+        self.user_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="User's Workflow"
+        )
+        self.other_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="Other's Workflow"
+        )
+        self.unattached_workflow = self.create_workflow(
+            organization_id=self.organization.id, name="Unattached Workflow"
+        )
+
+        # Create detectors in each project
+        self.user_detector = self.create_detector(project=self.user_project)
+        self.other_detector = self.create_detector(project=self.other_project)
+
+        # Connect workflows to detectors
+        DetectorWorkflow.objects.create(workflow=self.user_workflow, detector=self.user_detector)
+        DetectorWorkflow.objects.create(workflow=self.other_workflow, detector=self.other_detector)
+        # unattached_workflow has no detectors connected


### PR DESCRIPTION
Several auth checks are missing around detector workflows. 
- fix IDOR in detector_workflow.py, ensure project scopes are checked
- organziation_workflow_index changes
  - filter_workflows() would return early and bypass auth check entirely, removed it
  - Added include_all_accessible=True to get_projects() call
  - Added a project access checks in convert_args
- Add 17 tests to protect against auth check regressions
