### PR TITLE
chore(api): Update group-event-details URLs to org-scoped pattern

### DIFF
--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -14,26 +14,26 @@ describe('IssueDiff', () => {
 
   beforeEach(() => {
     MockApiClient.addMockResponse({
-      url: '/issues/base/events/latest/',
+      url: '/organizations/org-slug/issues/base/events/latest/',
       body: {
         eventID: '123base',
       },
     });
     MockApiClient.addMockResponse({
-      url: '/issues/target/events/latest/',
+      url: '/organizations/org-slug/issues/target/events/latest/',
       body: {
         eventID: '123target',
       },
     });
     MockApiClient.addMockResponse({
-      url: '/issues/target/events/123target/',
+      url: '/organizations/org-slug/issues/target/events/123target/',
       body: {
         entries: entries123Target,
       },
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/base/events/123base/',
+      url: '/organizations/org-slug/issues/base/events/123base/',
       body: {
         platform: 'javascript',
         entries: entries123Base,
@@ -67,13 +67,13 @@ describe('IssueDiff', () => {
 
   it('can diff message', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/target/events/123target/',
+      url: '/organizations/org-slug/issues/target/events/123target/',
       body: {
         entries: [{type: 'message', data: {formatted: 'Hello World'}}],
       },
     });
     MockApiClient.addMockResponse({
-      url: '/issues/base/events/123base/',
+      url: '/organizations/org-slug/issues/base/events/123base/',
       body: {
         platform: 'javascript',
         entries: [{type: 'message', data: {formatted: 'Foo World'}}],

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -44,24 +44,32 @@ export function IssueDiff({
   const newestFirst = isStacktraceNewestFirst();
 
   const baseLatestQuery = useQuery({
-    ...apiOptions.as<{eventID: string}>()('/issues/$issueId/events/$eventId/', {
-      path: {
-        issueId: baseIssueId,
-        eventId: 'latest',
-      },
-      staleTime: 60_000,
-    }),
+    ...apiOptions.as<{eventID: string}>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          issueId: baseIssueId,
+          eventId: 'latest',
+        },
+        staleTime: 60_000,
+      }
+    ),
     enabled: baseEventId === 'latest',
   });
 
   const targetLatestQuery = useQuery({
-    ...apiOptions.as<{eventID: string}>()('/issues/$issueId/events/$eventId/', {
-      path: {
-        issueId: targetIssueId,
-        eventId: 'latest',
-      },
-      staleTime: 60_000,
-    }),
+    ...apiOptions.as<{eventID: string}>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          issueId: targetIssueId,
+          eventId: 'latest',
+        },
+        staleTime: 60_000,
+      }
+    ),
     enabled: targetEventId === 'latest',
   });
 
@@ -71,24 +79,32 @@ export function IssueDiff({
     targetEventId === 'latest' ? targetLatestQuery.data?.eventID : targetEventId;
 
   const baseEventQuery = useQuery({
-    ...apiOptions.as<Event>()('/issues/$issueId/events/$eventId/', {
-      path: {
-        issueId: baseIssueId,
-        eventId: resolvedBaseEventId ?? '',
-      },
-      staleTime: 60_000,
-    }),
+    ...apiOptions.as<Event>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          issueId: baseIssueId,
+          eventId: resolvedBaseEventId ?? '',
+        },
+        staleTime: 60_000,
+      }
+    ),
     enabled: Boolean(resolvedBaseEventId),
   });
 
   const targetEventQuery = useQuery({
-    ...apiOptions.as<Event>()('/issues/$issueId/events/$eventId/', {
-      path: {
-        issueId: targetIssueId,
-        eventId: resolvedTargetEventId ?? '',
-      },
-      staleTime: 60_000,
-    }),
+    ...apiOptions.as<Event>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          issueId: targetIssueId,
+          eventId: resolvedTargetEventId ?? '',
+        },
+        staleTime: 60_000,
+      }
+    ),
     enabled: Boolean(resolvedTargetEventId),
   });
 

--- a/static/app/components/modals/diffModal.spec.tsx
+++ b/static/app/components/modals/diffModal.spec.tsx
@@ -10,7 +10,7 @@ describe('DiffModal', () => {
   it('renders', () => {
     const project = ProjectFixture();
     MockApiClient.addMockResponse({
-      url: '/issues/123/events/latest/',
+      url: '/organizations/org-slug/issues/123/events/latest/',
       body: {
         eventID: '456',
       },
@@ -20,7 +20,7 @@ describe('DiffModal', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/issues/234/events/latest/',
+      url: '/organizations/org-slug/issues/234/events/latest/',
       body: {
         eventID: '789',
       },

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -38,9 +38,12 @@ const makeGroupPreviewRequestUrl = ({
   groupId: string;
   orgSlug: string;
 }) => {
-  return getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/', {
-    path: {organizationIdOrSlug: orgSlug, issueId: groupId, eventId: 'latest'},
-  });
+  return getApiUrl(
+    '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+    {
+      path: {organizationIdOrSlug: orgSlug, issueId: groupId, eventId: 'latest'},
+    }
+  );
 };
 
 function AllEventsTable({organization, excludedTags, group}: Props) {

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -31,9 +31,15 @@ interface Props {
   organization: Organization;
 }
 
-const makeGroupPreviewRequestUrl = ({groupId}: {groupId: string}) => {
-  return getApiUrl('/issues/$issueId/events/$eventId/', {
-    path: {issueId: groupId, eventId: 'latest'},
+const makeGroupPreviewRequestUrl = ({
+  orgSlug,
+  groupId,
+}: {
+  groupId: string;
+  orgSlug: string;
+}) => {
+  return getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/', {
+    path: {organizationIdOrSlug: orgSlug, issueId: groupId, eventId: 'latest'},
   });
 };
 
@@ -47,6 +53,7 @@ function AllEventsTable({organization, excludedTags, group}: Props) {
   const now = useMemo(() => Date.now(), []);
 
   const endpointUrl = makeGroupPreviewRequestUrl({
+    orgSlug: organization.slug,
     groupId: group.id,
   });
 

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -100,7 +100,7 @@ describe('groupEvents', () => {
 
     requests.latestEvent = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/issues/1/events/latest/',
+      url: '/organizations/org-slug/issues/1/events/latest/',
       body: {},
     });
 

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -55,7 +55,7 @@ describe('CreateSampleEventButton', () => {
     expect(createRequest).toHaveBeenCalled();
 
     const latestIssueRequest = MockApiClient.addMockResponse({
-      url: `/issues/${groupID}/events/latest/`,
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       body: {},
     });
 
@@ -94,7 +94,7 @@ describe('CreateSampleEventButton', () => {
 
     // Start with no latest event
     let latestIssueRequest = MockApiClient.addMockResponse({
-      url: `/issues/${groupID}/events/latest/`,
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 404,
       body: {},
     });
@@ -106,7 +106,7 @@ describe('CreateSampleEventButton', () => {
     // Second request will be successful
     MockApiClient.clearMockResponses();
     latestIssueRequest = MockApiClient.addMockResponse({
-      url: `/issues/${groupID}/events/latest/`,
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 200,
       body: {},
     });

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -36,6 +36,7 @@ const EVENT_POLL_INTERVAL = 1000;
 
 async function latestEventAvailable(
   api: Client,
+  orgSlug: string,
   groupID: string
 ): Promise<{eventCreated: boolean; retries: number}> {
   let retries = 0;
@@ -48,7 +49,9 @@ async function latestEventAvailable(
     await new Promise(resolve => window.setTimeout(resolve, EVENT_POLL_INTERVAL));
 
     try {
-      await api.requestPromise(`/issues/${groupID}/events/latest/`);
+      await api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupID}/events/latest/`
+      );
       return {eventCreated: true, retries};
     } catch {
       ++retries;
@@ -141,7 +144,11 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
     // Wait for the event to be fully processed and available on the group
     // before redirecting.
     const t0 = performance.now();
-    const {eventCreated, retries} = await latestEventAvailable(api, eventData.groupID);
+    const {eventCreated, retries} = await latestEventAvailable(
+      api,
+      organization.slug,
+      eventData.groupID
+    );
 
     // Navigated away before event was created - skip analytics and error messages
     // latestEventAvailable will succeed even if the request was cancelled


### PR DESCRIPTION
Update issueDiff component and related test mocks to use org-scoped URL pattern /organizations/{org}/issues/{id}/events/{eventId}/ instead of the deprecated /issues/{id}/events/{eventId}/ pattern.
