### PR TITLE
fix(eap-spans): handle None attribute with groupBy + topEvents

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -531,7 +531,6 @@ class SearchResolver:
 
         # Handle lists containing None for IN/NOT IN operators
         if isinstance(value, list) and None in value and term.operator in constants.IN_OPERATORS:
-            # Split None from non-None values
             non_none_values = [v for v in value if v is not None]
 
             exists_filter = TraceItemFilter(
@@ -541,12 +540,9 @@ class SearchResolver:
             )
 
             if term.operator == "IN":
-                # For IN: (field IS NULL) OR (field IN [non-none values])
                 filters = []
-                # Add NOT EXISTS filter for NULL values
                 filters.append(TraceItemFilter(not_filter=NotFilter(filters=[exists_filter])))
 
-                # Add IN filter for non-None values if any exist
                 if non_none_values:
                     filters.append(
                         TraceItemFilter(
@@ -567,10 +563,8 @@ class SearchResolver:
                     context_definition,
                 )
             else:  # NOT IN
-                # For NOT IN: (field IS NOT NULL) AND (field NOT IN [non-none values])
                 filters = [exists_filter]
 
-                # Add NOT IN filter for non-None values if any exist
                 if non_none_values:
                     filters.append(
                         TraceItemFilter(

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -720,20 +720,22 @@ class SearchResolver:
             column_type = column.proto_definition.type
             if column_type == constants.STRING:
                 if operator in constants.IN_OPERATORS:
-                    if isinstance(value, list) and all(isinstance(item, str) for item in value):
-                        return AttributeValue(val_str_array=StrArray(values=value))
-                    else:
-                        raise InvalidSearchQuery(
-                            f"{value} is not a valid value for doing an IN filter"
-                        )
+                    if isinstance(value, list):
+                        # Filter out None values from the list
+                        filtered_values = [item for item in value if item is not None]
+                        if all(isinstance(item, str) for item in filtered_values):
+                            return AttributeValue(val_str_array=StrArray(values=filtered_values))
+                    raise InvalidSearchQuery(f"{value} is not a valid value for doing an IN filter")
                 else:
                     return AttributeValue(val_str=str(value))
             elif column_type == constants.INT:
                 # The search parser will always convert a value to a float, so we need to cast back to an int
                 if operator in constants.IN_OPERATORS:
                     if isinstance(value, list):
+                        # Filter out None values from the list
+                        filtered_values = [val for val in value if val is not None]
                         return AttributeValue(
-                            val_int_array=IntArray(values=[int(val) for val in value])
+                            val_int_array=IntArray(values=[int(val) for val in filtered_values])
                         )
                     else:
                         raise InvalidSearchQuery(
@@ -744,11 +746,13 @@ class SearchResolver:
             elif column_type == constants.DOUBLE:
                 if operator in constants.IN_OPERATORS:
                     if isinstance(value, list):
+                        # Filter out None values from the list
+                        filtered_values = [val for val in value if val is not None]
                         return AttributeValue(
                             val_double_array=DoubleArray(
                                 values=[
                                     val.timestamp() if isinstance(val, datetime) else val
-                                    for val in value
+                                    for val in filtered_values
                                 ]
                             )
                         )

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -2558,7 +2558,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert response.status_code == 200, response.content
         assert len(response.data["timeSeries"]) == 3
 
-        time_series_by_release = {}
+        time_series_by_release: dict[str | None, dict[str, object]] = {}
         for ts in response.data["timeSeries"]:
             if ts["groupBy"] is None:
                 time_series_by_release["Other"] = ts
@@ -2572,10 +2572,10 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert "Other" not in time_series_by_release
 
         # All releases including None should now have data
-        assert len(time_series_by_release[None]["values"]) > 0
+        assert len(time_series_by_release[None]["values"]) > 0  # type: ignore[index]
         assert len(time_series_by_release["1.0.0"]["values"]) > 0
         assert len(time_series_by_release["2.0.0"]["values"]) > 0
 
         # Verify the None release actually has the span with no release
-        none_values = [v for v in time_series_by_release[None]["values"] if v["value"] > 0]
+        none_values = [v for v in time_series_by_release[None]["values"] if v["value"] > 0]  # type: ignore[index]
         assert len(none_values) > 0, "None release should have at least one data point"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -2558,7 +2559,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert response.status_code == 200, response.content
         assert len(response.data["timeSeries"]) == 3
 
-        time_series_by_release: dict[str | None, dict[str, object]] = {}
+        time_series_by_release: dict[str | None, Any] = {}
         for ts in response.data["timeSeries"]:
             if ts["groupBy"] is None:
                 time_series_by_release["Other"] = ts
@@ -2572,10 +2573,10 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert "Other" not in time_series_by_release
 
         # All releases including None should now have data
-        assert len(time_series_by_release[None]["values"]) > 0  # type: ignore[index]
+        assert len(time_series_by_release[None]["values"]) > 0
         assert len(time_series_by_release["1.0.0"]["values"]) > 0
         assert len(time_series_by_release["2.0.0"]["values"]) > 0
 
         # Verify the None release actually has the span with no release
-        none_values = [v for v in time_series_by_release[None]["values"] if v["value"] > 0]  # type: ignore[index]
+        none_values = [v for v in time_series_by_release[None]["values"] if v["value"] > 0]
         assert len(none_values) > 0, "None release should have at least one data point"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -2556,7 +2556,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
 
         assert response.status_code == 200, response.content
-        assert len(response.data["timeSeries"]) == 4
+        assert len(response.data["timeSeries"]) == 3
 
         time_series_by_release = {}
         for ts in response.data["timeSeries"]:
@@ -2569,8 +2569,13 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert None in time_series_by_release
         assert "1.0.0" in time_series_by_release
         assert "2.0.0" in time_series_by_release
-        assert "Other" in time_series_by_release
+        assert "Other" not in time_series_by_release
 
-        assert len(time_series_by_release[None]["values"]) == 0
+        # All releases including None should now have data
+        assert len(time_series_by_release[None]["values"]) > 0
         assert len(time_series_by_release["1.0.0"]["values"]) > 0
         assert len(time_series_by_release["2.0.0"]["values"]) > 0
+
+        # Verify the None release actually has the span with no release
+        none_values = [v for v in time_series_by_release[None]["values"] if v["value"] > 0]
+        assert len(none_values) > 0, "None release should have at least one data point"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -2515,3 +2515,62 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             },
         )
         assert response.status_code == 400, response.content
+
+    def test_with_no_value_release_data(self) -> None:
+        spans = [
+            self.create_span(
+                {
+                    "description": "foo",
+                    "sentry_tags": {"release": None},
+                },
+                start_ts=self.start + timedelta(minutes=1),
+            ),
+            self.create_span(
+                {
+                    "description": "foo",
+                    "sentry_tags": {"release": "1.0.0"},
+                },
+                start_ts=self.start + timedelta(minutes=2),
+            ),
+            self.create_span(
+                {
+                    "description": "foo",
+                    "sentry_tags": {"release": "2.0.0"},
+                },
+                start_ts=self.start + timedelta(minutes=2),
+            ),
+        ]
+        self.store_spans(spans, is_eap=True)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "4h",
+                "yAxis": "count(span.duration)",
+                "groupBy": "release",
+                "project": self.project.id,
+                "sort": "-count_span_duration",
+                "dataset": "spans",
+                "topEvents": 5,
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["timeSeries"]) == 4
+
+        time_series_by_release = {}
+        for ts in response.data["timeSeries"]:
+            if ts["groupBy"] is None:
+                time_series_by_release["Other"] = ts
+            else:
+                release_value = ts["groupBy"][0]["value"]
+                time_series_by_release[release_value] = ts
+
+        assert None in time_series_by_release
+        assert "1.0.0" in time_series_by_release
+        assert "2.0.0" in time_series_by_release
+        assert "Other" in time_series_by_release
+
+        assert len(time_series_by_release[None]["values"]) == 0
+        assert len(time_series_by_release["1.0.0"]["values"]) > 0
+        assert len(time_series_by_release["2.0.0"]["values"]) > 0


### PR DESCRIPTION
This is a quick fix to prevent errors when there data with `None` and we try to groupBy it resulting in `[None] is not a valid value for doing an IN filter`

Keep in mind, top events makes two queries under the hook
1. Find the top events
2. Place those top events into a `IN` filter, so each element in the filter has it's own timeseries. (this is where the issue originates)

We resolved this by allowing `None` in a `IN` filter and handling separately. If `None` is present in an IN filter, we add an exists filter for that attribute. This results in a `None` group.
i.e if the query is `release IN [None, "1.0.0", "2.0.0"]`, the result is `(release IS NULL) OR (release IN ["1.0.0", "2.0.0"])`