### PR TITLE
fix(preprod): Remove organization slug from legacy URL redirects

### DIFF
--- a/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 
+import ConfigStore from 'sentry/stores/configStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -21,19 +22,22 @@ export default function LegacyPreprodRedirect() {
     const isInstall = location.pathname.includes('/install/');
     const isCompare = location.pathname.includes('/compare/');
 
+    const {customerDomain} = ConfigStore.getState();
+    const orgPrefix = customerDomain ? '' : `/organizations/${organization.slug}`;
+
     let newPath = '';
 
     if (isCompare && headArtifactId) {
       const compareType = 'size';
       if (baseArtifactId) {
-        newPath = `/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
+        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
       } else {
-        newPath = `/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
+        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
       }
     } else if (isInstall && artifactId) {
-      newPath = `/preprod/install/${artifactId}/?project=${projectId}`;
+      newPath = `${orgPrefix}/preprod/install/${artifactId}/?project=${projectId}`;
     } else if (artifactId) {
-      newPath = `/preprod/size/${artifactId}/?project=${projectId}`;
+      newPath = `${orgPrefix}/preprod/size/${artifactId}/?project=${projectId}`;
     }
 
     if (newPath) {

--- a/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
@@ -26,14 +26,14 @@ export default function LegacyPreprodRedirect() {
     if (isCompare && headArtifactId) {
       const compareType = 'size';
       if (baseArtifactId) {
-        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
+        newPath = `/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
       } else {
-        newPath = `/organizations/${organization.slug}/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
+        newPath = `/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
       }
     } else if (isInstall && artifactId) {
-      newPath = `/organizations/${organization.slug}/preprod/install/${artifactId}/?project=${projectId}`;
+      newPath = `/preprod/install/${artifactId}/?project=${projectId}`;
     } else if (artifactId) {
-      newPath = `/organizations/${organization.slug}/preprod/size/${artifactId}/?project=${projectId}`;
+      newPath = `/preprod/size/${artifactId}/?project=${projectId}`;
     }
 
     if (newPath) {

--- a/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
+++ b/static/app/views/preprod/redirects/legacyUrlRedirect.tsx
@@ -5,6 +5,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 export default function LegacyPreprodRedirect() {
   const params = useParams<{
@@ -16,9 +17,15 @@ export default function LegacyPreprodRedirect() {
   const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
+  const project = useProjectFromSlug({organization, projectSlug: params.projectId});
 
   useEffect(() => {
-    const {projectId, artifactId, headArtifactId, baseArtifactId} = params;
+    if (!project) {
+      return;
+    }
+
+    const {artifactId, headArtifactId, baseArtifactId} = params;
+    const numericProjectId = project.id;
     const isInstall = location.pathname.includes('/install/');
     const isCompare = location.pathname.includes('/compare/');
 
@@ -30,20 +37,20 @@ export default function LegacyPreprodRedirect() {
     if (isCompare && headArtifactId) {
       const compareType = 'size';
       if (baseArtifactId) {
-        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${projectId}`;
+        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/${baseArtifactId}/?project=${numericProjectId}`;
       } else {
-        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/?project=${projectId}`;
+        newPath = `${orgPrefix}/preprod/${compareType}/compare/${headArtifactId}/?project=${numericProjectId}`;
       }
     } else if (isInstall && artifactId) {
-      newPath = `${orgPrefix}/preprod/install/${artifactId}/?project=${projectId}`;
+      newPath = `${orgPrefix}/preprod/install/${artifactId}/?project=${numericProjectId}`;
     } else if (artifactId) {
-      newPath = `${orgPrefix}/preprod/size/${artifactId}/?project=${projectId}`;
+      newPath = `${orgPrefix}/preprod/size/${artifactId}/?project=${numericProjectId}`;
     }
 
     if (newPath) {
       navigate(newPath, {replace: true});
     }
-  }, [params, navigate, organization, location]);
+  }, [params, navigate, organization, location, project]);
 
   return null;
 }


### PR DESCRIPTION
Fixes legacy preprod URL redirects to use clean URLs without the organization slug prefix.

**Before:** `/preprod/launchpad-test-ios/10516/` → `/organizations/sentry/preprod/size/10516/?project=launchpad-test-ios`  
**After:** `/preprod/launchpad-test-ios/10516/` → `/preprod/size/10516/?project=123`