### PR TITLE
fix(trace-waterfall): Only check direct children

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -390,6 +390,10 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
     return this.visibleChildren.length > 0;
   }
 
+  hasDirectVisibleChildren(): boolean {
+    return this.directVisibleChildren.length > 0;
+  }
+
   matchById(id: string): boolean {
     const hasMatchingErrors = Array.from(this.errors).some(
       error => error.event_id === id

--- a/static/app/views/performance/newTraceDetails/traceRow/traceRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceRow.tsx
@@ -67,7 +67,7 @@ export function TraceRowConnectors(props: {
   manager: VirtualizedViewManager;
   node: BaseNode;
 }) {
-  const hasChildren = props.node.hasVisibleChildren();
+  const hasChildren = props.node.hasDirectVisibleChildren();
   const nodeDepth = TraceTree.Depth(props.node);
 
   return (


### PR DESCRIPTION
This PR changes the way we determine rendering the vertical connecter. 

Added in new method `hasDirectVisibleChildren()` in from `O(n)` to `O(1)` complexity:
```tsx
hasDirectVisibleChildren(): boolean {
  return this.directVisibleChildren.length > 0;
}
```

Before: Calling `node.hasVisibleChildren()` which traversed the entire subtree - `O(n)` per call.
After: Calls `node.hasDirectVisibleChildren()` which returns only immediate children - `O(1)` per call.