### PR TITLE
chore(api): Update group-activities test mock URLs to org-scoped pattern

### DIFF
--- a/static/app/components/badge/groupPriority.spec.tsx
+++ b/static/app/components/badge/groupPriority.spec.tsx
@@ -35,7 +35,7 @@ describe('GroupPriority', () => {
 
     it('fetches the last priority edit when not passed in', async () => {
       MockApiClient.addMockResponse({
-        url: '/issues/1/activities/',
+        url: '/organizations/org-slug/issues/1/activities/',
         body: {
           activity: [
             ActivityFeedFixture({
@@ -61,7 +61,7 @@ describe('GroupPriority', () => {
 
     it('shows a learn more banner that may be dismissed', async () => {
       MockApiClient.addMockResponse({
-        url: '/issues/1/activities/',
+        url: '/organizations/org-slug/issues/1/activities/',
         body: {activity: []},
       });
       MockApiClient.addMockResponse({

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -52,10 +52,14 @@ function useLastEditedBy({
   groupId,
   lastEditedBy: incomingLastEditedBy,
 }: Pick<GroupPriorityDropdownProps, 'groupId' | 'lastEditedBy'>) {
-  const {data} = useApiQuery<{activity: Activity[]}>([`/issues/${groupId}/activities/`], {
-    enabled: !defined(incomingLastEditedBy),
-    staleTime: 0,
-  });
+  const organization = useOrganization();
+  const {data} = useApiQuery<{activity: Activity[]}>(
+    [`/organizations/${organization.slug}/issues/${groupId}/activities/`],
+    {
+      enabled: !defined(incomingLastEditedBy),
+      staleTime: 0,
+    }
+  );
 
   const lastEditedBy = useMemo(() => {
     if (incomingLastEditedBy) {


### PR DESCRIPTION
Update groupPriority test mocks to use org-scoped URL pattern /organizations/{org}/issues/{id}/activities/ instead of the deprecated /issues/{id}/activities/ pattern.
