### PR TITLE
ref(llm-detection): Convert detect_llm_issues_for_project to async batch processing

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import sentry_sdk
 from django.conf import settings
 from pydantic import BaseModel, Field
-from urllib3.exceptions import TimeoutError
 
 from sentry import features, options
 from sentry.constants import VALID_PLATFORMS
@@ -30,10 +29,10 @@ from sentry.utils.redis import redis_clusters
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
 
 SEER_ANALYZE_ISSUE_ENDPOINT_PATH = "/v1/automation/issue-detection/analyze"
-SEER_TIMEOUT_S = 180
+SEER_TIMEOUT_S = 10
 START_TIME_DELTA_MINUTES = 60
 TRANSACTION_BATCH_SIZE = 50
-NUM_TRANSACTIONS_TO_PROCESS = 10
+TRACES_TO_SEND_TO_SEER = 20
 TRACE_PROCESSING_TTL_SECONDS = 7200
 # Character limit for LLM-generated fields to protect against abuse.
 # Word limits are enforced by Seer's prompt (see seer/automation/issue_detection/analyze.py).
@@ -49,15 +48,32 @@ seer_issue_detection_connection_pool = connection_from_url(
 )
 
 
-def mark_trace_as_processed(trace_id: str) -> bool:
-    """
-    Mark trace as processed for LLM issue detection to prevent duplicate analysis.
-    Returns True if successfully marked, False if already marked.
-    """
+def _get_unprocessed_traces(trace_ids: list[str]) -> set[str]:
+    """Return set of trace_ids that have NOT been processed"""
+    if not trace_ids:
+        return set()
     cluster = redis_clusters.get("default")
-    key = f"llm_detection:processed:{trace_id}"
-    result = cluster.set(key, "1", nx=True, ex=TRACE_PROCESSING_TTL_SECONDS)
-    return bool(result)
+    keys = [f"llm_detection:processed:{tid}" for tid in trace_ids]
+    results = cluster.mget(keys)
+    return {tid for tid, val in zip(trace_ids, results) if val is None}
+
+
+def mark_traces_as_processed(trace_ids: list[str]) -> None:
+    """
+    Mark traces as processed for LLM issue detection to prevent duplicate analysis.
+
+    Will overwrite existing keys to refresh the TTL, since reaching this point
+    means we have confirmation that the trace is being processed.
+    """
+    if not trace_ids:
+        return
+
+    cluster = redis_clusters.get("default")
+    with cluster.pipeline() as pipeline:
+        for trace_id in trace_ids:
+            key = f"llm_detection:processed:{trace_id}"
+            pipeline.set(key, "1", ex=TRACE_PROCESSING_TTL_SECONDS)
+        pipeline.execute()
 
 
 class DetectedIssue(BaseModel):
@@ -74,11 +90,6 @@ class DetectedIssue(BaseModel):
     # context fields, not LLM generated
     trace_id: str
     transaction_name: str
-
-
-class IssueDetectionResponse(BaseModel):
-    issues: list[DetectedIssue]
-    traces_analyzed: int
 
 
 class IssueDetectionRequest(BaseModel):
@@ -113,17 +124,11 @@ def get_base_platform(platform: str | None) -> str | None:
 
 def create_issue_occurrence_from_detection(
     detected_issue: DetectedIssue,
-    project_id: int | None = None,
-    project: Project | None = None,
+    project: Project,
 ) -> None:
     """
     Create and produce an IssueOccurrence from an LLM-detected issue.
     """
-    if project is None:
-        if project_id is None:
-            raise ValueError("Either project or project_id must be provided")
-        project = Project.objects.get_from_cache(id=project_id)
-
     event_id = uuid4().hex
     occurrence_id = uuid4().hex
     detection_time = datetime.now(UTC)
@@ -200,7 +205,7 @@ def get_enabled_project_ids() -> list[int]:
 @instrumented_task(
     name="sentry.tasks.llm_issue_detection.run_llm_issue_detection",
     namespace=issues_tasks,
-    processing_deadline_duration=120,
+    processing_deadline_duration=120,  # 2 minutes
 )
 def run_llm_issue_detection() -> None:
     """
@@ -225,7 +230,7 @@ def run_llm_issue_detection() -> None:
 @instrumented_task(
     name="sentry.tasks.llm_issue_detection.detect_llm_issues_for_project",
     namespace=issues_tasks,
-    processing_deadline_duration=10 * 60,
+    processing_deadline_duration=180,  # 3 minutes
 )
 def detect_llm_issues_for_project(project_id: int) -> None:
     """
