### PR TITLE
test(dashboards): fix flakey test

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -806,9 +806,7 @@ describe('Modals -> WidgetViewerModal', () => {
         expect(eventsStatsMock).toHaveBeenCalled();
       });
 
-      // TODO: this test is flakey in CI https://linear.app/getsentry/issue/BROWSE-264/fix-flakey-test
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('appends the orderby to the query if it is not already selected as an aggregate', async () => {
+      it('appends the orderby to the query if it is not already selected as an aggregate', async () => {
         const eventsStatsMock = mockEventsStats();
         mockEvents();
 
@@ -826,15 +824,18 @@ describe('Modals -> WidgetViewerModal', () => {
         });
 
         await renderModal({initialData, widget});
+        await waitFor(() => {
+          expect(eventsStatsMock).toHaveBeenCalledWith(
+            '/organizations/org-slug/events-stats/',
+            expect.objectContaining({
+              query: expect.objectContaining({
+                field: ['country', 'count()', 'epm()'],
+              }),
+            })
+          );
+        });
+
         expect(await screen.findByText('epm()')).toBeInTheDocument();
-        expect(eventsStatsMock).toHaveBeenCalledWith(
-          '/organizations/org-slug/events-stats/',
-          expect.objectContaining({
-            query: expect.objectContaining({
-              field: ['country', 'count()', 'epm()'],
-            }),
-          })
-        );
       });
     });
 

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -806,7 +806,9 @@ describe('Modals -> WidgetViewerModal', () => {
         expect(eventsStatsMock).toHaveBeenCalled();
       });
 
-      it('appends the orderby to the query if it is not already selected as an aggregate', async () => {
+      // TODO: this test is flakey in CI https://linear.app/getsentry/issue/BROWSE-264/fix-flakey-test
+      // eslint-disable-next-line jest/no-disabled-tests
+      it.skip('appends the orderby to the query if it is not already selected as an aggregate', async () => {
         const eventsStatsMock = mockEventsStats();
         mockEvents();
 

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -806,9 +806,7 @@ describe('Modals -> WidgetViewerModal', () => {
         expect(eventsStatsMock).toHaveBeenCalled();
       });
 
-      // TODO: this test is flakey in CI https://linear.app/getsentry/issue/BROWSE-264/fix-flakey-test
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('appends the orderby to the query if it is not already selected as an aggregate', async () => {
+      it('appends the orderby to the query if it is not already selected as an aggregate', async () => {
         const eventsStatsMock = mockEventsStats();
         mockEvents();
 


### PR DESCRIPTION
Wait for the api call to finish, before asserting on what's rendered.
Going to run this several times to see if it passes consistently