### PR TITLE
feat(admin): add unit formatting for emerge categories in admin provisioning

### DIFF
--- a/static/gsAdmin/components/addGiftEventsAction.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.tsx
@@ -13,6 +13,7 @@ import {
   getPlanCategoryName,
   isByteCategory,
   isContinuousProfiling,
+  isEmergeCategory,
 } from 'getsentry/utils/dataCategory';
 
 export function getFreeEventsKey(dataCategory: DataCategory) {
@@ -105,6 +106,9 @@ class AddGiftEventsAction extends Component<Props, State> {
       if (isContinuousProfiling(dataCategory)) {
         return 'How many profile hours?';
       }
+      if (isEmergeCategory(dataCategory)) {
+        return `How many ${categoryName}?`;
+      }
 
       const multiplier = billedCategoryInfo?.freeEventsMultiple ?? 0;
       const addToMessage =
@@ -126,6 +130,12 @@ class AddGiftEventsAction extends Component<Props, State> {
       }
       if (isByteCategory(dataCategory)) {
         postFix = ' GB';
+      }
+      if (dataCategory === DataCategory.SIZE_ANALYSIS) {
+        postFix = total === '1' ? ' build' : ' builds';
+      }
+      if (dataCategory === DataCategory.INSTALLABLE_BUILD) {
+        postFix = total === '1' ? ' install' : ' installs';
       }
       return `Total: ${total}${postFix}`;
     }

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -42,8 +42,8 @@ import {
 } from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
+  getCategoryUnitSuffix,
   getPlanCategoryName,
-  isByteCategory,
 } from 'getsentry/utils/dataCategory';
 
 const CPE_DECIMAL_PRECISION = 8;
@@ -836,7 +836,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                         title: true,
                         hadCustomDynamicSampling: isAm3Ds,
                       });
-                      const suffix = isByteCategory(category) ? ' (in GB)' : '';
+                      const suffix = getCategoryUnitSuffix(category);
                       const capitalizedApiName = this.capitalizeForApiName(
                         categoryInfo.plural
                       );

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -42,8 +42,8 @@ import {
 } from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
-  getCategoryUnitSuffix,
   getPlanCategoryName,
+  isByteCategory,
 } from 'getsentry/utils/dataCategory';
 
 const CPE_DECIMAL_PRECISION = 8;
@@ -836,7 +836,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                         title: true,
                         hadCustomDynamicSampling: isAm3Ds,
                       });
-                      const suffix = getCategoryUnitSuffix(category);
+                      const suffix = isByteCategory(category) ? ' (in GB)' : '';
                       const capitalizedApiName = this.capitalizeForApiName(
                         categoryInfo.plural
                       );

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -220,12 +220,12 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SIZE_ANALYSIS],
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
-    shortenedUnitName: t('upload'),
+    shortenedUnitName: t('build'),
   },
   [DataCategoryExact.INSTALLABLE_BUILD]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.INSTALLABLE_BUILD],
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
-    shortenedUnitName: t('distribution'),
+    shortenedUnitName: t('install'),
   },
 } as const satisfies Record<DataCategoryExact, BilledDataCategoryInfo>;

