### PR TITLE
feat(dashboards): Add cell actions getter function

### DIFF
--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -289,17 +289,17 @@ describe('TableWidgetVisualization', () => {
       await screen.findByText('Add to filter');
     });
 
-    it('Calls getAllowedCellActions with correct cellInfo', () => {
-      const getAllowedCellActions = jest.fn(() => [Actions.ADD]);
+    it('Calls allowedCellActions with correct cellInfo', () => {
+      const allowedCellActions = jest.fn(() => [Actions.ADD]);
 
       render(
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          getAllowedCellActions={getAllowedCellActions}
+          allowedCellActions={allowedCellActions}
         />
       );
 
-      expect(getAllowedCellActions).toHaveBeenCalledWith(
+      expect(allowedCellActions).toHaveBeenCalledWith(
         expect.objectContaining({
           column: expect.objectContaining({key: 'http.request_method'}),
           dataRow: expect.objectContaining(sampleHTTPRequestTableData.data[0]!),
@@ -309,15 +309,15 @@ describe('TableWidgetVisualization', () => {
       );
     });
 
-    it('Renders per-cell actions from getAllowedCellActions', async () => {
-      const getAllowedCellActions = jest.fn(({column}: {column: TabularColumn}) =>
+    it('Renders per-cell actions from allowedCellActions', async () => {
+      const allowedCellActions = jest.fn(({column}: {column: TabularColumn}) =>
         column.type === 'integer' ? [Actions.SHOW_GREATER_THAN] : [Actions.ADD]
       );
 
       render(
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          getAllowedCellActions={getAllowedCellActions}
+          allowedCellActions={allowedCellActions}
         />
       );
 

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -3,7 +3,13 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TabularColumnsFixture} from 'sentry-fixture/tabularColumns';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {IconArrow} from 'sentry/icons';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
@@ -281,6 +287,51 @@ describe('TableWidgetVisualization', () => {
       const $cell = screen.getAllByRole('button')[0]!;
       await userEvent.click($cell);
       await screen.findByText('Add to filter');
+    });
+
+    it('Calls getAllowedCellActions with correct cellInfo', () => {
+      const getAllowedCellActions = jest.fn(() => [Actions.ADD]);
+
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          getAllowedCellActions={getAllowedCellActions}
+        />
+      );
+
+      expect(getAllowedCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          column: expect.objectContaining({key: 'http.request_method'}),
+          dataRow: expect.objectContaining(sampleHTTPRequestTableData.data[0]!),
+          columnIndex: 0,
+          rowIndex: 0,
+        })
+      );
+    });
+
+    it('Renders per-cell actions from getAllowedCellActions', async () => {
+      const getAllowedCellActions = jest.fn(({column}: {column: TabularColumn}) =>
+        column.type === 'integer' ? [Actions.SHOW_GREATER_THAN] : [Actions.ADD]
+      );
+
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          getAllowedCellActions={getAllowedCellActions}
+        />
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const stringCellTrigger = within(cells[0]!).getByRole('button');
+      await userEvent.click(stringCellTrigger);
+      expect(await screen.findByText('Add to filter')).toBeInTheDocument();
+      expect(screen.queryByText('Show values greater than')).not.toBeInTheDocument();
+      await userEvent.keyboard('{Escape}');
+
+      const numberCellTrigger = within(cells[1]!).getByRole('button');
+      await userEvent.click(numberCellTrigger);
+      expect(await screen.findByText('Show values greater than')).toBeInTheDocument();
+      expect(screen.queryByText('Add to filter')).not.toBeInTheDocument();
     });
 
     it('Uses onTriggerCellAction if supplied on action click', async () => {

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -391,6 +391,32 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
 }
         `}
         </CodeBlock>
+        <p>
+          To customize actions per cell, use <code>getAllowedCellActions</code>. This
+          overrides <code>allowedCellActions</code> and receives the full cell info,
+          including the column type.
+        </p>
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          getAllowedCellActions={cellInfo => {
+            if (cellInfo.column.type === 'integer') {
+              return [Actions.SHOW_GREATER_THAN, Actions.SHOW_LESS_THAN];
+            }
+
+            return [Actions.ADD, Actions.EXCLUDE];
+          }}
+        />
+        <CodeBlock language="tsx">
+          {`
+function getAllowedCellActions(cellInfo: {column: TabularColumn}) {
+  if (cellInfo.column.type === 'integer') {
+    return [Actions.SHOW_GREATER_THAN, Actions.SHOW_LESS_THAN];
+  }
+
+  return [Actions.ADD, Actions.EXCLUDE];
+}
+          `}
+        </CodeBlock>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -394,6 +394,8 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
         <p>
           To customize actions per cell, use <code>allowedCellActions</code> as a
           function. This function receives the full cell info, including the column type.
+          There are also default actions defined in <code>ALLOWED_CELL_ACTIONS</code>,
+          it's recommended to use them as a base.
         </p>
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -392,13 +392,12 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
         `}
         </CodeBlock>
         <p>
-          To customize actions per cell, use <code>getAllowedCellActions</code>. This
-          overrides <code>allowedCellActions</code> and receives the full cell info,
-          including the column type.
+          To customize actions per cell, use <code>allowedCellActions</code> as a
+          function. This function receives the full cell info, including the column type.
         </p>
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          getAllowedCellActions={cellInfo => {
+          allowedCellActions={cellInfo => {
             if (cellInfo.column.type === 'integer') {
               return [Actions.SHOW_GREATER_THAN, Actions.SHOW_LESS_THAN];
             }
@@ -408,13 +407,16 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
         />
         <CodeBlock language="tsx">
           {`
-function getAllowedCellActions(cellInfo: {column: TabularColumn}) {
-  if (cellInfo.column.type === 'integer') {
-    return [Actions.SHOW_GREATER_THAN, Actions.SHOW_LESS_THAN];
-  }
+<TableWidgetVisualization
+  tableData={sampleHTTPRequestTableData}
+  allowedCellActions={cellInfo => {
+    if (cellInfo.column.type === 'integer') {
+      return [Actions.SHOW_GREATER_THAN, Actions.SHOW_LESS_THAN];
+    }
 
-  return [Actions.ADD, Actions.EXCLUDE];
-}
+    return [Actions.ADD, Actions.EXCLUDE];
+  }}
+/>
           `}
         </CodeBlock>
       </Fragment>

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -70,7 +70,7 @@ interface TableWidgetVisualizationProps {
   /**
    * The cell actions that may appear when a user clicks on a table cell. By default, copying text and opening external links are enabled.
    */
-  allowedCellActions?: Actions[];
+  allowedCellActions?: Actions[] | GetAllowedCellActionsFn;
   /**
    * If supplied, will override the ordering of columns from `tableData`. Can also be used to
    * supply custom display names for columns, column widths and column data type
@@ -85,10 +85,6 @@ interface TableWidgetVisualizationProps {
    * If true, removes the borders of the sides and bottom of the table
    */
   frameless?: boolean;
-  /**
-   * If provided, returns a list of cell actions per cell. This overrides `allowedCellActions`. The function receives the full cell info, including the column type.
-   */
-  getAllowedCellActions?: GetAllowedCellActionsFn;
   /**
    * A function that returns a field renderer that can be used to render that field given the data and meta. A field renderer is a function that accepts a data row, and a baggage object, and returns a React node or `undefined`, and can be rendered as a table cell.
    * @param fieldName The name of the field to render
@@ -163,7 +159,6 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     resizable = true,
     onTriggerCellAction,
     allowedCellActions = ALLOWED_CELL_ACTIONS,
-    getAllowedCellActions,
   } = props;
 
   const theme = useTheme();
@@ -284,14 +279,15 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
           const cell = valueRenderer(dataRow, baggage);
 
           const column = columnOrder[columnIndex]!;
-          const cellAllowedActions = getAllowedCellActions
-            ? getAllowedCellActions({
-                column,
-                dataRow,
-                columnIndex,
-                rowIndex,
-              })
-            : allowedCellActions;
+          const cellAllowedActions =
+            typeof allowedCellActions === 'function'
+              ? allowedCellActions({
+                  column,
+                  dataRow,
+                  columnIndex,
+                  rowIndex,
+                })
+              : allowedCellActions;
           const formattedColumn = {
             key: column.key,
             name: column.key,

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -51,6 +51,13 @@ type BaggageMaker = (
   meta: TabularMeta
 ) => RenderFunctionBaggage;
 
+type GetAllowedCellActionsFn = (cellInfo: {
+  column: TabularColumn;
+  columnIndex: number;
+  dataRow: TabularRow;
+  rowIndex: number;
+}) => Actions[];
+
 interface TableWidgetVisualizationProps {
   /**
    * The object that contains all the data needed to render the table
@@ -78,6 +85,10 @@ interface TableWidgetVisualizationProps {
    * If true, removes the borders of the sides and bottom of the table
    */
   frameless?: boolean;
+  /**
+   * If provided, returns a list of cell actions per cell. This overrides `allowedCellActions`. The function receives the full cell info, including the column type.
+   */
+  getAllowedCellActions?: GetAllowedCellActionsFn;
   /**
    * A function that returns a field renderer that can be used to render that field given the data and meta. A field renderer is a function that accepts a data row, and a baggage object, and returns a React node or `undefined`, and can be rendered as a table cell.
    * @param fieldName The name of the field to render
@@ -152,6 +163,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     resizable = true,
     onTriggerCellAction,
     allowedCellActions = ALLOWED_CELL_ACTIONS,
+    getAllowedCellActions,
   } = props;
 
   const theme = useTheme();
@@ -272,6 +284,14 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
           const cell = valueRenderer(dataRow, baggage);
 
           const column = columnOrder[columnIndex]!;
+          const cellAllowedActions = getAllowedCellActions
+            ? getAllowedCellActions({
+                column,
+                dataRow,
+                columnIndex,
+                rowIndex,
+              })
+            : allowedCellActions;
           const formattedColumn = {
             key: column.key,
             name: column.key,
@@ -298,7 +318,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
                     break;
                 }
               }}
-              allowActions={allowedCellActions}
+              allowActions={cellAllowedActions}
             >
               {cell}
             </CellAction>


### PR DESCRIPTION
This PR extends the `TableWidgetVisualization` component by expanding the `allowedCellActions` prop. This prop now a function to be passed enabling finer grain control over which actions a cell has, that can be determined from the following info: `column`, `columnIndex`, `dataRow`, and `rowIndex`.

Ticket: DAIN-1170