### PR TITLE
ref(issues) push link higher in cascade

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -175,6 +175,11 @@ const GroupExtra = styled('div')`
 
   & > a {
     color: ${p => p.theme.tokens.content.secondary};
+    position: relative;
+  }
+
+  & > a:hover {
+    color: ${p => p.theme.tokens.interactive.link.accent.hover};
   }
 
   @media (min-width: ${p => p.theme.breakpoints.xl}) {


### PR DESCRIPTION
Fixes Seer Link hover issue which as opposed to replays, was not  being colored as accent on hover. 