--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -18,7 +18,6 @@ import {MILLISECONDS_IN_HOUR} from 'getsentry/utils/billing';
 import {
   calculateSeerUserSpend,
   formatCategoryQuantityWithDisplayName,
-  getCategoryUnitSuffix,
   getPlanCategoryName,
   getReservedBudgetDisplayName,
   getSingularCategoryName,
@@ -523,33 +522,6 @@ describe('isEmergeCategory', () => {
     expect(isEmergeCategory(DataCategory.TRANSACTIONS)).toBe(false);
     expect(isEmergeCategory(DataCategory.ATTACHMENTS)).toBe(false);
     expect(isEmergeCategory(DataCategory.REPLAYS)).toBe(false);
-  });
-});
-
-describe('getCategoryUnitSuffix', () => {
-  it('returns " (in GB)" for byte categories', () => {
-    expect(getCategoryUnitSuffix(DataCategory.ATTACHMENTS)).toBe(' (in GB)');
-    expect(getCategoryUnitSuffix(DataCategory.LOG_BYTE)).toBe(' (in GB)');
-  });
-
-  it('returns " (in hours)" for profiling categories', () => {
-    expect(getCategoryUnitSuffix(DataCategory.PROFILE_DURATION)).toBe(' (in hours)');
-    expect(getCategoryUnitSuffix(DataCategory.PROFILE_DURATION_UI)).toBe(' (in hours)');
-  });
-
-  it('returns " (in builds)" for SIZE_ANALYSIS', () => {
-    expect(getCategoryUnitSuffix(DataCategory.SIZE_ANALYSIS)).toBe(' (in builds)');
-  });
-
-  it('returns " (in installs)" for INSTALLABLE_BUILD', () => {
-    expect(getCategoryUnitSuffix(DataCategory.INSTALLABLE_BUILD)).toBe(' (in installs)');
-  });
-
-  it('returns empty string for other categories', () => {
-    expect(getCategoryUnitSuffix(DataCategory.ERRORS)).toBe('');
-    expect(getCategoryUnitSuffix(DataCategory.TRANSACTIONS)).toBe('');
-    expect(getCategoryUnitSuffix(DataCategory.REPLAYS)).toBe('');
-    expect(getCategoryUnitSuffix(DataCategory.SPANS)).toBe('');
   });
 });
 

--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -18,11 +18,13 @@ import {MILLISECONDS_IN_HOUR} from 'getsentry/utils/billing';
 import {
   calculateSeerUserSpend,
   formatCategoryQuantityWithDisplayName,
+  getCategoryUnitSuffix,
   getPlanCategoryName,
   getReservedBudgetDisplayName,
   getSingularCategoryName,
   hasCategoryFeature,
   isByteCategory,
+  isEmergeCategory,
   listDisplayNames,
   sortCategories,
   sortCategoriesWithKeys,
@@ -507,6 +509,47 @@ describe('isByteCategory', () => {
     expect(isByteCategory(DataCategory.LOG_BYTE)).toBe(true);
     expect(isByteCategory(DataCategory.ERRORS)).toBe(false);
     expect(isByteCategory(DataCategory.TRANSACTIONS)).toBe(false);
+  });
+});
+
+describe('isEmergeCategory', () => {
+  it('returns true for SIZE_ANALYSIS and INSTALLABLE_BUILD', () => {
+    expect(isEmergeCategory(DataCategory.SIZE_ANALYSIS)).toBe(true);
+    expect(isEmergeCategory(DataCategory.INSTALLABLE_BUILD)).toBe(true);
+  });
+
+  it('returns false for other categories', () => {
+    expect(isEmergeCategory(DataCategory.ERRORS)).toBe(false);
+    expect(isEmergeCategory(DataCategory.TRANSACTIONS)).toBe(false);
+    expect(isEmergeCategory(DataCategory.ATTACHMENTS)).toBe(false);
+    expect(isEmergeCategory(DataCategory.REPLAYS)).toBe(false);
+  });
+});
+
+describe('getCategoryUnitSuffix', () => {
+  it('returns " (in GB)" for byte categories', () => {
+    expect(getCategoryUnitSuffix(DataCategory.ATTACHMENTS)).toBe(' (in GB)');
+    expect(getCategoryUnitSuffix(DataCategory.LOG_BYTE)).toBe(' (in GB)');
+  });
+
+  it('returns " (in hours)" for profiling categories', () => {
+    expect(getCategoryUnitSuffix(DataCategory.PROFILE_DURATION)).toBe(' (in hours)');
+    expect(getCategoryUnitSuffix(DataCategory.PROFILE_DURATION_UI)).toBe(' (in hours)');
+  });
+
+  it('returns " (in builds)" for SIZE_ANALYSIS', () => {
+    expect(getCategoryUnitSuffix(DataCategory.SIZE_ANALYSIS)).toBe(' (in builds)');
+  });
+
+  it('returns " (in installs)" for INSTALLABLE_BUILD', () => {
+    expect(getCategoryUnitSuffix(DataCategory.INSTALLABLE_BUILD)).toBe(' (in installs)');
+  });
+
+  it('returns empty string for other categories', () => {
+    expect(getCategoryUnitSuffix(DataCategory.ERRORS)).toBe('');
+    expect(getCategoryUnitSuffix(DataCategory.TRANSACTIONS)).toBe('');
+    expect(getCategoryUnitSuffix(DataCategory.REPLAYS)).toBe('');
+    expect(getCategoryUnitSuffix(DataCategory.SPANS)).toBe('');
   });
 });
 

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -291,26 +291,6 @@ export function isEmergeCategory(category: DataCategory | string) {
   );
 }
 
