### PR TITLE
ref(issues) use orange background for error state

### DIFF
--- a/static/app/components/events/errorLevel.tsx
+++ b/static/app/components/events/errorLevel.tsx
@@ -38,6 +38,7 @@ const ColoredLine = styled('span')<Props>`
       case 'warning':
         return p.theme.tokens.dataviz.semantic.meh;
       case 'error':
+        return p.theme.tokens.background.warning.vibrant;
       case 'fatal':
         return p.theme.tokens.dataviz.semantic.bad;
       case 'unknown':

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.spec.tsx
@@ -452,7 +452,7 @@ describe('ErrorNode', () => {
   });
 
   describe('makeBarColor', () => {
-    it('should return semantic bad token for error level', () => {
+    it('should return warning vibrant token for error level', () => {
       const extra = createMockExtra();
       const value = makeTraceError({
         title: 'Test Error',
@@ -462,7 +462,7 @@ describe('ErrorNode', () => {
       const node = new ErrorNode(null, value, extra);
       const theme = ThemeFixture();
 
-      expect(node.makeBarColor(theme)).toBe(theme.tokens.dataviz.semantic.bad);
+      expect(node.makeBarColor(theme)).toBe(theme.tokens.background.warning.vibrant);
     });
 
     it('should return semantic bad token for fatal level', () => {
@@ -559,10 +559,10 @@ describe('ErrorNode', () => {
       const theme = ThemeFixture();
 
       expect(warningNode.makeBarColor(theme)).toBe(theme.tokens.dataviz.semantic.meh);
-      expect(errorNode.makeBarColor(theme)).toBe(theme.tokens.dataviz.semantic.bad);
+      expect(errorNode.makeBarColor(theme)).toBe(theme.tokens.background.warning.vibrant);
     });
 
-    it('should use semantic bad token for error/fatal', () => {
+    it('should use warning vibrant token for error and semantic bad token for fatal', () => {
       const extra = createMockExtra();
       const errorValue = makeTraceError({
         title: 'Test Error',
@@ -577,7 +577,7 @@ describe('ErrorNode', () => {
       const fatalNode = new ErrorNode(null, fatalValue, extra);
       const theme = ThemeFixture();
 
-      expect(errorNode.makeBarColor(theme)).toBe(theme.tokens.dataviz.semantic.bad);
+      expect(errorNode.makeBarColor(theme)).toBe(theme.tokens.background.warning.vibrant);
       expect(fatalNode.makeBarColor(theme)).toBe(theme.tokens.dataviz.semantic.bad);
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.tsx
@@ -99,6 +99,7 @@ export class ErrorNode extends BaseNode<TraceTree.TraceErrorIssue> {
       case 'warning':
         return theme.tokens.dataviz.semantic.meh;
       case 'error':
+        return theme.tokens.background.warning.vibrant;
       case 'fatal':
         return theme.tokens.dataviz.semantic.bad;
       case 'unknown':


### PR DESCRIPTION
Revert change to treat error and fatal type errors in the same way