### PR TITLE
feat(preprod): Generate orgless URLs on customer domains

### DIFF
--- a/static/app/views/preprod/utils/buildLinkUtils.spec.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.spec.ts
@@ -1,3 +1,5 @@
+import ConfigStore from 'sentry/stores/configStore';
+
 import {
   getBaseBuildPath,
   getCompareBuildPath,
@@ -6,12 +8,24 @@ import {
   getSizeBuildPath,
 } from './buildLinkUtils';
 
-describe('buildLinkUtils', () => {
+describe('buildLinkUtils with customer domain', () => {
   const params = {
     organizationSlug: 'test-org',
     projectId: 'test-project',
     baseArtifactId: 'artifact-123',
   };
+
+  beforeEach(() => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'test-org',
+      organizationUrl: 'https://test-org.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
+  });
+
+  afterEach(() => {
+    ConfigStore.set('customerDomain', null);
+  });
 
   describe('getSizeBuildPath', () => {
     it('returns undefined when baseArtifactId is not provided', () => {
@@ -23,7 +37,110 @@ describe('buildLinkUtils', () => {
       ).toBeUndefined();
     });
 
-    it('generates correct size build path with new URL format', () => {
+    it('generates orgless path for size view', () => {
+      expect(getSizeBuildPath(params)).toBe(
+        '/preprod/size/artifact-123/?project=test-project'
+      );
+    });
+  });
+
+  describe('getInstallBuildPath', () => {
+    it('returns undefined when baseArtifactId is not provided', () => {
+      expect(
+        getInstallBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+        })
+      ).toBeUndefined();
+    });
+
+    it('generates orgless path for install view', () => {
+      expect(getInstallBuildPath(params)).toBe(
+        '/preprod/install/artifact-123/?project=test-project'
+      );
+    });
+  });
+
+  describe('getCompareBuildPath', () => {
+    it('generates orgless path for comparison without base artifact', () => {
+      expect(
+        getCompareBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+          headArtifactId: 'head-123',
+        })
+      ).toBe('/preprod/size/compare/head-123/?project=test-project');
+    });
+
+    it('generates orgless path for comparison with base artifact', () => {
+      expect(
+        getCompareBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+          headArtifactId: 'head-123',
+          baseArtifactId: 'base-456',
+        })
+      ).toBe('/preprod/size/compare/head-123/base-456/?project=test-project');
+    });
+  });
+
+  describe('getListBuildPath', () => {
+    it('generates orgless path for list', () => {
+      expect(
+        getListBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+        })
+      ).toBe('/preprod/?project=test-project');
+    });
+  });
+
+  describe('getBaseBuildPath', () => {
+    it('returns undefined when baseArtifactId is not provided', () => {
+      expect(
+        getBaseBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+        })
+      ).toBeUndefined();
+    });
+
+    it('generates orgless path for size view', () => {
+      expect(getBaseBuildPath(params, 'size')).toBe(
+        '/preprod/size/artifact-123/?project=test-project'
+      );
+    });
+
+    it('generates orgless path for install view', () => {
+      expect(getBaseBuildPath(params, 'install')).toBe(
+        '/preprod/install/artifact-123/?project=test-project'
+      );
+    });
+  });
+});
+
+describe('buildLinkUtils without customer domain', () => {
+  const params = {
+    organizationSlug: 'test-org',
+    projectId: 'test-project',
+    baseArtifactId: 'artifact-123',
+  };
+
+  beforeEach(() => {
+    ConfigStore.set('customerDomain', null);
+  });
+
+  describe('getSizeBuildPath', () => {
+    it('returns undefined when baseArtifactId is not provided', () => {
+      expect(
+        getSizeBuildPath({
+          organizationSlug: 'test-org',
+          projectId: 'test-project',
+        })
+      ).toBeUndefined();
+    });
+
+    it('generates org-prefixed path for size view', () => {
       expect(getSizeBuildPath(params)).toBe(
         '/organizations/test-org/preprod/size/artifact-123/?project=test-project'
       );
@@ -40,7 +157,7 @@ describe('buildLinkUtils', () => {
       ).toBeUndefined();
     });
 
-    it('generates correct install build path with new URL format', () => {
+    it('generates org-prefixed path for install view', () => {
       expect(getInstallBuildPath(params)).toBe(
         '/organizations/test-org/preprod/install/artifact-123/?project=test-project'
       );
@@ -48,7 +165,7 @@ describe('buildLinkUtils', () => {
   });
 
   describe('getCompareBuildPath', () => {
-    it('generates comparison path without base artifact', () => {
+    it('generates org-prefixed path for comparison without base artifact', () => {
       expect(
         getCompareBuildPath({
           organizationSlug: 'test-org',
@@ -60,7 +177,7 @@ describe('buildLinkUtils', () => {
       );
     });
 
-    it('generates comparison path with base artifact', () => {
+    it('generates org-prefixed path for comparison with base artifact', () => {
       expect(
         getCompareBuildPath({
           organizationSlug: 'test-org',
@@ -75,7 +192,7 @@ describe('buildLinkUtils', () => {
   });
 
   describe('getListBuildPath', () => {
-    it('generates correct list path with project query param', () => {
+    it('generates org-prefixed path for list', () => {
       expect(
         getListBuildPath({
           organizationSlug: 'test-org',
@@ -95,13 +212,13 @@ describe('buildLinkUtils', () => {
       ).toBeUndefined();
     });
 
-    it('generates size path when viewType is size', () => {
+    it('generates org-prefixed path for size view', () => {
       expect(getBaseBuildPath(params, 'size')).toBe(
         '/organizations/test-org/preprod/size/artifact-123/?project=test-project'
       );
     });
 
-    it('generates install path when viewType is install', () => {
+    it('generates org-prefixed path for install view', () => {
       expect(getBaseBuildPath(params, 'install')).toBe(
         '/organizations/test-org/preprod/install/artifact-123/?project=test-project'
       );

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -1,3 +1,5 @@
+import ConfigStore from 'sentry/stores/configStore';
+
 interface BuildLinkParams {
   organizationSlug: string;
   projectId: string;
@@ -12,6 +14,11 @@ export function getBaseBuildPath(
 
   if (!baseArtifactId) {
     return undefined;
+  }
+
+  const customerDomain = ConfigStore.get('customerDomain');
+  if (customerDomain?.subdomain) {
+    return `/preprod/${viewType}/${baseArtifactId}/?project=${projectId}`;
   }
 
   return `/organizations/${organizationSlug}/preprod/${viewType}/${baseArtifactId}/?project=${projectId}`;
@@ -33,6 +40,14 @@ export function getCompareBuildPath(params: {
 }): string {
   const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
 
+  const customerDomain = ConfigStore.get('customerDomain');
+  if (customerDomain?.subdomain) {
+    if (baseArtifactId) {
+      return `/preprod/size/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
+    }
+    return `/preprod/size/compare/${headArtifactId}/?project=${projectId}`;
+  }
+
   if (baseArtifactId) {
     return `/organizations/${organizationSlug}/preprod/size/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
   }
@@ -45,6 +60,12 @@ export function getListBuildPath(params: {
   projectId: string;
 }): string {
   const {organizationSlug, projectId} = params;
+
+  const customerDomain = ConfigStore.get('customerDomain');
+  if (customerDomain?.subdomain) {
+    return `/preprod/?project=${projectId}`;
+  }
+
   return `/organizations/${organizationSlug}/preprod/?project=${projectId}`;
 }
 


### PR DESCRIPTION
## Summary

Updates preprod link generation utilities to generate clean URLs without organization slug when on customer domains (e.g., `sentry.sentry.io`), while maintaining backwards compatibility with org-prefixed URLs.

**Before:**
```
https://sentry.sentry.io/organizations/sentry/preprod/size/15151/?project=demo
```

**After:**
```
https://sentry.sentry.io/preprod/size/15151/?project=demo
```

## Changes

- Updated `buildLinkUtils.ts` to check for customer domain via `ConfigStore`
- All link generation functions now generate orgless URLs when on customer domains:
  - `getBaseBuildPath()` - size/install build details
  - `getCompareBuildPath()` - build comparisons
  - `getListBuildPath()` - build list page
- Added comprehensive test coverage for both URL patterns (20 tests)

## How It Works

The routing infrastructure already supports this via `withOrgPath: true` in `routes.tsx`:

1. **Customer domain** (e.g., `sentry.sentry.io`):
   - Generates: `/preprod/size/123/?project=demo`
   - Organization resolved from subdomain

2. **Non-customer domain** (e.g., `sentry.io`):
   - Generates: `/organizations/sentry/preprod/size/123/?project=demo`
   - Organization resolved from URL params

## Backwards Compatibility

✅ Both URL patterns continue to work:
- Old org-prefixed URLs automatically redirect to orgless URLs on customer domains
- Non-customer domains continue to use org-prefixed URLs
- `useOrganization()` hook handles both scenarios

## Testing

- ✅ All 20 tests passing
- ✅ No linting errors
- ✅ No type errors