### PR TITLE
chore(billing): Remove seer-user-billing flag

### DIFF
--- a/static/app/utils/seer/showNewSeer.spec.ts
+++ b/static/app/utils/seer/showNewSeer.spec.ts
@@ -50,20 +50,12 @@ describe('showNewSeer', () => {
   });
 
   describe('seer-user-billing-launch flag', () => {
-    it('returns true when both seer-user-billing and seer-user-billing-launch are present', () => {
+    it('returns true when seer-user-billing-launch is present', () => {
       const organization = OrganizationFixture({
         features: ['seer-user-billing-launch'],
       });
 
       expect(showNewSeer(organization)).toBe(true);
-    });
-
-    it('returns false when only seer-user-billing-launch is present', () => {
-      const organization = OrganizationFixture({
-        features: ['seer-user-billing-launch'],
-      });
-
-      expect(showNewSeer(organization)).toBe(false);
     });
   });
 

--- a/static/app/utils/seer/showNewSeer.spec.ts
+++ b/static/app/utils/seer/showNewSeer.spec.ts
@@ -24,7 +24,7 @@ describe('showNewSeer', () => {
 
     it('returns false even with launch flags when seer-added is present', () => {
       const organization = OrganizationFixture({
-        features: ['seer-added', 'seer-user-billing', 'seer-user-billing-launch'],
+        features: ['seer-added', 'seer-user-billing-launch'],
       });
 
       expect(showNewSeer(organization)).toBe(false);
@@ -42,7 +42,7 @@ describe('showNewSeer', () => {
 
     it('returns false even with launch flags when code-review-beta is present', () => {
       const organization = OrganizationFixture({
-        features: ['code-review-beta', 'seer-user-billing', 'seer-user-billing-launch'],
+        features: ['code-review-beta', 'seer-user-billing-launch'],
       });
 
       expect(showNewSeer(organization)).toBe(false);
@@ -52,18 +52,10 @@ describe('showNewSeer', () => {
   describe('seer-user-billing-launch flag', () => {
     it('returns true when both seer-user-billing and seer-user-billing-launch are present', () => {
       const organization = OrganizationFixture({
-        features: ['seer-user-billing', 'seer-user-billing-launch'],
+        features: ['seer-user-billing-launch'],
       });
 
       expect(showNewSeer(organization)).toBe(true);
-    });
-
-    it('returns false when only seer-user-billing is present', () => {
-      const organization = OrganizationFixture({
-        features: ['seer-user-billing'],
-      });
-
-      expect(showNewSeer(organization)).toBe(false);
     });
 
     it('returns false when only seer-user-billing-launch is present', () => {

--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -24,10 +24,7 @@ export default function showNewSeer(organization: Organization) {
   }
 
   // This is the launch flag
-  if (
-    organization.features.includes('seer-user-billing') &&
-    organization.features.includes('seer-user-billing-launch')
-  ) {
+  if (organization.features.includes('seer-user-billing-launch')) {
     return true;
   }
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -326,7 +326,6 @@ describe('NotificationSettingsByType', () => {
         'continuous-profiling-billing',
         'seer-billing',
         'logs-billing',
-        'seer-user-billing',
         'seer-user-billing-launch',
       ],
     });

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -212,10 +212,8 @@ export function NotificationSettingsByType({notificationType}: Props) {
       organization.features?.includes('logs-billing')
     );
 
-    const hasSeerUserBilling = organizations.some(
-      organization =>
-        organization.features?.includes('seer-user-billing') &&
-        organization.features?.includes('seer-user-billing-launch')
+    const hasSeerUserBilling = organizations.some(organization =>
+      organization.features?.includes('seer-user-billing-launch')
     );
 
     const excludeTransactions = hasOrgWithAm3 && !hasOrgWithoutAm3;


### PR DESCRIPTION
Remove references to `seer-user-billing` feature. We're relying on `seer-user-billing-launch` instead.

I'll follow up with https://github.com/getsentry/getsentry/pull/19179 to remove `seer-user-billing` entirely