### PR TITLE
feat(spans): Use float precision for sentry.duration_ms calculation

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -80,7 +80,7 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
 
     try:
         attributes["sentry.duration_ms"] = AnyValue(
-            double_value=1000.0 * (span["end_timestamp"] - span["start_timestamp"])
+            double_value=round(1000.0 * (span["end_timestamp"] - span["start_timestamp"]), 6)
         )
     except Exception:
         sentry_sdk.capture_exception()

--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -80,7 +80,7 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
 
     try:
         attributes["sentry.duration_ms"] = AnyValue(
-            int_value=int(1000 * (span["end_timestamp"] - span["start_timestamp"]))
+            double_value=1000.0 * (span["end_timestamp"] - span["start_timestamp"])
         )
     except Exception:
         sentry_sdk.capture_exception()

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -158,7 +158,7 @@ def test_convert_span_to_item() -> None:
         "relay_use_post_or_schedule": AnyValue(string_value="True"),
         "sentry.category": AnyValue(string_value="http"),
         "sentry.client_sample_rate": AnyValue(double_value=0.1),
-        "sentry.duration_ms": AnyValue(double_value=152.15802192687988),
+        "sentry.duration_ms": AnyValue(double_value=152.158022),
         "sentry.end_timestamp_precise": AnyValue(double_value=1721319572.768806),
         "sentry.environment": AnyValue(string_value="development"),
         "sentry.is_segment": AnyValue(bool_value=True),

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -158,7 +158,7 @@ def test_convert_span_to_item() -> None:
         "relay_use_post_or_schedule": AnyValue(string_value="True"),
         "sentry.category": AnyValue(string_value="http"),
         "sentry.client_sample_rate": AnyValue(double_value=0.1),
-        "sentry.duration_ms": AnyValue(int_value=152),
+        "sentry.duration_ms": AnyValue(double_value=152.15802192687988),
         "sentry.end_timestamp_precise": AnyValue(double_value=1721319572.768806),
         "sentry.environment": AnyValue(string_value="development"),
         "sentry.is_segment": AnyValue(bool_value=True),


### PR DESCRIPTION
## Summary

- Changes span duration calculation from `int_value` to `double_value` to preserve sub-millisecond precision
- Duration is now stored as a float instead of being truncated to an integer

This allows `sentry.duration_ms` to retain the full precision from the precise start and end timestamps rather than losing fractional milliseconds through integer truncation.