### PR TITLE
feat(autofix): Support configurable intelligence-level-for-explorer-a…

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from django.utils import timezone
 from pydantic import BaseModel
@@ -134,6 +134,7 @@ def trigger_autofix_explorer(
     step: AutofixStep,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
+    intelligence_level: Literal["low", "medium", "high"] = "high",
 ) -> int:
     """
     Start or continue an Explorer-based autofix run.
@@ -157,7 +158,7 @@ def trigger_autofix_explorer(
         user=None,  # No user personalization for autofix
         category_key="autofix",
         category_value=str(group.id),
-        intelligence_level="high",
+        intelligence_level=intelligence_level,
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=config.enable_coding,
     )

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -98,6 +98,12 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
         required=False,
         help_text="Coding agent provider (e.g., 'github_copilot'). Alternative to integration_id for user-authenticated providers.",
     )
+    intelligence_level = serializers.ChoiceField(
+        required=False,
+        choices=["low", "medium", "high"],
+        default="high",
+        help_text="The intelligence level to use.",
+    )
 
 
 @region_silo_endpoint
@@ -210,6 +216,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 group=group,
                 step=AutofixStep(step),
                 run_id=data.get("run_id"),
+                intelligence_level=data.get("intelligence_level"),
             )
             return Response({"run_id": run_id}, status=202)
         except SeerPermissionError as e:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -216,7 +216,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 group=group,
                 step=AutofixStep(step),
                 run_id=data.get("run_id"),
-                intelligence_level=data.get("intelligence_level"),
+                intelligence_level=data["intelligence_level"],
             )
             return Response({"run_id": run_id}, status=202)
         except SeerPermissionError as e:


### PR DESCRIPTION
…utofix

To test different intelligence levels with autofix, allow it to be configurable via query params.