### PR TITLE
feat(ai-conversations): add user avatar to table and reorder nav

### DIFF
--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -29,8 +29,6 @@ import {
   type Conversation,
   type ConversationUser,
 } from 'sentry/views/insights/pages/conversations/hooks/useConversations';
-import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
-import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 
 export function ConversationsTable() {
   const organization = useOrganization();
@@ -47,21 +45,13 @@ const EMPTY_ARRAY: never[] = [];
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'conversationId', name: t('Conversation ID'), width: 0},
   {key: 'inputOutput', name: t('First Input / Last Output'), width: COL_WIDTH_UNDEFINED},
-  // {key: 'duration', name: t('Duration'), width: 130},
   {key: 'user', name: t('User'), width: 120},
-  // {key: 'llmCalls', name: t('LLM Calls'), width: 110},
   {key: 'llmToolCalls', name: t('LLM/Tool Calls'), width: 140},
   {key: 'tokensAndCost', name: t('Total Tokens / Cost'), width: 170},
   {key: 'timestamp', name: t('Last Message'), width: 120},
 ];
 
-const rightAlignColumns = new Set([
-  'llmCalls',
-  'toolCalls',
-  'tokensAndCost',
-  'timestamp',
-  'duration',
-]);
+const rightAlignColumns = new Set(['llmToolCalls', 'tokensAndCost', 'timestamp']);
 
 function ConversationsTableInner() {
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
@@ -230,11 +220,6 @@ const BodyCell = memo(function BodyCell({
         </InputOutputButton>
       );
     }
-    case 'duration':
-      return <DurationCell milliseconds={dataRow.duration} />;
-    case 'llmCalls':
-    case 'toolCalls':
-      return <NumberCell value={dataRow[column.key]} />;
     case 'llmToolCalls':
       return (
         <TextAlignRight>

--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -229,7 +229,7 @@ const BodyCell = memo(function BodyCell({
     case 'tokensAndCost':
       return (
         <TextAlignRight>
-          <Count value={dataRow.totalTokens} /> / <LLMCosts cost={dataRow.toolCalls} />
+          <Count value={dataRow.totalTokens} /> / <LLMCosts cost={dataRow.totalCost} />
         </TextAlignRight>
       );
     case 'timestamp':

--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -5,6 +5,7 @@ import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
 import Count from 'sentry/components/count';
@@ -44,13 +45,13 @@ export function ConversationsTable() {
 const EMPTY_ARRAY: never[] = [];
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: 'conversationId', name: t('Conversation ID'), width: 140},
+  {key: 'conversationId', name: t('Conversation ID'), width: 0},
   {key: 'inputOutput', name: t('First Input / Last Output'), width: COL_WIDTH_UNDEFINED},
-  {key: 'duration', name: t('Duration'), width: 130},
-  {key: 'llmCalls', name: t('LLM Calls'), width: 110},
-  {key: 'toolCalls', name: t('Tool Calls'), width: 110},
-  {key: 'tokensAndCost', name: t('Total Tokens / Cost'), width: 170},
+  // {key: 'duration', name: t('Duration'), width: 130},
   {key: 'user', name: t('User'), width: 120},
+  // {key: 'llmCalls', name: t('LLM Calls'), width: 110},
+  {key: 'llmToolCalls', name: t('LLM/Tool Calls'), width: 140},
+  {key: 'tokensAndCost', name: t('Total Tokens / Cost'), width: 170},
   {key: 'timestamp', name: t('Last Message'), width: 120},
 ];
 
@@ -157,7 +158,17 @@ const BodyCell = memo(function BodyCell({
         );
       }
       return (
-        <Flex align="center">
+        <Flex align="center" gap="sm">
+          <UserAvatar
+            user={{
+              id: dataRow.user.id ?? '',
+              name: getUserDisplayName(dataRow.user),
+              email: dataRow.user.email ?? '',
+              username: dataRow.user.username ?? '',
+              ip_address: dataRow.user.ip_address ?? '',
+            }}
+            size={20}
+          />
           <Tooltip title={getUserDisplayName(dataRow.user)} showOnlyOnOverflow>
             <Text ellipsis>{getUserDisplayName(dataRow.user)}</Text>
           </Tooltip>
@@ -224,10 +235,16 @@ const BodyCell = memo(function BodyCell({
     case 'llmCalls':
     case 'toolCalls':
       return <NumberCell value={dataRow[column.key]} />;
+    case 'llmToolCalls':
+      return (
+        <TextAlignRight>
+          <Count value={dataRow.llmCalls} /> / <Count value={dataRow.toolCalls} />
+        </TextAlignRight>
+      );
     case 'tokensAndCost':
       return (
         <TextAlignRight>
-          <Count value={dataRow.totalTokens} /> / <LLMCosts cost={dataRow.totalCost} />
+          <Count value={dataRow.totalTokens} /> / <LLMCosts cost={dataRow.toolCalls} />
         </TextAlignRight>
       );
     case 'timestamp':

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -83,6 +83,14 @@ export function InsightsSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section id="insights-ai" title={t('AI')}>
+          <Feature features="gen-ai-conversations">
+            <SecondaryNav.Item
+              to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
+              analyticsItemName="insights_conversations"
+            >
+              {CONVERSATIONS_SIDEBAR_LABEL}
+            </SecondaryNav.Item>
+          </Feature>
           <SecondaryNav.Item
             to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
             analyticsItemName="insights_agents"
@@ -95,14 +103,6 @@ export function InsightsSecondaryNav() {
           >
             {MCP_SIDEBAR_LABEL}
           </SecondaryNav.Item>
-          <Feature features="gen-ai-conversations">
-            <SecondaryNav.Item
-              to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
-              analyticsItemName="insights_conversations"
-            >
-              {CONVERSATIONS_SIDEBAR_LABEL}
-            </SecondaryNav.Item>
-          </Feature>
         </SecondaryNav.Section>
         <SecondaryNav.Section id="insights-monitors">
           <SecondaryNav.Item


### PR DESCRIPTION
closes [TET-1800: Remove conversation duration in favor of existing fields](https://linear.app/getsentry/issue/TET-1800/remove-conversation-duration-in-favor-of-existing-fields)

<img width="1710" height="995" alt="CleanShot 2026-01-26 at 14 29 56" src="https://github.com/user-attachments/assets/fece603e-51d7-4854-ae84-bdbf4f066845" />
