### PR TITLE
feat(js-loader): Pass feedback option in loader

### DIFF
--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -30,6 +30,7 @@ class SdkConfig(TypedDict):
     replaysSessionSampleRate: NotRequired[float]
     replaysOnErrorSampleRate: NotRequired[float]
     debug: NotRequired[bool]
+    autoInjectFeedback: NotRequired[bool]
 
 
 class LoaderInternalConfig(TypedDict):
@@ -171,6 +172,10 @@ class JavaScriptSdkLoader(View):
         if loader_config["hasReplay"]:
             config["replaysSessionSampleRate"] = 0.1
             config["replaysOnErrorSampleRate"] = 1
+
+        # Although this is not a top-level SDK option we pass this flag so we can auto-add the integration in the loader template later
+        if loader_config["hasFeedback"]:
+            config["autoInjectFeedback"] = True
 
         return (
             {

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -314,7 +314,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     }
                 },
                 b"/7.37.0/bundle.feedback.min.js",
-                {"dsn": dsn},
+                {"dsn": dsn, "autoInjectFeedback": True},
             ),
             (
                 {
@@ -324,7 +324,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     }
                 },
                 b"/7.37.0/bundle.feedback.debug.min.js",
-                {"dsn": dsn, "debug": True},
+                {"dsn": dsn, "debug": True, "autoInjectFeedback": True},
             ),
             # Note: There is no bundle.tracing.feedback or bundle.replay.feedback.
             # When feedback is combined with tracing or replay, we serve the full bundle.
@@ -341,6 +341,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     "tracesSampleRate": 1,
                     "replaysSessionSampleRate": 0.1,
                     "replaysOnErrorSampleRate": 1,
+                    "autoInjectFeedback": True,
                 },
             ),
             (
@@ -356,6 +357,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     "tracesSampleRate": 1,
                     "replaysSessionSampleRate": 0.1,
                     "replaysOnErrorSampleRate": 1,
+                    "autoInjectFeedback": True,
                 },
             ),
             (
@@ -372,6 +374,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     "tracesSampleRate": 1,
                     "replaysSessionSampleRate": 0.1,
                     "replaysOnErrorSampleRate": 1,
+                    "autoInjectFeedback": True,
                 },
             ),
             (
@@ -390,6 +393,7 @@ class JavaScriptSdkLoaderTest(TestCase):
                     "replaysSessionSampleRate": 0.1,
                     "replaysOnErrorSampleRate": 1,
                     "debug": True,
+                    "autoInjectFeedback": True,
                 },
             ),
         ]:


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/106444

We need to pass this option so we can consume it in the template later