### PR TITLE
ref: --reuse-db to avoid potential issues with pytest database teardown at session-end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build-chartcuterie-config:
 
 run-acceptance:
 	@echo "--> Running acceptance tests"
-	python3 -b -m pytest tests/acceptance --json-report --json-report-file=".artifacts/pytest.acceptance.json" --json-report-omit=log --junit-xml=".artifacts/acceptance.junit.xml" -o junit_suite_name=acceptance
+	python3 -b -m pytest tests/acceptance --reuse-db --json-report --json-report-file=".artifacts/pytest.acceptance.json" --json-report-omit=log --junit-xml=".artifacts/acceptance.junit.xml" -o junit_suite_name=acceptance
 	@echo ""
 
 test-cli: create-db
@@ -123,6 +123,7 @@ test-python-ci:
 	@echo "--> Running CI Python tests"
 	python3 -b -m pytest \
 		tests \
+		--reuse-db \
 		--ignore tests/acceptance \
 		--ignore tests/apidocs \
 		--ignore tests/js \
@@ -138,6 +139,7 @@ test-backend-ci-with-coverage:
 	@echo "--> Running CI Python tests with coverage"
 	python3 -b -m pytest \
 		tests \
+		--reuse-db \
 		--ignore tests/acceptance \
 		--ignore tests/apidocs \
 		--ignore tests/js \
@@ -174,6 +176,7 @@ test-monolith-dbs:
 	  tests/sentry/backup/test_exports.py \
 	  tests/sentry/backup/test_imports.py \
 	  tests/sentry/runner/commands/test_backup.py \
+	  --reuse-db \
 	  --json-report \
 	  --json-report-file=".artifacts/pytest.monolith-dbs.json" \
 	  --json-report-omit=log \
@@ -185,16 +188,16 @@ test-monolith-dbs:
 test-tools:
 	@echo "--> Running tools tests"
 	@# bogus configuration to force vanilla pytest
-	python3 -b -m pytest -c setup.cfg --confcutdir tests/tools tests/tools -vv --junit-xml=.artifacts/tools.junit.xml -o junit_suite_name=tools
+	python3 -b -m pytest -c setup.cfg --confcutdir tests/tools tests/tools --reuse-db -vv --junit-xml=.artifacts/tools.junit.xml -o junit_suite_name=tools
 	@echo ""
 
 # JavaScript relay tests are meant to be run within Symbolicator test suite, as they are parametrized to verify both processing pipelines during migration process.
 # Running Locally: Run `devservices up` before starting these tests
 test-symbolicator:
 	@echo "--> Running symbolicator tests"
-	python3 -b -m pytest tests/symbolicator -vv --junit-xml=.artifacts/symbolicator.junit.xml -o junit_suite_name=symbolicator
-	python3 -b -m pytest tests/relay_integration/lang/javascript/ -vv -m symbolicator
-	python3 -b -m pytest tests/relay_integration/lang/java/ -vv -m symbolicator
+	python3 -b -m pytest tests/symbolicator --reuse-db -vv --junit-xml=.artifacts/symbolicator.junit.xml -o junit_suite_name=symbolicator
+	python3 -b -m pytest tests/relay_integration/lang/javascript/ --reuse-db -vv -m symbolicator
+	python3 -b -m pytest tests/relay_integration/lang/java/ --reuse-db -vv -m symbolicator
 	@echo ""
 
 test-acceptance:
@@ -208,12 +211,13 @@ test-relay-integration:
 	python3 -b -m pytest \
 		tests/relay_integration \
 		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
+		--reuse-db \
 		-vv
 	@echo ""
 
 test-api-docs: build-api-docs
 	pnpm run validate-api-examples
-	python3 -b -m pytest tests/apidocs
+	python3 -b -m pytest tests/apidocs --reuse-db
 	@echo ""
 
 review-python-snapshots:


### PR DESCRIPTION
we've been having some maybe-test-pollution-related issues (example https://github.com/getsentry/sentry/actions/runs/20912887952/job/60079407114 but `tests/acceptance/test_trace_view_waterfall.py::TraceViewWaterfallTest::test_trace_view_waterfall_loads` is a [known flake](https://linear.app/getsentry/issue/ENG-5950/flaky-test-test-trace-view-waterfall-loads)) tearing down pytest-django's test db:

```
src/sentry/db/postgres/base.py:96: in execute
    return self.cursor.execute(sql)
E   django.db.utils.OperationalError: database "test_region" is being accessed by other users
E   DETAIL:  There are 2 other sessions using the database.
E   
E   SQL: DROP DATABASE "test_region"

During handling of the above exception, another exception occurred:
.venv/lib/python3.13/site-packages/pytest_django/fixtures.py:157: in django_db_setup
    request.node.warn(
E   pytest.PytestWarning: Error when trying to teardown test databases: OperationalError('database "test_region" is being accessed by other users\nDETAIL:  There are 2 other sessions using the database.\n')
```

`--reuse-db` is the only reasonable way i've found to skip db teardown at pytest session-end, and would prevent this entire class of errors

since our test shards are just one pytest invocation (and therefore one pytest test session) this is safe to do 