### PR TITLE
chore(cells): deprecate group-tag-key-values endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_tagkey_values.py
+++ b/src/sentry/issues/endpoints/group_tagkey_values.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
@@ -20,6 +21,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.tags_examples import TagsExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.tagstore.types import TagValueSerializerResponse
@@ -67,6 +69,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         },
         examples=[TagsExamples.GROUP_TAGKEY_VALUES],
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-values"])
     def get(self, request: Request, group, key) -> Response:
         """
         List a Tag's Values

--- a/tests/sentry/issues/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/issues/endpoints/test_group_tagkey_values.py
@@ -27,7 +27,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/{key}/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/{key}/values/"
 
         response = self.client.get(url)
 
@@ -55,7 +55,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/{key}/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/{key}/values/"
 
         response = self.client.get(url)
 
@@ -84,7 +84,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/user/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/user/values/"
 
         response = self.client.get(url)
 
@@ -116,9 +116,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = (
-            f"/api/0/issues/{group.id}/tags/message/values/?query=minidumpC%3A%5C%5CUsers%5C%5Ctest"
-        )
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/message/values/?query=minidumpC%3A%5C%5CUsers%5C%5Ctest"
 
         response = self.client.get(url)
 
@@ -149,7 +147,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/foo/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/foo/values/"
 
         response = self.client.get(url)
 
@@ -183,7 +181,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/foo/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/foo/values/"
 
         group_tag_key = tagstore.backend.get_group_tag_key(
             group,
@@ -235,7 +233,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/user/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/user/values/"
 
         # This should not crash with AttributeError: 'NoneType' object has no attribute 'split'
         response = self.client.get(url)
@@ -294,7 +292,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/user/values/?sort=count"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/user/values/?sort=count"
 
         response = self.client.get(url)
 
@@ -322,7 +320,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/{key}/values/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/{key}/values/"
 
         with freeze_time(datetime.datetime.now()):
             for i in range(150):


### PR DESCRIPTION
Deprecate GroupTagKeyValues endpoint and update tests to use correct org-scoped URL.