### PR TITLE
chore(cells): deprecate group-tag-key-details endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_tagkey_details.py
+++ b/src/sentry/issues/endpoints/group_tagkey_details.py
@@ -7,6 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environment_id
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -18,6 +19,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.tags_examples import TagsExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import RateLimitConfig
@@ -63,6 +65,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         },
         examples=[TagsExamples.GROUP_TAGKEY_DETAILS],
     )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-details"])
     def get(self, request: Request, group, key) -> Response:
         """
         Returns the values and aggregate details of a given tag key related to an issue.

--- a/tests/sentry/issues/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/issues/endpoints/test_group_tagkey_details.py
@@ -19,7 +19,7 @@ class GroupTagDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/tags/foo/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/tags/foo/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data["key"] == "foo"
@@ -40,7 +40,7 @@ class GroupTagDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/foo/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/foo/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data["key"] == "foo"
@@ -69,7 +69,7 @@ class GroupTagDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event.group.id}/tags/foo/"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/tags/foo/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content


### PR DESCRIPTION
Deprecate GroupTagKeyDetails endpoint and replace test URLs with org-scoped variant.