### PR TITLE
feat(preprod): Add support for Apple insight types on Compare

### DIFF
--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 from sentry.preprod.size_analysis.insight_models import (
@@ -31,6 +32,7 @@ from sentry.preprod.size_analysis.insight_models import (
 
 
 class AndroidInsightResults(BaseModel):
+    platform: Literal["android"] = "android"
     duplicate_files: DuplicateFilesInsightResult | None = None
     webp_optimization: WebPOptimizationInsightResult | None = None
     large_images: LargeImageFileInsightResult | None = None
@@ -41,6 +43,7 @@ class AndroidInsightResults(BaseModel):
 
 
 class AppleInsightResults(BaseModel):
+    platform: Literal["apple"] = "apple"
     duplicate_files: DuplicateFilesInsightResult | None = None
     large_images: LargeImageFileInsightResult | None = None
     large_audios: LargeAudioFileInsightResult | None = None
@@ -134,7 +137,10 @@ class SizeAnalysisResults(BaseModel):
     download_size: int
     install_size: int
     treemap: TreemapResults | None = None
-    insights: AndroidInsightResults | AppleInsightResults | None = None
+    insights: (
+        Annotated[AndroidInsightResults | AppleInsightResults, Field(discriminator="platform")]
+        | None
+    ) = None
     analysis_version: str | None = None
     file_analysis: FileAnalysis | None = None
     app_components: list[AppComponent] | None = None

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -33,6 +33,7 @@ const FILE_DIFF_INSIGHT_TYPES = [
   'multiple_native_library_archs',
   'video_compression',
   'image_optimization',
+  'strip_binary',
 ];
 
 const GROUP_DIFF_INSIGHT_TYPES = ['duplicate_files', 'loose_images'];

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -7,7 +7,11 @@ from sentry.preprod.size_analysis.insight_models import (
     DuplicateFilesInsightResult,
     FileSavingsResult,
     FileSavingsResultGroup,
+    ImageOptimizationInsightResult,
     LargeImageFileInsightResult,
+    OptimizableImageFile,
+    StripBinaryFileInfo,
+    StripBinaryInsightResult,
     WebPOptimizationInsightResult,
 )
 from sentry.preprod.size_analysis.models import (
@@ -1306,13 +1310,17 @@ class CompareInsightsTest(TestCase):
         insights: AndroidInsightResults | AppleInsightResults | None = None,
         analysis_version="1.0.0",
     ):
-        return SizeAnalysisResults(
+        # Use construct() to bypass Pydantic union coercion which would
+        # otherwise convert AppleInsightResults to AndroidInsightResults
+        return SizeAnalysisResults.construct(
             analysis_duration=1.0,
             download_size=500,
             install_size=1000,
             treemap=None,
             insights=insights,
             analysis_version=analysis_version,
+            file_analysis=None,
+            app_components=None,
         )
 
     def test_compare_insights_new_insight_in_head(self):
@@ -2100,3 +2108,233 @@ class CompareInsightsTest(TestCase):
 
         # No insight diff items should be returned
         assert len(result.insight_diff_items) == 0
+
+    def test_compare_insights_image_optimization_with_diffs(self):
+        """Test ImageOptimizationInsightResult with file-level differences."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1000,
+            max_download_size=500,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1000,
+            max_download_size=500,
+        )
+
+        # Head: icon.png (increased), banner.png (new)
+        # Base: icon.png (original), logo.png (removed)
+        head_insights = AppleInsightResults(
+            duplicate_files=None,
+            large_images=None,
+            large_audios=None,
+            large_videos=None,
+            strip_binary=None,
+            localized_strings_minify=None,
+            small_files=None,
+            loose_images=None,
+            hermes_debug_info=None,
+            image_optimization=ImageOptimizationInsightResult(
+                total_savings=6000,
+                optimizable_files=[
+                    OptimizableImageFile(
+                        file_path="/path/icon.png",
+                        current_size=10000,
+                        minify_savings=3000,
+                        conversion_savings=4000,
+                    ),
+                    OptimizableImageFile(
+                        file_path="/path/banner.png",
+                        current_size=5000,
+                        minify_savings=2000,
+                        conversion_savings=1000,
+                    ),
+                ],
+            ),
+            main_binary_exported_symbols=None,
+            unnecessary_files=None,
+            audio_compression=None,
+            video_compression=None,
+            alternate_icons_optimization=None,
+        )
+        base_insights = AppleInsightResults(
+            duplicate_files=None,
+            large_images=None,
+            large_audios=None,
+            large_videos=None,
+            strip_binary=None,
+            localized_strings_minify=None,
+            small_files=None,
+            loose_images=None,
+            hermes_debug_info=None,
+            image_optimization=ImageOptimizationInsightResult(
+                total_savings=5000,
+                optimizable_files=[
+                    OptimizableImageFile(
+                        file_path="/path/icon.png",
+                        current_size=10000,
+                        minify_savings=2000,
+                        conversion_savings=2000,
+                    ),
+                    OptimizableImageFile(
+                        file_path="/path/logo.png",
+                        current_size=6000,
+                        minify_savings=1000,
+                        conversion_savings=3000,
+                    ),
+                ],
+            ),
+            main_binary_exported_symbols=None,
+            unnecessary_files=None,
+            audio_compression=None,
+            video_compression=None,
+            alternate_icons_optimization=None,
+        )
+
+        head_results = self._create_size_analysis_results(insights=head_insights)
+        base_results = self._create_size_analysis_results(insights=base_insights)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.insight_diff_items) == 1
+        insight_diff = result.insight_diff_items[0]
+        assert insight_diff.insight_type == "image_optimization"
+        assert insight_diff.status == "unresolved"
+        assert insight_diff.total_savings_change == 1000
+
+        # Should have 3 file diffs: icon.png increased, banner.png added, logo.png removed
+        assert len(insight_diff.file_diffs) == 3
+        file_diffs_by_path = {d.path: d for d in insight_diff.file_diffs}
+
+        # icon.png - increased (potential_savings: 2000 -> 4000)
+        assert file_diffs_by_path["/path/icon.png"].type.value == "increased"
+        assert file_diffs_by_path["/path/icon.png"].size_diff == 2000
+
+        # banner.png - added (potential_savings: 2000)
+        assert file_diffs_by_path["/path/banner.png"].type.value == "added"
+        assert file_diffs_by_path["/path/banner.png"].size_diff == 2000
+
+        # logo.png - removed (potential_savings: 3000)
+        assert file_diffs_by_path["/path/logo.png"].type.value == "removed"
+        assert file_diffs_by_path["/path/logo.png"].size_diff == -3000
+
+    def test_compare_insights_strip_binary_with_diffs(self):
+        """Test StripBinaryInsightResult with file-level differences."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1000,
+            max_download_size=500,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1000,
+            max_download_size=500,
+        )
+
+        # Head: MyApp (increased), NewFramework (added)
+        # Base: MyApp (original), OldFramework (removed)
+        head_insights = AppleInsightResults(
+            duplicate_files=None,
+            large_images=None,
+            large_audios=None,
+            large_videos=None,
+            strip_binary=StripBinaryInsightResult(
+                total_savings=18000,
+                files=[
+                    StripBinaryFileInfo(
+                        file_path="/path/MyApp",
+                        debug_sections_savings=8000,
+                        symbol_table_savings=4000,
+                        total_savings=12000,
+                    ),
+                    StripBinaryFileInfo(
+                        file_path="/path/NewFramework",
+                        debug_sections_savings=4000,
+                        symbol_table_savings=2000,
+                        total_savings=6000,
+                    ),
+                ],
+                total_debug_sections_savings=12000,
+                total_symbol_table_savings=6000,
+            ),
+            localized_strings_minify=None,
+            small_files=None,
+            loose_images=None,
+            hermes_debug_info=None,
+            image_optimization=None,
+            main_binary_exported_symbols=None,
+            unnecessary_files=None,
+            audio_compression=None,
+            video_compression=None,
+            alternate_icons_optimization=None,
+        )
+        base_insights = AppleInsightResults(
+            duplicate_files=None,
+            large_images=None,
+            large_audios=None,
+            large_videos=None,
+            strip_binary=StripBinaryInsightResult(
+                total_savings=15000,
+                files=[
+                    StripBinaryFileInfo(
+                        file_path="/path/MyApp",
+                        debug_sections_savings=6000,
+                        symbol_table_savings=4000,
+                        total_savings=10000,
+                    ),
+                    StripBinaryFileInfo(
+                        file_path="/path/OldFramework",
+                        debug_sections_savings=3000,
+                        symbol_table_savings=2000,
+                        total_savings=5000,
+                    ),
+                ],
+                total_debug_sections_savings=9000,
+                total_symbol_table_savings=6000,
+            ),
+            localized_strings_minify=None,
+            small_files=None,
+            loose_images=None,
+            hermes_debug_info=None,
+            image_optimization=None,
+            main_binary_exported_symbols=None,
+            unnecessary_files=None,
+            audio_compression=None,
+            video_compression=None,
+            alternate_icons_optimization=None,
+        )
+
+        head_results = self._create_size_analysis_results(insights=head_insights)
+        base_results = self._create_size_analysis_results(insights=base_insights)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.insight_diff_items) == 1
+        insight_diff = result.insight_diff_items[0]
+        assert insight_diff.insight_type == "strip_binary"
+        assert insight_diff.status == "unresolved"
+        assert insight_diff.total_savings_change == 3000
+
+        # Should have 3 file diffs: MyApp increased, NewFramework added, OldFramework removed
+        assert len(insight_diff.file_diffs) == 3
+        file_diffs_by_path = {d.path: d for d in insight_diff.file_diffs}
+
+        # MyApp - increased (10000 -> 12000)
+        assert file_diffs_by_path["/path/MyApp"].type.value == "increased"
+        assert file_diffs_by_path["/path/MyApp"].size_diff == 2000
+
+        # NewFramework - added (6000)
+        assert file_diffs_by_path["/path/NewFramework"].type.value == "added"
+        assert file_diffs_by_path["/path/NewFramework"].size_diff == 6000
+
+        # OldFramework - removed (5000)
+        assert file_diffs_by_path["/path/OldFramework"].type.value == "removed"
+        assert file_diffs_by_path["/path/OldFramework"].size_diff == -5000

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -787,6 +787,7 @@ class RunSizeAnalysisComparisonTest(TestCase):
             "download_size": 1000,
             "install_size": 2000,
             "insights": {
+                "platform": "apple",
                 "image_optimization": {
                     "total_savings": 1200,
                     "optimizable_files": [

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -780,6 +780,73 @@ class RunSizeAnalysisComparisonTest(TestCase):
         assert "diff_items" in file_content
         assert "size_metric_diff_item" in file_content
 
+    def test_run_size_analysis_comparison_preserves_apple_insights(self):
+        """Test _run_size_analysis_comparison with Apple-only insights."""
+        head_analysis_data = {
+            "analysis_duration": 0.5,
+            "download_size": 1000,
+            "install_size": 2000,
+            "insights": {
+                "image_optimization": {
+                    "total_savings": 1200,
+                    "optimizable_files": [
+                        {
+                            "file_path": "Assets/foo.png",
+                            "current_size": 2000,
+                            "minify_savings": 1200,
+                            "minified_size": 800,
+                            "conversion_savings": 0,
+                            "heic_size": None,
+                        }
+                    ],
+                },
+                "strip_binary": {
+                    "total_savings": 500,
+                    "files": [
+                        {
+                            "file_path": "HackerNews",
+                            "debug_sections_savings": 300,
+                            "symbol_table_savings": 200,
+                            "total_savings": 500,
+                        }
+                    ],
+                    "total_debug_sections_savings": 300,
+                    "total_symbol_table_savings": 200,
+                },
+            },
+        }
+        base_analysis_data = {
+            "analysis_duration": 0.4,
+            "download_size": 800,
+            "install_size": 1500,
+        }
+
+        head_size_metrics = self._create_size_metrics_with_analysis_file(head_analysis_data)
+        base_size_metrics = self._create_size_metrics_with_analysis_file(base_analysis_data)
+
+        self.create_preprod_artifact_size_comparison(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+            organization=self.organization,
+            state=PreprodArtifactSizeComparison.State.PENDING,
+        )
+
+        _run_size_analysis_comparison(
+            self.organization.id,
+            head_size_metrics,
+            base_size_metrics,
+        )
+
+        comparison = PreprodArtifactSizeComparison.objects.get(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        comparison_file = File.objects.get(id=comparison.file_id)
+        file_content = json.loads(comparison_file.getfile().read().decode())
+        insight_types = [item["insight_type"] for item in file_content["insight_diff_items"]]
+        assert "image_optimization" in insight_types
+        assert "strip_binary" in insight_types
+
     def test_run_size_analysis_comparison_existing_comparison_processing(self):
         """Test _run_size_analysis_comparison with existing processing comparison."""
         # Create size metrics


### PR DESCRIPTION
Add comparison support for insights:

- `ImageOptimizationInsightResult`
- `StripBinaryInsightResult`

Fixes bug that prevented `LocalizedStringInsightResult` results from showing.

These Apple-specific insights now display file-level diffs on the Compare page, showing which optimizable images or strippable binaries were added, removed, or changed between builds.

**Changes:**
- Add `_compare_optimizable_images` and `_compare_strip_binary_files` functions to handle the different file structures of these insight types
- Update `_compare_insights` to route these insight types to their specialized comparison functions
- Add `platform` discriminator field to `AndroidInsightResults` and `AppleInsightResults` to fix union type parsing - without this, Pydantic uses left-to-right validation order which caused iOS insights to be incorrectly parsed as `AndroidInsightResults`, silently dropping iOS-specific fields like `strip_binary` and `image_optimization`
- Add `image_optimization` to the frontend insight type union

Requires: https://github.com/getsentry/launchpad/pull/544

## Backwards Compatibility

These changes are backwards compatible with existing cached comparison results. When the `platform` discriminator field is missing from cached data (generated before the launchpad service changes), Pydantic falls back to the default value on each model. Since both `AndroidInsightResults` and `AppleInsightResults` have defaults for their `platform` field, Pydantic reverts to left-to-right union validation - preserving the existing (buggy) behavior where iOS results map to `AndroidInsightResults`.

This means iOS-only insights (`image_optimization`, `strip_binary`, 'minify_localized_strings`) will only appear for new comparisons processed after https://github.com/getsentry/launchpad/pull/544 is deployed.

## Before

<img width="917" height="683" alt="Screenshot 2026-01-26 at 15 06 28" src="https://github.com/user-attachments/assets/69d680d8-0b6a-4d61-a059-8e0bfbc57252" />

## After 

<img width="895" height="801" alt="Screenshot 2026-01-26 at 15 06 40" src="https://github.com/user-attachments/assets/9f7a2f89-0327-42e7-9ca5-d36a58db7b12" />

Refs EME-678