### PR TITLE
feat(attributes): Support fetching explicit boolean attributes

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -65,14 +65,18 @@ export function OurlogsDrawer({
     useTraceItemAttributes('string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributes('number');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributes('boolean');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),
     searchSource: 'ourlogs',
     onSearch: (query: string) => setLogsQuery(query),
+    booleanAttributes,
     numberAttributes,
     stringAttributes,
     itemType: TraceItemDataset.LOGS,
+    booleanSecondaryAliases,
     numberSecondaryAliases,
     stringSecondaryAliases,
   };

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -50,6 +50,8 @@ export interface UseSpanSearchQueryBuilderProps {
   useEap?: boolean;
 }
 export interface SpanSearchQueryBuilderProps extends UseSpanSearchQueryBuilderProps {
+  booleanAttributes: TagCollection;
+  booleanSecondaryAliases: TagCollection;
   itemType: TraceItemDataset;
   numberAttributes: TagCollection;
   numberSecondaryAliases: TagCollection;
@@ -69,6 +71,8 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     useTraceItemTags('number');
   const {tags: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useTraceItemTags('string');
+  const {tags: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemTags('boolean');
 
   const stringAttributesWithSemver = useMemo(() => {
     if (SpanFields.RELEASE in stringAttributes) {
@@ -84,6 +88,8 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     () => ({
       ...props,
       itemType: TraceItemDataset.SPANS,
+      booleanAttributes,
+      booleanSecondaryAliases,
       numberAttributes,
       stringAttributes: stringAttributesWithSemver,
       numberSecondaryAliases,
@@ -91,6 +97,8 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
       caseInsensitive: props.caseInsensitive ? true : undefined,
     }),
     [
+      booleanAttributes,
+      booleanSecondaryAliases,
       numberAttributes,
       numberSecondaryAliases,
       props,
@@ -102,6 +110,8 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
   const spanSearchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps({
     ...props,
     itemType: TraceItemDataset.SPANS,
+    booleanAttributes,
+    booleanSecondaryAliases,
     numberAttributes,
     stringAttributes: stringAttributesWithSemver,
     numberSecondaryAliases,

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -83,6 +83,8 @@ export function PreprodSearchBar({
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string', hiddenKeys);
   const {attributes: rawNumberAttributes, secondaryAliases: rawNumberSecondaryAliases} =
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number', hiddenKeys);
+  const {attributes: rawBooleanAttributes, secondaryAliases: rawBooleanSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'boolean', hiddenKeys);
 
   const stringAttributes = useMemo(
     () =>
@@ -116,6 +118,22 @@ export function PreprodSearchBar({
     [allowedKeys, rawNumberSecondaryAliases]
   );
 
+  const booleanAttributes = useMemo(
+    () =>
+      allowedKeys
+        ? filterToAllowedKeys(rawBooleanAttributes, allowedKeys)
+        : rawBooleanAttributes,
+    [allowedKeys, rawBooleanAttributes]
+  );
+
+  const booleanSecondaryAliases = useMemo(
+    () =>
+      allowedKeys
+        ? filterToAllowedKeys(rawBooleanSecondaryAliases, allowedKeys)
+        : rawBooleanSecondaryAliases,
+    [allowedKeys, rawBooleanSecondaryAliases]
+  );
+
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={initialQuery}
@@ -126,6 +144,8 @@ export function PreprodSearchBar({
       stringAttributes={stringAttributes}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
+      booleanAttributes={booleanAttributes}
+      booleanSecondaryAliases={booleanSecondaryAliases}
       searchSource={searchSource}
       projects={projects}
       portalTarget={portalTarget}

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -86,12 +86,13 @@ function EAPField({aggregate, onChange, eventTypes}: Props) {
 
   const {attributes: storedNumberTags} = useTraceItemAttributes('number');
   const {attributes: storedStringTags} = useTraceItemAttributes('string');
+  const {attributes: storedBooleanTags} = useTraceItemAttributes('boolean');
 
   const storedTags = useMemo(() => {
     return aggregation === AggregationKey.COUNT_UNIQUE
-      ? {...storedNumberTags, ...storedStringTags}
+      ? {...storedNumberTags, ...storedStringTags, ...storedBooleanTags}
       : storedNumberTags;
-  }, [aggregation, storedNumberTags, storedStringTags]);
+  }, [aggregation, storedBooleanTags, storedNumberTags, storedStringTags]);
 
   const fieldsArray = useMemo(() => {
     return Object.values(storedTags).toSorted((a, b) => {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -872,6 +872,8 @@ function EAPSearchQueryBuilderWithContext({
     useTraceItemAttributes('number');
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useTraceItemAttributes('string');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributes('boolean');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery,
@@ -879,10 +881,12 @@ function EAPSearchQueryBuilderWithContext({
     onSearch,
     numberAttributes,
     stringAttributes,
+    booleanAttributes,
     itemType: traceItemType,
     projects: [parseInt(project.id, 10)],
     numberSecondaryAliases,
     stringSecondaryAliases,
+    booleanSecondaryAliases,
   };
 
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -127,13 +127,17 @@ function LogsSearchBar({
     useTraceItemAttributes('string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributes('number');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributes('boolean');
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.LOGS}
+      booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
       searchSource="dashboards"
@@ -159,12 +163,16 @@ function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): Search
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'boolean');
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.LOGS,
+      booleanAttributes,
       numberAttributes,
       stringAttributes,
+      booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
       searchSource: 'dashboards',

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -199,14 +199,18 @@ function useMobileAppSizeSearchBarDataProvider(
     useTraceItemAttributes('string', HIDDEN_PREPROD_ATTRIBUTES);
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributes('number', HIDDEN_PREPROD_ATTRIBUTES);
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributes('boolean', HIDDEN_PREPROD_ATTRIBUTES);
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.PREPROD,
       numberAttributes,
       stringAttributes,
+      booleanAttributes,
       numberSecondaryAliases,
       stringSecondaryAliases,
+      booleanSecondaryAliases,
       searchSource: 'dashboards',
       initialQuery: props.widgetQuery?.conditions ?? '',
       projects,

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -146,12 +146,16 @@ function useSpansSearchBarDataProvider(props: SearchBarDataProviderProps): Searc
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'boolean');
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.SPANS,
+      booleanAttributes,
       numberAttributes,
       stringAttributes,
+      booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
       searchSource: 'dashboards',

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -101,14 +101,22 @@ function TraceMetricsSearchBar({
       'number',
       HiddenTraceMetricSearchFields
     );
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributesWithConfig(
+      traceItemAttributeConfig,
+      'boolean',
+      HiddenTraceMetricSearchFields
+    );
 
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.TRACEMETRICS}
+      booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
       searchSource="dashboards"
@@ -141,12 +149,16 @@ function useTraceMetricsSearchBarDataProvider(
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'boolean');
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.TRACEMETRICS,
+      booleanAttributes,
       numberAttributes,
       stringAttributes,
+      booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
       searchSource: 'dashboards',

--- a/static/app/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder.tsx
@@ -21,6 +21,7 @@ export function ExploreArithmeticBuilder({equation, onUpdate}: Props) {
   const expression = stripEquationPrefix(equation);
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const functionArguments: FunctionArgument[] = useMemo(() => {
     return [
@@ -59,6 +60,7 @@ export function ExploreArithmeticBuilder({equation, onUpdate}: Props) {
   const getSuggestedAttribute = useExploreSuggestedAttribute({
     numberAttributes: numberTags,
     stringAttributes: stringTags,
+    booleanAttributes: booleanTags,
   });
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -40,6 +40,7 @@ function WidgetBuilderGroupBySelector({
   }
   const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
   const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
+  const {tags: booleanSpanTags} = useTraceItemTags('boolean', hiddenKeys);
 
   const groupByOptions = useMemo(() => {
     const datasetConfig = getDatasetConfig(state.dataset);
@@ -56,11 +57,19 @@ function WidgetBuilderGroupBySelector({
       return datasetConfig.getGroupByFieldOptions(organization, {
         ...numericSpanTags,
         ...stringSpanTags,
+        ...booleanSpanTags,
       });
     }
 
     return datasetConfig.getGroupByFieldOptions(organization, tags);
-  }, [numericSpanTags, organization, state.dataset, stringSpanTags, tags]);
+  }, [
+    booleanSpanTags,
+    numericSpanTags,
+    organization,
+    state.dataset,
+    stringSpanTags,
+    tags,
+  ]);
 
   const handleGroupByChange = (newValue: QueryFieldValue[]) => {
     dispatch({type: BuilderStateAction.SET_FIELDS, payload: newValue});

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -45,12 +45,14 @@ function WidgetBuilderSortBySelector() {
   }
   const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
   const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
+  const {tags: booleanSpanTags} = useTraceItemTags('boolean', hiddenKeys);
+
   if (
     state.dataset === WidgetType.SPANS ||
     state.dataset === WidgetType.LOGS ||
     state.dataset === WidgetType.TRACEMETRICS
   ) {
-    tags = {...numericSpanTags, ...stringSpanTags};
+    tags = {...numericSpanTags, ...stringSpanTags, ...booleanSpanTags};
   }
 
   let disableSort = false;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -36,44 +36,57 @@ describe('Visualize', () => {
 
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
 
-    jest.mocked(useTraceItemTags).mockImplementation((type?: 'number' | 'string') => {
-      if (type === 'number') {
+    jest
+      .mocked(useTraceItemTags)
+      .mockImplementation((type?: 'number' | 'string' | 'boolean') => {
+        if (type === 'number') {
+          const tags: TagCollection = {
+            'span.duration': {
+              key: 'span.duration',
+              name: 'span.duration',
+              kind: FieldKind.MEASUREMENT,
+              secondaryAliases: [],
+            },
+            'span.self_time': {
+              key: 'span.self_time',
+              name: 'span.self_time',
+              kind: FieldKind.MEASUREMENT,
+              secondaryAliases: [],
+            },
+          };
+          return {tags, isLoading: false, secondaryAliases: {}};
+        }
+
+        if (type === 'boolean') {
+          const tags: TagCollection = {
+            'span.status': {
+              key: 'span.status',
+              name: 'span.status',
+              kind: FieldKind.BOOLEAN,
+            },
+          };
+          return {tags, isLoading: false, secondaryAliases: {}};
+        }
+
         const tags: TagCollection = {
-          'span.duration': {
-            key: 'span.duration',
-            name: 'span.duration',
-            kind: FieldKind.MEASUREMENT,
-            secondaryAliases: [],
+          'span.op': {
+            key: 'span.op',
+            name: 'span.op',
+            kind: FieldKind.TAG,
           },
-          'span.self_time': {
-            key: 'span.self_time',
-            name: 'span.self_time',
-            kind: FieldKind.MEASUREMENT,
-            secondaryAliases: [],
+          'span.description': {
+            key: 'span.description',
+            name: 'span.description',
+            kind: FieldKind.TAG,
           },
         };
-        return {tags, isLoading: false, secondaryAliases: {}};
-      }
 
-      const tags: TagCollection = {
-        'span.op': {
-          key: 'span.op',
-          name: 'span.op',
-          kind: FieldKind.TAG,
-        },
-        'span.description': {
-          key: 'span.description',
-          name: 'span.description',
-          kind: FieldKind.TAG,
-        },
-      };
-
-      return {
-        tags,
-        secondaryAliases: {},
-        isLoading: false,
-      };
-    });
+        return {
+          tags,
+          secondaryAliases: {},
+          isLoading: false,
+        };
+      });
 
     mockNavigate = jest.fn();
     jest.mocked(useNavigate).mockReturnValue(mockNavigate);
@@ -1246,38 +1259,44 @@ describe('Visualize', () => {
 
   describe('spans', () => {
     beforeEach(() => {
-      jest.mocked(useTraceItemTags).mockImplementation((type?: 'string' | 'number') => {
-        if (type === 'number') {
+      jest
+        .mocked(useTraceItemTags)
+        .mockImplementation((type?: 'string' | 'number' | 'boolean') => {
+          if (type === 'number') {
+            return {
+              tags: {
+                'span.duration': {
+                  key: 'span.duration',
+                  name: 'span.duration',
+                  kind: 'measurement',
+                },
+                'tags[anotherNumericTag,number]': {
+                  key: 'anotherNumericTag',
+                  name: 'anotherNumericTag',
+                  kind: 'measurement',
+                },
+              } as TagCollection,
+              secondaryAliases: {},
+              isLoading: false,
+            };
+          }
+
+          if (type === 'boolean') {
+            return {tags: {}, isLoading: false, secondaryAliases: {}};
+          }
+
           return {
             tags: {
-              'span.duration': {
-                key: 'span.duration',
-                name: 'span.duration',
-                kind: 'measurement',
-              },
-              'tags[anotherNumericTag,number]': {
-                key: 'anotherNumericTag',
-                name: 'anotherNumericTag',
-                kind: 'measurement',
+              'span.description': {
+                key: 'span.description',
+                name: 'span.description',
+                kind: 'tag',
               },
             } as TagCollection,
             secondaryAliases: {},
             isLoading: false,
           };
-        }
-
-        return {
-          tags: {
-            'span.description': {
-              key: 'span.description',
-              name: 'span.description',
-              kind: 'tag',
-            },
-          } as TagCollection,
-          secondaryAliases: {},
-          isLoading: false,
-        };
-      });
+        });
     });
 
     it('shows numeric tags as primary options for chart widgets', async () => {
@@ -1413,23 +1432,29 @@ describe('Visualize', () => {
     });
 
     it('differentiates between function and column values in selection', async () => {
-      jest.mocked(useTraceItemTags).mockImplementation((type?: 'string' | 'number') => {
-        if (type === 'number') {
+      jest
+        .mocked(useTraceItemTags)
+        .mockImplementation((type?: 'string' | 'number' | 'boolean') => {
+          if (type === 'number') {
+            return {
+              tags: {
+                'tags[count,number]': {key: 'count', name: 'count', kind: 'measurement'},
+              } as TagCollection,
+              secondaryAliases: {},
+              isLoading: false,
+            };
+          }
+
+          if (type === 'boolean') {
+            return {tags: {}, secondaryAliases: {}, isLoading: false};
+          }
+
           return {
-            tags: {
-              'tags[count,number]': {key: 'count', name: 'count', kind: 'measurement'},
-            } as TagCollection,
+            tags: {count: {key: 'count', name: 'count', kind: 'tag'}} as TagCollection,
             secondaryAliases: {},
             isLoading: false,
           };
-        }
-
-        return {
-          tags: {count: {key: 'count', name: 'count', kind: 'tag'}} as TagCollection,
-          secondaryAliases: {},
-          isLoading: false,
-        };
-      });
+        });
       render(
         <WidgetBuilderProvider>
           <Visualize />

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -352,7 +352,7 @@ function Visualize({error, setError}: VisualizeProps) {
     ];
     options.sort(_sortFn);
     return options;
-  }, [state.dataset, state.fields, stringSpanTags, numericSpanTags]);
+  }, [state.dataset, state.fields, stringSpanTags, numericSpanTags, booleanSpanTags]);
 
   const datasetConfig = useMemo(() => getDatasetConfig(state.dataset), [state.dataset]);
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -294,6 +294,7 @@ function Visualize({error, setError}: VisualizeProps) {
   }
   const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
   const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
+  const {tags: booleanSpanTags} = useTraceItemTags('boolean', hiddenKeys);
 
   // Span column options are explicitly defined and bypass all of the
   // fieldOptions filtering and logic used for showing options for
@@ -317,7 +318,8 @@ function Visualize({error, setError}: VisualizeProps) {
           column =>
             column !== '' &&
             !stringSpanTags.hasOwnProperty(column) &&
-            !numericSpanTags.hasOwnProperty(column)
+            !numericSpanTags.hasOwnProperty(column) &&
+            !booleanSpanTags.hasOwnProperty(column)
         )
         .map(column => {
           return {
@@ -326,6 +328,13 @@ function Visualize({error, setError}: VisualizeProps) {
             trailingItems: () => <TypeBadge kind={classifyTagKey(column)} />,
           };
         }),
+      ...Object.values(booleanSpanTags).map(tag => {
+        return {
+          label: tag.name,
+          value: tag.key,
+          trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
+        };
+      }),
       ...Object.values(stringSpanTags).map(tag => {
         return {
           label: tag.name,
@@ -366,7 +375,7 @@ function Visualize({error, setError}: VisualizeProps) {
     ) {
       return datasetConfig.getTableFieldOptions(
         organization,
-        {...numericSpanTags, ...stringSpanTags},
+        {...booleanSpanTags, ...numericSpanTags, ...stringSpanTags},
         customMeasurements
       );
     }
@@ -378,14 +387,15 @@ function Visualize({error, setError}: VisualizeProps) {
       state.displayType
     );
   }, [
-    state.dataset,
-    datasetConfig,
-    organization,
-    tags,
+    booleanSpanTags,
     customMeasurements,
+    datasetConfig,
     numericSpanTags,
-    stringSpanTags,
+    organization,
+    state.dataset,
     state.displayType,
+    stringSpanTags,
+    tags,
   ]);
 
   const aggregates = useMemo(

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -32,6 +32,7 @@ import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetC
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useCustomMeasurements} from 'sentry/views/detectors/datasetConfig/useCustomMeasurements';
 import {
+  useTraceItemBooleanAttributes,
   useTraceItemNumberAttributes,
   useTraceItemStringAttributes,
 } from 'sentry/views/detectors/datasetConfig/useTraceItemAttributes';
@@ -240,6 +241,10 @@ export function Visualize() {
     traceItemType,
     projectIds: [Number(projectId)],
   });
+  const {attributes: booleanSpanTags} = useTraceItemBooleanAttributes({
+    traceItemType,
+    projectIds: [Number(projectId)],
+  });
   const formContext = useContext(FormContext);
 
   const isTransactionsDataset = dataset === DetectorDataset.TRANSACTIONS;
@@ -284,6 +289,12 @@ export function Visualize() {
               prettifyTagKey(tag.name),
             ])
           : []),
+        ...(isTypeAllowed(FieldValueType.BOOLEAN)
+          ? Object.values(booleanSpanTags).map((tag): [string, string] => [
+              tag.key,
+              prettifyTagKey(tag.name),
+            ])
+          : []),
       ];
       return spanColumnOptions.sort((a, b) => a[1].localeCompare(b[1]));
     }
@@ -296,7 +307,14 @@ export function Visualize() {
       )
       .map((option): [string, string] => [option.value.meta.name, option.value.meta.name])
       .sort((a, b) => a[1].localeCompare(b[1]));
-  }, [dataset, stringSpanTags, numericSpanTags, aggregateOptions, aggregate]);
+  }, [
+    aggregate,
+    aggregateOptions,
+    booleanSpanTags,
+    dataset,
+    numericSpanTags,
+    stringSpanTags,
+  ]);
 
   const fieldOptionsDropdown = useMemo(() => {
     return fieldOptions.map(([value, label]) => ({

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -5,6 +5,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES, FieldKind} from 'sentry/utils/fields';
 import type {DetectorSearchBarProps} from 'sentry/views/detectors/datasetConfig/base';
 import {
+  useTraceItemBooleanAttributes,
   useTraceItemNumberAttributes,
   useTraceItemStringAttributes,
 } from 'sentry/views/detectors/datasetConfig/useTraceItemAttributes';
@@ -22,6 +23,10 @@ export function TraceSearchBar({
   const isLogs = dataset === DiscoverDatasets.OURLOGS;
   const traceDataset = isLogs ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
   const {attributes: numberAttributes} = useTraceItemNumberAttributes({
+    traceItemType: traceDataset,
+    projectIds,
+  });
+  const {attributes: booleanAttributes} = useTraceItemBooleanAttributes({
     traceItemType: traceDataset,
     projectIds,
   });
@@ -49,14 +54,25 @@ export function TraceSearchBar({
     return secondaryAliases;
   }, [stringAttributes]);
 
+  const booleanSecondaryAliases = useMemo(() => {
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(booleanAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.BOOLEAN}])
+    );
+    return secondaryAliases;
+  }, [booleanAttributes]);
+
   return (
     <TraceItemSearchQueryBuilder
       itemType={traceDataset}
       initialQuery={initialQuery}
       onSearch={onSearch}
+      booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       numberSecondaryAliases={numberSecondaryAliases}
       stringAttributes={stringAttributes}
+      booleanSecondaryAliases={booleanSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
       supportedAggregates={isLogs ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
       searchSource="detectors"

--- a/static/app/views/detectors/datasetConfig/useTraceItemAttributes.tsx
+++ b/static/app/views/detectors/datasetConfig/useTraceItemAttributes.tsx
@@ -106,10 +106,13 @@ export function useTraceItemNumberAttributes({
       {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
     ]);
 
-    return removeHiddenKeys(
-      {...numberAttributes, ...Object.fromEntries(measurements)},
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    const combined = {...numberAttributes, ...Object.fromEntries(measurements)};
+
+    if (traceItemType === TraceItemDataset.PREPROD) {
+      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
+    }
+
+    return combined;
   }, [numberAttributes, traceItemType]);
 
   return {
@@ -142,10 +145,13 @@ export function useTraceItemStringAttributes({
       {key: tag, name: tag, kind: FieldKind.TAG},
     ]);
 
-    return removeHiddenKeys(
-      {...stringAttributes, ...Object.fromEntries(tags)},
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    const combined = {...stringAttributes, ...Object.fromEntries(tags)};
+
+    if (traceItemType === TraceItemDataset.PREPROD) {
+      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
+    }
+
+    return combined;
   }, [stringAttributes, traceItemType]);
 
   return {
@@ -189,10 +195,13 @@ export function useTraceItemBooleanAttributes({
       {key: tag, name: tag, kind: FieldKind.BOOLEAN},
     ]);
 
-    return removeHiddenKeys(
-      {...booleanAttributes, ...Object.fromEntries(tags)},
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    const combined = {...booleanAttributes, ...Object.fromEntries(tags)};
+
+    if (traceItemType === TraceItemDataset.PREPROD) {
+      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
+    }
+
+    return combined;
   }, [booleanAttributes, hasBooleanFilters, traceItemType]);
 
   return {

--- a/static/app/views/detectors/datasetConfig/useTraceItemAttributes.tsx
+++ b/static/app/views/detectors/datasetConfig/useTraceItemAttributes.tsx
@@ -7,7 +7,6 @@ import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
-  HIDDEN_PREPROD_ATTRIBUTES,
   SENTRY_LOG_BOOLEAN_TAGS,
   SENTRY_LOG_NUMBER_TAGS,
   SENTRY_LOG_STRING_TAGS,
@@ -26,7 +25,6 @@ import {
   makeTraceItemAttributeKeysQueryOptions,
 } from 'sentry/views/explore/hooks/useGetTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {removeHiddenKeys} from 'sentry/views/explore/utils';
 
 interface UseTraceItemAttributeKeysProps {
   projectIds: number[];
@@ -108,10 +106,6 @@ export function useTraceItemNumberAttributes({
 
     const combined = {...numberAttributes, ...Object.fromEntries(measurements)};
 
-    if (traceItemType === TraceItemDataset.PREPROD) {
-      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
-    }
-
     return combined;
   }, [numberAttributes, traceItemType]);
 
@@ -146,10 +140,6 @@ export function useTraceItemStringAttributes({
     ]);
 
     const combined = {...stringAttributes, ...Object.fromEntries(tags)};
-
-    if (traceItemType === TraceItemDataset.PREPROD) {
-      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
-    }
 
     return combined;
   }, [stringAttributes, traceItemType]);
@@ -196,10 +186,6 @@ export function useTraceItemBooleanAttributes({
     ]);
 
     const combined = {...booleanAttributes, ...Object.fromEntries(tags)};
-
-    if (traceItemType === TraceItemDataset.PREPROD) {
-      return removeHiddenKeys(combined, HIDDEN_PREPROD_ATTRIBUTES);
-    }
 
     return combined;
   }, [booleanAttributes, hasBooleanFilters, traceItemType]);

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -21,6 +21,10 @@ const mockCustomTags: TagCollection = {
   customTag: {key: 'customTag', kind: FieldKind.TAG, name: 'customTag'},
 };
 
+const mockBooleanTags: TagCollection = {
+  booleanTag1: {key: 'booleanTag1', kind: FieldKind.BOOLEAN, name: 'booleanTag1'},
+};
+
 const mockDispatch = jest.fn();
 
 // Add mock for useSearchQueryBuilder
@@ -91,6 +95,7 @@ describe('SchemaHintsList', () => {
     render(
       <Subject
         stringTags={mockStringTags}
+        booleanTags={mockBooleanTags}
         numberTags={mockNumberTags}
         supportedAggregates={[AggregationKey.COUNT]}
       />
@@ -100,13 +105,14 @@ describe('SchemaHintsList', () => {
     const withinContainer = within(container);
     expect(withinContainer.getByText('stringTag1')).toBeInTheDocument();
     expect(withinContainer.getByText('stringTag2')).toBeInTheDocument();
-    expect(withinContainer.getAllByText('is')).toHaveLength(2);
+    expect(withinContainer.getAllByText('is')).toHaveLength(3);
     expect(withinContainer.getByText('numberTag1')).toBeInTheDocument();
     expect(withinContainer.getByText('numberTag2')).toBeInTheDocument();
     expect(withinContainer.getByText('count(...)')).toBeInTheDocument();
     expect(withinContainer.getAllByText('>')).toHaveLength(3);
-    expect(withinContainer.getAllByText('...')).toHaveLength(5);
+    expect(withinContainer.getAllByText('...')).toHaveLength(6);
     expect(withinContainer.getByText('See full list')).toBeInTheDocument();
+    expect(withinContainer.getByText('booleanTag1')).toBeInTheDocument();
   });
 
   it('should call dispatch with correct parameters when hint is clicked', async () => {
@@ -114,6 +120,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[]}
       />
     );
@@ -144,6 +151,7 @@ describe('SchemaHintsList', () => {
     render(
       <Subject
         stringTags={mockStringTags}
+        booleanTags={mockBooleanTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
       />
@@ -161,12 +169,16 @@ describe('SchemaHintsList', () => {
     Object.values(mockNumberTags).forEach(tag => {
       expect(withinDrawer.getByText(tag.key)).toBeInTheDocument();
     });
+    Object.values(mockBooleanTags).forEach(tag => {
+      expect(withinDrawer.getByText(tag.key)).toBeInTheDocument();
+    });
   });
 
-  it('should add hint to query when clicked on drawer', async () => {
+  it('should add string hint to query when clicked on drawer', async () => {
     render(
       <Subject
         stringTags={mockStringTags}
+        booleanTags={mockBooleanTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
       />
@@ -181,9 +193,39 @@ describe('SchemaHintsList', () => {
     const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
-    expect(mockDispatch).toHaveBeenCalledWith({
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'UPDATE_QUERY',
       query: 'stringTag1:""',
+      focusOverride: {
+        itemKey: 'filter:0',
+        part: 'value',
+      },
+      shouldCommitQuery: false,
+    });
+  });
+
+  it('should add boolean hint to query when clicked on drawer', async () => {
+    render(
+      <Subject
+        stringTags={mockStringTags}
+        booleanTags={mockBooleanTags}
+        numberTags={mockNumberTags}
+        supportedAggregates={[]}
+      />
+    );
+
+    const seeFullList = screen.getByText('See full list');
+    await userEvent.click(seeFullList);
+
+    expect(screen.getByLabelText('Schema Hints Drawer')).toBeInTheDocument();
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
+
+    const booleanTag1Checkbox = withinDrawer.getByText('booleanTag1');
+    await userEvent.click(booleanTag1Checkbox);
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'UPDATE_QUERY',
+      query: 'booleanTag1:True',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',
@@ -197,6 +239,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[AggregationKey.COUNT_UNIQUE]}
       />
     );
@@ -248,6 +291,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[]}
       />
     );
@@ -289,6 +333,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[AggregationKey.COUNT_UNIQUE]}
       />
     );
@@ -318,6 +363,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[]}
       />,
       {
@@ -350,6 +396,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[]}
       />
     );
@@ -384,6 +431,7 @@ describe('SchemaHintsList', () => {
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
+        booleanTags={mockBooleanTags}
         supportedAggregates={[]}
       />
     );
@@ -416,6 +464,7 @@ describe('SchemaHintsList', () => {
         stringTags={logsStringTags}
         numberTags={{}}
         supportedAggregates={[]}
+        booleanTags={mockBooleanTags}
         source={SchemaHintsSources.LOGS}
       />
     );

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -51,6 +51,7 @@ interface SchemaHintsListProps extends SchemaHintsPageParams {
   numberTags: TagCollection;
   stringTags: TagCollection;
   supportedAggregates: AggregationKey[];
+  booleanTags?: TagCollection;
   isLoading?: boolean;
   /**
    * The width of all elements to the right of the search bar.
@@ -140,6 +141,7 @@ function formatHintOperator(hint: Tag) {
 
 function SchemaHintsList({
   supportedAggregates,
+  booleanTags = {},
   numberTags,
   stringTags,
   isLoading,
@@ -169,6 +171,7 @@ function SchemaHintsList({
     const filterTags = removeHiddenSchemaHintsKeys({
       ...functionTags,
       ...numberTags,
+      ...booleanTags,
       ...stringTags,
     });
 
@@ -188,7 +191,7 @@ function SchemaHintsList({
     const otherTags = getTagsFromKeys(otherKeys, filterTags);
 
     return [...schemaHintsPresetTags, ...sectionSortedTags, ...otherTags];
-  }, [functionTags, numberTags, stringTags, source]);
+  }, [functionTags, numberTags, booleanTags, stringTags, source]);
 
   // In the bar, we can limit the schema hints shown to ONLY be ones in the list order set (eg. logs), but should still show the fullFilterTagsSorted in the drawer.
   const filterTagsSorted = useMemo(() => {

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -36,6 +36,7 @@ export function VisualizeEquation({
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const functionArguments: FunctionArgument[] = useMemo(() => {
     return [
@@ -77,6 +78,7 @@ export function VisualizeEquation({
   const getSuggestedAttribute = useExploreSuggestedAttribute({
     numberAttributes: numberTags,
     stringAttributes: stringTags,
+    booleanAttributes: booleanTags,
   });
 
   return (

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -1,0 +1,62 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {FieldKind} from 'sentry/utils/fields';
+import {useTraceItemSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+describe('useTraceItemSearchQueryBuilderProps', () => {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+  });
+
+  it('wires boolean attributes into filter keys, aliases, and sections', () => {
+    const booleanAttributes = {
+      'feature.enabled': {
+        key: 'feature.enabled',
+        name: 'feature.enabled',
+        kind: FieldKind.BOOLEAN,
+      },
+    };
+    const booleanSecondaryAliases = {
+      'feature.enabled_alias': {
+        key: 'feature.enabled_alias',
+        name: 'feature.enabled_alias',
+        kind: FieldKind.BOOLEAN,
+      },
+    };
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemSearchQueryBuilderProps({
+          itemType: TraceItemDataset.SPANS,
+          booleanAttributes,
+          booleanSecondaryAliases,
+          numberAttributes: {},
+          numberSecondaryAliases: {},
+          stringAttributes: {},
+          stringSecondaryAliases: {},
+          initialQuery: '',
+          searchSource: 'test',
+        }),
+      {
+        organization: {
+          features: ['search-query-builder-explicit-boolean-filters'],
+        },
+      }
+    );
+
+    expect(result.current.filterKeys['feature.enabled']).toBeDefined();
+    expect(result.current.filterKeyAliases?.['feature.enabled_alias']).toBeDefined();
+  });
+});

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -121,6 +121,7 @@ export function useTraceItemSearchQueryBuilderProps({
   const getSuggestedAttribute = useExploreSuggestedAttribute({
     numberAttributes,
     stringAttributes,
+    booleanAttributes,
   });
 
   return useMemo(

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -19,6 +19,8 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
 export type TraceItemSearchQueryBuilderProps = {
+  booleanAttributes: TagCollection;
+  booleanSecondaryAliases: TagCollection;
   itemType: TraceItemDataset;
   numberAttributes: TagCollection;
   numberSecondaryAliases: TagCollection;
@@ -75,6 +77,8 @@ function getTraceItemFieldDefinitionFunction(
 
 export function useTraceItemSearchQueryBuilderProps({
   itemType,
+  booleanAttributes,
+  booleanSecondaryAliases,
   numberAttributes,
   numberSecondaryAliases,
   stringAttributes,
@@ -100,12 +104,13 @@ export function useTraceItemSearchQueryBuilderProps({
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
   const filterKeySections = useFilterKeySections(itemType, stringAttributes);
-  const filterTags = useFilterTags(
+  const filterTags = useFilterTags({
     numberAttributes,
     stringAttributes,
     functionTags,
-    disallowHas ?? false
-  );
+    booleanAttributes,
+    disallowHas: disallowHas ?? false,
+  });
 
   const getTraceItemAttributeValues = useGetTraceItemAttributeValues({
     traceItemType: itemType,
@@ -141,11 +146,16 @@ export function useTraceItemSearchQueryBuilderProps({
       portalTarget,
       replaceRawSearchKeys,
       matchKeySuggestions,
-      filterKeyAliases: {...numberSecondaryAliases, ...stringSecondaryAliases},
+      filterKeyAliases: {
+        ...numberSecondaryAliases,
+        ...stringSecondaryAliases,
+        ...booleanSecondaryAliases,
+      },
       caseInsensitive,
       onCaseInsensitiveClick,
     }),
     [
+      booleanSecondaryAliases,
       caseInsensitive,
       disallowFreeText,
       disallowLogicalOperators,
@@ -175,6 +185,8 @@ export function useTraceItemSearchQueryBuilderProps({
 export function TraceItemSearchQueryBuilder({
   autoFocus,
   initialQuery,
+  booleanSecondaryAliases,
+  booleanAttributes,
   numberSecondaryAliases,
   numberAttributes,
   stringSecondaryAliases,
@@ -201,6 +213,8 @@ export function TraceItemSearchQueryBuilder({
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
+    booleanAttributes,
+    booleanSecondaryAliases,
     numberAttributes,
     stringAttributes,
     numberSecondaryAliases,
@@ -245,27 +259,36 @@ function useFunctionTags(
   }, [itemType, supportedAggregates]);
 }
 
-function useFilterTags(
-  numberAttributes: TagCollection,
-  stringAttributes: TagCollection,
-  functionTags: TagCollection,
-  disallowHas: boolean
-) {
+function useFilterTags({
+  numberAttributes,
+  stringAttributes,
+  booleanAttributes,
+  functionTags,
+  disallowHas,
+}: {
+  booleanAttributes: TagCollection;
+  disallowHas: boolean;
+  functionTags: TagCollection;
+  numberAttributes: TagCollection;
+  stringAttributes: TagCollection;
+}) {
   return useMemo(() => {
     const tags: TagCollection = {
       ...functionTags,
       ...numberAttributes,
       ...stringAttributes,
+      ...booleanAttributes,
     };
 
     if (!disallowHas) {
       tags.has = getHasTag({
         ...numberAttributes,
         ...stringAttributes,
+        ...booleanAttributes,
       });
     }
     return tags;
-  }, [numberAttributes, stringAttributes, functionTags, disallowHas]);
+  }, [booleanAttributes, disallowHas, functionTags, numberAttributes, stringAttributes]);
 }
 
 function useFilterKeySections(

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -52,7 +52,7 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanFields.TIMESTAMP,
   SpanFields.TRANSACTION,
   SpanFields.TRACE,
-  SpanFields.IS_TRANSACTION, // boolean field but we can expose it as a string
+  SpanFields.IS_TRANSACTION, // boolean field but keep for non-boolean queries
   SpanFields.NORMALIZED_DESCRIPTION,
   SpanFields.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
@@ -67,6 +67,11 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
 ];
 
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS];
+
+export const SENTRY_SPAN_BOOLEAN_TAGS: string[] = [
+  // duplicating until we've fully rolled out boolean attributes
+  SpanFields.IS_TRANSACTION,
+];
 
 export const SENTRY_LOG_STRING_TAGS: string[] = [
   OurLogKnownFieldKey.TRACE_ID,
@@ -93,6 +98,8 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
 
 export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [];
 
+export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = [];
+
 export const HIDDEN_PREPROD_ATTRIBUTES = [
   'min_install_size',
   'tags[min_install_size,number]',
@@ -118,5 +125,9 @@ export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [
 ];
 
 export const SENTRY_TRACEMETRIC_NUMBER_TAGS: string[] = [];
+
+export const SENTRY_LOG_BOOLEAN_TAGS: string[] = [];
+
+export const SENTRY_TRACEMETRIC_BOOLEAN_TAGS: string[] = [];
 
 export const MAX_CROSS_EVENT_QUERIES = 2;

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,6 +1,9 @@
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 
-export function useTraceItemTags(type?: 'number' | 'string', hiddenKeys?: string[]) {
+export function useTraceItemTags(
+  type?: 'number' | 'string' | 'boolean',
+  hiddenKeys?: string[]
+) {
   const {attributes, isLoading, secondaryAliases} = useTraceItemAttributes(
     type,
     hiddenKeys

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -4,13 +4,18 @@ import {createContext, useContext, useMemo} from 'react';
 import type {TagCollection} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {FieldKind} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
+  SENTRY_LOG_BOOLEAN_TAGS,
   SENTRY_LOG_NUMBER_TAGS,
   SENTRY_LOG_STRING_TAGS,
+  SENTRY_PREPROD_BOOLEAN_TAGS,
   SENTRY_PREPROD_NUMBER_TAGS,
   SENTRY_PREPROD_STRING_TAGS,
+  SENTRY_SPAN_BOOLEAN_TAGS,
   SENTRY_SPAN_NUMBER_TAGS,
   SENTRY_SPAN_STRING_TAGS,
+  SENTRY_TRACEMETRIC_BOOLEAN_TAGS,
   SENTRY_TRACEMETRIC_NUMBER_TAGS,
   SENTRY_TRACEMETRIC_STRING_TAGS,
 } from 'sentry/views/explore/constants';
@@ -19,6 +24,8 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {removeHiddenKeys} from 'sentry/views/explore/utils';
 
 type TypedTraceItemAttributes = {
+  boolean: TagCollection;
+  booleanSecondaryAliases: TagCollection;
   number: TagCollection;
   numberSecondaryAliases: TagCollection;
   string: TagCollection;
@@ -26,6 +33,7 @@ type TypedTraceItemAttributes = {
 };
 
 type TypedTraceItemAttributesStatus = {
+  booleanAttributesLoading: boolean;
   numberAttributesLoading: boolean;
   stringAttributesLoading: boolean;
 };
@@ -79,6 +87,11 @@ function useTraceItemAttributeConfig({
   search,
   query,
 }: TraceItemAttributeConfig) {
+  const organization = useOrganization();
+  const hasBooleanFilters = organization.features.includes(
+    'search-query-builder-explicit-boolean-filters'
+  );
+
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useTraceItemAttributeKeys({
       enabled,
@@ -93,6 +106,16 @@ function useTraceItemAttributeConfig({
     useTraceItemAttributeKeys({
       enabled,
       type: 'string',
+      traceItemType,
+      projects,
+      search,
+      query,
+    });
+
+  const {attributes: booleanAttributes, isLoading: booleanAttributesLoading} =
+    useTraceItemAttributeKeys({
+      enabled: enabled && hasBooleanFilters,
+      type: 'boolean',
       traceItemType,
       projects,
       search,
@@ -134,20 +157,47 @@ function useTraceItemAttributeConfig({
     };
   }, [stringAttributes, traceItemType]);
 
+  const allBooleanAttributes = useMemo(() => {
+    if (!hasBooleanFilters) {
+      return {attributes: {}, secondaryAliases: {}};
+    }
+
+    const tags = getDefaultBooleanAttributes(traceItemType).map(tag => [
+      tag,
+      {key: tag, name: tag, kind: FieldKind.BOOLEAN},
+    ]);
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(booleanAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.BOOLEAN}])
+    );
+
+    return {
+      attributes: {...booleanAttributes, ...Object.fromEntries(tags)},
+      secondaryAliases,
+    };
+  }, [booleanAttributes, hasBooleanFilters, traceItemType]);
+
   return useMemo(
     () => ({
+      boolean: allBooleanAttributes.attributes,
       number: allNumberAttributes.attributes,
       string: allStringAttributes.attributes,
+      booleanSecondaryAliases: allBooleanAttributes.secondaryAliases,
       numberSecondaryAliases: allNumberAttributes.secondaryAliases,
       stringSecondaryAliases: allStringAttributes.secondaryAliases,
+      booleanAttributesLoading,
       numberAttributesLoading,
       stringAttributesLoading,
     }),
     [
+      allBooleanAttributes.attributes,
+      allBooleanAttributes.secondaryAliases,
       allNumberAttributes.attributes,
       allNumberAttributes.secondaryAliases,
       allStringAttributes.attributes,
       allStringAttributes.secondaryAliases,
+      booleanAttributesLoading,
       numberAttributesLoading,
       stringAttributesLoading,
     ]
@@ -156,9 +206,20 @@ function useTraceItemAttributeConfig({
 
 function processTraceItemAttributes(
   typedAttributesResult: TypedTraceItemAttributesResult,
-  type?: 'number' | 'string',
+  type?: 'number' | 'string' | 'boolean',
   hiddenKeys?: string[]
 ) {
+  if (type === 'boolean') {
+    return {
+      attributes: hiddenKeys
+        ? removeHiddenKeys(typedAttributesResult.boolean, hiddenKeys)
+        : typedAttributesResult.boolean,
+      secondaryAliases: hiddenKeys
+        ? removeHiddenKeys(typedAttributesResult.booleanSecondaryAliases, hiddenKeys)
+        : typedAttributesResult.booleanSecondaryAliases,
+      isLoading: typedAttributesResult.booleanAttributesLoading,
+    };
+  }
   if (type === 'number') {
     return {
       attributes: hiddenKeys
@@ -182,7 +243,7 @@ function processTraceItemAttributes(
 }
 
 export function useTraceItemAttributes(
-  type?: 'number' | 'string',
+  type?: 'number' | 'string' | 'boolean',
   hiddenKeys?: string[]
 ) {
   const typedAttributesResult = useContext(TraceItemAttributeContext);
@@ -198,7 +259,7 @@ export function useTraceItemAttributes(
 
 export function useTraceItemAttributesWithConfig(
   config: TraceItemAttributeConfig,
-  type?: 'number' | 'string',
+  type?: 'number' | 'string' | 'boolean',
   hiddenKeys?: string[]
 ) {
   const typedAttributesResult = useTraceItemAttributeConfig(config);
@@ -229,4 +290,17 @@ function getDefaultNumberAttributes(itemType: TraceItemDataset) {
     return SENTRY_TRACEMETRIC_NUMBER_TAGS;
   }
   return SENTRY_LOG_NUMBER_TAGS;
+}
+
+function getDefaultBooleanAttributes(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return SENTRY_SPAN_BOOLEAN_TAGS;
+  }
+  if (itemType === TraceItemDataset.PREPROD) {
+    return SENTRY_PREPROD_BOOLEAN_TAGS;
+  }
+  if (itemType === TraceItemDataset.TRACEMETRICS) {
+    return SENTRY_TRACEMETRIC_BOOLEAN_TAGS;
+  }
+  return SENTRY_LOG_BOOLEAN_TAGS;
 }

--- a/static/app/views/explore/hooks/useExploreSuggestedAttribute.tsx
+++ b/static/app/views/explore/hooks/useExploreSuggestedAttribute.tsx
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import type {TagCollection} from 'sentry/types/group';
 
 interface UseExploreSuggestedAttributeOptions {
+  booleanAttributes: TagCollection;
   numberAttributes: TagCollection;
   stringAttributes: TagCollection;
 }
@@ -10,6 +11,7 @@ interface UseExploreSuggestedAttributeOptions {
 export function useExploreSuggestedAttribute({
   numberAttributes,
   stringAttributes,
+  booleanAttributes,
 }: UseExploreSuggestedAttributeOptions) {
   return useCallback(
     (key: string): string | null => {
@@ -18,6 +20,10 @@ export function useExploreSuggestedAttribute({
       }
 
       if (key in numberAttributes) {
+        return key;
+      }
+
+      if (key in booleanAttributes) {
         return key;
       }
 
@@ -31,8 +37,13 @@ export function useExploreSuggestedAttribute({
         return explicitNumberAttribute;
       }
 
+      const explicitBooleanAttribute = `tags[${key},boolean]`;
+      if (explicitBooleanAttribute in booleanAttributes) {
+        return explicitBooleanAttribute;
+      }
+
       return null;
     },
-    [numberAttributes, stringAttributes]
+    [booleanAttributes, numberAttributes, stringAttributes]
   );
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -21,7 +21,7 @@ type TraceItemAttributeKeyOptions = Pick<
   ReturnType<typeof normalizeDateTimeParams>,
   'end' | 'start' | 'statsPeriod' | 'utc'
 > & {
-  attributeType: 'string' | 'number';
+  attributeType: 'string' | 'number' | 'boolean';
   itemType: TraceItemDataset;
   project?: string[];
   query?: string;
@@ -38,7 +38,7 @@ export function makeTraceItemAttributeKeysQueryOptions({
 }: {
   datetime: PageFilters['datetime'];
   traceItemType: TraceItemDataset;
-  type: 'string' | 'number';
+  type: 'string' | 'number' | 'boolean';
   projectIds?: Array<string | number>;
   query?: string;
   search?: string;
@@ -115,15 +115,22 @@ export function getTraceItemTagCollection(
     // SnQL forbids `-` but is allowed in RPC. So add it back later
     if (
       !/^[a-zA-Z0-9_.:-]+$/.test(attribute.key) &&
-      !/^tags\[[a-zA-Z0-9_.:-]+,number\]$/.test(attribute.key)
+      !/^tags\[[a-zA-Z0-9_.:-]+,(number|boolean)\]$/.test(attribute.key)
     ) {
       continue;
+    }
+
+    let kind = FieldKind.TAG;
+    if (type === 'number') {
+      kind = FieldKind.MEASUREMENT;
+    } else if (type === 'boolean') {
+      kind = FieldKind.BOOLEAN;
     }
 
     attributes[attribute.key] = {
       key: attribute.key,
       name: attribute.name,
-      kind: type === 'number' ? FieldKind.MEASUREMENT : FieldKind.TAG,
+      kind,
       secondaryAliases: attribute?.secondaryAliases ?? [],
     };
   }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -108,4 +108,46 @@ describe('useGetTraceItemAttributeValues', () => {
     expect(searchQueryMock).not.toHaveBeenCalled();
     expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for numbers
   });
+
+  it('getTraceItemAttributeValues returns empty array for boolean type', async () => {
+    const mockSearchResponse = [
+      {
+        key: attributeKey,
+        value: 'true',
+        first_seen: null,
+        last_seen: null,
+        times_seen: null,
+      },
+    ];
+    const searchQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockSearchResponse,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return query.attributeType === 'boolean';
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useGetTraceItemAttributeValues({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'boolean',
+      })
+    );
+
+    const tag = {
+      key: attributeKey,
+      name: attributeKey,
+      kind: FieldKind.TAG,
+    };
+
+    expect(searchQueryMock).not.toHaveBeenCalled();
+
+    const searchResults = await result.current(tag, 'search-query');
+
+    expect(searchQueryMock).not.toHaveBeenCalled();
+    expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for booleans
+  });
 });

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -43,7 +43,7 @@ function traceItemAttributeValuesQueryKey({
   datetime?: PageFilters['datetime'];
   projectIds?: number[];
   search?: string;
-  type?: 'string' | 'number';
+  type?: 'string' | 'number' | 'boolean';
 }): ApiQueryKey {
   const query: Record<string, string | string[] | number[]> = {
     itemType: traceItemType,
@@ -94,8 +94,8 @@ export function useGetTraceItemAttributeValues({
   // Create a function that can be used as getTagValues
   const getTraceItemAttributeValues = useCallback<GetTagValues>(
     async (tag, queryString) => {
-      if (tag.kind === FieldKind.FUNCTION || type === 'number') {
-        // We can't really auto suggest values for aggregate functions or numbers
+      if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
+        // We can't really auto suggest values for aggregate functions, numbers, or booleans
         return Promise.resolve([]);
       }
 

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -12,6 +12,7 @@ import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBy
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface UseGroupByFieldsProps {
+  booleanTags: TagCollection;
   /**
    * All the group bys that are in use. They will be injected if
    * they dont exist already.
@@ -26,6 +27,7 @@ interface UseGroupByFieldsProps {
 export function useGroupByFields({
   numberTags,
   stringTags,
+  booleanTags,
   groupBys,
   traceItemType,
   hideEmptyOption,
@@ -38,9 +40,16 @@ export function useGroupByFields({
       ...Object.entries(stringTags)
         .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
         .map(([_, tag]) => optionFromTag(tag, traceItemType)),
+      ...Object.entries(booleanTags)
+        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
+        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
       ...groupBys
         .filter(
-          groupBy => groupBy && !(groupBy in numberTags) && !(groupBy in stringTags)
+          groupBy =>
+            groupBy &&
+            !(groupBy in numberTags) &&
+            !(groupBy in stringTags) &&
+            !(groupBy in booleanTags)
         )
         .map(groupBy =>
           optionFromTag(
@@ -69,7 +78,7 @@ export function useGroupByFields({
           ]),
       ...options,
     ];
-  }, [numberTags, stringTags, groupBys, hideEmptyOption, traceItemType]);
+  }, [booleanTags, groupBys, hideEmptyOption, numberTags, stringTags, traceItemType]);
 }
 
 function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {

--- a/static/app/views/explore/hooks/useSortByFields.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.tsx
@@ -18,6 +18,7 @@ interface Props {
 export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
     const uniqueOptions: string[] = [];
@@ -41,7 +42,7 @@ export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
     }
 
     const options = uniqueOptions.filter(Boolean).map(field => {
-      const tag = stringTags[field] ?? numberTags[field] ?? null;
+      const tag = stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
       if (tag) {
         return {
           label: tag.name,
@@ -82,7 +83,7 @@ export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
     });
 
     return options;
-  }, [fields, groupBys, mode, numberTags, stringTags, yAxes]);
+  }, [booleanTags, fields, groupBys, mode, numberTags, stringTags, yAxes]);
 
   return fieldOptions;
 }

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -34,9 +34,11 @@ function createWrapper(organization: Organization) {
 function useWrapper(yAxis: string) {
   const {tags: stringTags} = useTraceItemTags('string');
   const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
   return useVisualizeFields({
     numberTags,
     stringTags,
+    booleanTags,
     parsedFunction: parseFunction(yAxis) ?? undefined,
     traceItemType: TraceItemDataset.SPANS,
   });

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -18,6 +18,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
 interface UseVisualizeFieldsProps {
+  booleanTags: TagCollection;
   numberTags: TagCollection;
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;
@@ -25,6 +26,7 @@ interface UseVisualizeFieldsProps {
 }
 
 export function useVisualizeFields({
+  booleanTags,
   parsedFunction,
   numberTags,
   stringTags,
@@ -35,9 +37,10 @@ export function useVisualizeFields({
       functionName: parsedFunction?.name || '',
       numberTags,
       stringTags,
+      booleanTags,
       traceItemType,
     });
-  }, [parsedFunction, numberTags, stringTags, traceItemType]);
+  }, [booleanTags, numberTags, parsedFunction?.name, stringTags, traceItemType]);
 
   const unknownField = parsedFunction?.arguments[0];
 
@@ -103,9 +106,11 @@ export function useVisualizeFields({
 function getSupportedAttributes({
   functionName,
   numberTags,
+  booleanTags,
   stringTags,
   traceItemType,
 }: {
+  booleanTags: TagCollection;
   numberTags: TagCollection;
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;
@@ -133,7 +138,7 @@ function getSupportedAttributes({
     }
 
     if (functionName === AggregationKey.COUNT_UNIQUE) {
-      return {...numberTags, ...stringTags};
+      return {...numberTags, ...stringTags, ...booleanTags};
     }
 
     return numberTags;

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -178,6 +178,11 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
     isLoading: numberAttributesLoading,
     secondaryAliases: numberSecondaryAliases,
   } = useTraceItemAttributes('number', HiddenLogSearchFields);
+  const {
+    attributes: booleanAttributes,
+    isLoading: booleanAttributesLoading,
+    secondaryAliases: booleanSecondaryAliases,
+  } = useTraceItemAttributes('boolean', HiddenLogSearchFields);
 
   const averageLogsPerSecond = calculateAverageLogsPerSecond(timeseriesResult);
 
@@ -196,6 +201,8 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
 
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
+      booleanAttributes,
+      booleanSecondaryAliases,
       numberAttributes,
       stringAttributes,
       numberSecondaryAliases,
@@ -345,9 +352,14 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
           <ExploreSchemaHintsSection>
             <SchemaHintsList
               supportedAggregates={supportedAggregates}
+              booleanTags={booleanAttributes}
               numberTags={numberAttributes}
               stringTags={stringAttributes}
-              isLoading={numberAttributesLoading || stringAttributesLoading}
+              isLoading={
+                numberAttributesLoading ||
+                stringAttributesLoading ||
+                booleanAttributesLoading
+              }
               exploreQuery={logsSearch.formatString()}
               source={SchemaHintsSources.LOGS}
               searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -202,9 +202,9 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
       booleanAttributes,
-      booleanSecondaryAliases,
       numberAttributes,
       stringAttributes,
+      booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
     });
@@ -251,6 +251,7 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
           onColumnsChange={onColumnsChange}
           stringTags={stringAttributes}
           numberTags={numberAttributes}
+          booleanTags={booleanAttributes}
           hiddenKeys={HiddenColumnEditorLogFields}
           handleReset={() => {
             onColumnsChange(defaultLogFields());
@@ -260,7 +261,7 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
       ),
       {closeEvents: 'escape-key'}
     );
-  }, [fields, onColumnsChange, stringAttributes, numberAttributes]);
+  }, [booleanAttributes, fields, numberAttributes, onColumnsChange, stringAttributes]);
 
   const tableTab = mode === Mode.AGGREGATE ? 'aggregates' : 'logs';
   const setTableTab = useCallback(

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -147,6 +147,10 @@ function ToolbarVisualize({onSearch, onClose}: LogsToolbarProps) {
     'number',
     HiddenLogSearchFields
   );
+  const {attributes: booleanTags, isLoading: booleanTagsLoading} = useTraceItemAttributes(
+    'boolean',
+    HiddenLogSearchFields
+  );
 
   const sortedNumberKeys: string[] = useMemo(() => {
     const keys = Object.keys(numberTags);
@@ -159,6 +163,12 @@ function ToolbarVisualize({onSearch, onClose}: LogsToolbarProps) {
     keys.sort();
     return keys;
   }, [stringTags]);
+
+  const sortedBooleanKeys: string[] = useMemo(() => {
+    const keys = Object.keys(booleanTags);
+    keys.sort();
+    return keys;
+  }, [booleanTags]);
 
   const visualizes = useQueryParamsVisualizes();
   const setVisualizes = useSetQueryParamsVisualizes();
@@ -208,11 +218,12 @@ function ToolbarVisualize({onSearch, onClose}: LogsToolbarProps) {
               onDelete={() => onDelete(group)}
               onReplace={newVisualize => replaceOverlay(group, newVisualize)}
               visualize={visualize}
+              sortedBooleanKeys={sortedBooleanKeys}
               sortedNumberKeys={sortedNumberKeys}
               sortedStringKeys={sortedStringKeys}
               onSearch={onSearch}
               onClose={onClose}
-              loading={numberTagsLoading || stringTagsLoading}
+              loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
             />
           );
         }
@@ -235,6 +246,7 @@ interface VisualizeDropdownProps {
   onDelete: () => void;
   onReplace: (visualize: Visualize) => void;
   onSearch: (search: string) => void;
+  sortedBooleanKeys: string[];
   sortedNumberKeys: string[];
   sortedStringKeys: string[];
   visualize: VisualizeFunction;
@@ -248,6 +260,7 @@ function VisualizeDropdown({
   onSearch,
   onClose,
   visualize,
+  sortedBooleanKeys,
   sortedNumberKeys,
   sortedStringKeys,
 }: VisualizeDropdownProps) {
@@ -307,6 +320,24 @@ function VisualizeDropdown({
               ),
             };
           }),
+          ...sortedBooleanKeys.map(key => {
+            const label = prettifyTagKey(key);
+            return {
+              label,
+              value: key,
+              textValue: key,
+              trailingItems: <TypeBadge kind={FieldKind.BOOLEAN} />,
+              showDetailsInOverlay: true,
+              details: (
+                <AttributeDetails
+                  column={key}
+                  kind={FieldKind.BOOLEAN}
+                  label={label}
+                  traceItemType={TraceItemDataset.LOGS}
+                />
+              ),
+            };
+          }),
         ].toSorted((a, b) => {
           const aLabel = prettifyTagKey(a.value);
           const bLabel = prettifyTagKey(b.value);
@@ -330,7 +361,7 @@ function VisualizeDropdown({
             ),
           };
         });
-  }, [aggregateFunction, sortedStringKeys, sortedNumberKeys]);
+  }, [aggregateFunction, sortedBooleanKeys, sortedNumberKeys, sortedStringKeys]);
 
   const onChangeAggregate = useCallback(
     (option: SelectOption<SelectKey>) => {
@@ -382,6 +413,11 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
     'string',
     HiddenLogSearchFields
   );
+  const {attributes: booleanTags, isLoading: booleanTagsLoading} = useTraceItemAttributes(
+    'boolean',
+    HiddenLogSearchFields
+  );
+
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
 
@@ -429,12 +465,30 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
             ),
           };
         }),
+        ...Object.keys(booleanTags ?? {}).map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.BOOLEAN} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.BOOLEAN}
+                label={label}
+                traceItemType={TraceItemDataset.LOGS}
+              />
+            ),
+          };
+        }),
       ].toSorted((a, b) => {
         const aLabel = prettifyTagKey(a.value);
         const bLabel = prettifyTagKey(b.value);
         return aLabel.localeCompare(bLabel);
       }),
-    [numberTags, stringTags]
+    [booleanTags, numberTags, stringTags]
   );
 
   const setGroupBysWithOp = useCallback(
@@ -464,7 +518,7 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
               options={options}
               onSearch={onSearch}
               onClose={onClose}
-              loading={numberTagsLoading || stringTagsLoading}
+              loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
             />
           ))}
           <ToolbarFooter>

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -79,6 +79,7 @@ type LogsTableProps = {
     scrollToDisabled?: boolean;
   };
   allowPagination?: boolean;
+  booleanAttributes?: TagCollection;
   embedded?: boolean;
   embeddedOptions?: {
     openWithExpandedIds?: string[];
@@ -109,6 +110,7 @@ export function LogsInfiniteTable({
   emptyRenderer,
   numberAttributes,
   stringAttributes,
+  booleanAttributes,
   scrollContainer,
   embeddedStyling,
   embeddedOptions,
@@ -461,6 +463,7 @@ export function LogsInfiniteTable({
             isFrozen={embedded}
             numberAttributes={numberAttributes}
             stringAttributes={stringAttributes}
+            booleanAttributes={booleanAttributes}
             onResizeMouseDown={onResizeMouseDown}
           />
         )}
@@ -566,10 +569,11 @@ export function LogsInfiniteTable({
 
 function LogsTableHeader({
   isFrozen,
+  booleanAttributes,
   numberAttributes,
   stringAttributes,
   onResizeMouseDown,
-}: Pick<LogsTableProps, 'numberAttributes' | 'stringAttributes'> & {
+}: Pick<LogsTableProps, 'numberAttributes' | 'stringAttributes' | 'booleanAttributes'> & {
   isFrozen: boolean;
   onResizeMouseDown: (e: React.MouseEvent<HTMLDivElement>, index: number) => void;
 }) {
@@ -592,7 +596,8 @@ function LogsTableHeader({
           const headerLabel = getTableHeaderLabel(
             field,
             stringAttributes,
-            numberAttributes
+            numberAttributes,
+            booleanAttributes
           );
 
           if (isPending) {

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -48,6 +48,7 @@ export function useLogsSearchQueryBuilderProps({
       const suggestedColumns = findSuggestedColumns(newSearch, oldLogsSearch, {
         numberAttributes,
         stringAttributes,
+        booleanAttributes,
       });
 
       const existingFields = new Set(fields);
@@ -58,7 +59,14 @@ export function useLogsSearchQueryBuilderProps({
         fields: newColumns.length ? [...fields, ...newColumns] : undefined,
       });
     },
-    [oldLogsSearch, numberAttributes, stringAttributes, fields, setQueryParams]
+    [
+      booleanAttributes,
+      fields,
+      numberAttributes,
+      oldLogsSearch,
+      setQueryParams,
+      stringAttributes,
+    ]
   );
 
   const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps = {

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -18,11 +18,15 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {findSuggestedColumns} from 'sentry/views/explore/utils';
 
 export function useLogsSearchQueryBuilderProps({
+  booleanAttributes,
+  booleanSecondaryAliases,
   numberAttributes,
   stringAttributes,
   numberSecondaryAliases,
   stringSecondaryAliases,
 }: {
+  booleanAttributes: TagCollection;
+  booleanSecondaryAliases: TagCollection;
   numberAttributes: TagCollection;
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
@@ -61,9 +65,11 @@ export function useLogsSearchQueryBuilderProps({
     initialQuery: logsSearch.formatString(),
     searchSource: 'ourlogs',
     onSearch,
+    booleanAttributes,
     numberAttributes,
     stringAttributes,
     itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
+    booleanSecondaryAliases,
     numberSecondaryAliases,
     stringSecondaryAliases,
     caseInsensitive,

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -185,9 +185,14 @@ export function adjustAliases(attribute: TraceItemResponseAttribute) {
 export function getTableHeaderLabel(
   field: OurLogFieldKey,
   stringAttributes?: TagCollection,
-  numberAttributes?: TagCollection
+  numberAttributes?: TagCollection,
+  booleanAttributes?: TagCollection
 ) {
-  const attribute = stringAttributes?.[field] ?? numberAttributes?.[field] ?? null;
+  const attribute =
+    stringAttributes?.[field] ??
+    numberAttributes?.[field] ??
+    booleanAttributes?.[field] ??
+    null;
 
   return (
     LogAttributesHumanLabel[field] ?? attribute?.name ?? prettifyAttributeName(field)

--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -22,6 +22,7 @@ type Props = {index: number; query: ReadableExploreQueryParts};
 export function GroupBySection({query, index}: Props) {
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const updateGroupBys = useUpdateQueryAtIndex(index);
 
@@ -29,6 +30,7 @@ export function GroupBySection({query, index}: Props) {
     groupBys: [],
     numberTags,
     stringTags,
+    booleanTags,
     traceItemType: TraceItemDataset.SPANS,
     hideEmptyOption: true,
   });

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -32,12 +32,14 @@ type Props = {
 export function VisualizeSection({query, index}: Props) {
   const {tags: stringTags} = useTraceItemTags('string');
   const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const parsedFunction = findFirstFunction(query.yAxes);
 
   const options: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
+    booleanTags,
     parsedFunction,
     traceItemType: TraceItemDataset.SPANS,
   });

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -98,6 +98,7 @@ function AggregatesTable({
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const tableRef = useRef<HTMLTableElement>(null);
   const {initialTableStyles} = useTableStyles(fields, tableRef, {
@@ -127,7 +128,8 @@ function AggregatesTable({
 
               const fieldType = meta.fields?.[field];
               const align = fieldAlignment(field, fieldType);
-              const tag = stringTags[field] ?? numberTags[field] ?? null;
+              const tag =
+                stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
               if (tag) {
                 label = tag.name;
               }
@@ -234,6 +236,7 @@ function SpansTable({spansTableResult, query: queryParts, index}: SampleTablePro
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const tableRef = useRef<HTMLTableElement>(null);
   const {initialTableStyles} = useTableStyles(visibleFields, tableRef, {
@@ -253,7 +256,8 @@ function SpansTable({spansTableResult, query: queryParts, index}: SampleTablePro
 
               const fieldType = meta.fields?.[field];
               const align = fieldAlignment(field, fieldType);
-              const tag = stringTags[field] ?? numberTags[field] ?? null;
+              const tag =
+                stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
 
               const direction = sortBys.find(s => s.field === field)?.kind;
               const label = tag?.name ?? prettifyTagKey(field);

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -131,6 +131,8 @@ const SpansTabCrossEventSearchBar = memo(
       useTraceItemTags('number');
     const {tags: stringAttributes, secondaryAliases: stringSecondaryAliases} =
       useTraceItemTags('string');
+    const {tags: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+      useTraceItemTags('boolean');
 
     let traceItemType = TraceItemDataset.SPANS;
     if (type === 'logs') {
@@ -166,16 +168,20 @@ const SpansTabCrossEventSearchBar = memo(
             : undefined,
         supportedAggregates:
           mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+        booleanAttributes,
         numberAttributes,
         stringAttributes,
         matchKeySuggestions: [
           {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
           {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
         ],
+        booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
       }),
       [
+        booleanAttributes,
+        booleanSecondaryAliases,
         crossEvents,
         index,
         mode,
@@ -286,8 +292,10 @@ function SpansTabCrossEventSearchBars() {
               disabled
               itemType={traceItemType}
               initialQuery={crossEvent.query}
+              booleanAttributes={{}}
               numberAttributes={{}}
               stringAttributes={{}}
+              booleanSecondaryAliases={{}}
               numberSecondaryAliases={{}}
               stringSecondaryAliases={{}}
               searchSource="explore"
@@ -376,6 +384,8 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
     useTraceItemTags('number');
   const {tags: stringAttributes, isLoading: stringAttributesLoading} =
     useTraceItemTags('string');
+  const {tags: booleanAttributes, isLoading: booleanAttributesLoading} =
+    useTraceItemTags('boolean');
 
   const search = useMemo(() => new MutableSearch(query), [query]);
   const oldSearch = usePrevious(search);
@@ -476,9 +486,14 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
                     supportedAggregates={
                       mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
                     }
+                    booleanTags={booleanAttributes}
                     numberTags={numberAttributes}
                     stringTags={stringAttributes}
-                    isLoading={numberAttributesLoading || stringAttributesLoading}
+                    isLoading={
+                      numberAttributesLoading ||
+                      stringAttributesLoading ||
+                      booleanAttributesLoading
+                    }
                     exploreQuery={query}
                     source={SchemaHintsSources.EXPLORE}
                   />

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -396,6 +396,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
       onSearch: (newQuery: string) => {
         const newSearch = new MutableSearch(newQuery);
         const suggestedColumns = findSuggestedColumns(newSearch, oldSearch, {
+          booleanAttributes,
           numberAttributes,
           stringAttributes,
         });
@@ -431,6 +432,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
       onCaseInsensitiveClick: setCaseInsensitive,
     }),
     [
+      booleanAttributes,
       caseInsensitive,
       fields,
       hasRawSearchReplacement,

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -63,6 +63,14 @@ const numberTags: TagCollection = {
   },
 };
 
+const booleanTags: TagCollection = {
+  'feature.enabled': {
+    key: 'feature.enabled',
+    name: 'feature.enabled',
+    kind: FieldKind.BOOLEAN,
+  },
+};
+
 describe('AggregateColumnEditorModal', () => {
   it('allows closes modal on apply', async () => {
     const onClose = jest.fn();
@@ -78,6 +86,7 @@ describe('AggregateColumnEditorModal', () => {
             onColumnsChange={() => {}}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={booleanTags}
           />
         ),
         {onClose}
@@ -108,6 +117,7 @@ describe('AggregateColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={booleanTags}
           />
         ),
         {onClose: jest.fn()}
@@ -173,6 +183,7 @@ describe('AggregateColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={booleanTags}
           />
         ),
         {onClose: jest.fn()}
@@ -239,6 +250,7 @@ describe('AggregateColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={booleanTags}
           />
         ),
         {onClose: jest.fn()}
@@ -311,6 +323,7 @@ describe('AggregateColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={booleanTags}
           />
         ),
         {onClose: jest.fn()}

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -267,6 +267,7 @@ describe('AggregateColumnEditorModal', () => {
 
     const options: string[] = [
       '\u2014',
+      'feature.enabled',
       'foo',
       'geo.city',
       'geo.country',
@@ -286,7 +287,7 @@ describe('AggregateColumnEditorModal', () => {
       expect(option).toHaveTextContent(options[i]!);
     });
 
-    await userEvent.click(groupByOptions[2]!);
+    await userEvent.click(groupByOptions[3]!);
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.city'},

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -61,6 +61,7 @@ import {
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface AggregateColumnEditorModalProps extends ModalRenderProps {
+  booleanTags: TagCollection;
   columns: AggregateField[];
   numberTags: TagCollection;
   onColumnsChange: (columns: WritableAggregateField[]) => void;
@@ -74,6 +75,7 @@ export function AggregateColumnEditorModal({
   closeModal,
   columns,
   onColumnsChange,
+  booleanTags,
   numberTags,
   stringTags,
 }: AggregateColumnEditorModalProps) {
@@ -129,6 +131,7 @@ export function AggregateColumnEditorModal({
                   options={[]}
                   onColumnChange={c => updateColumnAtIndex(i, c)}
                   onColumnDelete={() => deleteColumnAtIndex(i)}
+                  booleanTags={booleanTags}
                   numberTags={numberTags}
                   stringTags={stringTags}
                   groupBys={groupBys}
@@ -194,6 +197,7 @@ export function AggregateColumnEditorModal({
 }
 
 interface ColumnEditorRowProps {
+  booleanTags: TagCollection;
   canDelete: boolean;
   column: Column<AggregateField>;
   groupBys: string[];
@@ -214,6 +218,7 @@ function ColumnEditorRow({
   onColumnDelete,
   numberTags,
   stringTags,
+  booleanTags,
 }: ColumnEditorRowProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
@@ -250,6 +255,7 @@ function ColumnEditorRow({
           organization={organization}
           visualize={column.column}
           onChange={onColumnChange}
+          booleanTags={booleanTags}
           numberTags={numberTags}
           stringTags={stringTags}
         />
@@ -323,6 +329,7 @@ function GroupBySelector({
 }
 
 interface VisualizeSelectorProps {
+  booleanTags: TagCollection;
   numberTags: TagCollection;
   onChange: (visualize: Visualize) => void;
   organization: Organization;
@@ -460,6 +467,7 @@ function AggregateSelector({
 function EquationSelector({
   numberTags,
   stringTags,
+  booleanTags,
   onChange,
   visualize,
 }: VisualizeSelectorProps) {
@@ -502,6 +510,7 @@ function EquationSelector({
   const getSuggestedAttribute = useExploreSuggestedAttribute({
     numberAttributes: numberTags,
     stringAttributes: stringTags,
+    booleanAttributes: booleanTags,
   });
 
   return (

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -353,6 +353,7 @@ function AggregateSelector({
   onChange,
   numberTags,
   stringTags,
+  booleanTags,
   visualize,
 }: VisualizeSelectorProps) {
   const yAxis = visualize.yAxis;
@@ -375,6 +376,7 @@ function AggregateSelector({
   const argumentOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
+    booleanTags,
     parsedFunction,
     traceItemType: TraceItemDataset.SPANS,
   });

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -249,6 +249,7 @@ function ColumnEditorRow({
           numberTags={numberTags}
           onChange={onColumnChange}
           stringTags={stringTags}
+          booleanTags={booleanTags}
         />
       ) : (
         <VisualizeSelector
@@ -273,6 +274,7 @@ function ColumnEditorRow({
 }
 
 interface GroupBySelectorProps {
+  booleanTags: TagCollection;
   groupBy: GroupBy;
   groupBys: string[];
   numberTags: TagCollection;
@@ -286,11 +288,13 @@ function GroupBySelector({
   numberTags,
   onChange,
   stringTags,
+  booleanTags,
 }: GroupBySelectorProps) {
   const options: Array<SelectOption<string>> = useGroupByFields({
     groupBys,
     numberTags,
     stringTags,
+    booleanTags,
     traceItemType: TraceItemDataset.SPANS,
   });
 

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -104,6 +104,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 
@@ -150,7 +151,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
               const fieldType = meta.fields?.[field];
               const align = fieldAlignment(field, fieldType);
-              const label = prettifyField(field, stringTags, numberTags);
+              const label = prettifyField(field, stringTags, numberTags, booleanTags);
 
               const direction = sorts.find(s => s.field === field)?.kind;
 
@@ -268,9 +269,10 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 function prettifyField(
   field: string,
   stringTags: TagCollection,
-  numberTags: TagCollection
+  numberTags: TagCollection,
+  booleanTags: TagCollection
 ): string {
-  const tag = stringTags[field] ?? numberTags[field] ?? null;
+  const tag = stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
   if (tag) {
     return tag.name;
   }

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -37,6 +37,19 @@ const numberTags: TagCollection = {
   },
 };
 
+const booleanTags: TagCollection = {
+  'span.is_segment': {
+    key: 'span.is_segment',
+    name: 'span.is_segment',
+    kind: FieldKind.BOOLEAN,
+  },
+  exclusive_time_lost: {
+    key: 'exclusive_time_lost',
+    name: 'exclusive_time_lost',
+    kind: FieldKind.BOOLEAN,
+  },
+};
+
 describe('ColumnEditorModal', () => {
   it('allows closes modal on apply', async () => {
     const onClose = jest.fn();
@@ -217,5 +230,107 @@ describe('ColumnEditorModal', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
     expect(onColumnsChange).toHaveBeenCalledWith(['id', 'span.op']);
+  });
+
+  it('displays boolean tags in column options with correct type', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id']}
+            onColumnsChange={() => {}}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={booleanTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const column = screen.getByTestId('editor-column');
+    await userEvent.click(within(column).getByRole('button', {name: 'Column id string'}));
+
+    const columnOptions = await screen.findAllByRole('option');
+
+    const booleanOptions = columnOptions.filter(option =>
+      option.textContent?.includes('boolean')
+    );
+    expect(booleanOptions).toHaveLength(2);
+    expect(booleanOptions[0]).toHaveTextContent('exclusive_time_lost');
+    expect(booleanOptions[0]).toHaveTextContent('boolean');
+    expect(booleanOptions[1]).toHaveTextContent('span.is_segment');
+    expect(booleanOptions[1]).toHaveTextContent('boolean');
+  });
+
+  it('allows selecting a boolean tag as a column', async () => {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id']}
+            onColumnsChange={onColumnsChange}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={booleanTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const column = screen.getByTestId('editor-column');
+    await userEvent.click(within(column).getByRole('button', {name: 'Column id string'}));
+
+    const columnOptions = await screen.findAllByRole('option');
+    const booleanOption = columnOptions.find(
+      option =>
+        option.textContent?.includes('span.is_segment') &&
+        option.textContent?.includes('boolean')
+    );
+    expect(booleanOption).toBeDefined();
+    await userEvent.click(booleanOption!);
+
+    expect(screen.getByTestId('editor-column')).toHaveTextContent('span.is_segment');
+    expect(screen.getByTestId('editor-column')).toHaveTextContent('boolean');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['span.is_segment']);
+  });
+
+  it('renders existing boolean column with correct type badge', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['span.is_segment', 'id']}
+            onColumnsChange={() => {}}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={booleanTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
+
+    const columns = screen.getAllByTestId('editor-column');
+    expect(columns[0]).toHaveTextContent('span.is_segment');
+    expect(columns[0]).toHaveTextContent('boolean');
+    expect(columns[1]).toHaveTextContent('id');
+    expect(columns[1]).toHaveTextContent('string');
   });
 });

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -52,6 +52,7 @@ describe('ColumnEditorModal', () => {
             onColumnsChange={() => {}}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={{}}
           />
         ),
         {onClose}
@@ -77,6 +78,7 @@ describe('ColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={{}}
           />
         ),
         {onClose: jest.fn()}
@@ -116,6 +118,7 @@ describe('ColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={{}}
           />
         ),
         {onClose: jest.fn()}
@@ -176,6 +179,7 @@ describe('ColumnEditorModal', () => {
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
+            booleanTags={{}}
           />
         ),
         {onClose: jest.fn()}

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -57,6 +57,7 @@ export function ExploreTables(props: ExploreTablesProps) {
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const attributeBreakdownsEnabled = organization.features.includes(
     'performance-spans-suspect-attributes'
@@ -86,11 +87,12 @@ export function ExploreTables(props: ExploreTablesProps) {
           onColumnsChange={setAggregateFields}
           stringTags={stringTags}
           numberTags={numberTags}
+          booleanTags={booleanTags}
         />
       ),
       {closeEvents: 'escape-key'}
     );
-  }, [aggregateFields, setAggregateFields, stringTags, numberTags]);
+  }, [aggregateFields, booleanTags, numberTags, setAggregateFields, stringTags]);
 
   useEffect(() => {
     if (

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -72,11 +72,12 @@ export function ExploreTables(props: ExploreTablesProps) {
           onColumnsChange={setFields}
           stringTags={stringTags}
           numberTags={numberTags}
+          booleanTags={booleanTags}
         />
       ),
       {closeEvents: 'escape-key'}
     );
-  }, [fields, setFields, stringTags, numberTags]);
+  }, [booleanTags, fields, numberTags, setFields, stringTags]);
 
   const openAggregateColumnEditor = useCallback(() => {
     openModal(

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -63,6 +63,7 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: booleanTags} = useTraceItemTags('boolean');
 
   const paginationAnalyticsEvent = usePaginationAnalytics(
     'samples',
@@ -82,7 +83,8 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
 
               const fieldType = meta.fields?.[field];
               const align = fieldAlignment(field, fieldType);
-              const tag = stringTags[field] ?? numberTags[field] ?? null;
+              const tag =
+                stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
 
               const direction = sortBys.find(s => s.field === field)?.kind;
 

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -115,15 +115,17 @@ function ToolbarGroupByItemContent({
 }: ToolbarGroupByItemContentProps) {
   const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
   const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
+  const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
 
   const options: Array<SelectOption<string>> = useGroupByFields({
     groupBys,
     numberTags,
     stringTags,
+    booleanTags,
     traceItemType: TraceItemDataset.SPANS,
   });
 
-  const loading = numberTagsLoading || stringTagsLoading;
+  const loading = numberTagsLoading || stringTagsLoading || booleanTagsLoading;
 
   return (
     <ToolbarGroupByDropdown

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -200,6 +200,7 @@ function VisualizeDropdown({
 }: VisualizeDropdownProps & {onClose: () => void; onSearch: (search: string) => void}) {
   const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
   const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
+  const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
 
   const aggregateOptions = useMemo(
     () =>
@@ -218,6 +219,7 @@ function VisualizeDropdown({
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
+    booleanTags,
     parsedFunction,
     traceItemType: TraceItemDataset.SPANS,
   });
@@ -262,7 +264,7 @@ function VisualizeDropdown({
       onDelete={onDelete}
       parsedFunction={parsedFunction}
       label={label}
-      loading={numberTagsLoading || stringTagsLoading}
+      loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
       onSearch={onSearch}
       onClose={onClose}
     />

--- a/static/app/views/explore/types.tsx
+++ b/static/app/views/explore/types.tsx
@@ -17,7 +17,7 @@ export interface UseTraceItemAttributeBaseProps {
   /**
    * The attribute type supported by the endpoint, currently only supports string and number.
    */
-  type: 'number' | 'string';
+  type: 'number' | 'string' | 'boolean';
   /**
    * Optional list of projects to search. If not provided, it'll use the page filters.
    */

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -270,12 +270,20 @@ describe('findSuggestedColumns', () => {
       oldQuery: '',
       newQuery: 'count():>0',
     },
+    {
+      cols: [],
+      oldQuery: '',
+      newQuery: 'boolean:true',
+    },
   ])(
     'should inject $cols when changing from `$oldQuery` to `$newQuery`',
     ({cols, oldQuery, newQuery}) => {
       const oldSearch = new MutableSearch(oldQuery);
       const newSearch = new MutableSearch(newQuery);
       const suggestion = findSuggestedColumns(newSearch, oldSearch, {
+        booleanAttributes: {
+          boolean: {key: 'boolean', name: 'boolean'},
+        },
         numberAttributes: {
           num: {key: 'num', name: 'num'},
         },

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -478,6 +478,7 @@ export function findSuggestedColumns(
   newSearch: MutableSearch,
   oldSearch: MutableSearch,
   attributes: {
+    booleanAttributes: TagCollection;
     numberAttributes: TagCollection;
     stringAttributes: TagCollection;
   }
@@ -499,9 +500,12 @@ export function findSuggestedColumns(
     const isNumberAttribute = key.startsWith('!')
       ? key.slice(1) in attributes.numberAttributes
       : key in attributes.numberAttributes;
+    const isBooleanAttribute = key.startsWith('!')
+      ? key.slice(1) in attributes.booleanAttributes
+      : key in attributes.booleanAttributes;
 
     // guard against unknown keys and aggregate keys
-    if (!isStringAttribute && !isNumberAttribute) {
+    if (!isStringAttribute && !isNumberAttribute && !isBooleanAttribute) {
       continue;
     }
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -550,6 +550,7 @@ function isSimpleFilter(
   key: string,
   value: string[],
   attributes: {
+    booleanAttributes: TagCollection;
     numberAttributes: TagCollection;
     stringAttributes: TagCollection;
   }
@@ -564,6 +565,12 @@ function isSimpleFilter(
   // almost always match on a range of values
   if (key in attributes.numberAttributes) {
     return false;
+  }
+
+  // boolean attributes are always considered trivial because they almost match on a
+  // single value, so there's no value in adding a column
+  if (key in attributes.booleanAttributes) {
+    return true;
   }
 
   if (value.length === 1) {

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -73,6 +73,8 @@ function ConversationsOverviewPage({
     useTraceItemTags('number');
   const {tags: stringTags = [], isLoading: stringTagsLoading} =
     useTraceItemTags('string');
+  const {tags: booleanTags = [], isLoading: booleanTagsLoading} =
+    useTraceItemTags('boolean');
 
   const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'
@@ -138,9 +140,12 @@ function ConversationsOverviewPage({
                     </ToolRibbon>
                     <SchemaHintsList
                       supportedAggregates={DISABLE_AGGREGATES}
+                      booleanTags={booleanTags as TagCollection}
                       numberTags={numberTags as TagCollection}
                       stringTags={stringTags as TagCollection}
-                      isLoading={numberTagsLoading || stringTagsLoading}
+                      isLoading={
+                        numberTagsLoading || stringTagsLoading || booleanTagsLoading
+                      }
                       exploreQuery={searchQuery ?? ''}
                       source={SchemaHintsSources.CONVERSATIONS}
                     />

--- a/static/app/views/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/replays/detail/ourlogs/index.tsx
@@ -78,6 +78,7 @@ interface OurLogsContentProps {
 function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
   const {attributes: stringAttributes} = useTraceItemAttributes('string');
   const {attributes: numberAttributes} = useTraceItemAttributes('number');
+  const {attributes: booleanAttributes} = useTraceItemAttributes('boolean');
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
   const {currentTime, setCurrentTime} = useReplayContext();
@@ -133,6 +134,7 @@ function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
           <LogsInfiniteTable
             stringAttributes={stringAttributes}
             numberAttributes={numberAttributes}
+            booleanAttributes={booleanAttributes}
             scrollContainer={scrollContainerRef}
             allowPagination
             embedded


### PR DESCRIPTION
This PR brings in support for fetching boolean attributes for trace related attributes. It updates data fetching hooks, updating all locations to pull in these attributes, and update utility functions to support handling/passing boolean attributes around.

Fetching of these attributes is behind a flag so that we can roll it out slowly, and test it fully before releasing to all users.

Ticket: EXP-689