### PR TITLE
feat(dynamic-sampling): allow spen segment metrics in GetActiveOrgs and GetActiveOrgsVolumes

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -24,7 +24,7 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import extrapolate_mon
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
@@ -50,10 +50,20 @@ class GetActiveOrgs:
         max_projects: int | None = None,
         time_interval: timedelta = ACTIVE_ORGS_DEFAULT_TIME_INTERVAL,
         granularity: Granularity = ACTIVE_ORGS_DEFAULT_GRANULARITY,
+        use_span_metric: bool = False,
     ) -> None:
-        self.metric_id = indexer.resolve_shared_org(
-            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
-        )
+        if use_span_metric:
+            is_segment_string_id = indexer.resolve_shared_org("is_segment")
+            self.is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+            self.metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+            self.use_case_id = UseCaseID.SPANS
+        else:
+            self.is_segment_tag = None
+            self.metric_id = indexer.resolve_shared_org(
+                str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+            )
+            self.use_case_id = UseCaseID.TRANSACTIONS
+
         self.offset = 0
         self.last_result: list[tuple[int, int]] = []
         self.has_more_results = True
@@ -72,6 +82,18 @@ class GetActiveOrgs:
 
         if self.has_more_results:
             # not enough for the current iteration and data still in the db top it up from db
+            where_conditions = [
+                Condition(
+                    Column("timestamp"),
+                    Op.GTE,
+                    datetime.utcnow() - self.time_interval,
+                ),
+                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("metric_id"), Op.EQ, self.metric_id),
+            ]
+            if self.is_segment_tag is not None:
+                where_conditions.append(Condition(Column(self.is_segment_tag), Op.EQ, "true"))
+
             query = (
                 Query(
                     match=Entity(EntityKey.GenericOrgMetricsCounters.value),
@@ -82,15 +104,7 @@ class GetActiveOrgs:
                     groupby=[
                         Column("org_id"),
                     ],
-                    where=[
-                        Condition(
-                            Column("timestamp"),
-                            Op.GTE,
-                            datetime.utcnow() - self.time_interval,
-                        ),
-                        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
-                        Condition(Column("metric_id"), Op.EQ, self.metric_id),
-                    ],
+                    where=where_conditions,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
                     ],
@@ -104,7 +118,7 @@ class GetActiveOrgs:
                 app_id="dynamic_sampling",
                 query=query,
                 tenant_ids={
-                    "use_case_id": UseCaseID.TRANSACTIONS.value,
+                    "use_case_id": self.use_case_id.value,
                     "cross_org_query": 1,
                 },
             )
@@ -200,12 +214,22 @@ class GetActiveOrgsVolumes:
         granularity: Granularity = ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY,
         include_keep: bool = True,
         orgs: list[int] | None = None,
+        use_span_metric: bool = False,
     ) -> None:
         self.include_keep = include_keep
         self.orgs = orgs
-        self.metric_id = indexer.resolve_shared_org(
-            str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
-        )
+
+        if use_span_metric:
+            is_segment_string_id = indexer.resolve_shared_org("is_segment")
+            self.is_segment_tag = f"tags_raw[{is_segment_string_id}]"
+            self.metric_id = indexer.resolve_shared_org(str(SpanMRI.COUNT_PER_ROOT_PROJECT.value))
+            self.use_case_id = UseCaseID.SPANS
+        else:
+            self.is_segment_tag = None
+            self.metric_id = indexer.resolve_shared_org(
+                str(TransactionMRI.COUNT_PER_ROOT_PROJECT.value)
+            )
+            self.use_case_id = UseCaseID.TRANSACTIONS
 
         if self.include_keep:
             decision_string_id = indexer.resolve_shared_org("decision")
@@ -251,6 +275,9 @@ class GetActiveOrgsVolumes:
             Condition(Column("metric_id"), Op.EQ, self.metric_id),
         ]
 
+        if self.is_segment_tag is not None:
+            where.append(Condition(Column(self.is_segment_tag), Op.EQ, "true"))
+
         if self.orgs:
             where.append(Condition(Column("org_id"), Op.IN, self.orgs))
 
