### PR TITLE
fix(preprod): hide the discover button for mobile app size

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -911,6 +911,9 @@ function OpenButton({
       openLabel = t('Open in Explore');
       path = getWidgetMetricsUrl(widget, dashboardFilters, selection, organization);
       break;
+    case WidgetType.PREPROD_APP_SIZE:
+      // Mobile app size widgets are not integrated with Explore or Discover
+      return null;
     case WidgetType.DISCOVER:
     default:
       openLabel = t('Open in Discover');


### PR DESCRIPTION
We previously showed an "Open in Discover" button when fullscreening a dashboard widget that would lead to a broken page. We can investigate getting our data in Discover/Explore at some later point.