### PR TITLE
feat(billing): Add Emerge quota exceeded UI with Contact Sales CTA

### DIFF
--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -2,9 +2,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
+
+import {DataCategory} from 'sentry/types/core';
 
 import PrimaryNavigationQuotaExceeded from 'getsentry/components/navBillingStatus';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
@@ -437,5 +440,252 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     render(<PrimaryNavigationQuotaExceeded organization={organization} />);
     expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
     assertLocalStorageStateAfterAutoOpen();
+  });
+
+  describe('Emerge categories', () => {
+    it('should render Size Analysis quota exceeded with Contact Sales CTA', async () => {
+      const newSub = SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Add SIZE_ANALYSIS category with usageExceeded
+      newSub.categories.sizeAnalyses = MetricHistoryFixture({
+        category: DataCategory.SIZE_ANALYSIS,
+        reserved: 100,
+        prepaid: 100,
+        usageExceeded: true,
+        order: 20,
+      });
+      // Clear other exceeded flags
+      for (const key of Object.keys(newSub.categories) as Array<
+        keyof typeof newSub.categories
+      >) {
+        if (key !== 'sizeAnalyses' && newSub.categories[key]) {
+          newSub.categories[key].usageExceeded = false;
+        }
+      }
+      SubscriptionStore.set(organization.slug, newSub);
+      localStorage.setItem(
+        `billing-status-last-shown-categories-${organization.id}`,
+        'sizeAnalyses'
+      );
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
+
+      expect(
+        await screen.findByText('Size Analysis Builds - Quota Exceeded')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Your organization has used your full quota of 100 Size Analysis builds uploaded this billing period/
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /contact sales to discuss custom pricing available on the Enterprise plan/
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
+        'href',
+        'mailto:sales@sentry.io'
+      );
+      expect(
+        screen.getByRole('button', {
+          name: 'Dismiss alert for the rest of the billing cycle',
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('should display dynamic quota from subscription for Size Analysis', async () => {
+      const newSub = SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Add SIZE_ANALYSIS category with a different quota value (200 instead of default 100)
+      newSub.categories.sizeAnalyses = MetricHistoryFixture({
+        category: DataCategory.SIZE_ANALYSIS,
+        reserved: 200,
+        prepaid: 200,
+        usageExceeded: true,
+        order: 20,
+      });
+      // Clear other exceeded flags
+      for (const key of Object.keys(newSub.categories) as Array<
+        keyof typeof newSub.categories
+      >) {
+        if (key !== 'sizeAnalyses' && newSub.categories[key]) {
+          newSub.categories[key].usageExceeded = false;
+        }
+      }
+      SubscriptionStore.set(organization.slug, newSub);
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      // The alert auto-opens, verify content shows dynamic quota (200 instead of hardcoded 100)
+      expect(
+        await screen.findByText(
+          /Your organization has used your full quota of 200 Size Analysis builds uploaded this billing period/
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should render Build Distribution quota exceeded with Contact Sales CTA', async () => {
+      const newSub = SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Add INSTALLABLE_BUILD category with usageExceeded
+      newSub.categories.installableBuilds = MetricHistoryFixture({
+        category: DataCategory.INSTALLABLE_BUILD,
+        reserved: 25000,
+        prepaid: 25000,
+        usageExceeded: true,
+        order: 21,
+      });
+      // Clear other exceeded flags
+      for (const key of Object.keys(newSub.categories) as Array<
+        keyof typeof newSub.categories
+      >) {
+        if (key !== 'installableBuilds' && newSub.categories[key]) {
+          newSub.categories[key].usageExceeded = false;
+        }
+      }
+      SubscriptionStore.set(organization.slug, newSub);
+      localStorage.setItem(
+        `billing-status-last-shown-categories-${organization.id}`,
+        'installableBuilds'
+      );
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
+
+      expect(
+        await screen.findByText('Build Distribution - Quota Exceeded')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Your organization has used your full quota of Build Distribution installs this billing period/
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
+        'href',
+        'mailto:sales@sentry.io'
+      );
+    });
+
+    it('should render both Emerge categories exceeded', async () => {
+      const newSub = SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Add both Emerge categories with usageExceeded
+      newSub.categories.sizeAnalyses = MetricHistoryFixture({
+        category: DataCategory.SIZE_ANALYSIS,
+        reserved: 100,
+        prepaid: 100,
+        usageExceeded: true,
+        order: 20,
+      });
+      newSub.categories.installableBuilds = MetricHistoryFixture({
+        category: DataCategory.INSTALLABLE_BUILD,
+        reserved: 25000,
+        prepaid: 25000,
+        usageExceeded: true,
+        order: 21,
+      });
+      // Clear other exceeded flags
+      for (const key of Object.keys(newSub.categories) as Array<
+        keyof typeof newSub.categories
+      >) {
+        if (
+          key !== 'sizeAnalyses' &&
+          key !== 'installableBuilds' &&
+          newSub.categories[key]
+        ) {
+          newSub.categories[key].usageExceeded = false;
+        }
+      }
+      SubscriptionStore.set(organization.slug, newSub);
+      localStorage.setItem(
+        `billing-status-last-shown-categories-${organization.id}`,
+        'sizeAnalyses-installableBuilds'
+      );
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
+
+      expect(
+        await screen.findByText('Size Analysis & Build Distribution - Quota Exceeded')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Your organization has used your full quota of Size Analysis builds and Build Distribution installs this billing period/
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
+        'href',
+        'mailto:sales@sentry.io'
+      );
+    });
+
+    it('should render mixed Emerge and other categories exceeded', async () => {
+      const newSub = SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Add SIZE_ANALYSIS with usageExceeded
+      newSub.categories.sizeAnalyses = MetricHistoryFixture({
+        category: DataCategory.SIZE_ANALYSIS,
+        reserved: 100,
+        prepaid: 100,
+        usageExceeded: true,
+        order: 20,
+      });
+      // Set errors as exceeded too
+      newSub.categories.errors!.usageExceeded = true;
+      // Clear other exceeded flags
+      for (const key of Object.keys(newSub.categories) as Array<
+        keyof typeof newSub.categories
+      >) {
+        if (key !== 'sizeAnalyses' && key !== 'errors' && newSub.categories[key]) {
+          newSub.categories[key].usageExceeded = false;
+        }
+      }
+      SubscriptionStore.set(organization.slug, newSub);
+      localStorage.setItem(
+        `billing-status-last-shown-categories-${organization.id}`,
+        'errors-sizeAnalyses'
+      );
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
+
+      // Should show Emerge section
+      expect(
+        await screen.findByText('Size Analysis Builds - Quota Exceeded')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Your organization has used your full quota of 100 Size Analysis builds uploaded this billing period/
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
+        'href',
+        'mailto:sales@sentry.io'
+      );
+
+      // Should also show standard category section
+      expect(screen.getByText('Error Quota Exceeded')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /You have used up your quota for errors. Monitoring and new data are paused until your quota resets./
+        )
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -479,7 +479,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of 100 Size Analysis builds uploaded this billing period/
+          /Your organization has used your full quota of Size Analysis builds uploaded this billing period/
         )
       ).toBeInTheDocument();
       expect(
@@ -495,39 +495,6 @@ describe('PrimaryNavigationQuotaExceeded', () => {
         screen.getByRole('button', {
           name: 'Dismiss alert for the rest of the billing cycle',
         })
-      ).toBeInTheDocument();
-    });
-
-    it('should display dynamic quota from subscription for Size Analysis', async () => {
-      const newSub = SubscriptionFixture({
-        organization,
-        plan: 'am3_business',
-      });
-      // Add SIZE_ANALYSIS category with a different quota value (200 instead of default 100)
-      newSub.categories.sizeAnalyses = MetricHistoryFixture({
-        category: DataCategory.SIZE_ANALYSIS,
-        reserved: 200,
-        prepaid: 200,
-        usageExceeded: true,
-        order: 20,
-      });
-      // Clear other exceeded flags
-      for (const key of Object.keys(newSub.categories) as Array<
-        keyof typeof newSub.categories
-      >) {
-        if (key !== 'sizeAnalyses' && newSub.categories[key]) {
-          newSub.categories[key].usageExceeded = false;
-        }
-      }
-      SubscriptionStore.set(organization.slug, newSub);
-
-      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
-
-      // The alert auto-opens, verify content shows dynamic quota (200 instead of hardcoded 100)
-      expect(
-        await screen.findByText(
-          /Your organization has used your full quota of 200 Size Analysis builds uploaded this billing period/
-        )
       ).toBeInTheDocument();
     });
 
@@ -671,7 +638,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of 100 Size Analysis builds uploaded this billing period/
+          /Your organization has used your full quota of Size Analysis builds uploaded this billing period/
         )
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -442,7 +442,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     assertLocalStorageStateAfterAutoOpen();
   });
 
-  describe('Emerge categories', () => {
+  describe('PAYG ineligible categories', () => {
     it('should render Size Analysis quota exceeded with Contact Sales CTA', async () => {
       const newSub = SubscriptionFixture({
         organization,
@@ -543,12 +543,12 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       );
     });
 
-    it('should render both Emerge categories exceeded', async () => {
+    it('should render both PAYG ineligible categories exceeded', async () => {
       const newSub = SubscriptionFixture({
         organization,
         plan: 'am3_business',
       });
-      // Add both Emerge categories with usageExceeded
+      // Add both PAYG ineligible categories with usageExceeded
       newSub.categories.sizeAnalyses = MetricHistoryFixture({
         category: DataCategory.SIZE_ANALYSIS,
         reserved: 100,
@@ -599,7 +599,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       );
     });
 
-    it('should render mixed Emerge and other categories exceeded', async () => {
+    it('should render mixed PAYG ineligible and other categories exceeded', async () => {
       const newSub = SubscriptionFixture({
         organization,
         plan: 'am3_business',
@@ -632,7 +632,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
 
       await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
 
-      // Should show Emerge section
+      // Should show PAYG ineligible section
       expect(
         await screen.findByText('Size Analysis Builds - Quota Exceeded')
       ).toBeInTheDocument();

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -479,7 +479,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of Size Analysis builds uploaded this billing period/
+          /Your organization has used your full quota of size analysis builds this billing period/
         )
       ).toBeInTheDocument();
       expect(
@@ -530,11 +530,11 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
 
       expect(
-        await screen.findByText('Build Distribution - Quota Exceeded')
+        await screen.findByText('Build Distribution Installs - Quota Exceeded')
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of Build Distribution installs this billing period/
+          /Your organization has used your full quota of build distribution installs this billing period/
         )
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
@@ -586,11 +586,13 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
 
       expect(
-        await screen.findByText('Size Analysis & Build Distribution - Quota Exceeded')
+        await screen.findByText(
+          'Size Analysis Builds and Build Distribution Installs - Quota Exceeded'
+        )
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of Size Analysis builds and Build Distribution installs this billing period/
+          /Your organization has used your full quota of size analysis builds and build distribution installs this billing period/
         )
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(
@@ -638,7 +640,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Your organization has used your full quota of Size Analysis builds uploaded this billing period/
+          /Your organization has used your full quota of size analysis builds this billing period/
         )
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Contact Sales'})).toHaveAttribute(

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {Fragment, useCallback, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import snakeCase from 'lodash/snakeCase';
@@ -61,7 +62,7 @@ function isPaygIneligibleCategory(category: DataCategory): boolean {
 function getPaygIneligibleSubheader(
   paygIneligibleCategories: DataCategory[],
   subscription: Subscription
-): string {
+): React.ReactNode {
   const paygIneligibleCategoryList = listDisplayNames({
     plan: subscription.planDetails,
     categories: paygIneligibleCategories,
@@ -74,7 +75,7 @@ function getPaygIneligibleSubheader(
 function getPaygIneligibleBodyCopy(
   paygIneligibleCategories: DataCategory[],
   subscription: Subscription
-): string {
+): React.ReactNode {
   const paygIneligibleCategoryList = listDisplayNames({
     plan: subscription.planDetails,
     categories: paygIneligibleCategories,

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -58,39 +58,31 @@ function isPaygIneligibleCategory(category: DataCategory): boolean {
   );
 }
 
-function getPaygIneligibleSubheader(paygIneligibleCategories: DataCategory[]): string {
-  const hasSizeAnalysis = paygIneligibleCategories.includes(DataCategory.SIZE_ANALYSIS);
-  const hasInstallableBuild = paygIneligibleCategories.includes(
-    DataCategory.INSTALLABLE_BUILD
-  );
-
-  if (hasSizeAnalysis && hasInstallableBuild) {
-    return t('Size Analysis & Build Distribution - Quota Exceeded');
-  }
-  if (hasSizeAnalysis) {
-    return t('Size Analysis Builds - Quota Exceeded');
-  }
-  return t('Build Distribution - Quota Exceeded');
+function getPaygIneligibleSubheader(
+  paygIneligibleCategories: DataCategory[],
+  subscription: Subscription
+): string {
+  const paygIneligibleCategoryList = listDisplayNames({
+    plan: subscription.planDetails,
+    categories: paygIneligibleCategories,
+    hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+    shouldTitleCase: true,
+  });
+  return tct('[categories] - Quota Exceeded', {categories: paygIneligibleCategoryList});
 }
 
-function getPaygIneligibleBodyCopy(paygIneligibleCategories: DataCategory[]): string {
-  const hasSizeAnalysis = paygIneligibleCategories.includes(DataCategory.SIZE_ANALYSIS);
-  const hasInstallableBuild = paygIneligibleCategories.includes(
-    DataCategory.INSTALLABLE_BUILD
-  );
-
-  if (hasSizeAnalysis && hasInstallableBuild) {
-    return t(
-      'Your organization has used your full quota of Size Analysis builds and Build Distribution installs this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:'
-    );
-  }
-  if (hasSizeAnalysis) {
-    return t(
-      'Your organization has used your full quota of Size Analysis builds uploaded this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:'
-    );
-  }
-  return t(
-    'Your organization has used your full quota of Build Distribution installs this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:'
+function getPaygIneligibleBodyCopy(
+  paygIneligibleCategories: DataCategory[],
+  subscription: Subscription
+): string {
+  const paygIneligibleCategoryList = listDisplayNames({
+    plan: subscription.planDetails,
+    categories: paygIneligibleCategories,
+    hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+  });
+  return tct(
+    'Your organization has used your full quota of [categories] this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:',
+    {categories: paygIneligibleCategoryList}
   );
 }
 
@@ -158,8 +150,12 @@ function QuotaExceededContent({
           <HeaderTitle>{t('Billing Status')}</HeaderTitle>
         </Header>
         <Body>
-          <Title>{getPaygIneligibleSubheader(paygIneligibleCategories)}</Title>
-          <Description>{getPaygIneligibleBodyCopy(paygIneligibleCategories)}</Description>
+          <Title>
+            {getPaygIneligibleSubheader(paygIneligibleCategories, subscription)}
+          </Title>
+          <Description>
+            {getPaygIneligibleBodyCopy(paygIneligibleCategories, subscription)}
+          </Description>
           <Flex justify="between" align="center">
             <LinkButton
               priority="primary"
@@ -198,8 +194,12 @@ function QuotaExceededContent({
         </Header>
         <Body>
           {/* PAYG-ineligible categories section */}
-          <Title>{getPaygIneligibleSubheader(paygIneligibleCategories)}</Title>
-          <Description>{getPaygIneligibleBodyCopy(paygIneligibleCategories)}</Description>
+          <Title>
+            {getPaygIneligibleSubheader(paygIneligibleCategories, subscription)}
+          </Title>
+          <Description>
+            {getPaygIneligibleBodyCopy(paygIneligibleCategories, subscription)}
+          </Description>
           <Flex justify="start" align="center">
             <LinkButton
               priority="primary"

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -66,10 +66,7 @@ function getEmergeSubheader(emergeCategories: DataCategory[]): string {
   return t('Build Distribution - Quota Exceeded');
 }
 
-function getEmergeBodyCopy(
-  emergeCategories: DataCategory[],
-  subscription: Subscription
-): string {
+function getEmergeBodyCopy(emergeCategories: DataCategory[]): string {
   const hasSizeAnalysis = emergeCategories.includes(DataCategory.SIZE_ANALYSIS);
   const hasInstallableBuild = emergeCategories.includes(DataCategory.INSTALLABLE_BUILD);
 
@@ -79,10 +76,8 @@ function getEmergeBodyCopy(
     );
   }
   if (hasSizeAnalysis) {
-    const quota = subscription.categories.sizeAnalyses?.reserved ?? 100;
     return t(
-      'Your organization has used your full quota of %s Size Analysis builds uploaded this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:',
-      quota
+      'Your organization has used your full quota of Size Analysis builds uploaded this billing period. Your quota will reset when the next billing period begins. For an unlimited quota, you can contact sales to discuss custom pricing available on the Enterprise plan:'
     );
   }
   return t(
@@ -153,7 +148,7 @@ function QuotaExceededContent({
         </Header>
         <Body>
           <Title>{getEmergeSubheader(emergeCategories)}</Title>
-          <Description>{getEmergeBodyCopy(emergeCategories, subscription)}</Description>
+          <Description>{getEmergeBodyCopy(emergeCategories)}</Description>
           <Flex justify="between" align="center">
             <LinkButton
               priority="primary"
@@ -193,7 +188,7 @@ function QuotaExceededContent({
         <Body>
           {/* Emerge categories section */}
           <Title>{getEmergeSubheader(emergeCategories)}</Title>
-          <Description>{getEmergeBodyCopy(emergeCategories, subscription)}</Description>
+          <Description>{getEmergeBodyCopy(emergeCategories)}</Description>
           <Flex justify="start" align="center">
             <LinkButton
               priority="primary"


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-2005/add-emerge-billing-overage-ui-with-contact-sales-cta

## Summary

- Add special handling for Emerge data categories (SIZE_ANALYSIS, INSTALLABLE_BUILD) in the navigation billing status component
- Show "Contact Sales" CTA (mailto:sales@sentry.io) instead of AddEventsCTA since Emerge categories don't have PAYG available
- Support three scenarios:
  - Only Emerge categories exceeded → Contact Sales CTA
  - Both Emerge and standard categories exceeded → Both sections displayed
  - Only standard categories exceeded → Original AddEventsCTA behavior

<img width="504" height="383" alt="Screenshot 2026-01-24 at 4 16 39 PM" src="https://github.com/user-attachments/assets/1aab103e-7d33-47f1-ad98-3e2a599f93d9" />


## Test plan

- [x] Added tests for Size Analysis quota exceeded with Contact Sales CTA
- [x] Added tests for Build Distribution quota exceeded with Contact Sales CTA
- [x] Added tests for both Emerge categories exceeded together
- [x] Added tests for mixed Emerge and standard categories exceeded
- [x] All 21 tests in navBillingStatus.spec.tsx pass
- [x] Manually verified UI in dev environment with mocked database changes