### PR TITLE
fix(theme): dark chart palette

### DIFF
--- a/static/app/utils/theme/theme.spec.tsx
+++ b/static/app/utils/theme/theme.spec.tsx
@@ -29,7 +29,7 @@ describe('theme', () => {
 
       expectTypeOf(colors).toEqualTypeOf<
         | readonly ['#7B52FF', '#401477', '#FF049B']
-        | readonly ['#7B52FF', '#613CB9', '#FF049B']
+        | readonly ['#7B52FF', '#561EA2', '#FF049B']
       >();
     });
   });

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -845,6 +845,13 @@ const lightThemeDefinition = {
 
   ...generateThemeUtils(),
 
+  /**
+   * @deprecated do not use this.
+   */
+  level: {
+    orange: ccl.orange,
+  },
+
   chart: {
     getColorPalette: makeChartColorPalette(CHART_PALETTE_LIGHT),
   },
@@ -872,6 +879,13 @@ export const darkTheme: SentryTheme = {
   }),
 
   ...generateThemeUtils(),
+
+  /**
+   * @deprecated do not use this.
+   */
+  level: {
+    orange: ccd.orange,
+  },
 
   chart: {
     getColorPalette: makeChartColorPalette(CHART_PALETTE_DARK),

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -471,11 +471,11 @@ const ccd = color.categorical.dark;
 
 const CHART_PALETTE_DARK = [
   [ccd.blurple],
-  [ccd.blurple, ccd.purple],
-  [ccd.blurple, ccd.purple, ccd.pink],
-  [ccd.blurple, ccd.purple, ccd.pink, ccd.orange],
-  [ccd.blurple, ccd.purple, ccd.pink, ccd.orange, ccd.yellow],
-  [ccd.blurple, ccd.purple, ccd.pink, ccd.orange, ccd.yellow, ccd.green],
+  [ccd.blurple, ccd.indigo],
+  [ccd.blurple, ccd.indigo, ccd.pink],
+  [ccd.blurple, ccd.indigo, ccd.pink, ccd.orange],
+  [ccd.blurple, ccd.indigo, ccd.pink, ccd.orange, ccd.yellow],
+  [ccd.blurple, ccd.indigo, ccd.pink, ccd.orange, ccd.yellow, ccd.green],
   [ccd.blurple, ccd.purple, ccd.indigo, ccd.pink, ccd.orange, ccd.yellow, ccd.green],
   [
     ccd.blurple,
@@ -845,13 +845,6 @@ const lightThemeDefinition = {
 
   ...generateThemeUtils(),
 
-  /**
-   * @deprecated do not use this.
-   */
-  level: {
-    orange: ccl.orange,
-  },
-
   chart: {
     getColorPalette: makeChartColorPalette(CHART_PALETTE_LIGHT),
   },
@@ -879,13 +872,6 @@ export const darkTheme: SentryTheme = {
   }),
 
   ...generateThemeUtils(),
-
-  /**
-   * @deprecated do not use this.
-   */
-  level: {
-    orange: ccd.orange,
-  },
 
   chart: {
     getColorPalette: makeChartColorPalette(CHART_PALETTE_DARK),


### PR DESCRIPTION
The chart palette in dark mode incorrectly used `purple` instead of `indigo`, making charts with less than 6 series difficult to differentiate

**Before**
`#7B52FF`
`#613CB9`
Contrast of 1.57

**After**
`#7B52FF`
`#561EA2`
Contrast of 2.14