### PR TITLE
Update OwnerActorField usage, refactor RuleSerializer, OpenAPI serializers

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -185,14 +185,19 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         rule_data_before = dict(rule.data)
         if rule.environment_id:
             rule_data_before["environment_id"] = rule.environment_id
+        current_owner = None
         if rule.owner_team_id or rule.owner_user_id:
-            rule_data_before["owner"] = Actor.from_id(
-                user_id=rule.owner_user_id, team_id=rule.owner_team_id
-            )
+            current_owner = Actor.from_id(user_id=rule.owner_user_id, team_id=rule.owner_team_id)
+            rule_data_before["owner"] = current_owner
         rule_data_before["label"] = rule.label
 
         serializer = DrfRuleSerializer(
-            context={"project": project, "organization": project.organization, "request": request},
+            context={
+                "project": project,
+                "organization": project.organization,
+                "request": request,
+                "current_owner": current_owner,
+            },
             data=request.data,
             partial=True,
         )

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -19,7 +19,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
@@ -88,7 +88,7 @@ class ProjectRuleDetailsPutSerializer(serializers.Serializer):
         required=False,
         help_text="A list of filters that determine if a rule fires after the necessary conditions have been met. See [Create an Issue Alert Rule](/api/alerts/create-an-issue-alert-rule-for-a-project) for valid filters.",
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False, allow_null=True, help_text="The ID of the team or user that owns the rule."
     )
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -15,7 +15,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, RuleSerializerResponse
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
@@ -284,7 +284,7 @@ class ProjectRulesPostSerializer(serializers.Serializer):
     environment = serializers.CharField(
         required=False, allow_null=True, help_text="The name of the environment to filter by."
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False, allow_null=True, help_text="The ID of the team or user that owns the rule."
     )
     frequency = serializers.IntegerField(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -309,6 +309,7 @@ def validate_request(
                 "project": project,
                 "organization": project.organization,
                 "access": getattr(request, "access", None),
+                "request": request,
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -46,6 +46,7 @@ from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.grouptombstone import TOMBSTONE_FIELDS_FROM_GROUP, GroupTombstone
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.release import Release, ReleaseStatus, follows_semver_versioning_scheme
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
@@ -190,7 +191,7 @@ def update_groups(
     if not groups:
         return Response({"detail": "No groups found"}, status=204)
 
-    serializer = validate_request(request, projects, data)
+    serializer = validate_request(request, projects, data, user)
 
     if serializer is None:
         logger.error("Error validating request. Investigate.")
@@ -248,6 +249,7 @@ def update_groups(
         )
 
     return prepare_response(
+        request,
         result,
         groups,
         project_lookup,
@@ -296,6 +298,7 @@ def validate_request(
     request: Request,
     projects: Sequence[Project],
     data: Mapping[str, Any],
+    user: RpcUser | User | AnonymousUser | None = None,
 ) -> GroupValidator | None:
     serializer = None
     # TODO(jess): We may want to look into refactoring GroupValidator
@@ -310,6 +313,14 @@ def validate_request(
                 "organization": project.organization,
                 "access": getattr(request, "access", None),
                 "request": request,
+                # Pass user explicitly for cases like Slack webhooks where
+                # request.user may be anonymous but the actual user is known
+                "user": user or getattr(request, "user", None),
+                # Skip team validation in OwnerActorField because:
+                # 1. For bulk updates, each group may have a different current assignee
+                # 2. Team membership validation happens later in validate_bulk_reassignment
+                #    with full access to the groups' current assignments
+                "skip_team_validation": True,
             },
         )
         if not serializer.is_valid():
@@ -752,6 +763,7 @@ def handle_other_status_updates(
 
 
 def prepare_response(
+    request: Request,
     result: dict[str, Any],
     group_list: Sequence[Group],
     project_lookup: Mapping[int, Project],
@@ -776,6 +788,12 @@ def prepare_response(
         pass
 
     if "assignedTo" in result:
+        # Validate reassignment permissions for bulk updates
+        try:
+            validate_bulk_reassignment(request, group_list, result["assignedTo"], acting_user)
+        except serializers.ValidationError as e:
+            return Response(e.detail, status=400)
+
         result["assignedTo"] = handle_assigned_to(
             result["assignedTo"],
             data.get("assignedBy"),
@@ -1022,6 +1040,87 @@ def handle_is_public(
                 )
 
     return share_id
+
+
+def validate_bulk_reassignment(
+    request: Request,
+    group_list: Sequence[Group],
+    assigned_actor: Actor | None,
+    user: RpcUser | User | None = None,
+) -> None:
+    """
+    Validate that the user has permission to reassign all groups.
+
+    A user can reassign a group if:
+    - They have team:admin scope, OR
+    - They are a member of the team the new assignment is going to, OR
+    - The group is currently assigned to a team they are a member of (can reassign from their team)
+
+    For bulk updates, all groups must pass this validation.
+
+    Args:
+        request: The request object (used for access scope check)
+        group_list: List of groups being reassigned
+        assigned_actor: The actor being assigned to (team or user)
+        user: The user performing the action. For Slack webhooks, this may differ
+              from request.user which could be anonymous.
+
+    Raises:
+        serializers.ValidationError: If the user doesn't have permission to reassign any group.
+    """
+    # Skip validation if not assigning to a team
+    if assigned_actor is None or not assigned_actor.is_team:
+        return
+
+    # Users with team:admin scope can reassign any group
+    access = getattr(request, "access", None)
+    if access and access.has_scope("team:admin"):
+        return
+
+    # Use explicitly passed user, fall back to request.user
+    user = user or getattr(request, "user", None)
+    if not user or not getattr(user, "is_authenticated", False):
+        raise serializers.ValidationError(
+            {"assignedTo": "You do not have permission to assign this owner"}
+        )
+
+    # Check if user is a member of the target team (existing validation)
+    user_is_target_team_member = OrganizationMemberTeam.objects.filter(
+        team_id=assigned_actor.id,
+        organizationmember__user_id=user.id,
+        is_active=True,
+    ).exists()
+
+    if user_is_target_team_member:
+        return
+
+    # Get current assignees for all groups
+    current_assignees = GroupAssignee.objects.filter(group__in=group_list).select_related("team")
+
+    current_team_ids = {
+        assignee.team_id for assignee in current_assignees if assignee.team_id is not None
+    }
+
+    if not current_team_ids:
+        # No current team assignments, and user is not a member of target team
+        raise serializers.ValidationError(
+            {"assignedTo": "You do not have permission to assign this owner"}
+        )
+
+    # Check if user is a member of ALL currently assigned teams
+    user_team_memberships = set(
+        OrganizationMemberTeam.objects.filter(
+            team_id__in=current_team_ids,
+            organizationmember__user_id=user.id,
+            is_active=True,
+        ).values_list("team_id", flat=True)
+    )
+
+    # If any group is assigned to a team the user is not a member of, deny
+    if current_team_ids - user_team_memberships:
+        raise serializers.ValidationError(
+            {"assignedTo": "You do not have permission to assign this owner"}
+        )
 
 
 def handle_assigned_to(

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -4,7 +4,7 @@ from typing import Any
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
-from sentry.api.fields import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.group_index.validators.inbox_details import InboxDetailsValidator
 from sentry.api.helpers.group_index.validators.status_details import StatusDetailsValidator
 from sentry.models.group import STATUS_UPDATE_CHOICES, Group
@@ -53,7 +53,7 @@ class GroupValidator(serializers.Serializer[Group]):
     discard = serializers.BooleanField(
         help_text="If true, discards the issues instead of updating them."
     )
-    assignedTo = ActorField(
+    assignedTo = OwnerActorField(
         help_text="The user or team that should be assigned to the issues. Values take the form of `<user_id>`, `user:<user_id>`, `<username>`, `<user_primary_email>`, or `team:<team_id>`."
     )
     priority = serializers.ChoiceField(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -112,6 +112,7 @@ def update_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule
 ) -> Response:
     data = request.data
+    current_owner = alert_rule.owner
     validator = DrfAlertRuleSerializer(
         context={
             "organization": organization,
@@ -121,6 +122,7 @@ def update_alert_rule(
             "installations": app_service.installations_for_organization(
                 organization_id=organization.id
             ),
+            "current_owner": current_owner,
         },
         instance=alert_rule,
         data=data,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -14,7 +14,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.apidocs.constants import (
@@ -308,7 +308,7 @@ Metric alert rule trigger actions follow the following structure:
         required=False,
         help_text="Optional value that the metric needs to reach to resolve the alert. If no value is provided, this is set automatically based on the lowest severity trigger's `alertThreshold`. For example, if the alert is set to trigger at the warning level when the number of errors is above 50, then the alert would be set to resolve when there are less than 50 errors. If `thresholdType` is `0`, `resolveThreshold` must be greater than the critical threshold. Otherwise, it must be less than the critical threshold.",
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False, allow_null=True, help_text="The ID of the team or user that owns the rule."
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -17,7 +17,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.fields.actor import ActorField
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCRIPTIONS_HEADER
 from sentry.api.paginator import (
     CombinedQuerysetIntermediary,
@@ -590,7 +590,7 @@ Metric alert rule trigger actions follow the following structure:
         required=False,
         help_text="Optional value that the metric needs to reach to resolve the alert. If no value is provided, this is set automatically based on the lowest severity trigger's `alertThreshold`. For example, if the alert is set to trigger at the warning level when the number of errors is above 50, then the alert would be set to resolve when there are less than 50 errors. If `thresholdType` is `0`, `resolveThreshold` must be greater than the critical threshold, otherwise, it must be less than the critical threshold.",
     )
-    owner = ActorField(
+    owner = OwnerActorField(
         required=False, allow_null=True, help_text="The ID of the team or user that owns the rule."
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -697,10 +697,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             **payload,
         )
         assert "owner" in response.data
-        assert (
-            str(response.data["owner"][0])
-            == "You must be a member of a team to assign it as the rule owner."
-        )
+        assert str(response.data["owner"][0]) == "You do not have permission to assign this owner"
 
     def test_team_owner_not_member_with_team_admin_scope(self) -> None:
         """Test that users with team:admin scope can assign a team they're not a member of as the owner"""

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -567,10 +567,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
         assert "owner" in response.data
-        assert (
-            str(response.data["owner"][0])
-            == "You must be a member of a team to assign it as the rule owner."
-        )
+        assert str(response.data["owner"][0]) == "You do not have permission to assign this owner"
 
     def test_team_owner_not_member_with_team_admin_scope(self) -> None:
         """Test that users with team:admin scope can assign a team they're not a member of as the owner"""

--- a/tests/sentry/api/fields/test_actor.py
+++ b/tests/sentry/api/fields/test_actor.py
@@ -166,3 +166,52 @@ class OwnerActorFieldTest(TestCase):
                 )
             ]
         }
+
+    def test_member_can_reassign_from_own_team_to_any_team(self) -> None:
+        """Members can reassign ownership from their team to any team."""
+        from sentry.types.actor import Actor
+
+        # Current owner is self.team which self.user is a member of
+        current_owner = Actor.from_id(user_id=None, team_id=self.team.id)
+
+        request = self.make_request(user=self.user)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.other_team.id}"},
+            context={
+                "organization": self.organization,
+                "request": request,
+                "current_owner": current_owner,
+            },
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.other_team.id
+        assert serializer.validated_data["owner"].is_team
+
+    def test_member_cannot_reassign_from_other_team(self) -> None:
+        """Members cannot reassign ownership from a team they don't belong to."""
+        from sentry.types.actor import Actor
+
+        # Current owner is other_team which self.user is NOT a member of
+        current_owner = Actor.from_id(user_id=None, team_id=self.other_team.id)
+
+        # Create a third team to try to assign to
+        third_team = self.create_team(organization=self.organization, name="third-team")
+
+        request = self.make_request(user=self.user)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{third_team.id}"},
+            context={
+                "organization": self.organization,
+                "request": request,
+                "current_owner": current_owner,
+            },
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "owner": [
+                ErrorDetail(
+                    string="You do not have permission to assign this owner",
+                    code="invalid",
+                )
+            ]
+        }


### PR DESCRIPTION
Issue Assignments GroupValidator.validate_assignedTo was still using ActorField, updated it to use the auth-check'd OwnerActorField to prevent the IDOR. 

For the RuleSerializer, refactored its validate_owner for the duplicate auth check that OwnerActorField provides.

Updated the OpenAPI serializer too for docs: 
- OrganizationAlertRuleIndexPostSerializer
- OrganizationAlertRuleDetailsPutSerializer
- ProjectRulesPostSerializer
- ProjectRuleDetailsPutSerializer