### PR TITLE
fix(trace-waterfall): Add cycle protections

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
@@ -766,7 +766,7 @@ describe('autogrouping', () => {
                   parent_span_id: '0000',
                 }),
                 makeEAPSpan({
-                  event_id: '0003',
+                  event_id: '0004',
                   op: 'db',
                   name: 'GET',
                   start_timestamp: start,
@@ -774,7 +774,7 @@ describe('autogrouping', () => {
                   parent_span_id: '0000',
                 }),
                 makeEAPSpan({
-                  event_id: '0003',
+                  event_id: '0005',
                   op: 'db',
                   name: 'GET',
                   start_timestamp: start,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -436,6 +436,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
       replayTraceSlug: options.replayTraceSlug,
     });
 
+    // Track visited event_ids to prevent cycles during tree construction.
+    // Cyclic nodes are skipped and logged to Sentry for monitoring.
     const visitedIds = new Set<string>();
 
     function visit(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -424,6 +424,13 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   }
 
   /**
+   * Cycle Detection Strategy
+   *
+   * Traversals track visited nodes to prevent infinite loops when trace data
+   * contains circular references (for example, a parent_span_id chain that
+   * loops back to an ancestor). When a cycle is detected, the node is skipped
+   * so the UI can render the remaining subtree safely.
+   *
    * Traverses all children using depth-first search with cycle detection.
    * @param callback - Called for each node. Return `true` to stop traversal early.
    */

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -278,6 +278,9 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   get visibleChildren(): BaseNode[] {
     const queue: BaseNode[] = [];
     const visibleChildren: BaseNode[] = [];
+    const visited = new Set<BaseNode>();
+    visited.add(this);
+
     if (this.directVisibleChildren.length > 0) {
       for (let i = this.directVisibleChildren.length - 1; i >= 0; i--) {
         queue.push(this.directVisibleChildren[i]!);
@@ -286,6 +289,12 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
 
     while (queue.length > 0) {
       const node = queue.pop()!;
+
+      // Cycle detection: skip already-visited nodes
+      if (visited.has(node)) {
+        continue;
+      }
+      visited.add(node);
 
       visibleChildren.push(node);
 
@@ -418,9 +427,17 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
     predicate: (child: BaseNode) => boolean
   ): ChildType | null {
     const queue: BaseNode[] = [...this.getNextTraversalNodes()];
+    const visited = new Set<BaseNode>();
+    visited.add(this);
 
     while (queue.length > 0) {
       const next = queue.pop()!;
+
+      // Cycle detection: skip already-visited nodes
+      if (visited.has(next)) {
+        continue;
+      }
+      visited.add(next);
 
       if (predicate(next)) {
         return next as ChildType;
@@ -440,9 +457,17 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   ): ChildType[] {
     const queue: BaseNode[] = [...this.getNextTraversalNodes()];
     const results: ChildType[] = [];
+    const visited = new Set<BaseNode>();
+    visited.add(this);
 
     while (queue.length > 0) {
       const next = queue.pop()!;
+
+      // Cycle detection: skip already-visited nodes
+      if (visited.has(next)) {
+        continue;
+      }
+      visited.add(next);
 
       if (predicate(next)) {
         results.push(next as ChildType);
@@ -459,9 +484,17 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
 
   forEachChild(callback: (child: BaseNode) => void) {
     const queue: BaseNode[] = [...this.getNextTraversalNodes()];
+    const visited = new Set<BaseNode>();
+    visited.add(this);
 
     while (queue.length > 0) {
       const next = queue.pop()!;
+
+      // Cycle detection: skip already-visited nodes
+      if (visited.has(next)) {
+        continue;
+      }
+      visited.add(next);
 
       callback(next);
 
@@ -475,8 +508,17 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   findParent<ChildType extends BaseNode = BaseNode>(
     predicate: (parent: BaseNode) => boolean
   ): ChildType | null {
+    const visited = new Set<BaseNode>();
+    visited.add(this);
+
     let current = this.parent;
     while (current) {
+      // Cycle detection: stop if we've seen this node before
+      if (visited.has(current)) {
+        break;
+      }
+      visited.add(current);
+
       if (predicate(current)) {
         return current as ChildType;
       }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
@@ -57,6 +57,7 @@ export class ParentAutogroupNode extends BaseNode<TraceTree.ChildrenAutogroup> {
     // Only add the tail if we actually reached it (no cycle detected).
     // If a cycle was detected, we return partial segments rather than risk an infinite loop.
     // This results in incomplete but safe rendering of the autogrouped spans.
+    // We prefer a truncated bar to a hung UI when trace data is malformed.
     if (start === this.tail) {
       children.push(this.tail);
     }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
@@ -42,13 +42,24 @@ export class ParentAutogroupNode extends BaseNode<TraceTree.ChildrenAutogroup> {
 
     const children: BaseNode[] = [];
     let start: BaseNode | undefined = this.head;
+    const visited = new Set<BaseNode>();
 
     while (start && start !== this.tail) {
+      // Cycle detection: stop if we've seen this node before
+      if (visited.has(start)) {
+        break;
+      }
+      visited.add(start);
       children.push(start);
       start = start.children[0];
     }
 
-    children.push(this.tail);
+    // Only add the tail if we actually reached it (no cycle detected).
+    // If a cycle was detected, we return partial segments rather than risk an infinite loop.
+    // This results in incomplete but safe rendering of the autogrouped spans.
+    if (start === this.tail) {
+      children.push(this.tail);
+    }
 
     this._autogroupedSegments = computeCollapsedBarSpace(children);
     return this._autogroupedSegments;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -261,12 +261,45 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
       spanNodes.push(spanNode);
     }
 
-    // Construct the span tree
+    // Construct the span tree with cycle detection
     for (const span of spanNodes) {
       // If the span has no parent span id, nest it under the root
-      const parent = span.value.parent_span_id
-        ? (spanIdToNode.get(span.value.parent_span_id) ?? this)
-        : this;
+      if (!span.value.parent_span_id) {
+        span.parent = this;
+        this.children.push(span);
+        continue;
+      }
+
+      // Check for cycle: trace the parent chain to detect if it would create a cycle
+      let hasCycle = false;
+      const ancestorChain = new Set<string>([span.value.span_id]);
+      let currentParentId: string | null | undefined = span.value.parent_span_id;
+
+      while (currentParentId) {
+        if (ancestorChain.has(currentParentId)) {
+          // Cycle detected - log to Sentry and attach to root instead
+          hasCycle = true;
+          // Avoid capturing the loop variable inside the arrow function
+          const cycleParentId = currentParentId;
+          Sentry.withScope(scope => {
+            scope.setFingerprint(['trace-tree-span-cycle-detected']);
+            scope.captureMessage('Span cycle detected in trace tree');
+            info(fmt`Span cycle detected: ${span.value.span_id} -> ${cycleParentId}`);
+          });
+          break;
+        }
+        ancestorChain.add(currentParentId);
+        const parentNode = spanIdToNode.get(currentParentId);
+        if (!parentNode?.value || !('parent_span_id' in parentNode.value)) {
+          break;
+        }
+        currentParentId = parentNode.value.parent_span_id;
+      }
+
+      // If cycle detected, attach to root; otherwise attach to parent
+      const parent = hasCycle
+        ? this
+        : (spanIdToNode.get(span.value.parent_span_id) ?? this);
 
       span.parent = parent;
       parent.children.push(span);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -270,7 +270,8 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
         continue;
       }
 
-      // Check for cycle: trace the parent chain to detect if it would create a cycle
+      // Check for cycle: trace the parent chain to detect if it would create a cycle.
+      // If we loop back to the current span, attach it to the transaction root instead.
       let hasCycle = false;
       const ancestorChain = new Set<string>([span.value.span_id]);
       let currentParentId: string | null | undefined = span.value.parent_span_id;


### PR DESCRIPTION
This PR makes some changes to the trace tree to add in protection for potential cycles potentially leading infinite loops.

Ticket: EXP-707

### Why cycles might happen

Cycles in trace data can occur from:
- **Corrupted span data** where `parent_span_id` references create circular dependencies (e.g., span A → B → C → A)
- **Duplicate event IDs** causing multiple spans to be treated as the same node
- **Data ingestion edge cases** that incorrectly link spans

### What the UI does when cycles are detected

| Location | Behavior |
| --- | --- |
| Tree construction (`traceTree.tsx`) | Skips duplicate `event_id` nodes, logs to Sentry |
| Span tree (`transactionNode.tsx`) | Detects ancestor cycles, attaches cyclic spans to transaction root |
| Traversal methods (`baseNode.tsx`) | Uses `visited` Set to skip already-seen nodes |
| Autogroup segments (`parentAutogroupNode.tsx`) | Breaks out of loop, renders partial segments |

In all cases, the UI renders safely with the non-cyclic portion of the tree rather than crashing or hanging.