@@ -252,70 +257,65 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     if not evidence_traces:
         return
 
-    # Shuffle to randomize order
+    # Shuffle to randomize selection
     random.shuffle(evidence_traces)
-    processed_traces = 0
 
-    for trace in evidence_traces:
-        if processed_traces >= NUM_TRANSACTIONS_TO_PROCESS:
-            break
+    # Bulk check which traces are already processed
+    all_trace_ids = [t.trace_id for t in evidence_traces]
+    unprocessed_ids = _get_unprocessed_traces(all_trace_ids)
+    skipped = len(all_trace_ids) - len(unprocessed_ids)
+    if skipped:
+        sentry_sdk.metrics.count("llm_issue_detection.trace.skipped", skipped)
 
-        if not mark_trace_as_processed(trace.trace_id):
-            sentry_sdk.metrics.count(
-                "llm_issue_detection.trace.skipped",
-                1,
-            )
-            continue
+    # Take up to TRACES_TO_SEND_TO_SEER unprocessed traces
+    traces_to_send: list[TraceMetadata] = [
+        t for t in evidence_traces if t.trace_id in unprocessed_ids
+    ][:TRACES_TO_SEND_TO_SEER]
 
-        trace_id = trace.trace_id
-        sentry_sdk.metrics.count(
-            "llm_issue_detection.seer_request", 1, attributes={"trace_id": trace_id}
+    if not traces_to_send:
+        return
+
+    sentry_sdk.metrics.count(
+        "llm_issue_detection.seer_request",
+        1,
+        attributes={"trace_count": len(traces_to_send)},
+    )
+
+    seer_request = IssueDetectionRequest(
+        traces=traces_to_send,
+        organization_id=organization_id,
+        project_id=project_id,
+    )
+
+    response = make_signed_seer_api_request(
+        connection_pool=seer_issue_detection_connection_pool,
+        path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
+        body=json.dumps(seer_request.dict()).encode("utf-8"),
+        timeout=SEER_TIMEOUT_S,
+        retries=0,
+    )
+
+    if response.status == 202:
+        mark_traces_as_processed([trace.trace_id for trace in traces_to_send])
+
+        logger.info(
+            "llm_issue_detection.request_accepted",
+            extra={
+                "project_id": project_id,
+                "organization_id": organization_id,
+                "trace_count": len(traces_to_send),
+            },
         )
-        seer_request = IssueDetectionRequest(
-            traces=[trace],
-            organization_id=organization_id,
-            project_id=project_id,
-        )
+        return
 
-        try:
-            response = make_signed_seer_api_request(
-                connection_pool=seer_issue_detection_connection_pool,
-                path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
-                body=json.dumps(seer_request.dict()).encode("utf-8"),
-                timeout=SEER_TIMEOUT_S,
-                retries=0,
-            )
-        except TimeoutError:
-            logger.exception("LLM Issue Detection Seer timeout", extra={"trace_id": trace_id})
-            continue
-
-        if response.status < 200 or response.status >= 300:
-            logger.error(
-                "LLM issue Detection Seer response failure",
-                extra={
-                    "status_code": response.status,
-                    "response_data": response.data,
-                    "trace_id": trace_id,
-                },
-            )
-            continue
-
-        raw_response_data = response.json()
-        response_data = IssueDetectionResponse.parse_obj(raw_response_data)
-        processed_traces += response_data.traces_analyzed
-
-        for detected_issue in response_data.issues:
-            logger.info(
-                "LLM Issue Detection Result",
-                extra={
-                    "title": detected_issue.title,
-                    "trace_id": trace_id,
-                    "project_id": project_id,
-                    "category": detected_issue.category,
-                    "subcategory": detected_issue.subcategory,
-                },
-            )
-            create_issue_occurrence_from_detection(
-                detected_issue=detected_issue,
-                project_id=project_id,
-            )
+    # Log (+ send to sentry) unexpected responses
+    logger.error(
+        "llm_issue_detection.unexpected_response",
+        extra={
+            "status_code": response.status,
+            "response_data": response.data,
+            "project_id": project_id,
+            "organization_id": organization_id,
+            "trace_count": len(traces_to_send),
+        },
+    )

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -2,6 +2,8 @@ import uuid
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import pytest
+
 from sentry.issues.grouptype import LLMDetectedExperimentalGroupType
 from sentry.tasks.llm_issue_detection import (
     DetectedIssue,
@@ -12,6 +14,8 @@ from sentry.tasks.llm_issue_detection import (
 from sentry.tasks.llm_issue_detection.detection import (
     START_TIME_DELTA_MINUTES,
     TRANSACTION_BATCH_SIZE,
+    _get_unprocessed_traces,
+    mark_traces_as_processed,
 )
 from sentry.tasks.llm_issue_detection.trace_data import (
     get_project_top_transaction_traces_for_llm_detection,
@@ -25,7 +29,6 @@ from sentry.utils import json
 class LLMIssueDetectionTest(TestCase):
     @patch("sentry.tasks.llm_issue_detection.detection.detect_llm_issues_for_project.apply_async")
     def test_run_detection_dispatches_sub_tasks(self, mock_apply_async):
-        """Test run_detection spawns sub-tasks for each project."""
         project = self.create_project()
 
         with self.options(
@@ -46,7 +49,6 @@ class LLMIssueDetectionTest(TestCase):
         "sentry.tasks.llm_issue_detection.detection.get_project_top_transaction_traces_for_llm_detection"
     )
     def test_detect_llm_issues_no_transactions(self, mock_get_transactions, mock_seer_request):
-        """Test that the task returns early when there are no transactions."""
         mock_get_transactions.return_value = []
 
         detect_llm_issues_for_project(self.project.id)
@@ -62,7 +64,6 @@ class LLMIssueDetectionTest(TestCase):
     @patch("sentry.tasks.llm_issue_detection.trace_data.Spans.run_table_query")
     @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     def test_detect_llm_issues_no_traces(self, mock_seer_request, mock_spans_query):
-        """Test that the task returns early when traces can't be fetched for top transactions."""
         mock_spans_query.side_effect = [
             # First call: Return a transaction
             {
@@ -95,7 +96,7 @@ class LLMIssueDetectionTest(TestCase):
 
         create_issue_occurrence_from_detection(
             detected_issue=detected_issue,
-            project_id=self.project.id,
+            project=self.project,
         )
 
         assert mock_produce_occurrence.called
@@ -146,7 +147,8 @@ class LLMIssueDetectionTest(TestCase):
         assert "timestamp" in event_data
 
     @with_feature("organizations:gen-ai-features")
-    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")
+    @patch("sentry.tasks.llm_issue_detection.detection._get_unprocessed_traces")
     @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.trace_data.Spans.run_table_query")
     @patch("sentry.tasks.llm_issue_detection.detection.random.shuffle")
@@ -155,10 +157,11 @@ class LLMIssueDetectionTest(TestCase):
         mock_shuffle,
         mock_spans_query,
         mock_seer_request,
-        mock_produce_occurrence,
+        mock_get_unprocessed,
+        mock_mark_processed,
     ):
-        """Test the full detect_llm_issues_for_project flow with Seer API interaction."""
-        mock_shuffle.return_value = None  # shuffles in-place, mock to block from changing order
+        mock_shuffle.return_value = None  # shuffles in-place, mock to prevent reordering
+        mock_get_unprocessed.return_value = {"trace_id_1", "trace_id_2"}  # All unprocessed
 
         mock_spans_query.side_effect = [
             # First call: transaction spans
@@ -185,146 +188,121 @@ class LLMIssueDetectionTest(TestCase):
             },
         ]
 
-        seer_response_data = {
-            "issues": [
-                {
-                    "title": "N+1 Query Detected",
-                    "explanation": "Multiple sequential database queries detected in loop",
-                    "impact": "High - causes performance degradation",
-                    "evidence": "15 queries executed sequentially",
-                    "missing_telemetry": "Database query attribution",
-                    "offender_span_ids": ["span_1", "span_2"],
-                    "trace_id": "trace_id_1",
-                    "transaction_name": "POST /some/thing",
-                    "category": "Database",
-                    "subcategory": "N+1 Query",
-                    "verification_reason": "Problem is correctly identified",
-                },
-                {
-                    "title": "Memory Leak Risk",
-                    "explanation": "Large object allocations without cleanup",
-                    "impact": "Medium - may cause OOM",
-                    "evidence": "Objects not released after use",
-                    "missing_telemetry": None,
-                    "offender_span_ids": ["span_3"],
-                    "trace_id": "trace_id_2",
-                    "transaction_name": "GET /another/",
-                    "category": "Memory",
-                    "subcategory": "Memory Leak",
-                    "verification_reason": "Problem is correctly identified",
-                },
-            ],
-            "traces_analyzed": 1,
-        }
-
-        mock_response_with_2_issues = Mock()
-        mock_response_with_2_issues.status = 200
-        mock_response_with_2_issues.json.return_value = seer_response_data
-        mock_response_with_no_issues = Mock()
-        mock_response_with_no_issues.status = 200
-        mock_response_with_no_issues.json.return_value = {"issues": [], "traces_analyzed": 1}
-        mock_seer_request.side_effect = [mock_response_with_2_issues, mock_response_with_no_issues]
+        # Seer returns 202 for async processing
+        mock_accepted_response = Mock()
+        mock_accepted_response.status = 202
+        mock_seer_request.return_value = mock_accepted_response
 
         detect_llm_issues_for_project(self.project.id)
 
         assert mock_spans_query.call_count == 3  # 1 for transactions, 2 for traces
-        assert mock_seer_request.call_count == 2  # 1 per trace
+        assert mock_seer_request.call_count == 1  # Single batch request
 
-        first_seer_call = mock_seer_request.call_args_list[0].kwargs
-        assert first_seer_call["path"] == "/v1/automation/issue-detection/analyze"
-        first_request_body = json.loads(first_seer_call["body"].decode("utf-8"))
-        assert first_request_body["project_id"] == self.project.id
-        assert first_request_body["organization_id"] == self.project.organization_id
-        assert len(first_request_body["traces"]) == 1
-        assert first_request_body["traces"][0]["trace_id"] == "trace_id_1"
-        assert first_request_body["traces"][0]["transaction_name"] == "POST /some/thing"
+        seer_call = mock_seer_request.call_args.kwargs
+        assert seer_call["path"] == "/v1/automation/issue-detection/analyze"
+        request_body = json.loads(seer_call["body"].decode("utf-8"))
+        assert request_body["project_id"] == self.project.id
+        assert request_body["organization_id"] == self.project.organization_id
+        assert len(request_body["traces"]) == 2
+        trace_ids = {t["trace_id"] for t in request_body["traces"]}
+        assert trace_ids == {"trace_id_1", "trace_id_2"}
 
-        second_seer_call = mock_seer_request.call_args_list[1].kwargs
-        assert second_seer_call["path"] == "/v1/automation/issue-detection/analyze"
-        second_request_body = json.loads(second_seer_call["body"].decode("utf-8"))
-        assert second_request_body["project_id"] == self.project.id
-        assert second_request_body["organization_id"] == self.project.organization_id
-        assert len(second_request_body["traces"]) == 1
-        assert second_request_body["traces"][0]["trace_id"] == "trace_id_2"
-        assert second_request_body["traces"][0]["transaction_name"] == "GET /another/"
-
-        assert mock_produce_occurrence.call_count == 2
-
-        first_occurrence = mock_produce_occurrence.call_args_list[0].kwargs["occurrence"]
-        assert first_occurrence.type == LLMDetectedExperimentalGroupType
-        assert first_occurrence.issue_title == "N+1 Query Detected"
-        assert first_occurrence.culprit == "POST /some/thing"
-        assert first_occurrence.project_id == self.project.id
-        assert len(first_occurrence.evidence_display) == 3
-
-        second_occurrence = mock_produce_occurrence.call_args_list[1].kwargs["occurrence"]
-        assert second_occurrence.issue_title == "Memory Leak Risk"
-        assert len(second_occurrence.evidence_display) == 3
+        assert mock_mark_processed.call_count == 1
+        mock_mark_processed.assert_called_once_with(["trace_id_1", "trace_id_2"])
 
     @with_feature("organizations:gen-ai-features")
-    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")
+    @patch("sentry.tasks.llm_issue_detection.detection._get_unprocessed_traces")
     @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.trace_data.Spans.run_table_query")
     @patch("sentry.tasks.llm_issue_detection.detection.random.shuffle")
     @patch("sentry.tasks.llm_issue_detection.detection.logger.error")
-    def test_detect_llm_issues_continues_on_seer_error(
+    def test_detect_llm_issues_seer_error_no_traces_marked(
         self,
         mock_logger_error,
         mock_shuffle,
         mock_spans_query,
         mock_seer_request,
-        mock_produce_occurrence,
+        mock_get_unprocessed,
+        mock_mark_processed,
     ):
         mock_shuffle.return_value = None
+        mock_get_unprocessed.return_value = {"trace_id_1"}
 
         mock_spans_query.side_effect = [
             {
                 "data": [
                     {"transaction": "POST /some/thing", "sum(span.duration)": 1007},
-                    {"transaction": "GET /another/", "sum(span.duration)": 1003},
                 ],
                 "meta": {},
             },
             {"data": [{"trace": "trace_id_1", "precise.start_ts": 1234}], "meta": {}},
-            {"data": [{"trace": "trace_id_2", "precise.start_ts": 1235}], "meta": {}},
         ]
 
         mock_error_response = Mock()
         mock_error_response.status = 500
-        mock_error_response.data.decode.return_value = "Internal Server Error"
-
-        mock_success_response = Mock()
-        mock_success_response.status = 200
-        mock_success_response.json.return_value = {
-            "issues": [
-                {
-                    "title": "Success Issue",
-                    "explanation": "This one worked",
-                    "impact": "Low",
-                    "evidence": "All good",
-                    "missing_telemetry": None,
-                    "offender_span_ids": ["span_1"],
-                    "trace_id": "trace_id_2",
-                    "transaction_name": "GET /another/",
-                    "category": "General",
-                    "subcategory": "Success",
-                    "verification_reason": "Problem is correctly identified",
-                }
-            ],
-            "traces_analyzed": 1,
-        }
-
-        mock_seer_request.side_effect = [mock_error_response, mock_success_response]
+        mock_error_response.data = b"Internal Server Error"
+        mock_seer_request.return_value = mock_error_response
 
         detect_llm_issues_for_project(self.project.id)
 
-        assert mock_seer_request.call_count == 2
+        assert mock_seer_request.call_count == 1
         assert mock_logger_error.call_count == 1
-        assert mock_produce_occurrence.call_count == 1
+        # Traces NOT marked as processed on error - will be retried next run
+        assert mock_mark_processed.call_count == 0
 
-        occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
-        assert occurrence.issue_title == "Success Issue"
-        assert occurrence.culprit == "GET /another/"
+
+class TestTraceProcessingFunctions:
+    @pytest.mark.parametrize(
+        ("trace_ids", "mget_return", "expected"),
+        [
+            # All unprocessed (mget returns None for missing keys)
+            (["a", "b", "c"], [None, None, None], {"a", "b", "c"}),
+            # Some processed (mget returns "1" for existing keys)
+            (["a", "b", "c"], ["1", None, "1"], {"b"}),
+            # All processed
+            (["a", "b"], ["1", "1"], set()),
+            # Empty input
+            ([], [], set()),
+        ],
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.redis_clusters")
+    def test_get_unprocessed_traces(
+        self, mock_redis_clusters: Mock, trace_ids: list, mget_return: list, expected: set
+    ) -> None:
+        mock_cluster = Mock()
+        mock_redis_clusters.get.return_value = mock_cluster
+        mock_cluster.mget.return_value = mget_return
+
+        result = _get_unprocessed_traces(trace_ids)
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        ("trace_ids", "expected_set_calls"),
+        [
+            (["trace_123"], 1),  # Single trace
+            (["trace_1", "trace_2", "trace_3"], 3),  # Multiple traces
+            ([], 0),  # Empty list - early return, no pipeline calls
+        ],
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.redis_clusters")
+    def test_mark_traces_as_processed(
+        self, mock_redis_clusters: Mock, trace_ids: list[str], expected_set_calls: int
+    ) -> None:
+        mock_cluster = Mock()
+        mock_pipeline = Mock()
+        mock_redis_clusters.get.return_value = mock_cluster
+        mock_cluster.pipeline.return_value.__enter__ = Mock(return_value=mock_pipeline)
+        mock_cluster.pipeline.return_value.__exit__ = Mock(return_value=False)
+
+        mark_traces_as_processed(trace_ids)
+
+        assert mock_pipeline.set.call_count == expected_set_calls
+        if expected_set_calls == 0:
+            mock_cluster.pipeline.assert_not_called()
+        else:
+            mock_pipeline.execute.assert_called_once()
 
 
 class TestGetProjectTopTransactionTracesForLLMDetection(


### PR DESCRIPTION
**Note:** This PR is being merged into parent branch `ID-1151`. It depends on additional changes that are not yet written. Full cutover will happen when all pieces are ready. Tech spec [here](https://www.notion.so/sentry/Add-Create-Issue-Occurrence-RPC-Method-2e78b10e4b5d8021a518c43e2090769b?source=copy_link)

Converts `detect_llm_issues_for_project` from synchronous per-trace requests to async batch processing. This is a breaking change that depends on corresponding Seer changes and does not need to be backwards compatible.

## Changes

- Send up to 20 traces per project in a single batch request (2x target to give Seer selection buffer)
- Expect 202 response indicating Seer accepted the work
- Mark traces as processed after 202 
- Add `_get_unprocessed_traces()` using bulk Redis mget instead of per-trace checks
- Replace `mark_trace_as_processed()` with `mark_traces_as_processed()` using Redis pipeline
- Reduce timeouts: Seer request 180s → 10s, task deadline 10min → 3min