### PR TITLE
fix(encryption): Fix encrypted field metrics table_name tag

### DIFF
--- a/src/sentry/db/models/fields/encryption/_base.py
+++ b/src/sentry/db/models/fields/encryption/_base.py
@@ -88,7 +88,7 @@ class EncryptedField(Field):
         removes fields from the class dict and stores them in _meta, so Python's
         __set_name__() is never called for Django model fields.
         """
-        super().contribute_to_class(cls, name, private_only=private_only)  # type: ignore[misc]
+        super().contribute_to_class(cls, name, private_only=private_only)
         self._model_name = cls.__name__
 
     @sentry_sdk.trace

--- a/src/sentry/db/models/fields/encryption/_base.py
+++ b/src/sentry/db/models/fields/encryption/_base.py
@@ -59,6 +59,10 @@ class EncryptedField(Field):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Default to "unknown" - will be overridden by __set_name__ or contribute_to_class
+        # when the field is properly attached to a model
+        self._model_name = "unknown"
+
         self._encryption_handlers: dict[_EncryptionMethod, _EncryptionHandler] = {
             "plaintext": {
                 "marker": MARKER_PLAINTEXT,
@@ -77,9 +81,15 @@ class EncryptedField(Field):
             },
         }
 
-    def __set_name__(self, owner: type, name: str) -> None:
-        super().__set_name__(owner, name)  # type: ignore[misc]
-        self._model_name = owner.__name__
+    def contribute_to_class(self, cls: type, name: str, private_only: bool = False) -> None:
+        """Called by Django's ModelBase metaclass when field is added to a model.
+
+        This is where we capture the model name for metrics. Django's metaclass
+        removes fields from the class dict and stores them in _meta, so Python's
+        __set_name__() is never called for Django model fields.
+        """
+        super().contribute_to_class(cls, name, private_only=private_only)  # type: ignore[misc]
+        self._model_name = cls.__name__
 
     @sentry_sdk.trace
     def _format_encrypted_value(
@@ -124,7 +134,7 @@ class EncryptedField(Field):
         tags = {
             "method": encryption_method,
             "field_type": self.__class__.__name__,
-            "model": getattr(self, "_model_name", "unknown"),
+            "table_name": self._model_name,
         }
 
         try:
@@ -285,7 +295,7 @@ class EncryptedField(Field):
                 tags = {
                     "method": method_name,
                     "field_type": self.__class__.__name__,
-                    "model": getattr(self, "_model_name", "unknown"),
+                    "table_name": self._model_name,
                     "marker": marker,
                 }
 

--- a/tests/sentry/db/models/fields/encryption/test_encrypted_char_field.py
+++ b/tests/sentry/db/models/fields/encryption/test_encrypted_char_field.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.db import connection, models
 from django.test import override_settings
@@ -85,3 +87,70 @@ def test_encrypted_char_field_null_value():
             )
             raw_value = cursor.fetchone()[0]
             assert raw_value is None
+
+
+@pytest.mark.django_db
+def test_encrypted_char_field_metrics_on_encrypt():
+    """Test that encryption sends metrics with correct tags including table_name."""
+    with (
+        override_options({"database.encryption.method": "plaintext"}),
+        patch("sentry.db.models.fields.encryption._base.metrics") as mock_metrics,
+    ):
+        test_data = "test data for metrics"
+        EncryptedFieldModel.objects.create(data=test_data)
+
+        # Verify timer was called
+        mock_metrics.timer.assert_called_once()
+        timer_call = mock_metrics.timer.call_args
+        assert timer_call[0][0] == "database.encrypted_field.encrypt.duration"
+        timer_tags = timer_call[1]["tags"]
+        assert timer_tags["method"] == "plaintext"
+        assert timer_tags["field_type"] == "EncryptedCharField"
+        assert timer_tags["table_name"] == "EncryptedFieldModel"
+
+        # Verify incr was called for success
+        mock_metrics.incr.assert_called_once()
+        incr_call = mock_metrics.incr.call_args
+        assert incr_call[0][0] == "database.encrypted_field.encrypt"
+        incr_tags = incr_call[1]["tags"]
+        assert incr_tags["method"] == "plaintext"
+        assert incr_tags["field_type"] == "EncryptedCharField"
+        assert incr_tags["table_name"] == "EncryptedFieldModel"
+        assert incr_tags["status"] == "success"
+
+
+@pytest.mark.django_db
+def test_encrypted_char_field_metrics_on_decrypt(fernet_keys_store):
+    """Test that decryption sends metrics with correct tags including table_name."""
+    key_id, _fernet_key = fernet_keys_store
+
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        test_data = "test data for decrypt metrics"
+        model_instance = EncryptedFieldModel.objects.create(data=test_data)
+
+    # Now retrieve with metrics mocked
+    with patch("sentry.db.models.fields.encryption._base.metrics") as mock_metrics:
+        EncryptedFieldModel.objects.get(id=model_instance.id)
+
+        # Verify timer was called for decrypt
+        mock_metrics.timer.assert_called_once()
+        timer_call = mock_metrics.timer.call_args
+        assert timer_call[0][0] == "database.encrypted_field.decrypt.duration"
+        timer_tags = timer_call[1]["tags"]
+        assert timer_tags["method"] == "fernet"
+        assert timer_tags["field_type"] == "EncryptedCharField"
+        assert timer_tags["table_name"] == "EncryptedFieldModel"
+        assert timer_tags["marker"] == MARKER_FERNET
+
+        # Verify incr was called for success
+        mock_metrics.incr.assert_called_once()
+        incr_call = mock_metrics.incr.call_args
+        assert incr_call[0][0] == "database.encrypted_field.decrypt"
+        incr_tags = incr_call[1]["tags"]
+        assert incr_tags["method"] == "fernet"
+        assert incr_tags["field_type"] == "EncryptedCharField"
+        assert incr_tags["table_name"] == "EncryptedFieldModel"
+        assert incr_tags["status"] == "success"


### PR DESCRIPTION
Fix encrypted field metrics to properly send the table name in metric tags.

The original code implemented `__set_name__()` to capture the model name, expecting Python's descriptor protocol to call it. However, Django's `ModelBase` metaclass removes fields from the class dict and stores them in `_meta` before Python can call `__set_name__()`. Django uses `contribute_to_class()` instead, which the encrypted field wasn't implementing.
