### PR TITLE
fix(settings): When an org has a disabled github integration we incorrectly detected it as being setup

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import connectGithubImg from 'sentry-images/spot/seer-config-connect-1.svg';
@@ -17,25 +17,23 @@ export function ConnectGithubStep() {
   }, []);
 
   return (
-    <Fragment>
-      <StepContentWithBackground>
-        <MaxWidthPanel>
-          <PanelBody withPadding>
-            <Text density="comfortable">
-              {t(
-                'In order to get the most out of Sentry and to use Seer, we will need to access your code repositories in GitHub. (We do not currently support Gitlab, Bitbucket, or others) '
-              )}
-            </Text>
-            <ActionSection>
-              <GithubButton
-                onAddIntegration={handleAddIntegration}
-                analyticsView="seer_onboarding_github"
-              />
-            </ActionSection>
-          </PanelBody>
-        </MaxWidthPanel>
-      </StepContentWithBackground>
-    </Fragment>
+    <StepContentWithBackground>
+      <MaxWidthPanel>
+        <PanelBody withPadding>
+          <Text density="comfortable">
+            {t(
+              'In order to get the most out of Sentry and to use Seer, we will need to access your code repositories in GitHub. (We do not currently support Gitlab, Bitbucket, or others) '
+            )}
+          </Text>
+          <ActionSection>
+            <GithubButton
+              onAddIntegration={handleAddIntegration}
+              analyticsView="seer_onboarding_github"
+            />
+          </ActionSection>
+        </PanelBody>
+      </MaxWidthPanel>
+    </StepContentWithBackground>
   );
 }
 

--- a/static/gsApp/views/seerAutomation/onboarding/githubButton.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/githubButton.tsx
@@ -26,8 +26,11 @@ export function GithubButton({
   const {provider, isProviderPending, installationData, isInstallationPending} =
     useSeerOnboardingContext();
   const organization = useOrganization();
-  const hasInstallation = installationData?.find(
-    installation => installation.provider.key === 'github'
+  const githubInstallation = installationData?.find(
+    installation =>
+      installation.provider.key === 'github' &&
+      installation.organizationIntegrationStatus === 'active' &&
+      installation.status === 'active'
   );
 
   if (!provider || isProviderPending || isInstallationPending) {
@@ -39,10 +42,10 @@ export function GithubButton({
       value={{
         provider,
         type: 'first_party',
-        installStatus: hasInstallation ? 'Installed' : 'Not Installed', // `AddIntegrationButton` only handles `Disabled`
+        installStatus: githubInstallation ? 'Installed' : 'Not Installed', // `AddIntegrationButton` only handles `Disabled`
         analyticsParams: {
           view: analyticsView,
-          already_installed: Boolean(hasInstallation),
+          already_installed: Boolean(githubInstallation),
         },
       }}
     >
@@ -54,8 +57,8 @@ export function GithubButton({
             onExternalClick={() => {}}
             buttonProps={
               buttonProps ?? {
-                icon: hasInstallation ? <IconSettings /> : <IconAdd />,
-                buttonText: hasInstallation
+                icon: githubInstallation ? <IconSettings /> : <IconAdd />,
+                buttonText: githubInstallation
                   ? t('Manage GitHub Integration')
                   : t('Connect GitHub'),
                 priority: 'primary',


### PR DESCRIPTION
The messages that users see on other pages indicated that they need to re-install the integration. lets check that when we find an integration the status is ready before skipping steps.

On the Integration page we can see these errors:
<img width="1173" height="407" alt="SCR-20260123-liqr" src="https://github.com/user-attachments/assets/e68421e4-64da-4bf1-b6aa-ce9f9f965462" />


And we can see from the integration itself that it's in a type of disabled state: disabled by the system (not by the user)
<img width="712" height="266" alt="SCR-20260123-lhsx" src="https://github.com/user-attachments/assets/bd85a619-76ff-4d3a-b1e7-77b22580d450" />

So we cannot rely on the presence of an integration to mean that things are good. Instead we should check that the integration is good-to-go. 

Fixes https://linear.app/getsentry/issue/CW-676/user-feedback-cannot-connect-to-projects-or-organization