### PR TITLE
fix(aci): Add helper to ensure malformed IDs always result in 400s

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -7,6 +7,7 @@ from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.models.incident import Incident
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 class IncidentPermission(OrganizationPermission):
@@ -39,12 +40,13 @@ class IncidentEndpoint(OrganizationEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        if not incident_identifier.isdigit():
-            raise ResourceDoesNotExist
+        validated_incident_identifier = to_valid_int_id(
+            "incident_identifier", incident_identifier, raise_404=True
+        )
 
         try:
             incident = kwargs["incident"] = Incident.objects.get(
-                organization=organization, identifier=incident_identifier
+                organization=organization, identifier=validated_incident_identifier
             )
         except Incident.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -378,7 +378,8 @@ class OrganizationEndpoint(Endpoint):
         permission checks. We should ideally standardize how this is used and remove this parameter.
         :param project_ids: Projects if they were passed via request data instead of get params
         :param project_slugs: Project slugs if they were passed via request  data instead of get params
-        :return: A list of Project objects, or raises PermissionDenied.
+        :return: A list of Project objects, or raises PermissionDenied. When project_ids or project_slugs
+        are explicitly provided, the returned list is guaranteed non-empty (or PermissionDenied is raised).
 
         NOTE: If both project_ids and project_slugs are passed, we will default
         to fetching projects via project_id list.

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -10,6 +10,7 @@ from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -55,6 +56,7 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
 
         # Allow orgs that have downgraded plans to delete metric alerts
         if request.method != "DELETE" and not features.has(
@@ -66,7 +68,9 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
             raise PermissionDenied
 
         try:
-            kwargs["alert_rule"] = AlertRule.objects.get(projects=project, id=alert_rule_id)
+            kwargs["alert_rule"] = AlertRule.objects.get(
+                projects=project, id=validated_alert_rule_id
+            )
         except AlertRule.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -81,6 +85,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
 
         # Allow orgs that have downgraded plans to delete metric alerts
         if request.method != "DELETE" and not features.has(
@@ -90,7 +95,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
 
         try:
             kwargs["alert_rule"] = AlertRule.objects.get(
-                organization=organization, id=alert_rule_id
+                organization=organization, id=validated_alert_rule_id
             )
         except AlertRule.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -56,7 +56,7 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
-        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
 
         # Allow orgs that have downgraded plans to delete metric alerts
         if request.method != "DELETE" and not features.has(
@@ -85,7 +85,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
-        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
 
         # Allow orgs that have downgraded plans to delete metric alerts
         if request.method != "DELETE" and not features.has(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -81,6 +81,7 @@ from sentry.uptime.types import (
     UptimeMonitorMode,
 )
 from sentry.utils.cursors import Cursor, StringCursor
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models import Detector, DetectorState
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
@@ -228,12 +229,7 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         project_id = request.GET.get("project_id")
         if project_id is None:
             raise ParseError(detail="Invalid project_id")
-        try:
-            project_id_int = int(project_id)
-        except ValueError:
-            raise ParseError(detail="Invalid project_id")
-        if project_id_int <= 0:
-            raise ParseError(detail="Invalid project_id")
+        project_id_int = to_valid_int_id("project_id", project_id)
 
         projects = self.get_projects(request, organization, project_ids={project_id_int})
         project = projects[0]

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -232,6 +232,7 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         project_id_int = to_valid_int_id("project_id", project_id)
 
         projects = self.get_projects(request, organization, project_ids={project_id_int})
+        assert projects  # should be guaranteed non-empty
         project = projects[0]
         enabled_features = on_demand_metrics_feature_flags(organization)
         prefilling = "organizations:on-demand-metrics-prefill" in enabled_features

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -20,6 +20,7 @@ from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 from .utils import parse_team_params
@@ -58,7 +59,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         query_alert_rule = request.GET.get("alertRule")
         query_include_snapshots = request.GET.get("includeSnapshots")
         if query_alert_rule is not None:
-            query_alert_rule_id = int(query_alert_rule)
+            query_alert_rule_id = to_valid_int_id("alertRule", query_alert_rule)
             alert_rule_ids = [query_alert_rule_id]
             if query_include_snapshots:
                 snapshot_alerts = list(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
@@ -16,6 +16,7 @@ from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_threshold_data_from_seer
 from sentry.snuba.models import QuerySubscription
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models import Detector
 
 logger = logging.getLogger(__name__)
@@ -39,11 +40,12 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
         self, detector_id: str, organization: Organization
     ) -> QuerySubscription:
         """Look up QuerySubscription from a detector ID."""
+        validated_detector_id = to_valid_int_id("detector_id", detector_id)
         try:
             detector = Detector.objects.with_type_filters().get(
-                id=int(detector_id), project__organization=organization
+                id=validated_detector_id, project__organization=organization
             )
-        except (Detector.DoesNotExist, ValueError):
+        except Detector.DoesNotExist:
             raise ResourceDoesNotExist
 
         data_source = detector.data_sources.first()
@@ -59,8 +61,11 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
         self, alert_rule_id: str, organization: Organization
     ) -> QuerySubscription:
         """Look up QuerySubscription from a legacy alert rule ID."""
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
         try:
-            alert_rule = AlertRule.objects.get(id=int(alert_rule_id), organization=organization)
+            alert_rule = AlertRule.objects.get(
+                id=validated_alert_rule_id, organization=organization
+            )
             logger.info(
                 "anomaly_data.legacy_alert_found",
                 extra={
@@ -69,7 +74,7 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
                     "organization_id": organization.id,
                 },
             )
-        except (AlertRule.DoesNotExist, ValueError):
+        except AlertRule.DoesNotExist:
             logger.warning(
                 "anomaly_data.legacy_alert_not_found",
                 extra={"alert_rule_id": alert_rule_id, "organization_id": organization.id},

--- a/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
@@ -40,7 +40,7 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
         self, detector_id: str, organization: Organization
     ) -> QuerySubscription:
         """Look up QuerySubscription from a detector ID."""
-        validated_detector_id = to_valid_int_id("detector_id", detector_id)
+        validated_detector_id = to_valid_int_id("detector_id", detector_id, raise_404=True)
         try:
             detector = Detector.objects.with_type_filters().get(
                 id=validated_detector_id, project__organization=organization
@@ -61,7 +61,7 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
         self, alert_rule_id: str, organization: Organization
     ) -> QuerySubscription:
         """Look up QuerySubscription from a legacy alert rule ID."""
-        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id)
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
         try:
             alert_rule = AlertRule.objects.get(
                 id=validated_alert_rule_id, organization=organization

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -69,7 +69,7 @@ def get_detector_validator(
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     def convert_args(self, request: Request, detector_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
-        validated_detector_id = to_valid_int_id("detector_id", detector_id)
+        validated_detector_id = to_valid_int_id("detector_id", detector_id, raise_404=True)
         try:
             detector = (
                 Detector.objects.with_type_filters()

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -29,6 +29,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkDetectorWorkflowsValidator,
@@ -68,12 +69,13 @@ def get_detector_validator(
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     def convert_args(self, request: Request, detector_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
+        validated_detector_id = to_valid_int_id("detector_id", detector_id)
         try:
             detector = (
                 Detector.objects.with_type_filters()
                 .select_related("project")
                 .get(
-                    id=detector_id,
+                    id=validated_detector_id,
                     project__organization_id=kwargs["organization"].id,
                 )
             )

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -53,6 +53,7 @@ from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
     DetectorSerializerResponse,
 )
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id, to_valid_int_id_list
 from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkDetectorWorkflowsValidator,
@@ -164,20 +165,17 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             return Detector.objects.none()
 
         if raw_idlist := request.GET.getlist("id"):
-            try:
-                ids = [int(id) for id in raw_idlist]
-                # If filtering by IDs, we must search across all accessible projects
-                projects = self.get_projects(
-                    request,
-                    organization,
-                    include_all_accessible=True,
-                )
-                return Detector.objects.with_type_filters().filter(
-                    project_id__in=projects,
-                    id__in=ids,
-                )
-            except ValueError:
-                raise ValidationError({"id": ["Invalid ID format"]})
+            ids = to_valid_int_id_list("id", raw_idlist)
+            # If filtering by IDs, we must search across all accessible projects
+            projects = self.get_projects(
+                request,
+                organization,
+                include_all_accessible=True,
+            )
+            return Detector.objects.with_type_filters().filter(
+                project_id__in=projects,
+                id__in=ids,
+            )
 
         projects = self.get_projects(
             request,
@@ -331,12 +329,13 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         ):
             raise ResourceDoesNotExist
 
-        try:
-            project_id = request.data.get("projectId")
-            if not project_id:
-                raise ValidationError({"projectId": ["This field is required."]})
+        project_id = request.data.get("projectId")
+        if not project_id:
+            raise ValidationError({"projectId": ["This field is required."]})
 
-            project = Project.objects.get(id=project_id)
+        validated_project_id = to_valid_int_id("projectId", project_id)
+        try:
+            project = Project.objects.get(id=validated_project_id)
         except Project.DoesNotExist:
             raise ValidationError({"projectId": ["Project not found"]})
 

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -17,7 +17,7 @@ from django.db.models import (
 from django.db.models.functions import Coalesce
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers, status
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -102,7 +102,7 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
 
     def convert_args(self, request: Request, workflow_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
-        validated_workflow_id = to_valid_int_id("workflow_id", workflow_id)
+        validated_workflow_id = to_valid_int_id("workflow_id", workflow_id, raise_404=True)
         try:
             kwargs["workflow"] = Workflow.objects.get(
                 organization=kwargs["organization"], id=validated_workflow_id

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -54,6 +54,7 @@ from sentry.workflow_engine.endpoints.serializers.workflow_serializer import (
     WorkflowSerializerResponse,
 )
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id, to_valid_int_id_list
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
 from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
@@ -101,9 +102,10 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
 
     def convert_args(self, request: Request, workflow_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
+        validated_workflow_id = to_valid_int_id("workflow_id", workflow_id)
         try:
             kwargs["workflow"] = Workflow.objects.get(
-                organization=kwargs["organization"], id=workflow_id
+                organization=kwargs["organization"], id=validated_workflow_id
             )
         except Workflow.DoesNotExist:
             raise ResourceDoesNotExist
@@ -148,17 +150,11 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         queryset: QuerySet[Workflow] = Workflow.objects.filter(organization_id=organization.id)
 
         if raw_idlist := request.GET.getlist("id"):
-            try:
-                ids = [int(id) for id in raw_idlist]
-            except ValueError:
-                raise ValidationError({"id": ["Invalid ID format"]})
+            ids = to_valid_int_id_list("id", raw_idlist)
             queryset = queryset.filter(id__in=ids)
 
         if raw_detectorlist := request.GET.getlist("detector"):
-            try:
-                detector_ids = [int(id) for id in raw_detectorlist]
-            except ValueError:
-                raise ValidationError({"detector": ["Invalid detector ID format"]})
+            detector_ids = to_valid_int_id_list("detector", raw_detectorlist)
             queryset = queryset.filter(detectorworkflow__detector_id__in=detector_ids).distinct()
 
         if raw_query := request.GET.get("query"):
@@ -232,10 +228,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         # When the `priorityDetector` query param is provided, workflows connected to this detector are sorted first
         priority_detector_id: int | None = None
         if raw_priority := request.GET.get("priorityDetector"):
-            try:
-                priority_detector_id = int(raw_priority)
-            except ValueError:
-                raise ValidationError({"priorityDetector": ["Invalid detector ID format"]})
+            priority_detector_id = to_valid_int_id("priorityDetector", raw_priority)
 
             is_priority = Exists(
                 DetectorWorkflow.objects.filter(

--- a/src/sentry/workflow_engine/endpoints/utils/ids.py
+++ b/src/sentry/workflow_engine/endpoints/utils/ids.py
@@ -1,0 +1,33 @@
+from collections.abc import Sequence
+
+from rest_framework.exceptions import ValidationError
+
+from sentry.db.models.fields.bounded import BoundedBigAutoField
+
+
+def to_valid_int_id(name: str, val: str | int) -> int:
+    """
+    Convert a string or integer to a valid integer id.
+    Raises a ValidationError if the value is not a valid integer id.
+    NOTE: This function is no stricter than int(); if the annotated types
+    aren't honored (eg passing in a float or bool), an int may still be returned.
+    """
+    ival: int
+    if isinstance(val, int):
+        ival = val
+    else:
+        try:
+            ival = int(val)
+        except ValueError:
+            raise ValidationError({name: f"Value {val} is not a valid integer id"})
+    if ival >= 0 and ival <= BoundedBigAutoField.MAX_VALUE:
+        return ival
+    raise ValidationError({name: f"Value {val} is not a valid integer id"})
+
+
+def to_valid_int_id_list(name: str, val: Sequence[str | int]) -> list[int]:
+    """
+    Convert a sequence of strings or integers to a list of valid integer ids.
+    Raises a ValidationError if any of the values are not a valid integer id.
+    """
+    return [to_valid_int_id(name, v) for v in val]

--- a/src/sentry/workflow_engine/endpoints/utils/ids.py
+++ b/src/sentry/workflow_engine/endpoints/utils/ids.py
@@ -2,13 +2,15 @@ from collections.abc import Sequence
 
 from rest_framework.exceptions import ValidationError
 
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.db.models.fields.bounded import BoundedBigAutoField
 
 
-def to_valid_int_id(name: str, val: str | int) -> int:
+def to_valid_int_id(name: str, val: str | int, raise_404: bool = False) -> int:
     """
     Convert a string or integer to a valid integer id.
     Raises a ValidationError if the value is not a valid integer id.
+    If raise_404 is True, raises ResourceDoesNotExist instead.
     NOTE: This function is no stricter than int(); if the annotated types
     aren't honored (eg passing in a float or bool), an int may still be returned.
     """
@@ -19,9 +21,13 @@ def to_valid_int_id(name: str, val: str | int) -> int:
         try:
             ival = int(val)
         except ValueError:
+            if raise_404:
+                raise ResourceDoesNotExist
             raise ValidationError({name: f"Value {val} is not a valid integer id"})
     if ival >= 0 and ival <= BoundedBigAutoField.MAX_VALUE:
         return ival
+    if raise_404:
+        raise ResourceDoesNotExist
     raise ValidationError({name: f"Value {val} is not a valid integer id"})
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
+++ b/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
@@ -142,13 +142,13 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
 
     @with_feature("organizations:anomaly-detection-threshold-data")
     def test_invalid_detector_id(self):
-        """Test that non-numeric detector IDs return 400"""
+        """Test that non-numeric detector IDs return 404"""
         self.get_error_response(
             self.organization.slug,
             "not-a-number",
             start="1729178100.0",
             end="1729179000.0",
-            status_code=400,
+            status_code=404,
         )
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
+++ b/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
@@ -142,13 +142,13 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
 
     @with_feature("organizations:anomaly-detection-threshold-data")
     def test_invalid_detector_id(self):
-        """Test that non-numeric detector IDs return 404"""
+        """Test that non-numeric detector IDs return 400"""
         self.get_error_response(
             self.organization.slug,
             "not-a-number",
             start="1729178100.0",
             end="1729179000.0",
-            status_code=404,
+            status_code=400,
         )
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_ondemand_rule_stats_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_ondemand_rule_stats_endpoint.py
@@ -101,4 +101,5 @@ class OrganizationOnDemandRuleStatsEndpointTest(BaseAlertRuleSerializerTest, API
             response = self.get_error_response(
                 self.organization.slug, project_id=-1, status_code=400
             )
-            assert response.data["detail"] == "Invalid project_id"
+            assert "project_id" in response.data
+            assert "not a valid integer id" in response.data["project_id"]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -102,7 +102,7 @@ class OrganizationDetectorDetailsGetTest(OrganizationDetectorDetailsBaseTest):
         assert response.data == serialize(self.detector)
 
     def test_does_not_exist(self) -> None:
-        self.get_error_response(self.organization.slug, 3, status_code=404)
+        self.get_error_response(self.organization.slug, 999999999, status_code=404)
 
     def test_permission_denied_when_open_membership_disabled(self) -> None:
         """

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -191,7 +191,8 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             qs_params={"id": "not-an-id"},
             status_code=400,
         )
-        assert response.data == {"id": ["Invalid ID format"]}
+        assert "id" in response.data
+        assert "not a valid integer id" in str(response.data["id"])
 
     def test_invalid_sort_by(self) -> None:
         response = self.get_error_response(
@@ -1482,7 +1483,8 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
             status_code=400,
         )
 
-        assert "Invalid ID format" in str(response.data["id"])
+        assert "id" in response.data
+        assert "not a valid integer id" in str(response.data["id"])
 
     def test_update_detectors_no_matching_detectors(self) -> None:
         response = self.get_error_response(
@@ -1809,7 +1811,8 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
             status_code=400,
         )
 
-        assert "Invalid ID format" in str(response.data["id"])
+        assert "id" in response.data
+        assert "not a valid integer id" in str(response.data["id"])
 
     def test_delete_detectors_filtering_ignored_with_ids(self) -> None:
         # Other project detector

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -113,7 +113,8 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
             qs_params={"id": "not-an-id"},
             status_code=400,
         )
-        assert response.data == {"id": ["Invalid ID format"]}
+        assert "id" in response.data
+        assert "not a valid integer id" in str(response.data["id"])
 
     def test_sort_by_name(self) -> None:
         response = self.get_success_response(self.organization.slug, qs_params={"sortBy": "-name"})
@@ -460,7 +461,8 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
             qs_params={"detector": "not-an-id"},
             status_code=400,
         )
-        assert response4.data == {"detector": ["Invalid detector ID format"]}
+        assert "detector" in response4.data
+        assert "not a valid integer id" in str(response4.data["detector"])
 
     def test_compound_query(self) -> None:
         self.create_detector_workflow(
@@ -1284,7 +1286,8 @@ class OrganizationWorkflowDeleteTest(OrganizationWorkflowAPITestCase):
             status_code=400,
         )
 
-        assert "Invalid ID format" in str(response.data["id"])
+        assert "id" in response.data
+        assert "not a valid integer id" in str(response.data["id"])
 
     def test_delete_workflows_filtering_ignored_with_ids(self) -> None:
         # Link workflow to project via detector

--- a/tests/sentry/workflow_engine/endpoints/utils/test_ids.py
+++ b/tests/sentry/workflow_engine/endpoints/utils/test_ids.py
@@ -1,0 +1,114 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from sentry.db.models.fields.bounded import BoundedBigAutoField
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id, to_valid_int_id_list
+
+
+class TestToValidIntId:
+    def test_valid_integer_input(self) -> None:
+        assert to_valid_int_id("test_id", 123) == 123
+
+    def test_valid_string_input(self) -> None:
+        assert to_valid_int_id("test_id", "456") == 456
+
+    def test_zero_is_valid(self) -> None:
+        assert to_valid_int_id("test_id", 0) == 0
+        assert to_valid_int_id("test_id", "0") == 0
+
+    def test_negative_numbers_are_invalid(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", -1)
+        assert "test_id" in exc_info.value.detail
+        assert "not a valid integer id" in exc_info.value.detail["test_id"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", "-1")
+        assert "test_id" in exc_info.value.detail
+        assert "not a valid integer id" in exc_info.value.detail["test_id"]
+
+    def test_max_value_boundary(self) -> None:
+        max_val = BoundedBigAutoField.MAX_VALUE
+        assert to_valid_int_id("test_id", max_val) == max_val
+        assert to_valid_int_id("test_id", str(max_val)) == max_val
+
+    def test_exceeds_max_value(self) -> None:
+        too_large = BoundedBigAutoField.MAX_VALUE + 1
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", too_large)
+        assert "test_id" in exc_info.value.detail
+        assert "not a valid integer id" in exc_info.value.detail["test_id"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", str(too_large))
+        assert "test_id" in exc_info.value.detail
+        assert "not a valid integer id" in exc_info.value.detail["test_id"]
+
+    def test_non_numeric_string(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", "not_a_number")
+        assert "test_id" in exc_info.value.detail
+        assert "not a valid integer id" in exc_info.value.detail["test_id"]
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", "")
+        assert "test_id" in exc_info.value.detail
+
+    def test_float_string(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("test_id", "123.45")
+        assert "test_id" in exc_info.value.detail
+
+    def test_field_name_in_error(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("projectId", "invalid")
+        assert "projectId" in exc_info.value.detail
+
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id("detectorId", -1)
+        assert "detectorId" in exc_info.value.detail
+
+
+class TestToValidIntIdList:
+    def test_empty_list(self) -> None:
+        assert to_valid_int_id_list("test_ids", []) == []
+
+    def test_valid_integer_list(self) -> None:
+        assert to_valid_int_id_list("test_ids", [1, 2, 3]) == [1, 2, 3]
+
+    def test_valid_string_list(self) -> None:
+        assert to_valid_int_id_list("test_ids", ["1", "2", "3"]) == [1, 2, 3]
+
+    def test_mixed_string_and_int_list(self) -> None:
+        assert to_valid_int_id_list("test_ids", [1, "2", 3, "4"]) == [1, 2, 3, 4]
+
+    def test_list_with_zero(self) -> None:
+        assert to_valid_int_id_list("test_ids", [0, 1, 2]) == [0, 1, 2]
+        assert to_valid_int_id_list("test_ids", ["0", "1", "2"]) == [0, 1, 2]
+
+    def test_list_with_invalid_value(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id_list("test_ids", [1, "invalid", 3])
+        assert "test_ids" in exc_info.value.detail
+
+    def test_list_with_negative_value(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id_list("test_ids", [1, -2, 3])
+        assert "test_ids" in exc_info.value.detail
+
+    def test_list_with_value_exceeding_max(self) -> None:
+        too_large = BoundedBigAutoField.MAX_VALUE + 1
+        with pytest.raises(ValidationError) as exc_info:
+            to_valid_int_id_list("test_ids", [1, too_large, 3])
+        assert "test_ids" in exc_info.value.detail
+
+    def test_list_fails_on_first_invalid(self) -> None:
+        # Should fail on the first invalid value encountered
+        with pytest.raises(ValidationError):
+            to_valid_int_id_list("test_ids", ["invalid", "also_invalid"])
+
+    def test_list_with_max_boundary_value(self) -> None:
+        max_val = BoundedBigAutoField.MAX_VALUE
+        result = to_valid_int_id_list("test_ids", [1, max_val, 100])
+        assert result == [1, max_val, 100]

--- a/tests/sentry/workflow_engine/endpoints/utils/test_ids.py
+++ b/tests/sentry/workflow_engine/endpoints/utils/test_ids.py
@@ -19,11 +19,13 @@ class TestToValidIntId:
     def test_negative_numbers_are_invalid(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             to_valid_int_id("test_id", -1)
+        assert isinstance(exc_info.value.detail, dict)
         assert "test_id" in exc_info.value.detail
         assert "not a valid integer id" in exc_info.value.detail["test_id"]
 
         with pytest.raises(ValidationError) as exc_info:
             to_valid_int_id("test_id", "-1")
+        assert isinstance(exc_info.value.detail, dict)
         assert "test_id" in exc_info.value.detail
         assert "not a valid integer id" in exc_info.value.detail["test_id"]
 
@@ -36,17 +38,20 @@ class TestToValidIntId:
         too_large = BoundedBigAutoField.MAX_VALUE + 1
         with pytest.raises(ValidationError) as exc_info:
             to_valid_int_id("test_id", too_large)
+        assert isinstance(exc_info.value.detail, dict)
         assert "test_id" in exc_info.value.detail
         assert "not a valid integer id" in exc_info.value.detail["test_id"]
 
         with pytest.raises(ValidationError) as exc_info:
             to_valid_int_id("test_id", str(too_large))
+        assert isinstance(exc_info.value.detail, dict)
         assert "test_id" in exc_info.value.detail
         assert "not a valid integer id" in exc_info.value.detail["test_id"]
 
     def test_non_numeric_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             to_valid_int_id("test_id", "not_a_number")
+        assert isinstance(exc_info.value.detail, dict)
         assert "test_id" in exc_info.value.detail
         assert "not a valid integer id" in exc_info.value.detail["test_id"]
 


### PR DESCRIPTION
Rather than ad-hoc try/catch and responsive fixes to turn 500s from bad parameters into 400s, this adds two new small helper methods to act as our default approach to converting IDs and uses them everywhere.
If we continue with this pattern, ids should always be validated.

