### PR TITLE
chore(dynamic-sampling): sample all executions for boost lv transactions

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -381,6 +381,7 @@ class FetchProjectTransactionTotals:
             metrics.incr(
                 "dynamic_sampling.boost_low_volume_transactions.query",
                 tags={"query_type": "totals", "metric_type": metric_type},
+                sample_rate=1,
             )
 
             count = len(data)
@@ -548,6 +549,7 @@ class FetchProjectTransactionVolumes:
                     "metric_type": metric_type,
                     "volume_type": volume_type,
                 },
+                sample_rate=1,
             )
 
             count = len(data)


### PR DESCRIPTION
- Metrics are sampled in datadog, so when looking at single test orgs, this is very unreliable
- Set the metric sample rate to 1 for the rollout metric