### PR TITLE
ref(issues): hide view in discover button when unable to access discover

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('sentry/utils/useRoutes');
 const mockUseRoutes = jest.mocked(useRoutes);
 
 describe('EventNavigation', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({features: ['discover-basic']});
   const group = GroupFixture({id: 'group-id'});
   const testEvent = EventFixture({
     id: 'event-id',
@@ -81,6 +81,7 @@ describe('EventNavigation', () => {
     it('renders the all events controls', () => {
       render(<IssueEventNavigation {...defaultProps} />, {
         initialRouterConfig,
+        organization,
       });
 
       const discoverButton = screen.getByLabelText('Open in Discover');
@@ -103,6 +104,7 @@ describe('EventNavigation', () => {
     it('supplies the default timestamp sort when no sort is set in the query params', () => {
       render(<IssueEventNavigation {...defaultProps} />, {
         initialRouterConfig,
+        organization,
       });
 
       const discoverButton = screen.getByLabelText('Open in Discover');
@@ -123,6 +125,7 @@ describe('EventNavigation', () => {
             query: {sort: '-title'},
           },
         },
+        organization,
       });
 
       const discoverButton = screen.getByLabelText('Open in Discover');

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
+import Feature from 'sentry/components/acl/feature';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
@@ -229,19 +230,21 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
                 isSmallNav={isSmallNav}
               />
               {issueTypeConfig.pages.events.enabled && (
-                <LinkButton
-                  to={{
-                    pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
-                    query: location.query,
-                  }}
-                  size="xs"
-                  analyticsEventKey="issue_details.all_events_clicked"
-                  analyticsEventName="Issue Details: All Events Clicked"
-                >
-                  {isSmallNav
-                    ? t('More %s', issueTypeConfig.customCopy.eventUnits)
-                    : t('View More %s', issueTypeConfig.customCopy.eventUnits)}
-                </LinkButton>
+                <Feature features="discover-basic" organization={organization}>
+                  <LinkButton
+                    to={{
+                      pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
+                      query: location.query,
+                    }}
+                    size="xs"
+                    analyticsEventKey="issue_details.all_events_clicked"
+                    analyticsEventName="Issue Details: All Events Clicked"
+                  >
+                    {isSmallNav
+                      ? t('More %s', issueTypeConfig.customCopy.eventUnits)
+                      : t('View More %s', issueTypeConfig.customCopy.eventUnits)}
+                  </LinkButton>
+                </Feature>
               )}
               {issueTypeConfig.pages.openPeriods.enabled && (
                 <LinkButton


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/101578

Hide 'View more events' button when discover isn't available, since clicking it leads to an empty view anyways.
<img width="291" height="45" alt="Screenshot 2026-01-23 at 9 47 02 AM" src="https://github.com/user-attachments/assets/245a269b-d5dc-4a30-a573-9838c8820b6c" />
