### PR TITLE
feat(notifications): Add QUOTA_SIZE_ANALYSIS for Size Analysis spend notifications

### DIFF
--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -25,6 +25,7 @@ NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
     NotificationSettingEnum.QUOTA_SEER_BUDGET: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_LOG_BYTES: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_SEER_USERS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_SIZE_ANALYSIS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_THRESHOLDS: NotificationSettingsOptionEnum.ALWAYS,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -35,6 +35,7 @@ class NotificationSettingEnum(ValueEqualityEnum):
     QUOTA_SPEND_ALLOCATIONS = "quotaSpendAllocations"
     QUOTA_LOG_BYTES = "quotaLogBytes"
     QUOTA_SEER_USERS = "quotaSeerUsers"
+    QUOTA_SIZE_ANALYSIS = "quotaSizeAnalysis"
     SPIKE_PROTECTION = "spikeProtection"
     MISSING_MEMBERS = "missingMembers"
     REPORTS = "reports"
@@ -152,6 +153,10 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingsOptionEnum.NEVER,
     },
     NotificationSettingEnum.QUOTA_SEER_USERS: {
+        NotificationSettingsOptionEnum.ALWAYS,
+        NotificationSettingsOptionEnum.NEVER,
+    },
+    NotificationSettingEnum.QUOTA_SIZE_ANALYSIS: {
         NotificationSettingsOptionEnum.ALWAYS,
         NotificationSettingsOptionEnum.NEVER,
     },

--- a/tests/sentry/notifications/api/endpoints/test_notification_defaults.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_defaults.py
@@ -35,5 +35,6 @@ class NotificationDefaultTest(APITestCase):
                 "workflow": "subscribe_only",
                 "brokenMonitors": "always",
                 "quotaSeerUsers": "always",
+                "quotaSizeAnalysis": "always",
             },
         }

--- a/tests/sentry/notifications/api/endpoints/test_user_notification_settings_options.py
+++ b/tests/sentry/notifications/api/endpoints/test_user_notification_settings_options.py
@@ -106,6 +106,7 @@ class UserNotificationSettingsOptionsPutTest(UserNotificationSettingsOptionsBase
             NotificationSettingEnum.QUOTA_SPANS,
             NotificationSettingEnum.QUOTA_LOG_BYTES,
             NotificationSettingEnum.QUOTA_SEER_USERS,
+            NotificationSettingEnum.QUOTA_SIZE_ANALYSIS,
         ]
 
         # turn on notification settings


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1918/update-spend-notification-user-settings

## Summary

Adds spend notification settings for Size Analysis (emerge category) following the established pattern from previous product launches (Logs, Uptime, Seer).

- Add `QUOTA_SIZE_ANALYSIS = "quotaSizeAnalysis"` to `NotificationSettingEnum`
- Add to `VALID_VALUES_FOR_KEY` with ALWAYS/NEVER options
- Add to `NOTIFICATION_SETTINGS_TYPE_DEFAULTS` with ALWAYS default
- Update notification defaults and user settings tests

This is Phase 1 of the Size Analysis spend notifications implementation. Phase 2 (BIL-1916) will add the event mapping in getsentry after this PR is merged.

## Test Plan

- [x] Unit tests pass (9 tests)
- [x] Pre-commit checks pass
- [ ] Verify notification defaults API returns `quotaSizeAnalysis: "always"`