### PR TITLE
fix(alerts): Clear Slack channel_id when channel name is modified

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -436,6 +436,36 @@ describe('IssueRuleEditor', () => {
         'staging'
       );
     });
+
+    it('clears channel_id when Slack channel name is modified', async () => {
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/rules/1/',
+        body: ProjectAlertRuleFixture({
+          actions: [
+            {
+              id: 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction',
+              workspace: '123',
+              channel: '#old-channel',
+              channel_id: 'C12345',
+            },
+          ],
+        }),
+      });
+      createWrapper();
+
+      const channelInput = await screen.findByPlaceholderText(
+        'i.e #critical, Jane Schmidt'
+      );
+      expect(channelInput).toHaveValue('#old-channel');
+
+      const channelIdInput = screen.getByPlaceholderText('i.e. CA2FRA079 or UA1J9RTE1');
+      expect(channelIdInput).toHaveValue('C12345');
+
+      await userEvent.clear(channelInput);
+      await userEvent.type(channelInput, '#new-channel');
+
+      expect(channelIdInput).toHaveValue('');
+    });
   });
 
   describe('Edit Rule: Slack Channel Look Up', () => {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -642,6 +642,16 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
     this.setState(prevState => {
       const clonedState = cloneDeep(prevState);
       set(clonedState, `rule[${type}][${idx}][${prop}]`, val);
+
+      // If changing the channel name for a Slack action, clear the channel id for convenience
+      if (
+        type === 'actions' &&
+        prop === 'channel' &&
+        prevState.rule?.actions?.[idx]?.id === IssueAlertActionType.SLACK
+      ) {
+        set(clonedState, `rule[${type}][${idx}][channel_id]`, '');
+      }
+
       return clonedState;
     });
   };


### PR DESCRIPTION
when editing an issue alert and changing the slack channel name, the old channel_id wasn't being cleared, causing validation errors on save. this clears the channel_id automatically when the channel name changes.

https://github.com/user-attachments/assets/2f5c2e67-e7eb-4861-bad1-842803f0f6ca


