### PR TITLE
feat(tracemetrics): Consistently distribute space for metric toolbar

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -17,13 +17,18 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   return (
     <CompactSelect
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Agg')} />
+        <OverlayTrigger.Button
+          {...triggerProps}
+          prefix={t('Agg')}
+          style={{width: '100%'}}
+        />
       )}
       options={OPTIONS_BY_TYPE[traceMetric.type] ?? []}
       value={visualize.parsedFunction?.name ?? ''}
       onChange={option => {
         setVisualize(updateVisualizeYAxis(visualize, option.value, traceMetric));
       }}
+      style={{width: '100%'}}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -80,7 +80,11 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
       multiple
       searchable
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Group by')} />
+        <OverlayTrigger.Button
+          {...triggerProps}
+          prefix={t('Group by')}
+          style={{width: '100%'}}
+        />
       )}
       options={enabledOptions}
       value={[...groupBys]}
@@ -89,6 +93,7 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
       onChange={selectedOptions => {
         setGroupBys(selectedOptions.map(option => option.value));
       }}
+      style={{width: '100%'}}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -1,5 +1,6 @@
 import {useCallback} from 'react';
 
+import {Flex} from 'sentry/components/core/layout/flex';
 import {Grid} from 'sentry/components/core/layout/grid';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
@@ -34,7 +35,7 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
       width="100%"
       align="center"
       gap="md"
-      columns={`34px auto auto auto 1fr ${metricQueries.length > 1 ? '40px' : '0'}`}
+      columns={`34px 1fr 1fr 1fr ${metricQueries.length > 1 ? '40px' : '0'}`}
       data-test-id="metric-toolbar"
     >
       <VisualizeLabel
@@ -42,10 +43,16 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
         visualize={visualize}
         onClick={toggleVisibility}
       />
-      <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
-      <AggregateDropdown traceMetric={traceMetric} />
-      <GroupBySelector traceMetric={traceMetric} />
-      <Filter traceMetric={traceMetric} />
+      <Flex minWidth={0}>
+        <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
+      </Flex>
+      <Flex gap="md" minWidth={0}>
+        <AggregateDropdown traceMetric={traceMetric} />
+        <GroupBySelector traceMetric={traceMetric} />
+      </Flex>
+      <Flex minWidth={0}>
+        <Filter traceMetric={traceMetric} />
+      </Flex>
       {metricQueries.length > 1 && <DeleteMetricButton />}
     </Grid>
   );

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -35,7 +35,7 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
       width="100%"
       align="center"
       gap="md"
-      columns={`34px minmax(auto, 300px) minmax(auto, 350px) minmax(200px, 1fr) ${metricQueries.length > 1 ? '40px' : '0'}`}
+      columns={`34px 2fr 3fr 6fr ${metricQueries.length > 1 ? '40px' : '0'}`}
       data-test-id="metric-toolbar"
     >
       <VisualizeLabel

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -47,8 +47,12 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
         <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
       </Flex>
       <Flex gap="md" minWidth={0}>
-        <AggregateDropdown traceMetric={traceMetric} />
-        <GroupBySelector traceMetric={traceMetric} />
+        <Flex flex="2 1 0" minWidth={0}>
+          <AggregateDropdown traceMetric={traceMetric} />
+        </Flex>
+        <Flex flex="3 1 0" minWidth={0}>
+          <GroupBySelector traceMetric={traceMetric} />
+        </Flex>
       </Flex>
       <Flex minWidth={0}>
         <Filter traceMetric={traceMetric} />

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -35,7 +35,7 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
       width="100%"
       align="center"
       gap="md"
-      columns={`34px 1fr 1fr 1fr ${metricQueries.length > 1 ? '40px' : '0'}`}
+      columns={`34px minmax(auto, 300px) minmax(auto, 350px) minmax(200px, 1fr) ${metricQueries.length > 1 ? '40px' : '0'}`}
       data-test-id="metric-toolbar"
     >
       <VisualizeLabel

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -3,6 +3,7 @@ import debounce from 'lodash/debounce';
 
 import {Tag} from '@sentry/scraps/badge/tag';
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -110,6 +111,13 @@ export function MetricSelector({
           });
         }
       }}
+      style={{width: '100%'}}
+      trigger={triggerProps => (
+        <OverlayTrigger.Button
+          {...triggerProps}
+          style={{width: '100%', fontWeight: 'bold'}}
+        />
+      )}
     />
   );
 }


### PR DESCRIPTION
The spacing for the metric selectors and filter bar were inconsistent. This PR makes the selectors and filter bar distribute with a consistent width for the current size. We started with 1/3 across all 3, but this made it easy for the search bar to overflow and clutter up the right side. I played around with it to distribute it so the search bar got more space.

<img width="1444" height="204" alt="Screenshot 2026-01-26 at 1 24 20 PM" src="https://github.com/user-attachments/assets/6101575e-8bf2-4dcb-8df3-53e8fbdb7d8e" />

Last PR to close LOGS-532