### PR TITLE
feat(dynamic-sampling): add span metric support for sliding_window_org task

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from sentry import options
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import (
     GetActiveOrgsVolumes,
@@ -20,6 +21,23 @@ from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.taskworker.retry import Retry
 
 
+def _partition_orgs_by_span_metric_option(
+    org_ids: list[int],
+) -> tuple[list[int], list[int]]:
+    """
+    Partitions organization IDs based on the span metric option.
+
+    Returns:
+        A tuple of (span_metric_orgs, transaction_metric_orgs)
+    """
+    span_metric_org_ids = set(
+        options.get("dynamic-sampling.sliding_window_org.span-metric-orgs") or []
+    )
+    span_orgs = [org_id for org_id in org_ids if org_id in span_metric_org_ids]
+    transaction_orgs = [org_id for org_id in org_ids if org_id not in span_metric_org_ids]
+    return span_orgs, transaction_orgs
+
+
 @instrumented_task(
     name="sentry.dynamic_sampling.tasks.sliding_window_org",
     namespace=telemetry_experience_tasks,
@@ -32,23 +50,45 @@ def sliding_window_org() -> None:
     window_size = get_sliding_window_size()
     # In case the size is None it means that we disabled the sliding window entirely.
     if window_size is not None:
-        orgs_volumes_iterator = GetActiveOrgsVolumes(
-            max_orgs=CHUNK_SIZE,
-            time_interval=timedelta(hours=window_size),
-            include_keep=False,
-        )
-
-        for orgs_volume in orgs_volumes_iterator:
-            for org_volume in orgs_volume:
-                adjust_base_sample_rate_of_org(
-                    org_id=org_volume.org_id,
-                    total_root_count=org_volume.total,
-                    window_size=window_size,
-                )
+        # Process orgs using transaction metrics (default)
+        _process_orgs_volumes(window_size, use_span_metric=False)
+        # Process orgs using span metrics (opted-in via option)
+        _process_orgs_volumes(window_size, use_span_metric=True)
 
         # Due to the synchronous nature of the sliding window org, when we arrived here, we can confidently say
         # that the execution of the sliding window org was successful. We will keep this state for 1 hour.
         mark_sliding_window_org_executed()
+
+
+def _process_orgs_volumes(window_size: int, use_span_metric: bool) -> None:
+    """
+    Process organization volumes for sliding window calculation.
+
+    Args:
+        window_size: The size of the sliding window in hours.
+        use_span_metric: Whether to use span metrics instead of transaction metrics.
+    """
+    orgs_volumes_iterator = GetActiveOrgsVolumes(
+        max_orgs=CHUNK_SIZE,
+        time_interval=timedelta(hours=window_size),
+        include_keep=False,
+        use_span_metric=use_span_metric,
+    )
+
+    for orgs_volume in orgs_volumes_iterator:
+        # Filter to only orgs that match the metric type based on option
+        org_ids = [v.org_id for v in orgs_volume]
+        span_orgs, transaction_orgs = _partition_orgs_by_span_metric_option(org_ids)
+        target_orgs = set(span_orgs if use_span_metric else transaction_orgs)
+
+        for org_volume in orgs_volume:
+            if org_volume.org_id not in target_orgs:
+                continue
+            adjust_base_sample_rate_of_org(
+                org_id=org_volume.org_id,
+                total_root_count=org_volume.total,
+                window_size=window_size,
+            )
 
 
 def adjust_base_sample_rate_of_org(org_id: int, total_root_count: int, window_size: int) -> None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2276,6 +2276,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# List of organization IDs that should be using span metrics for sliding_window_org.
+register(
+    "dynamic-sampling.sliding_window_org.span-metric-orgs",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # === Hybrid cloud subsystem options ===
 # UI rollout


### PR DESCRIPTION
Add support for querying span metrics in sliding_window_org task by:
- Adding new option 'dynamic-sampling.sliding_window_org.span-metric-orgs' to control which organizations use span metrics
- Adding partition function to split orgs by the option
- Processing orgs in two passes: one with transaction metrics, one with span metrics
- Adding use_span_metric parameter to GetActiveOrgsVolumes for is_segment filtering

Organizations in the span-metric-orgs option will have their sliding window sample rates calculated using span metrics with is_segment=true filter, while others use transaction metrics.

Closes TET-1681