@@ -277,7 +304,7 @@ class GetActiveOrgsVolumes:
                 app_id="dynamic_sampling",
                 query=query,
                 tenant_ids={
-                    "use_case_id": UseCaseID.TRANSACTIONS.value,
+                    "use_case_id": self.use_case_id.value,
                     "cross_org_query": 1,
                 },
             )

--- a/tests/sentry/dynamic_sampling/tasks/test_common.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_common.py
@@ -9,7 +9,7 @@ from sentry.dynamic_sampling.tasks.common import (
     OrganizationDataVolume,
     get_organization_volume,
 )
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.testutils.cases import BaseMetricsLayerTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -138,3 +138,153 @@ class TestGetActiveOrgsVolumes(BaseMetricsLayerTestCase, TestCase, SnubaTestCase
         org_id = 99999999  # can we do better, an id we know for sure is not in the DB?
         org_volume = get_organization_volume(org_id)
         assert org_volume is None
+
+
+@freeze_time(MOCK_DATETIME)
+class TestGetActiveOrgsSpanMetric(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
+    """
+    Tests for GetActiveOrgs using span metrics with is_segment filter.
+    """
+
+    @property
+    def now(self):
+        return MOCK_DATETIME
+
+    def test_get_active_orgs_with_span_metric_only_counts_segment_spans(self) -> None:
+        """
+        Test that span metrics only count spans with is_segment=true.
+        """
+        org1 = self.create_organization("test-org-1")
+        project1 = self.create_project(organization=org1)
+
+        # Store span metric with is_segment=true (should be counted)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=30,
+            value=1,
+            project_id=project1.id,
+            org_id=org1.id,
+        )
+
+        # Store span metric without is_segment (should NOT be counted)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "bar", "decision": "keep"},
+            minutes_before_now=30,
+            value=100,
+            project_id=project1.id,
+            org_id=org1.id,
+        )
+
+        found_orgs = []
+        for orgs in GetActiveOrgs(max_orgs=10, use_span_metric=True):
+            found_orgs.extend(orgs)
+
+        assert org1.id in found_orgs
+
+    def test_get_active_orgs_span_metric_multiple_orgs(self) -> None:
+        """
+        Test GetActiveOrgs with span metrics for multiple organizations.
+        """
+        # Create 5 orgs with span metrics
+        created_org_ids = []
+        for i in range(5):
+            org = self.create_organization(f"span-org-{i}")
+            created_org_ids.append(org.id)
+            project = self.create_project(organization=org)
+            self.store_performance_metric(
+                name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"transaction": "tx", "decision": "keep", "is_segment": "true"},
+                minutes_before_now=30,
+                value=1,
+                project_id=project.id,
+                org_id=org.id,
+            )
+
+        found_orgs = []
+        for orgs in GetActiveOrgs(max_orgs=10, use_span_metric=True):
+            found_orgs.extend(orgs)
+
+        for org_id in created_org_ids:
+            assert org_id in found_orgs
+
+
+@freeze_time(MOCK_DATETIME)
+class TestGetActiveOrgsVolumesSpanMetric(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
+    """
+    Tests for GetActiveOrgsVolumes using span metrics with is_segment filter.
+    """
+
+    @property
+    def now(self):
+        return MOCK_DATETIME
+
+    def test_get_active_orgs_volumes_with_span_metric(self) -> None:
+        """
+        Test that GetActiveOrgsVolumes correctly queries span metrics with is_segment filter.
+        """
+        org = self.create_organization("test-org")
+        project = self.create_project(organization=org)
+
+        # Store span metrics with is_segment=true
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=1,
+            value=5,
+            project_id=project.id,
+            org_id=org.id,
+        )
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "drop", "is_segment": "true"},
+            minutes_before_now=1,
+            value=10,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        # Store span metrics without is_segment (should NOT be counted)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "bar", "decision": "keep"},
+            minutes_before_now=1,
+            value=100,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        found_volumes = []
+        for volumes in GetActiveOrgsVolumes(max_orgs=10, use_span_metric=True):
+            found_volumes.extend(volumes)
+
+        # Should only find the is_segment=true metrics
+        assert len(found_volumes) == 1
+        assert found_volumes[0].org_id == org.id
+        assert found_volumes[0].total == 15  # 5 + 10
+        assert found_volumes[0].indexed == 5  # only keep
+
+    def test_get_active_orgs_volumes_span_metric_excludes_non_segment(self) -> None:
+        """
+        Test that non-segment spans are excluded from volume calculation.
+        """
+        org = self.create_organization("test-org")
+        project = self.create_project(organization=org)
+
+        # Only store non-segment spans
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep"},
+            minutes_before_now=1,
+            value=100,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        found_volumes = []
+        for volumes in GetActiveOrgsVolumes(max_orgs=10, use_span_metric=True):
+            found_volumes.extend(volumes)
+
+        # Should find no volumes since there are no is_segment=true spans
+        assert len(found_volumes) == 0

