### PR TITLE
fix(preprod): Use project ID instead of slug in legacy URL redirects

### DIFF
--- a/static/app/views/preprod/redirects/legacyUrlRedirect.spec.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.spec.tsx
@@ -1,0 +1,115 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import LegacyPreprodRedirect from './legacyUrlRedirect';
+
+describe('LegacyPreprodRedirect', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const project = ProjectFixture({
+    id: '12345',
+    slug: 'fishbox-ios',
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('redirects size view with project ID instead of slug', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+
+    const {router} = render(<LegacyPreprodRedirect />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/preprod/fishbox-ios/17532/',
+        },
+        route: '/organizations/:orgId/preprod/:projectId/:artifactId/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/preprod/size/17532/'
+      );
+    });
+    expect(router.location.query).toEqual({project: '12345'});
+  });
+
+  it('redirects compare view with project ID', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+
+    const {router} = render(<LegacyPreprodRedirect />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/preprod/fishbox-ios/compare/100/99/',
+        },
+        route:
+          '/organizations/:orgId/preprod/:projectId/compare/:headArtifactId/:baseArtifactId/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/preprod/size/compare/100/99/'
+      );
+    });
+    expect(router.location.query).toEqual({project: '12345'});
+  });
+
+  it('redirects install view with project ID', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+
+    const {router} = render(<LegacyPreprodRedirect />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/preprod/fishbox-ios/install/17532/',
+        },
+        route: '/organizations/:orgId/preprod/:projectId/install/:artifactId/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/preprod/install/17532/'
+      );
+    });
+    expect(router.location.query).toEqual({project: '12345'});
+  });
+
+  it('falls back to slug if project is not found', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+
+    const {router} = render(<LegacyPreprodRedirect />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/preprod/unknown-project/17532/',
+        },
+        route: '/organizations/:orgId/preprod/:projectId/:artifactId/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/preprod/size/17532/'
+      );
+    });
+    expect(router.location.query).toEqual({project: 'unknown-project'});
+  });
+});

--- a/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
@@ -4,6 +4,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 export default function LegacyPreprodRedirect() {
   const params = useParams<{
@@ -15,31 +16,38 @@ export default function LegacyPreprodRedirect() {
   const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
+  const project = useProjectFromSlug({
+    organization,
+    projectSlug: params.projectId,
+  });
 
   useEffect(() => {
     const {projectId, artifactId, headArtifactId, baseArtifactId} = params;
     const isInstall = location.pathname.includes('/install/');
     const isCompare = location.pathname.includes('/compare/');
 
+    // Use project ID if available, fallback to slug for backward compatibility
+    const projectParam = project?.id ?? projectId;
+
     let newPath = '';
 
     if (isCompare && headArtifactId) {
       const compareType = 'size';
       if (baseArtifactId) {
-        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
+        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectParam}`;
       } else {
-        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
+        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/?project=${projectParam}`;
       }
     } else if (isInstall && artifactId) {
-      newPath = `/organizations/${organization.slug}/preprod/install/${artifactId}/?project=${projectId}`;
+      newPath = `/organizations/${organization.slug}/preprod/install/${artifactId}/?project=${projectParam}`;
     } else if (artifactId) {
-      newPath = `/organizations/${organization.slug}/preprod/size/${artifactId}/?project=${projectId}`;
+      newPath = `/organizations/${organization.slug}/preprod/size/${artifactId}/?project=${projectParam}`;
     }
 
     if (newPath) {
       navigate(newPath, {replace: true});
     }
-  }, [params, navigate, organization, location]);
+  }, [params, navigate, organization, location, project]);
 
   return null;
 }

--- a/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
@@ -8,7 +8,7 @@ import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 export default function LegacyPreprodRedirect() {
   const params = useParams<{
-    projectId: string;
+    projectId: string; // Note: Despite the name, this contains a project SLUG from the legacy URL
     artifactId?: string;
     baseArtifactId?: string;
     headArtifactId?: string;
@@ -16,18 +16,22 @@ export default function LegacyPreprodRedirect() {
   const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
+
+  // Extract slug from route param (misnamed as "projectId" in the legacy route)
+  const projectSlugFromUrl = params.projectId;
+
   const project = useProjectFromSlug({
     organization,
-    projectSlug: params.projectId,
+    projectSlug: projectSlugFromUrl,
   });
 
   useEffect(() => {
-    const {projectId, artifactId, headArtifactId, baseArtifactId} = params;
+    const {artifactId, headArtifactId, baseArtifactId} = params;
     const isInstall = location.pathname.includes('/install/');
     const isCompare = location.pathname.includes('/compare/');
 
-    // Use project ID if available, fallback to slug for backward compatibility
-    const projectParam = project?.id ?? projectId;
+    // Prefer numeric project ID, fallback to slug if project not found
+    const projectParam = project?.id ?? projectSlugFromUrl;
 
     let newPath = '';
 
@@ -47,7 +51,7 @@ export default function LegacyPreprodRedirect() {
     if (newPath) {
       navigate(newPath, {replace: true});
     }
-  }, [params, navigate, organization, location, project]);
+  }, [params, navigate, organization, location, project, projectSlugFromUrl]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes legacy preprod URL redirects to use numeric project IDs instead of project slugs in the query parameter, with fallback to slug for backward compatibility.

## Problem

When users access legacy preprod URLs in the format `/preprod/{projectSlug}/{artifactId}/`, the redirect was passing the project slug directly to the `?project=` query parameter. However, the rest of the application expects numeric project IDs in this parameter for consistency and stability (project IDs don't change, slugs can).

## Solution

- Modified `LegacyPreprodRedirect` component to use `useProjectFromSlug` hook to fetch the full project object
- Extracts the numeric ID from the project and uses it in the redirect
- **Falls back to using the slug** if the project lookup fails (API error, project not found, etc.)
- Applies to all redirect scenarios: size view, compare view, and install view

## Behavior

### When project is found:
```
/preprod/fishbox-ios/17532/ → /preprod/size/17532/?project=12345
```

### When project is not found (fallback):
```
/preprod/unknown-project/17532/ → /preprod/size/17532/?project=unknown-project
```

This maintains backward compatibility and ensures users are never stuck on the legacy URL.

## Testing

Added comprehensive test coverage in `legacyUrlRedirect.spec.tsx` covering:
- Size view redirect with project ID
- Compare view redirect with project ID
- Install view redirect with project ID  
- Fallback to slug when project is not found