### PR TITLE
fix(anomaly detection): don't allow enable anomaly detection on free/team plan

### DIFF
--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -51,12 +51,15 @@ export function DisableDetectorAction({detector}: {detector: Detector}) {
     return null;
   }
 
-  // Check if this is a metric detector without the required feature
-  const isMetricDetector = detector.type === 'metric_issue';
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'
   );
-  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+  const requiresUpgrade = isAnomalyDetector && !hasAnomalyDetectionFeature;
 
   // If it's a metric detector without the feature, disable the Enable button
   const isButtonDisabled = isUpdating || (requiresUpgrade && !detector.enabled);

--- a/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
@@ -1,4 +1,4 @@
-import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {MetricDetectorFixture, UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -73,5 +73,27 @@ describe('DisabledAlert', () => {
         })
       );
     });
+  });
+
+  it('shows upgrade message for disabled metric detector without feature', () => {
+    const orgWithoutFeature = OrganizationFixture({
+      access: ['org:write', 'alerts:write'],
+      features: [],
+    });
+    const metricDetector = MetricDetectorFixture({
+      enabled: false,
+      projectId: project.id,
+    });
+
+    render(<DisabledAlert detector={metricDetector} message="Test message" />, {
+      organization: orgWithoutFeature,
+    });
+
+    expect(
+      screen.getByText(
+        /Anomaly detection is only available on Business and Enterprise plans/
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Enable'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
@@ -75,17 +75,18 @@ describe('DisabledAlert', () => {
     });
   });
 
-  it('shows upgrade message for disabled metric detector without feature', () => {
+  it('shows upgrade message for disabled anomaly detector without feature', () => {
     const orgWithoutFeature = OrganizationFixture({
       access: ['org:write', 'alerts:write'],
       features: [],
     });
-    const metricDetector = MetricDetectorFixture({
+    const anomalyDetector = MetricDetectorFixture({
       enabled: false,
       projectId: project.id,
+      config: {detectionType: 'dynamic'},
     });
 
-    render(<DisabledAlert detector={metricDetector} message="Test message" />, {
+    render(<DisabledAlert detector={anomalyDetector} message="Test message" />, {
       organization: orgWithoutFeature,
     });
 

--- a/static/app/views/detectors/components/details/common/disabledAlert.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.tsx
@@ -1,8 +1,10 @@
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
@@ -17,6 +19,7 @@ type DisabledAlertProps = {
  * to enable it. The alert automatically hides when the detector is enabled.
  */
 export function DisabledAlert({detector, message}: DisabledAlertProps) {
+  const organization = useOrganization();
   const {mutate: updateDetector, isPending: isEnabling} = useUpdateDetector();
   const canEdit = useCanEditDetector({
     detectorType: detector.type,
@@ -30,6 +33,30 @@ export function DisabledAlert({detector, message}: DisabledAlertProps) {
   const handleEnable = () => {
     updateDetector({detectorId: detector.id, enabled: true});
   };
+
+  // Check if this is a metric (anomaly detection) detector without the required feature
+  const isMetricDetector = detector.type === 'metric_issue';
+  const hasAnomalyDetectionFeature = organization.features.includes(
+    'anomaly-detection-alerts'
+  );
+  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+
+  if (requiresUpgrade) {
+    return (
+      <Alert.Container>
+        <Alert variant="muted">
+          {tct(
+            'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
+            {
+              link: (
+                <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />
+              ),
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
 
   return (
     <Alert.Container>

--- a/static/app/views/detectors/components/details/common/disabledAlert.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.tsx
@@ -34,12 +34,15 @@ export function DisabledAlert({detector, message}: DisabledAlertProps) {
     updateDetector({detectorId: detector.id, enabled: true});
   };
 
-  // Check if this is a metric (anomaly detection) detector without the required feature
-  const isMetricDetector = detector.type === 'metric_issue';
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'
   );
-  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+  const requiresUpgrade = isAnomalyDetector && !hasAnomalyDetectionFeature;
 
   if (requiresUpgrade) {
     return (


### PR DESCRIPTION
Free/team plans can enable dynamic detectors that already exist on a project, which should not be possible. Changed banner to say "Anomaly detection is only available on Business and Enterprise plans. [Upgrade your plan](https://sentry.io/pricing/?referrer=anomaly-detection) to enable this monitor." and disabled `enable` button.

no `anomaly-detection-alerts`
<img width="1246" height="358" alt="image" src="https://github.com/user-attachments/assets/7dccb9aa-571d-4b18-9592-498f56fdb96a" />

with `anomaly-detection-alerts`
<img width="1247" height="306" alt="image" src="https://github.com/user-attachments/assets/abdbe0bb-8f4f-4b85-b229-fe78c9c713b2" />