--- a/tests/sentry/dynamic_sampling/tasks/test_common.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_common.py
@@ -142,21 +142,96 @@ class TestGetActiveOrgsVolumes(BaseMetricsLayerTestCase, TestCase, SnubaTestCase
 
 
 @freeze_time(MOCK_DATETIME)
-class TestGetActiveOrgsSegmentsMeasure(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
+class TestGetActiveOrgsMeasureFiltering(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     """
-    Tests for GetActiveOrgs using SamplingMeasure.SEGMENTS (span metrics with is_segment filter).
+    Tests that TRANSACTIONS and SEGMENTS measures filter metrics correctly.
+    Both measures should behave equivalently when the appropriate metrics are emitted.
     """
 
     @property
     def now(self):
         return MOCK_DATETIME
 
-    def test_get_active_orgs_segments_measure_only_counts_segment_spans(self) -> None:
+    def test_transactions_measure_only_counts_transaction_metrics(self) -> None:
         """
-        Test that SEGMENTS measure only counts spans with is_segment=true.
+        Test that TRANSACTIONS measure only counts TransactionMRI metrics, not SpanMRI.
         """
         org1 = self.create_organization("test-org-1")
         project1 = self.create_project(organization=org1)
+        org2 = self.create_organization("test-org-2")
+        project2 = self.create_project(organization=org2)
+
+        # Store transaction metric (should be counted by TRANSACTIONS measure)
+        self.store_performance_metric(
+            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep"},
+            minutes_before_now=30,
+            value=1,
+            project_id=project1.id,
+            org_id=org1.id,
+        )
+
+        # Store span metric with is_segment=true (should NOT be counted by TRANSACTIONS measure)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "bar", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=30,
+            value=100,
+            project_id=project2.id,
+            org_id=org2.id,
+        )
+
+        found_orgs = []
+        for orgs in GetActiveOrgs(max_orgs=10, measure=SamplingMeasure.TRANSACTIONS):
+            found_orgs.extend(orgs)
+
+        assert org1.id in found_orgs
+        assert org2.id not in found_orgs
+
+    def test_segments_measure_only_counts_segment_spans(self) -> None:
+        """
+        Test that SEGMENTS measure only counts SpanMRI with is_segment=true, not TransactionMRI.
+        """
+        org1 = self.create_organization("test-org-1")
+        project1 = self.create_project(organization=org1)
+        org2 = self.create_organization("test-org-2")
+        project2 = self.create_project(organization=org2)
+
+        # Store span metric with is_segment=true (should be counted by SEGMENTS measure)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=30,
+            value=1,
+            project_id=project1.id,
+            org_id=org1.id,
+        )
+
+        # Store transaction metric (should NOT be counted by SEGMENTS measure)
+        self.store_performance_metric(
+            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "bar", "decision": "keep"},
+            minutes_before_now=30,
+            value=100,
+            project_id=project2.id,
+            org_id=org2.id,
+        )
+
+        found_orgs = []
+        for orgs in GetActiveOrgs(max_orgs=10, measure=SamplingMeasure.SEGMENTS):
+            found_orgs.extend(orgs)
+
+        assert org1.id in found_orgs
+        assert org2.id not in found_orgs
+
+    def test_segments_measure_excludes_non_segment_spans(self) -> None:
+        """
+        Test that SEGMENTS measure excludes SpanMRI without is_segment=true.
+        """
+        org1 = self.create_organization("test-org-1")
+        project1 = self.create_project(organization=org1)
+        org2 = self.create_organization("test-org-2")
+        project2 = self.create_project(organization=org2)
 
         # Store span metric with is_segment=true (should be counted)
         self.store_performance_metric(
@@ -174,8 +249,8 @@ class TestGetActiveOrgsSegmentsMeasure(BaseMetricsLayerTestCase, TestCase, Snuba
             tags={"transaction": "bar", "decision": "keep"},
             minutes_before_now=30,
             value=100,
-            project_id=project1.id,
-            org_id=org1.id,
+            project_id=project2.id,
+            org_id=org2.id,
         )
 
         found_orgs = []
@@ -183,15 +258,40 @@ class TestGetActiveOrgsSegmentsMeasure(BaseMetricsLayerTestCase, TestCase, Snuba
             found_orgs.extend(orgs)
 
         assert org1.id in found_orgs
+        assert org2.id not in found_orgs
 
-    def test_get_active_orgs_segments_measure_multiple_orgs(self) -> None:
+    def test_transactions_measure_multiple_orgs(self) -> None:
+        """
+        Test GetActiveOrgs with TRANSACTIONS measure for multiple organizations.
+        """
+        created_org_ids = []
+        for i in range(5):
+            org = self.create_organization(f"tx-org-{i}")
+            created_org_ids.append(org.id)
+            project = self.create_project(organization=org)
+            self.store_performance_metric(
+                name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"transaction": "tx", "decision": "keep"},
+                minutes_before_now=30,
+                value=1,
+                project_id=project.id,
+                org_id=org.id,
+            )
+
+        found_orgs = []
+        for orgs in GetActiveOrgs(max_orgs=10, measure=SamplingMeasure.TRANSACTIONS):
+            found_orgs.extend(orgs)
+
+        for org_id in created_org_ids:
+            assert org_id in found_orgs
+
+    def test_segments_measure_multiple_orgs(self) -> None:
         """
         Test GetActiveOrgs with SEGMENTS measure for multiple organizations.
         """
-        # Create 5 orgs with span metrics
         created_org_ids = []
         for i in range(5):
-            org = self.create_organization(f"span-org-{i}")
+            org = self.create_organization(f"segment-org-{i}")
             created_org_ids.append(org.id)
             project = self.create_project(organization=org)
             self.store_performance_metric(
@@ -212,18 +312,64 @@ class TestGetActiveOrgsSegmentsMeasure(BaseMetricsLayerTestCase, TestCase, Snuba
 
 
 @freeze_time(MOCK_DATETIME)
-class TestGetActiveOrgsVolumesSegmentsMeasure(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
+class TestGetActiveOrgsVolumesMeasureFiltering(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     """
-    Tests for GetActiveOrgsVolumes using SamplingMeasure.SEGMENTS (span metrics with is_segment filter).
+    Tests that TRANSACTIONS and SEGMENTS measures filter volumes correctly.
+    Both measures should behave equivalently when the appropriate metrics are emitted.
     """
 
     @property
     def now(self):
         return MOCK_DATETIME
 
-    def test_get_active_orgs_volumes_segments_measure(self) -> None:
+    def test_transactions_measure_volumes(self) -> None:
         """
-        Test that GetActiveOrgsVolumes correctly queries SEGMENTS measure with is_segment filter.
+        Test that GetActiveOrgsVolumes correctly queries TRANSACTIONS measure.
+        """
+        org = self.create_organization("test-org")
+        project = self.create_project(organization=org)
+
+        # Store transaction metrics
+        self.store_performance_metric(
+            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep"},
+            minutes_before_now=1,
+            value=5,
+            project_id=project.id,
+            org_id=org.id,
+        )
+        self.store_performance_metric(
+            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "drop"},
+            minutes_before_now=1,
+            value=10,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        # Store span metrics (should NOT be counted by TRANSACTIONS measure)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "bar", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=1,
+            value=100,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        found_volumes = []
+        for volumes in GetActiveOrgsVolumes(max_orgs=10, measure=SamplingMeasure.TRANSACTIONS):
+            found_volumes.extend(volumes)
+
+        # Should only find the transaction metrics
+        assert len(found_volumes) == 1
+        assert found_volumes[0].org_id == org.id
+        assert found_volumes[0].total == 15  # 5 + 10
+        assert found_volumes[0].indexed == 5  # only keep
+
+    def test_segments_measure_volumes(self) -> None:
+        """
+        Test that GetActiveOrgsVolumes correctly queries SEGMENTS measure.
         """
         org = self.create_organization("test-org")
         project = self.create_project(organization=org)
@@ -246,9 +392,9 @@ class TestGetActiveOrgsVolumesSegmentsMeasure(BaseMetricsLayerTestCase, TestCase
             org_id=org.id,
         )
 
-        # Store span metrics without is_segment (should NOT be counted)
+        # Store transaction metrics (should NOT be counted by SEGMENTS measure)
         self.store_performance_metric(
-            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
             tags={"transaction": "bar", "decision": "keep"},
             minutes_before_now=1,
             value=100,
@@ -260,15 +406,15 @@ class TestGetActiveOrgsVolumesSegmentsMeasure(BaseMetricsLayerTestCase, TestCase
         for volumes in GetActiveOrgsVolumes(max_orgs=10, measure=SamplingMeasure.SEGMENTS):
             found_volumes.extend(volumes)
 
-        # Should only find the is_segment=true metrics
+        # Should only find the is_segment=true span metrics
         assert len(found_volumes) == 1
         assert found_volumes[0].org_id == org.id
         assert found_volumes[0].total == 15  # 5 + 10
         assert found_volumes[0].indexed == 5  # only keep
 
-    def test_get_active_orgs_volumes_segments_measure_excludes_non_segment(self) -> None:
+    def test_segments_measure_excludes_non_segment_spans(self) -> None:
         """
-        Test that non-segment spans are excluded from volume calculation.
+        Test that non-segment spans are excluded from SEGMENTS volume calculation.
         """
         org = self.create_organization("test-org")
         project = self.create_project(organization=org)
@@ -288,4 +434,28 @@ class TestGetActiveOrgsVolumesSegmentsMeasure(BaseMetricsLayerTestCase, TestCase
             found_volumes.extend(volumes)
 
         # Should find no volumes since there are no is_segment=true spans
+        assert len(found_volumes) == 0
+
+    def test_transactions_measure_excludes_span_metrics(self) -> None:
+        """
+        Test that span metrics are excluded from TRANSACTIONS volume calculation.
+        """
+        org = self.create_organization("test-org")
+        project = self.create_project(organization=org)
+
+        # Only store span metrics (even with is_segment=true)
+        self.store_performance_metric(
+            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={"transaction": "foo", "decision": "keep", "is_segment": "true"},
+            minutes_before_now=1,
+            value=100,
+            project_id=project.id,
+            org_id=org.id,
+        )
+
+        found_volumes = []
+        for volumes in GetActiveOrgsVolumes(max_orgs=10, measure=SamplingMeasure.TRANSACTIONS):
+            found_volumes.extend(volumes)
+
+        # Should find no volumes since there are no transaction metrics
         assert len(found_volumes) == 0


### PR DESCRIPTION
Add support for querying span metrics in GetActiveOrgs and GetActiveOrgsVolumes by:
- Adding use_span_metric parameter (default False) to both classes
- Pass the measure into the query classes to control which metrics are queried - which is consistent with the way it is done in https://github.com/getsentry/sentry/commit/bd5c47f88c5c1d010e51c6c432dc25be4f97ee3f

This allows callers to switch between transaction and span-based metrics tagged with is_segment for organization volume queries.

Closes TET-1532