### PR TITLE
feat(preprod): Reflect queuing state on size build details

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -337,7 +337,8 @@ describe('BuildDetails', () => {
     });
 
     await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(1));
-    expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
+    // First call returns PENDING state - shows queued message
+    expect(await screen.findByText('Queued for analysis')).toBeInTheDocument();
 
     await waitFor(
       () => {
@@ -346,7 +347,7 @@ describe('BuildDetails', () => {
       {timeout: 12000}
     );
 
-    // Still showing processing state (not completed yet)
+    // Second call returns PROCESSING state - shows processing message
     expect(screen.getByText('Running size analysis')).toBeInTheDocument();
 
     // Size analysis should not be refetched since we're still processing

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -29,7 +29,7 @@ import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
 import {
-  isSizeInfoProcessing,
+  isSizeInfoPendingOrProcessing,
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 
@@ -70,13 +70,13 @@ export default function BuildDetails() {
         refetchInterval: query => {
           const data = query.state.data;
           const sizeInfo = data?.[0]?.size_info;
-          return isSizeInfoProcessing(sizeInfo) ? 10_000 : false;
+          return isSizeInfoPendingOrProcessing(sizeInfo) ? 10_000 : false;
         },
       }
     );
 
   const sizeInfo = buildDetailsQuery.data?.size_info;
-  const isProcessing = isSizeInfoProcessing(sizeInfo);
+  const isPendingOrProcessing = isSizeInfoPendingOrProcessing(sizeInfo);
 
   const appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError> =
     useApiQuery<AppSizeApiResponse>(
@@ -109,14 +109,14 @@ export default function BuildDetails() {
       }
     );
 
-  const wasProcessingRef = useRef(isProcessing);
+  const wasPendingOrProcessingRef = useRef(isPendingOrProcessing);
 
   useEffect(() => {
-    if (wasProcessingRef.current && !isProcessing) {
+    if (wasPendingOrProcessingRef.current && !isPendingOrProcessing) {
       appSizeQuery.refetch();
     }
-    wasProcessingRef.current = isProcessing;
-  }, [isProcessing, appSizeQuery]);
+    wasPendingOrProcessingRef.current = isPendingOrProcessing;
+  }, [isPendingOrProcessing, appSizeQuery]);
 
   const {mutate: onRerunAnalysis, isPending: isRerunning} = useMutation<
     void,

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -28,6 +28,7 @@ import {TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
 import {
   BuildDetailsSizeAnalysisState,
+  isSizeInfoPending,
   isSizeInfoProcessing,
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -142,6 +143,17 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   }
 
   const isWaitingForData = !appSizeData && !isAppSizeError;
+
+  if (isSizeInfoPending(sizeInfo)) {
+    return (
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
+        <BuildProcessing
+          title={t('Queued for analysis')}
+          message={t('Your build is in the queue and will start processing soon...')}
+        />
+      </Flex>
+    );
+  }
 
   if (isSizeInfoProcessing(sizeInfo) || isWaitingForData) {
     return (

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -95,13 +95,23 @@ export function isSizeInfoCompleted(
   return sizeInfo?.state === BuildDetailsSizeAnalysisState.COMPLETED;
 }
 
-export function isSizeInfoProcessing(
+export function isSizeInfoPendingOrProcessing(
   sizeInfo: BuildDetailsSizeInfo | undefined
 ): boolean {
   return (
     sizeInfo?.state === BuildDetailsSizeAnalysisState.PENDING ||
     sizeInfo?.state === BuildDetailsSizeAnalysisState.PROCESSING
   );
+}
+
+export function isSizeInfoPending(sizeInfo: BuildDetailsSizeInfo | undefined): boolean {
+  return sizeInfo?.state === BuildDetailsSizeAnalysisState.PENDING;
+}
+
+export function isSizeInfoProcessing(
+  sizeInfo: BuildDetailsSizeInfo | undefined
+): boolean {
+  return sizeInfo?.state === BuildDetailsSizeAnalysisState.PROCESSING;
 }
 
 export function getMainArtifactSizeMetric(


### PR DESCRIPTION
Closes EME-757

Intended to improve user comprehension ("why is my build stuck" might actually be "hmm just have to wait for my build to get queued")


Current processing UI:
<img width="1004" height="762" alt="image" src="https://github.com/user-attachments/assets/34f94896-571e-426c-a00d-a0cece2feb42" />

Added alternative UI:
<img width="984" height="746" alt="image" src="https://github.com/user-attachments/assets/a98bb98a-9eda-463f-aab0-8be03bee1b42" />