-/**
- * Get the unit suffix for a data category, used in admin UI for clarity.
- * Returns a string like ' (in GB)' or ' (in builds)' to append to field labels.
- */
-export function getCategoryUnitSuffix(category: DataCategory | string): string {
-  if (isByteCategory(category)) {
-    return ' (in GB)';
-  }
-  if (isContinuousProfiling(category)) {
-    return ' (in hours)';
-  }
-  if (category === DataCategory.SIZE_ANALYSIS) {
-    return ' (in builds)';
-  }
-  if (category === DataCategory.INSTALLABLE_BUILD) {
-    return ' (in installs)';
-  }
-  return '';
-}
-
 export function getChunkCategoryFromDuration(category: DataCategory) {
   if (category === DataCategory.PROFILE_DURATION) {
     return DataCategory.PROFILE_CHUNKS;

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -282,6 +282,35 @@ export function isByteCategory(category: DataCategory | string) {
   return category === DataCategory.ATTACHMENTS || category === DataCategory.LOG_BYTE;
 }
 
+/**
+ * Whether the category is an emerge category (size analysis or build distribution).
+ */
+export function isEmergeCategory(category: DataCategory | string) {
+  return (
+    category === DataCategory.SIZE_ANALYSIS || category === DataCategory.INSTALLABLE_BUILD
+  );
+}
+
+/**
+ * Get the unit suffix for a data category, used in admin UI for clarity.
+ * Returns a string like ' (in GB)' or ' (in builds)' to append to field labels.
+ */
+export function getCategoryUnitSuffix(category: DataCategory | string): string {
+  if (isByteCategory(category)) {
+    return ' (in GB)';
+  }
+  if (isContinuousProfiling(category)) {
+    return ' (in hours)';
+  }
+  if (category === DataCategory.SIZE_ANALYSIS) {
+    return ' (in builds)';
+  }
+  if (category === DataCategory.INSTALLABLE_BUILD) {
+    return ' (in installs)';
+  }
+  return '';
+}
+
 export function getChunkCategoryFromDuration(category: DataCategory) {
   if (category === DataCategory.PROFILE_DURATION) {
     return DataCategory.PROFILE_CHUNKS;


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1928/add-formatting-for-admin-provisioning

## Summary

Adds unit formatting for emerge data categories (SIZE_ANALYSIS, INSTALLABLE_BUILD) in the admin provisioning UI:

- Add `isEmergeCategory()` and `getCategoryUnitSuffix()` helper functions in `dataCategory.tsx`
- Fix `shortenedUnitName` values: "upload" → "build", "distribution" → "install"
- Update provision subscription modal to use new helper for all category unit suffixes
- Add emerge category handling in gift events modal with proper unit labels

## Test plan

- [x] Unit tests added for `isEmergeCategory()` and `getCategoryUnitSuffix()`
- [ ] Verify admin provisioning modal shows "(in builds)" suffix for SIZE_ANALYSIS
- [ ] Verify admin provisioning modal shows "(in installs)" suffix for INSTALLABLE_BUILD
- [ ] Verify gift events modal shows correct unit in label/help for emerge categories