### PR TITLE
fix: Seer Settings should respect existing billing period seats

### DIFF
--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.spec.tsx
@@ -1,0 +1,93 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
+
+describe('SeerSettingsPageWrapper', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows settings when feature flag is enabled', async () => {
+    const org = OrganizationFixture({
+      features: [
+        'seat-based-seer-enabled',
+        'seer-user-billing',
+        'seer-user-billing-launch',
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/seer/onboarding-check/`,
+      method: 'GET',
+      body: {
+        setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
+        billing: {hasAutofixQuota: true, hasScannerQuota: true},
+      },
+    });
+
+    render(
+      <SeerSettingsPageWrapper>
+        <div data-test-id="settings-content">Settings Content</div>
+      </SeerSettingsPageWrapper>,
+      {organization: org}
+    );
+
+    expect(await screen.findByTestId('settings-content')).toBeInTheDocument();
+    expect(screen.getByText('Seer')).toBeInTheDocument();
+  });
+
+  it('shows settings when no feature flag but has billed seats', async () => {
+    const org = OrganizationFixture({
+      features: ['seer-user-billing', 'seer-user-billing-launch'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/billing-seats/current/?billingMetric=seerUsers`,
+      method: 'GET',
+      body: [{id: '1', displayName: 'user1', created: new Date().toISOString()}],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/seer/onboarding-check/`,
+      method: 'GET',
+      body: {
+        setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
+        billing: {hasAutofixQuota: true, hasScannerQuota: true},
+      },
+    });
+
+    render(
+      <SeerSettingsPageWrapper>
+        <div data-test-id="settings-content">Settings Content</div>
+      </SeerSettingsPageWrapper>,
+      {organization: org}
+    );
+
+    expect(await screen.findByTestId('settings-content')).toBeInTheDocument();
+  });
+
+  it('shows no access when no feature flag and no billed seats', async () => {
+    const org = OrganizationFixture({
+      features: ['seer-user-billing', 'seer-user-billing-launch'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/billing-seats/current/?billingMetric=seerUsers`,
+      method: 'GET',
+      body: [],
+    });
+
+    render(
+      <SeerSettingsPageWrapper>
+        <div data-test-id="settings-content">Settings Content</div>
+      </SeerSettingsPageWrapper>,
+      {organization: org}
+    );
+
+    expect(
+      await screen.findByText("You don't have access to this feature")
+    ).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -8,20 +8,37 @@ import {NoAccess} from 'sentry/components/noAccess';
 import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
+import type {BillingSeatAssignment} from 'getsentry/types';
 
 export default function SeerAutomationRoot() {
   const organization = useOrganization();
   const {isLoading, billing, setupAcknowledgement} = useOrganizationSeerSetup();
+
+  // Query billed seats as a fallback when billing check fails.
+  // This allows users who have downgraded mid-period but still have seats assigned
+  // to continue managing their Seer settings.
+  const needsBillingCheck =
+    !billing.hasAutofixQuota && organization.features.includes('seer-billing');
+
+  const {data: billedSeats, isPending: isLoadingBilledSeats} = useApiQuery<
+    BillingSeatAssignment[]
+  >([`/customers/${organization.slug}/billing-seats/current/?billingMetric=seerUsers`], {
+    staleTime: 0,
+    enabled: needsBillingCheck && !isLoading,
+  });
+
+  const hasBilledSeats = billedSeats && billedSeats.length > 0;
 
   if (organization.hideAiFeatures) {
     return <NoAccess />;
   }
 
   // Show loading placeholders while checking setup
-  if (isLoading) {
+  if (isLoading || (needsBillingCheck && isLoadingBilledSeats)) {
     return (
       <Stack gap="lg">
         <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
@@ -34,8 +51,8 @@ export default function SeerAutomationRoot() {
 
   // Check if setup is needed
   const needsOrgAcknowledgement = !setupAcknowledgement.orgHasAcknowledged;
-  const needsBilling =
-    !billing.hasAutofixQuota && organization.features.includes('seer-billing');
+  // If billing check fails but user has billed seats, allow access
+  const needsBilling = needsBillingCheck && !hasBilledSeats;
 
   const needsSetup = needsOrgAcknowledgement || needsBilling;
 

--- a/static/gsApp/views/seerAutomation/trial.spec.tsx
+++ b/static/gsApp/views/seerAutomation/trial.spec.tsx
@@ -1,0 +1,54 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+import SeerAutomationTrial from 'getsentry/views/seerAutomation/trial';
+
+describe('SeerAutomationTrial', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows trial page when no feature flag and no billed seats', async () => {
+    const org = OrganizationFixture({
+      features: ['seer-user-billing', 'seer-user-billing-launch'],
+    });
+    const sub = SubscriptionFixture({organization: org});
+    SubscriptionStore.set(org.slug, sub);
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/billing-seats/current/?billingMetric=seerUsers`,
+      method: 'GET',
+      body: [],
+    });
+
+    render(<SeerAutomationTrial />, {organization: org});
+
+    expect(await screen.findByText('Say Hello to a Smarter Sentry')).toBeInTheDocument();
+    expect(screen.getByText('Try Out Seer Now')).toBeInTheDocument();
+  });
+
+  it('shows request upgrade alert when user lacks billing access', async () => {
+    const org = OrganizationFixture({
+      features: ['seer-user-billing', 'seer-user-billing-launch'],
+      access: [],
+    });
+    const sub = SubscriptionFixture({organization: org, canSelfServe: false});
+    SubscriptionStore.set(org.slug, sub);
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/billing-seats/current/?billingMetric=seerUsers`,
+      method: 'GET',
+      body: [],
+    });
+
+    render(<SeerAutomationTrial />, {organization: org});
+
+    expect(await screen.findByText('Say Hello to a Smarter Sentry')).toBeInTheDocument();
+    expect(
+      screen.getByText(/you need to be a billing member to try out seer/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR aims to fix an issue where if the seer billing add-on was disabled mid-period, the seer settings page would also be borked. We now add a fallback query such that, if the billing add-on is disabled, we make an API call to fetch the current billing seat assignments for the sentry organization, _and_ if there's more than 1 seat, we still show the settings page.

Also adds a couple minimal test files for this new behavior.

## Testing Steps

- Create sentry / github org with new seer enabled
- Open 2 Prs to trigger seat assignment
- Disable Seer in subscription
- Confirm Seer settings page still exists

**BEFORE**
<img width="1155" height="821" alt="Screenshot 2026-01-22 at 1 25 38 PM" src="https://github.com/user-attachments/assets/cc3775ab-3394-4d54-ac05-2b4d37e7ca09" />

**AFTER**
<img width="1415" height="931" alt="Screenshot 2026-01-22 at 1 25 45 PM" src="https://github.com/user-attachments/assets/f93c392f-1715-4ad8-8515-5c4a3e9f87c8" />


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
