### PR TITLE
fix(preprod): filter insight diff tabs by status

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -10,6 +10,8 @@ import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/mai
 import {GroupInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/groupInsightDiffTable';
 import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/insightDiffRow';
 import type {
+  DiffItem,
+  DiffType,
   InsightDiffItem,
   InsightStatus,
 } from 'sentry/views/preprod/types/appSizeTypes';
@@ -37,25 +39,128 @@ const FILE_DIFF_INSIGHT_TYPES = [
 
 const GROUP_DIFF_INSIGHT_TYPES = ['duplicate_files', 'loose_images'];
 
+const UNRESOLVED_DIFF_TYPES = new Set<DiffType>(['added', 'increased']);
+const RESOLVED_DIFF_TYPES = new Set<DiffType>(['removed', 'decreased']);
+
+function sumDiffItems(diffItems: DiffItem[]): number {
+  return diffItems.reduce((total, item) => total + (item.size_diff ?? 0), 0);
+}
+
+function filterDiffItems(
+  diffItems: DiffItem[],
+  allowedTypes: Set<DiffType>,
+  fallbackType: DiffType
+): DiffItem[] {
+  return diffItems.flatMap(item => {
+    const children = Array.isArray(item.diff_items) ? item.diff_items : [];
+    const filteredChildren = children.filter(child => allowedTypes.has(child.type));
+    const hasAllowedType = allowedTypes.has(item.type);
+
+    if (!hasAllowedType && filteredChildren.length === 0) {
+      return [];
+    }
+
+    if (filteredChildren.length === 0) {
+      return [
+        item.diff_items
+          ? {
+              ...item,
+              diff_items: undefined,
+            }
+          : item,
+      ];
+    }
+
+    const childTypes = new Set(filteredChildren.map(child => child.type));
+    const inferredType = childTypes.size === 1 ? filteredChildren[0]!.type : fallbackType;
+
+    return [
+      {
+        ...item,
+        type: inferredType,
+        size_diff: sumDiffItems(filteredChildren),
+        diff_items: filteredChildren,
+      },
+    ];
+  });
+}
+
+function getFilteredInsight(
+  insight: InsightDiffItem,
+  tab: 'all' | InsightStatus
+): InsightDiffItem | null {
+  if (tab === 'all') {
+    return insight;
+  }
+
+  if (tab === 'new') {
+    return insight.status === 'new' ? insight : null;
+  }
+
+  if (tab === 'unresolved' && insight.status !== 'unresolved') {
+    return null;
+  }
+
+  const allowedTypes = tab === 'unresolved' ? UNRESOLVED_DIFF_TYPES : RESOLVED_DIFF_TYPES;
+  const fallbackType = tab === 'unresolved' ? 'increased' : 'decreased';
+  const filteredFileDiffs = filterDiffItems(
+    insight.file_diffs,
+    allowedTypes,
+    fallbackType
+  );
+  const filteredGroupDiffs = filterDiffItems(
+    insight.group_diffs,
+    allowedTypes,
+    fallbackType
+  );
+  const filteredItems = [...filteredFileDiffs, ...filteredGroupDiffs];
+
+  if (filteredItems.length === 0) {
+    return null;
+  }
+
+  return {
+    ...insight,
+    file_diffs: filteredFileDiffs,
+    group_diffs: filteredGroupDiffs,
+    total_savings_change: sumDiffItems(filteredItems),
+  };
+}
+
 export function InsightComparisonSection({
   insightDiffItems,
   totalInstallSizeBytes,
 }: InsightComparisonSectionProps) {
-  const [selectedTab, setSelectedTab] = useState<'all' | InsightStatus>('all');
+  type InsightTab = 'all' | InsightStatus;
+  const [selectedTab, setSelectedTab] = useState<InsightTab>('all');
 
   const filteredInsights = useMemo(() => {
-    if (selectedTab === 'all') {
-      return insightDiffItems;
-    }
-    return insightDiffItems.filter(insight => insight.status === selectedTab);
+    return insightDiffItems
+      .map(insight => getFilteredInsight(insight, selectedTab))
+      .filter((insight): insight is InsightDiffItem => Boolean(insight));
   }, [insightDiffItems, selectedTab]);
 
   const statusCounts = useMemo(() => {
+    let newCount = 0;
+    let unresolvedCount = 0;
+    let resolvedCount = 0;
+    for (const insight of insightDiffItems) {
+      if (getFilteredInsight(insight, 'new')) {
+        newCount += 1;
+      }
+      if (getFilteredInsight(insight, 'unresolved')) {
+        unresolvedCount += 1;
+      }
+      if (getFilteredInsight(insight, 'resolved')) {
+        resolvedCount += 1;
+      }
+    }
+
     return {
       all: insightDiffItems.length,
-      new: insightDiffItems.filter(i => i.status === 'new').length,
-      unresolved: insightDiffItems.filter(i => i.status === 'unresolved').length,
-      resolved: insightDiffItems.filter(i => i.status === 'resolved').length,
+      new: newCount,
+      unresolved: unresolvedCount,
+      resolved: resolvedCount,
     };
   }, [insightDiffItems]);
 

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -39,8 +39,8 @@ const FILE_DIFF_INSIGHT_TYPES = [
 
 const GROUP_DIFF_INSIGHT_TYPES = ['duplicate_files', 'loose_images'];
 
-const UNRESOLVED_DIFF_TYPES = new Set<DiffType>(['added', 'increased']);
-const RESOLVED_DIFF_TYPES = new Set<DiffType>(['removed', 'decreased']);
+const UNRESOLVED_ITEM_TYPES = new Set<DiffType>(['added', 'increased']);
+const RESOLVED_ITEM_TYPES = new Set<DiffType>(['removed', 'decreased']);
 
 function sumDiffItems(diffItems: DiffItem[]): number {
   return diffItems.reduce((total, item) => total + item.size_diff, 0);
@@ -78,7 +78,7 @@ function filterDiffItems(
   });
 }
 
-function filterInsightByDiffTypes(
+function filterInsightByLineItemTypes(
   insight: InsightDiffItem,
   allowedTypes: Set<DiffType>,
   fallbackType: DiffType
@@ -130,9 +130,9 @@ export function InsightComparisonSection({
       }
 
       if (insight.status === 'unresolved') {
-        const unresolvedInsight = filterInsightByDiffTypes(
+        const unresolvedInsight = filterInsightByLineItemTypes(
           insight,
-          UNRESOLVED_DIFF_TYPES,
+          UNRESOLVED_ITEM_TYPES,
           'increased'
         );
         if (unresolvedInsight) {
@@ -140,9 +140,9 @@ export function InsightComparisonSection({
         }
       }
 
-      const resolvedInsight = filterInsightByDiffTypes(
+      const resolvedInsight = filterInsightByLineItemTypes(
         insight,
-        RESOLVED_DIFF_TYPES,
+        RESOLVED_ITEM_TYPES,
         'decreased'
       );
       if (resolvedInsight) {


### PR DESCRIPTION
NOTE: the insight tabs show the # of insight cards, where within the cards, its the number of insight items, so there's a mismatch between tabs and what is on the UI. That existed already, not going to touch in this PR
1. Prod didn't show Resolved tabs, only Unresolved
prod
<img width="1361" height="336" alt="CleanShot 2026-01-23 at 13 49 02@2x" src="https://github.com/user-attachments/assets/b7e736c1-663f-493d-864d-b121719a97e0" />
PR
<img width="1379" height="267" alt="CleanShot 2026-01-23 at 13 49 40@2x" src="https://github.com/user-attachments/assets/d4695b86-4e41-4c3d-ab32-285a85fff06d" />

2. The tabs now only show the insights that were resolved or unresolved (rather than both)
Prod
<img width="823" height="396" alt="CleanShot 2026-01-23 at 13 50 20@2x" src="https://github.com/user-attachments/assets/057047ec-ac57-4b7b-8cba-879a5c27b9c9" />

PR (filtered for unresolved)
<img width="476" height="296" alt="CleanShot 2026-01-23 at 13 51 10@2x" src="https://github.com/user-attachments/assets/0fcc6c5f-22c4-49d7-a42e-fc90ebb69769" />

PR (filter for resolved)
<img width="606" height="274" alt="CleanShot 2026-01-23 at 13 51 32@2x" src="https://github.com/user-attachments/assets/e0e7ec02-c120-48cd-b240-d4f687eb66b4" />

