### PR TITLE
fix(preprod): Fix search project selection

### DIFF
--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -10,6 +9,11 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface PreprodSearchBarProps {
   initialQuery: string;
+  /**
+   * Project IDs to scope the search to. In settings pages, get this from
+   * projectOutlet. In dashboard pages, get this from page filters.
+   */
+  projects: number[];
   /**
    * Optional list of attribute keys to show. If not provided, all attributes are shown.
    */
@@ -52,6 +56,7 @@ function filterAttributes(
  */
 export function PreprodSearchBar({
   initialQuery,
+  projects,
   allowedKeys,
   hiddenKeys = HIDDEN_PREPROD_ATTRIBUTES,
   onChange,
@@ -63,9 +68,6 @@ export function PreprodSearchBar({
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
   const organization = useOrganization();
-  const {
-    selection: {projects},
-  } = usePageFilters();
 
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.PREPROD,

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -169,9 +169,14 @@ function MobileAppSizeSearchBar({
   WidgetBuilderSearchBarProps,
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
+  const {
+    selection: {projects},
+  } = usePageFilters();
+
   return (
     <PreprodSearchBar
       initialQuery={widgetQuery.conditions}
+      projects={projects}
       onSearch={onSearch}
       portalTarget={portalTarget}
       searchSource="dashboards"

--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -90,6 +90,7 @@ export function FeatureFilter({
 
           <PreprodSearchBar
             initialQuery={localQuery}
+            projects={[Number(project.id)]}
             onChange={handleQueryChange}
             onSearch={handleSearch}
             searchSource="preprod_feature_filter"

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -9,6 +9,7 @@ import {Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
+import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {SectionLabel} from './statusCheckSharedComponents';
 import type {StatusCheckRule} from './types';
@@ -29,6 +30,7 @@ interface Props {
 }
 
 export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
+  const {project} = useProjectSettingsOutlet();
   const [metric, setMetric] = useState(rule.metric);
   const [measurement, setMeasurement] = useState(rule.measurement);
   const displayUnit = getDisplayUnit(measurement);
@@ -106,6 +108,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
         <SectionLabel>{t('For')}</SectionLabel>
         <PreprodSearchBar
           initialQuery={filterQuery}
+          projects={[Number(project.id)]}
           onChange={(query, _state) => handleQueryChange(query)}
           searchSource="preprod_status_check_filters"
           portalTarget={document.body}


### PR DESCRIPTION
To correctly autofill attribute values we need to select the correct projects.
How to get the 'selected' projects depends on what part of the site we're on.
- on the project settings page there is only one project, put as the slug in the URL.
- on most explore and dashboard projects the project is in the query string.

There could be a generic hook which would do the correct thing in either case but currently you have to use different
code depending on which context you are in:

For query string projects we do:
```
usePageFilters();
```


For projects pages we do:
```
useProjectSettingsOutlet();
```

Convert PreprodSearchbar to take project ids as an augment so it can be used in either place.  