### PR TITLE
fix(dashboards): Add timestamp to default dashboard name

### DIFF
--- a/static/app/views/dashboards/create.spec.tsx
+++ b/static/app/views/dashboards/create.spec.tsx
@@ -82,6 +82,30 @@ describe('Dashboards > CreateDashboard', () => {
     ).toBeInTheDocument();
   });
 
+  it('creates dashboard with timestamped default title', async () => {
+    render(<CreateDashboard />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/dashboards/new/',
+        },
+      },
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Save and Finish'}));
+
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: expect.stringMatching(
+            /^Untitled Dashboard - \w{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [AP]M$/
+          ),
+        }),
+      })
+    );
+  });
+
   it('auto-adds widgets from location.state.widgets to dashboard', async () => {
     const widget1 = WidgetFixture({
       id: '1',

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -5,6 +5,7 @@ import {Alert} from 'sentry/components/core/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
+import {getFormattedDate} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -26,9 +27,13 @@ export default function CreateDashboard() {
       )
     : undefined;
 
+  const timestamp = getFormattedDate(new Date(), 'MMM D, YYYY h:mm A', {local: true});
   const baseDashboard = template
     ? cloneDashboard(template)
-    : cloneDashboard(EMPTY_DASHBOARD);
+    : {
+        ...cloneDashboard(EMPTY_DASHBOARD),
+        title: `${t('Untitled Dashboard')} - ${timestamp}`,
+      };
 
   const hasWidgetsToAdd = !!location.state?.widgets && location.state.widgets.length > 0;
 


### PR DESCRIPTION
## Summary

When creating a new dashboard, the default name "Untitled Dashboard" causes a conflict if the user already has a dashboard with that name, resulting in a "Dashboard title already taken" error due to the unique constraint on `(organization, title)`.

This adds a timestamp to the default dashboard title when creating a new dashboard (e.g., "Untitled Dashboard - Jan 26, 2026 2:30 PM") to prevent naming collisions.

As i am a lazy person, this causes a bit of friction when i go to save my dashboard. Another possible update in the future would be to use the `user.name` / `user.email` field as well in the title. "Josh's Untitled Dashboard -- $TIMESTAMP"

## Changes

- Added timestamp generation using user's local timezone
- Modified `baseDashboard` to include timestamp in title when creating from `EMPTY_DASHBOARD` (templates retain their original names)


Tested locally and looks to work. 

PR made with claude code