### PR TITLE
fix(dashboards): trace metrics not grouping

### DIFF
--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
@@ -155,6 +155,51 @@ describe('useTraceMetricsSeriesQuery', () => {
       );
     });
   });
+
+  it('includes groupBy query param when widget has columns', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['project', 'avg(value,test_metric,millisecond,-)'],
+          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          columns: ['project'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [],
+      },
+    });
+
+    renderHook(
+      () =>
+        useTraceMetricsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-timeseries/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            groupBy: ['project'],
+          }),
+        })
+      );
+    });
+  });
 });
 
 describe('useTraceMetricsTableQuery', () => {

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -130,12 +130,14 @@ export function useTraceMetricsSeriesQuery(
         includePrevious: _includePrevious,
         generatePathname: _generatePathname,
         period,
+        queryExtras,
         ...restParams
       } = requestData;
 
       const queryParams = {
         ...restParams,
         ...(period ? {statsPeriod: period} : {}),
+        ...queryExtras,
       };
 
       if (queryParams.start) {


### PR DESCRIPTION
Fixes a bug where `groupBy` wasn't being provided in the trace metrics dataset