### PR TITLE
SCIM token masking after generation

### DIFF
--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
 
     from sentry.auth.provider import Provider
+    from sentry.models.authprovider import ScimTokenDisplay
 
 
 class RpcApiKey(RpcModel):
@@ -203,6 +204,13 @@ class RpcAuthProvider(RpcModel):
         from sentry.models.authprovider import get_scim_token
 
         return get_scim_token(self.flags.scim_enabled, self.organization_id, self.provider)
+
+    def get_scim_token_for_display(self) -> Optional["ScimTokenDisplay"]:
+        from sentry.models.authprovider import get_scim_token_for_display
+
+        return get_scim_token_for_display(
+            self.flags.scim_enabled, self.organization_id, self.provider
+        )
 
 
 class RpcAuthIdentity(RpcModel):

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -243,11 +243,11 @@ class ScimTokenDisplay:
     """
     Represents a SCIM token for display purposes.
 
-    If the token was created more than TOKEN_VISIBILITY_WINDOW_MINUTES minutes ago,
+    If the token was created more than TOKEN_VISIBILITY_WINDOW_SECONDS seconds ago,
     is_visible will be False and only the last 4 characters should be shown.
     """
 
-    TOKEN_VISIBILITY_WINDOW_MINUTES = 5
+    TOKEN_VISIBILITY_WINDOW_SECONDS = 300  # 5 minutes
 
     def __init__(
         self,
@@ -287,7 +287,7 @@ def get_scim_token_for_display(
 
     is_visible = (
         timezone.now() - token_info.date_added
-    ).total_seconds() < ScimTokenDisplay.TOKEN_VISIBILITY_WINDOW_MINUTES * 60
+    ).total_seconds() < ScimTokenDisplay.TOKEN_VISIBILITY_WINDOW_SECONDS
 
     return ScimTokenDisplay(
         token=token_info.token if is_visible else None,

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -33,7 +33,7 @@ from sentry.sentry_apps.services.app import (
     RpcSentryAppService,
     SentryAppInstallationFilterArgs,
 )
-from sentry.sentry_apps.services.app.model import SentryAppUpdateArgs
+from sentry.sentry_apps.services.app.model import RpcInstallationTokenInfo, SentryAppUpdateArgs
 from sentry.sentry_apps.services.app.serial import (
     serialize_sentry_app,
     serialize_sentry_app_component,
@@ -297,6 +297,19 @@ class DatabaseBackedAppService(AppService):
 
     def get_installation_token(self, *, organization_id: int, provider: str) -> str | None:
         return SentryAppInstallationToken.objects.get_token(organization_id, provider)
+
+    def get_installation_token_info(
+        self, *, organization_id: int, provider: str
+    ) -> RpcInstallationTokenInfo | None:
+        token_info = SentryAppInstallationToken.objects.get_token_info(organization_id, provider)
+        if token_info is None:
+            return None
+
+        return RpcInstallationTokenInfo(
+            token=token_info["token"],
+            token_last_characters=token_info["token_last_characters"],
+            date_added=token_info["date_added"],
+        )
 
     def trigger_sentry_app_action_creators(
         self, *, fields: list[Mapping[str, Any]], install_uuid: str | None

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -204,6 +204,10 @@ class SentryAppUpdateArgs(TypedDict, total=False):
     # TODO add whatever else as needed
 
 
+def _utc_now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
 class RpcInstallationTokenInfo(RpcModel):
     """
     Information about an installation token including its creation date.
@@ -212,4 +216,4 @@ class RpcInstallationTokenInfo(RpcModel):
 
     token: str = ""
     token_last_characters: str = ""
-    date_added: datetime.datetime = Field(default_factory=datetime.datetime.now)
+    date_added: datetime.datetime = Field(default_factory=_utc_now)

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -202,3 +202,14 @@ class SentryAppUpdateArgs(TypedDict, total=False):
     events: list[str]
     name: str
     # TODO add whatever else as needed
+
+
+class RpcInstallationTokenInfo(RpcModel):
+    """
+    Information about an installation token including its creation date.
+    Used for displaying token info with proper masking in the UI.
+    """
+
+    token: str = ""
+    token_last_characters: str = ""
+    date_added: datetime.datetime = Field(default_factory=datetime.datetime.now)

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -20,7 +20,11 @@ from sentry.sentry_apps.services.app import (
     RpcSentryAppService,
     SentryAppInstallationFilterArgs,
 )
-from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext, SentryAppUpdateArgs
+from sentry.sentry_apps.services.app.model import (
+    RpcInstallationTokenInfo,
+    RpcSentryAppComponentContext,
+    SentryAppUpdateArgs,
+)
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
 
@@ -118,6 +122,17 @@ class AppService(RpcService):
     @rpc_method
     @abc.abstractmethod
     def get_installation_token(self, *, organization_id: int, provider: str) -> str | None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_installation_token_info(
+        self, *, organization_id: int, provider: str
+    ) -> RpcInstallationTokenInfo | None:
+        """
+        Get installation token with metadata including creation date.
+        Used for displaying token info with proper masking in the UI.
+        """
         pass
 
     @rpc_method

--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -66,14 +66,20 @@
       </div>
     </div>
 
-    {% if scim_api_token %}
+    {% if scim_token_display %}
     <div class="box">
       <div class="box-header">
         <h3>SCIM Information</h3>
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
-        <pre>{{ scim_api_token }}</pre>
+        <pre>{{ scim_token_display.display_value }}</pre>
+        {% if not scim_token_display.is_visible %}
+        <p class="help-block">
+          <em>For security, the full token is only visible for 5 minutes after creation.
+          To get a new token, disable and re-enable SCIM.</em>
+        </p>
+        {% endif %}
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>
         <p>See provider specific SCIM documentation <a href="https://docs.sentry.io/product/accounts/sso/#scim-provisioning">here</a>.</p>

--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -74,10 +74,10 @@
       <div class="box-content with-padding">
         <b>Auth Token:</b>
         {% if scim_token_display.is_visible %}
-        <pre>{{ scim_token_display.display_value }}</pre>
+        <pre>{{ scim_token_display.token }}</pre>
         <p class="help-block">Your token is only available briefly after creation. Make sure to save this value!</p>
         {% else %}
-        <pre><em>hidden</em></pre>
+        <pre>************{{ scim_token_display.token_last_characters }}</pre>
         <p class="help-block">To generate a new token, disable and re-enable SCIM.</p>
         {% endif %}
         <b>SCIM URL:</b>

--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -73,12 +73,12 @@
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
+        {% if scim_token_display.is_visible %}
         <pre>{{ scim_token_display.display_value }}</pre>
-        {% if not scim_token_display.is_visible %}
-        <p class="help-block">
-          <em>For security, the full token is only visible for 5 minutes after creation.
-          To get a new token, disable and re-enable SCIM.</em>
-        </p>
+        <p class="help-block">Your token is only available briefly after creation. Make sure to save this value!</p>
+        {% else %}
+        <pre><em>hidden</em></pre>
+        <p class="help-block">To generate a new token, disable and re-enable SCIM.</p>
         {% endif %}
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -225,6 +225,10 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
         pending_links_count = organization_service.count_members_without_sso(
             organization_id=organization.id
         )
+
+        # Get SCIM token info with masking support
+        scim_token_display = auth_provider.get_scim_token_for_display()
+
         context = {
             "form": form,
             "pending_links_count": pending_links_count,
@@ -234,7 +238,7 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
             ),
             "auth_provider": auth_provider,
             "provider_name": provider.name,
-            "scim_api_token": auth_provider.get_scim_token(),
+            "scim_token_display": scim_token_display,
             "scim_url": get_scim_url(auth_provider, organization),
             "content": response,
             "disabled": provider.is_partner,

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -814,26 +814,8 @@ class OrganizationAuthSettingsGenericSAML2Test(AuthProviderTestCase):
 
 
 @control_silo_test
-class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
+class OrganizationAuthSettingsScimTokenMaskingTest(OrganizationAuthSettingsTest):
     """Tests for SCIM token masking security feature."""
-
-    def create_org_and_auth_provider(self, provider_name="dummy"):
-        self.user.update(is_managed=True)
-        with assume_test_silo_mode(SiloMode.REGION):
-            organization = self.create_organization(name="foo", owner=self.user)
-
-        auth_provider = AuthProvider.objects.create(
-            organization_id=organization.id, provider=provider_name
-        )
-        AuthIdentity.objects.create(user=self.user, ident="foo", auth_provider=auth_provider)
-        return organization, auth_provider
-
-    def create_om_and_link_sso(self, organization):
-        with assume_test_silo_mode(SiloMode.REGION):
-            om = OrganizationMember.objects.get(user_id=self.user.id, organization=organization)
-            setattr(om.flags, "sso:linked", True)
-            om.save()
-        return om
 
     def test_scim_token_visible_immediately_after_creation(self):
         """Test that SCIM token is fully visible within 5 minutes of creation."""

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -814,8 +814,26 @@ class OrganizationAuthSettingsGenericSAML2Test(AuthProviderTestCase):
 
 
 @control_silo_test
-class OrganizationAuthSettingsScimTokenMaskingTest(OrganizationAuthSettingsTest):
+class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
     """Tests for SCIM token masking security feature."""
+
+    def create_org_and_auth_provider(self, provider_name="dummy"):
+        self.user.update(is_managed=True)
+        with assume_test_silo_mode(SiloMode.REGION):
+            organization = self.create_organization(name="foo", owner=self.user)
+
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider=provider_name
+        )
+        AuthIdentity.objects.create(user=self.user, ident="foo", auth_provider=auth_provider)
+        return organization, auth_provider
+
+    def create_om_and_link_sso(self, organization):
+        with assume_test_silo_mode(SiloMode.REGION):
+            om = OrganizationMember.objects.get(user_id=self.user.id, organization=organization)
+            setattr(om.flags, "sso:linked", True)
+            om.save()
+        return om
 
     def test_scim_token_visible_immediately_after_creation(self):
         """Test that SCIM token is fully visible within 5 minutes of creation."""

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -869,9 +869,6 @@ class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
             assert scim_token_display is not None
             assert scim_token_display.is_visible is True
             assert scim_token_display.token is not None
-            # Token should be fully visible (not masked)
-            assert scim_token_display.display_value == scim_token_display.token
-            assert "***" not in scim_token_display.display_value
 
     def test_scim_token_masked_after_visibility_window(self):
         """Test that SCIM token is masked after 5 minutes."""
@@ -927,7 +924,8 @@ class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
             scim_token_display = resp.context["scim_token_display"]
             assert scim_token_display is not None
             assert scim_token_display.is_visible is False
-            # Token should be masked
-            assert "***" in scim_token_display.display_value
-            # Should show last 4 characters
-            assert scim_token_display.token_last_characters in scim_token_display.display_value
+            # Defense-in-depth: full token is not stored when masked
+            assert scim_token_display.token is None
+            # Only last 4 characters are available for display
+            assert scim_token_display.token_last_characters is not None
+            assert len(scim_token_display.token_last_characters) == 4


### PR DESCRIPTION
Unlike what we do with OAuth tokens, SCIM tokens aren't masked properly after creation. Managers with org:write then had access to the token indefinitely. Changed: 
- Mask the SCIM token after 5 minutes
- New display class ScimTokenDisplay for the masking logic in authprovider.py
- New get_installation_token_info RPC method to support it