### PR TITLE
fix(alerts): respect 24-hour clock preference in email notifications

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -118,11 +118,15 @@ class DigestNotification(ProjectNotification):
         self, recipient: Actor, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         tz: tzinfo = UTC
+        clock_24_hours = False
         if recipient.is_user:
             user_options = user_option_service.get_many(
-                filter={"user_ids": [recipient.id], "keys": ["timezone"]}
+                filter={"user_ids": [recipient.id], "keys": ["timezone", "clock_24_hours"]}
             )
             user_tz = get_option_from_list(user_options, key="timezone", default="UTC")
+            clock_24_hours = bool(
+                get_option_from_list(user_options, key="clock_24_hours", default=False)
+            )
             try:
                 tz = zoneinfo.ZoneInfo(user_tz)
             except (ValueError, zoneinfo.ZoneInfoNotFoundError):
@@ -130,6 +134,7 @@ class DigestNotification(ProjectNotification):
         return {
             **super().get_recipient_context(recipient, extra_context),
             "timezone": tz,
+            "clock_24_hours": clock_24_hours,
         }
 
     def get_context(self) -> MutableMapping[str, Any]:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -81,9 +81,12 @@ class DigestNotification(ProjectNotification):
             # This shouldn't be possible but adding a message just in case.
             return "Digest Report"
 
-        # Use timezone from context if available (added by get_recipient_context)
+        # Use timezone and clock format from context (added by get_recipient_context)
         timezone = context.get("timezone")
