### PR TITLE
feat(replays): Add saved query header for Replay pages

### DIFF
--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -5,6 +5,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
 import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 function ExploreBreadcrumb({traceItemDataset}: {traceItemDataset: TraceItemDataset}) {
@@ -26,6 +27,12 @@ function ExploreBreadcrumb({traceItemDataset}: {traceItemDataset: TraceItemDatas
     crumbs.push({
       to: makeMetricsPathname({organizationSlug: organization.slug, path: '/'}),
       label: t('Metrics'),
+    });
+  }
+  if (traceItemDataset === TraceItemDataset.REPLAYS) {
+    crumbs.push({
+      to: makeReplaysPathname({organization, path: '/'}),
+      label: t('Replays'),
     });
   }
   crumbs.push({

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -265,7 +265,7 @@ describe('SavedQueriesTable', () => {
     render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('Replays Query Name')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/replays/?end=2024-01-02T00%3A00%3A00.000&environment=production&environment=staging&project=1&project=2&query=user.email%3A%2A%40example.com&start=2024-01-01T00%3A00%3A00.000'
+      '/organizations/org-slug/explore/replays/?end=2024-01-02T00%3A00%3A00.000&environment=production&environment=staging&id=1&project=1&project=2&query=user.email%3A%2A%40example.com&start=2024-01-01T00%3A00%3A00.000&title=Replays%20Query%20Name'
     );
   });
 
@@ -295,7 +295,7 @@ describe('SavedQueriesTable', () => {
     render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('Recent Replays')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/replays/?environment=production&project=3&query=browser.name%3AChrome&statsPeriod=24h'
+      '/organizations/org-slug/explore/replays/?environment=production&id=2&project=3&query=browser.name%3AChrome&statsPeriod=24h&title=Recent%20Replays'
     );
   });
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -670,6 +670,8 @@ function getReplayUrlFromSavedQueryUrl({
     start: normalizeDateTimeString(savedQuery.start),
     end: normalizeDateTimeString(savedQuery.end),
     statsPeriod: savedQuery.range,
+    id: savedQuery.id,
+    title: savedQuery.name,
   };
 
   const queryString = qs.stringify(queryParams, {skipNull: true});

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -14,6 +14,7 @@ import {
 } from 'sentry/components/replays/replayAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import {ReplayPreferencesContextProvider} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
@@ -22,6 +23,13 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
+import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {
+  useQueryParamsId,
+  useQueryParamsTitle,
+} from 'sentry/views/explore/queryParams/context';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import ReplaysFilters from 'sentry/views/replays/list/filters';
 import ReplayIndexContainer from 'sentry/views/replays/list/replayIndexContainer';
 import ReplayIndexTimestampPrefPicker from 'sentry/views/replays/list/replayIndexTimestampPrefPicker';
@@ -34,6 +42,51 @@ const ReplayListPageHeaderHook = HookOrDefault({
   hookName: 'component:replay-list-page-header',
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
+
+function ReplaysHeader() {
+  const pageId = useQueryParamsId();
+  const title = useQueryParamsTitle();
+  const organization = useOrganization();
+  const {data: savedQuery} = useGetSavedQuery(pageId);
+
+  const hasSavedQueryTitle =
+    defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
+
+  return (
+    <Layout.Header unified>
+      <Layout.HeaderContent unified>
+        {hasSavedQueryTitle ? (
+          <SentryDocumentTitle
+            title={`${savedQuery.name} — ${t('Session Replay')}`}
+            orgSlug={organization?.slug}
+          />
+        ) : null}
+        {title && defined(pageId) ? (
+          <ExploreBreadcrumb traceItemDataset={TraceItemDataset.REPLAYS} />
+        ) : null}
+
+        <Layout.Title>
+          {title ? (
+            title
+          ) : (
+            <Fragment>
+              {t('Session Replay')}
+              <PageHeadingQuestionTooltip
+                title={t(
+                  'Video-like reproductions of user sessions so you can visualize repro steps to debug issues faster.'
+                )}
+                docsUrl="https://docs.sentry.io/product/session-replay/"
+              />
+            </Fragment>
+          )}
+        </Layout.Title>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <ReplayIndexTimestampPrefPicker />
+      </Layout.HeaderActions>
+    </Layout.Header>
+  );
+}
 
 export default function ReplaysListContainer() {
   useReplayPageview('replay.list-time-spent');
@@ -62,21 +115,7 @@ export default function ReplaysListContainer() {
       <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
         <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
           <ReplayQueryParamsProvider>
-            <Layout.Header unified>
-              <Layout.Title>
-                {t('Session Replay')}
-                <PageHeadingQuestionTooltip
-                  title={t(
-                    'Video-like reproductions of user sessions so you can visualize repro steps to debug issues faster.'
-                  )}
-                  docsUrl="https://docs.sentry.io/product/session-replay/"
-                />
-              </Layout.Title>
-
-              <Layout.HeaderActions>
-                <ReplayIndexTimestampPrefPicker />
-              </Layout.HeaderActions>
-            </Layout.Header>
+            <ReplaysHeader />
             <PageFiltersContainer>
               <Layout.Body>
                 <Layout.Main width="full">

--- a/static/app/views/replays/list/replayQueryParamsProvider.tsx
+++ b/static/app/views/replays/list/replayQueryParamsProvider.tsx
@@ -9,12 +9,20 @@ import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/conte
 import {updateNullableLocation} from 'sentry/views/explore/queryParams/location';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  getIdFromLocation,
+  getTitleFromLocation,
+  ID_KEY,
+  TITLE_KEY,
+} from 'sentry/views/explore/queryParams/savedQuery';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 const REPLAY_QUERY_KEY = 'query';
 
 function getReadableQueryParamsFromLocation(location: Location): ReadableQueryParams {
   const query = getQueryFromLocation(location, REPLAY_QUERY_KEY) ?? '';
+  const id = getIdFromLocation(location, ID_KEY);
+  const title = getTitleFromLocation(location, TITLE_KEY);
 
   return new ReadableQueryParams({
     extrapolate: false,
@@ -26,6 +34,8 @@ function getReadableQueryParamsFromLocation(location: Location): ReadableQueryPa
     aggregateCursor: '',
     aggregateFields: [],
     aggregateSortBys: [],
+    id,
+    title,
   });
 }
 


### PR DESCRIPTION
When navigating from Explore → Saved Queries to a Replay saved query,
the page now shows a breadcrumb ("Replays > Saved Query") and displays
the saved query name as the title, matching the behavior of Logs.

Changes:
- Pass `id` and `title` params in `getReplayUrlFromSavedQueryUrl()`
- Extract `id`/`title` from URL in `ReplayQueryParamsProvider`
- Add Replays case to `ExploreBreadcrumb` component
- Create `ReplaysHeader` component with saved query detection

Saved Query:
<img width="381" height="155" alt="image" src="https://github.com/user-attachments/assets/9a42574f-921c-4800-b6c1-8dc2b28916ca" />

No Saved Query:
<img width="381" height="125" alt="image" src="https://github.com/user-attachments/assets/d40a7d65-c55b-493e-ac85-6541cae521e6" />

