### PR TITLE
fix(trace-waterfall): Update chevron directions

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceIcons.tsx
@@ -32,12 +32,12 @@ export const TraceIcons = {
 // and removed from the emotion wrapper which is parsing and compiling unnecessary CSS as the
 // components rerended, which causes frame drops and performance issues that result in white
 // row flashes when scrolling.
-function Chevron(props: {direction: 'up' | 'down' | 'left'}) {
+function Chevron(props: {direction: 'up' | 'down' | 'left' | 'right'}) {
   return (
     <svg
       viewBox="0 0 16 16"
       style={{
-        transform: `rotate(${props.direction === 'up' ? 0 : props.direction === 'down' ? 180 : -90}deg)`,
+        transform: `rotate(${props.direction === 'up' ? 0 : props.direction === 'right' ? 90 : props.direction === 'down' ? 180 : 270}deg)`,
       }}
     >
       <path d="M14,11.75a.74.74,0,0,1-.53-.22L8,6.06,2.53,11.53a.75.75,0,0,1-1.06-1.06l6-6a.75.75,0,0,1,1.06,0l6,6a.75.75,0,0,1,0,1.06A.74.74,0,0,1,14,11.75Z" />

--- a/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
@@ -38,7 +38,7 @@ export function TraceAutogroupedRow(
             <TraceRowConnectors node={props.node} manager={props.manager} />
             <TraceChildrenButton
               icon={
-                <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                <TraceIcons.Chevron direction={props.node.expanded ? 'down' : 'right'} />
               }
               status={props.node.fetchStatus}
               expanded={!props.node.expanded}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -58,7 +58,9 @@ export function TraceEAPSpanRow(props: TraceRowProps<EapSpanNode>) {
                   props.node.canFetchChildren ? (
                     '+'
                   ) : (
-                    <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                    <TraceIcons.Chevron
+                      direction={props.node.expanded ? 'down' : 'right'}
+                    />
                   )
                 }
                 status={props.node.fetchStatus}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -51,7 +51,9 @@ export function TraceSpanRow(props: TraceRowProps<SpanNode>) {
                   props.node.canFetchChildren ? (
                     '+'
                   ) : (
-                    <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                    <TraceIcons.Chevron
+                      direction={props.node.expanded ? 'down' : 'right'}
+                    />
                   )
                 }
                 status={props.node.fetchStatus}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -42,7 +42,7 @@ export function TraceTransactionRow(props: TraceRowProps<TransactionNode>) {
                     props.node.fetchStatus === 'idle' ? (
                       '+'
                     ) : props.node.hasFetchedChildren ? (
-                      <TraceIcons.Chevron direction="right" />
+                      <TraceIcons.Chevron direction="down" />
                     ) : (
                       '+'
                     )

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -42,12 +42,14 @@ export function TraceTransactionRow(props: TraceRowProps<TransactionNode>) {
                     props.node.fetchStatus === 'idle' ? (
                       '+'
                     ) : props.node.hasFetchedChildren ? (
-                      <TraceIcons.Chevron direction="up" />
+                      <TraceIcons.Chevron direction="right" />
                     ) : (
                       '+'
                     )
                   ) : (
-                    <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                    <TraceIcons.Chevron
+                      direction={props.node.expanded ? 'down' : 'right'}
+                    />
                   )
                 }
                 status={props.node.fetchStatus}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckNode.tsx
@@ -46,7 +46,9 @@ export function TraceUptimeCheckNodeRow(props: TraceRowProps<UptimeCheckNode>) {
                   props.node.canFetchChildren ? (
                     '+'
                   ) : (
-                    <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                    <TraceIcons.Chevron
+                      direction={props.node.expanded ? 'down' : 'right'}
+                    />
                   )
                 }
                 status={props.node.fetchStatus}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckTimingNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckTimingNode.tsx
@@ -46,7 +46,9 @@ export function TraceUptimeCheckTimingNodeRow(
                   props.node.canFetchChildren ? (
                     '+'
                   ) : (
-                    <TraceIcons.Chevron direction={props.node.expanded ? 'up' : 'down'} />
+                    <TraceIcons.Chevron
+                      direction={props.node.expanded ? 'down' : 'right'}
+                    />
                   )
                 }
                 status={props.node.fetchStatus}


### PR DESCRIPTION
This PR updates the direction of the chevron's on the trace waterfall to match Sentry's standards for collapsed values.

Ticket: EXP-731

|Before|After|Change|
|-|-|-|
|<img width="135" height="263" alt="Screenshot 2026-01-26 at 07 30 26" src="https://github.com/user-attachments/assets/e495fc61-53cf-4050-97f1-1ea551c396e9" />|<img width="144" height="261" alt="Screenshot 2026-01-26 at 07 30 15" src="https://github.com/user-attachments/assets/6821e8dc-ea35-4525-a6aa-91de5c098349" />|Collapsed now points right, open now points down.