-        return get_digest_subject(context["group"], context["counts"], context["start"], timezone)
+        clock_24_hours = context.get("clock_24_hours", False)
+        return get_digest_subject(
+            context["group"], context["counts"], context["start"], timezone, clock_24_hours
+        )
 
     def get_notification_title(
         self, provider: ExternalProviders, context: Mapping[str, Any] | None = None

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -138,11 +138,15 @@ class AlertRuleNotification(ProjectNotification):
         self, recipient: Actor, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         tz: tzinfo = UTC
+        clock_24_hours = False
         if recipient.is_user:
             user_options = user_option_service.get_many(
-                filter={"user_ids": [recipient.id], "keys": ["timezone"]}
+                filter={"user_ids": [recipient.id], "keys": ["timezone", "clock_24_hours"]}
             )
             user_tz = get_option_from_list(user_options, key="timezone", default="UTC")
+            clock_24_hours = bool(
+                get_option_from_list(user_options, key="clock_24_hours", default=False)
+            )
             try:
                 tz = zoneinfo.ZoneInfo(user_tz)
             except (ValueError, zoneinfo.ZoneInfoNotFoundError):
@@ -150,6 +154,7 @@ class AlertRuleNotification(ProjectNotification):
         return {
             **super().get_recipient_context(recipient, extra_context),
             "timezone": tz,
+            "clock_24_hours": clock_24_hours,
         }
 
     def get_image_url(self) -> str | None:

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -16,17 +16,24 @@ if TYPE_CHECKING:
 
 
 def get_digest_subject(
-    group: Group, counts: Counter[Group], date: datetime, timezone: tzinfo | None = None
+    group: Group,
+    counts: Counter[Group],
+    date: datetime,
+    timezone: tzinfo | None = None,
+    clock_24_hours: bool = False,
 ) -> str:
     # Convert date to user's timezone if provided
     if timezone:
         date = date.astimezone(timezone)
 
+    # Use 24-hour format (H:i) or 12-hour format (P) based on user preference
+    date_format = "N j, Y, H:i e" if clock_24_hours else "N j, Y, P e"
+
     return "{short_id} - {count} new {noun} since {date}".format(
         short_id=group.qualified_short_id,
         count=len(counts),
         noun="alert" if len(counts) == 1 else "alerts",
-        date=dateformat.format(date, "N j, Y, P e"),
+        date=dateformat.format(date, date_format),
     )
 
 

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -24,14 +24,26 @@
 
 <div class="container" style="padding-top: 30px;">
   <h2>{{ counts|length }} new alert{{ counts|pluralize }} from <a href="{{ project.get_absolute_url }}">{{ project.slug }}</a></h2>
-  {% if timezone %}
-    {% with start=start|timezone:timezone|date:"N j, Y, P e" end=end|timezone:timezone|date:"N j, Y, P e" %}
-      <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
-    {% endwith %}
+  {% if clock_24_hours %}
+    {% if timezone %}
+      {% with start=start|timezone:timezone|date:"N j, Y, H:i e" end=end|timezone:timezone|date:"N j, Y, H:i e" %}
+        <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+      {% endwith %}
+    {% else %}
+      {% with start=start|date:"N j, Y, H:i e" end=end|date:"N j, Y, H:i e" %}
+        <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+      {% endwith %}
+    {% endif %}
   {% else %}
-    {% with start=start|date:"N j, Y, P e" end=end|date:"N j, Y, P e" %}
-      <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
-    {% endwith %}
+    {% if timezone %}
+      {% with start=start|timezone:timezone|date:"N j, Y, P e" end=end|timezone:timezone|date:"N j, Y, P e" %}
+        <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+      {% endwith %}
+    {% else %}
+      {% with start=start|date:"N j, Y, P e" end=end|date:"N j, Y, P e" %}
+        <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+      {% endwith %}
+    {% endif %}
   {% endif %}
 </div>
 
@@ -62,11 +74,13 @@
                   <td class="event-detail">
                       {% include "sentry/emails/_group.html" %}
                       <div>
-                        {% if timezone %}
-                          <small>{{ records.0.datetime|timezone:timezone|date:"N j, Y, g:i:s a e" }}</small>
-                        {% else %}
-                          <small>{{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
-                        {% endif %}
+                        <small>
+                          {% if clock_24_hours %}
+                            {% if timezone %}{{ records.0.datetime|timezone:timezone|date:"N j, Y, H:i:s e" }}{% else %}{{ records.0.datetime|date:"N j, Y, H:i:s e" }}{% endif %}
+                          {% else %}
+                            {% if timezone %}{{ records.0.datetime|timezone:timezone|date:"N j, Y, g:i:s a e" }}{% else %}{{ records.0.datetime|date:"N j, Y, g:i:s a e" }}{% endif %}
+                          {% endif %}
+                        </small>
                         {% if show_replay_links and group.has_replays %}
                           <span class="replay-link">
                             <a href="{{ group.get_absolute_url }}replays?referrer=alert_email">

--- a/src/sentry/templates/sentry/emails/digests/body.txt
+++ b/src/sentry/templates/sentry/emails/digests/body.txt
@@ -1,7 +1,7 @@
 {% load timezone from tz %}
 {% load sentry_helpers %}
 {% load sentry_features %}Notifications for {{ project.slug }}
-{% if timezone %}{{ start|timezone:timezone|date:"N j, Y, P e" }} to {{ end|timezone:timezone|date:"N j, Y, P e" }}{% else %}{{ start|date:"N j, Y, P e" }} to {{ end|date:"N j, Y, P e" }}{% endif %}
+{% if clock_24_hours %}{% if timezone %}{{ start|timezone:timezone|date:"N j, Y, H:i e" }} to {{ end|timezone:timezone|date:"N j, Y, H:i e" }}{% else %}{{ start|date:"N j, Y, H:i e" }} to {{ end|date:"N j, Y, H:i e" }}{% endif %}{% else %}{% if timezone %}{{ start|timezone:timezone|date:"N j, Y, P e" }} to {{ end|timezone:timezone|date:"N j, Y, P e" }}{% else %}{{ start|date:"N j, Y, P e" }} to {{ end|date:"N j, Y, P e" }}{% endif %}{% endif %}
 
 {% for rule, groups in digest.items %}{{ rule.label }}
 {% for group, records in groups.items %}{% with event_count=event_counts|get_item:group.id user_count=user_counts|get_item:group.id %}

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -67,11 +67,13 @@
     {% if enhanced_privacy %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-          {% if timezone %}
-            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
-          {% else %}
-            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
-          {% endif %}
+          <div class="event-date">
+            {% if clock_24_hours %}
+              {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, H:i:s e"}}{% else %}{{ event.datetime|date:"N j, Y, H:i:s e"}}{% endif %}
+            {% else %}
+              {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}{% else %}{{ event.datetime|date:"N j, Y, g:i:s a e"}}{% endif %}
+            {% endif %}
+          </div>
       </div>
 
       <div class="notice">Details about this feedback are not shown in this notification since enhanced privacy
@@ -101,11 +103,13 @@
                       {% endif %}
                       <div class="event">
                         <div class="event-id">ID: {{ event.event_id }}</div>
-                        {% if timezone %}
-                            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
-                        {% else %}
-                            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
-                        {% endif %}
+                        <div class="event-date">
+                          {% if clock_24_hours %}
+                            {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, H:i:s e"}}{% else %}{{ event.datetime|date:"N j, Y, H:i:s e"}}{% endif %}
+                          {% else %}
+                            {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}{% else %}{{ event.datetime|date:"N j, Y, g:i:s a e"}}{% endif %}
+                          {% endif %}
+                        </div>
                       </div>
                   </div>
               {% endwith %}

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -80,11 +80,13 @@
     {% if enhanced_privacy %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-          {% if timezone %}
-            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
-          {% else %}
-            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
-          {% endif %}
+          <div class="event-date">
+            {% if clock_24_hours %}
+              {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, H:i:s e"}}{% else %}{{ event.datetime|date:"N j, Y, H:i:s e"}}{% endif %}
+            {% else %}
+              {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}{% else %}{{ event.datetime|date:"N j, Y, g:i:s a e"}}{% endif %}
+            {% endif %}
+          </div>
       </div>
 
       <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
@@ -163,11 +165,13 @@
       {% if not is_new_design %}
         <div class="event">
           <div class="event-id">ID: {{ event.event_id }}</div>
-            {% if timezone %}
-                <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
-            {% else %}
-                <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
-            {% endif %}
+            <div class="event-date">
+              {% if clock_24_hours %}
+                {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, H:i:s e"}}{% else %}{{ event.datetime|date:"N j, Y, H:i:s e"}}{% endif %}
+              {% else %}
+                {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}{% else %}{{ event.datetime|date:"N j, Y, g:i:s a e"}}{% endif %}
+              {% endif %}
+            </div>
         </div>
       {% endif %}
 
@@ -206,10 +210,10 @@
               <tr>
                 <th>Start Time</th>
                 <td>
-                  {% if timezone %}
-                    {{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}
+                  {% if clock_24_hours %}
+                    {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, H:i:s e"}}{% else %}{{ event.datetime|date:"N j, Y, H:i:s e"}}{% endif %}
                   {% else %}
-                    {{ event.datetime|date:"N j, Y, g:i:s a e"}}
+                    {% if timezone %}{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}{% else %}{{ event.datetime|date:"N j, Y, g:i:s a e"}}{% endif %}
                   {% endif %}
                 </td>
               </tr>


### PR DESCRIPTION
emails now check if you're a 24-hour time person and format accordingly. issue alerts, digests, and feedback emails all got the change.

Fixes #106581

the html is kinda miserable to review but it works
<img width="586" height="113" alt="24tz" src="https://github.com/user-attachments/assets/a5d44869-aabb-42c6-a13f-bf9639b38d9b" />