### PR TITLE
chore(api): Update group-details test mock URLs to org-scoped pattern

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -179,7 +179,7 @@ describe('GroupSidebar', () => {
       group = GroupFixture();
 
       MockApiClient.addMockResponse({
-        url: '/organization/org-slug/issues/1/',
+        url: '/organizations/org-slug/issues/1/',
         body: group,
       });
       MockApiClient.addMockResponse({
@@ -261,7 +261,7 @@ describe('GroupSidebar', () => {
       group = GroupFixture();
 
       MockApiClient.addMockResponse({
-        url: '/issues/1/',
+        url: '/organizations/org-slug/issues/1/',
         body: group,
       });
     });


### PR DESCRIPTION
Update groupSidebar test mocks to use org-scoped URL pattern /organizations/{org}/issues/{id}/ instead of the deprecated /issues/{id}/ pattern. 