### PR TITLE
fix(data-forwarding): Disable CTAs for users without org:write permission

### DIFF
--- a/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
@@ -11,6 +11,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getCreateTooltip} from 'sentry/views/settings/organizationDataForwarding/util/forms';
 
 export function DataForwarderOnboarding({hasFeature}: {hasFeature: boolean}) {
   const organization = useOrganization();
@@ -39,15 +40,7 @@ export function DataForwarderOnboarding({hasFeature}: {hasFeature: boolean}) {
                   });
                 }}
                 disabled={!hasFeature || !hasAccess}
-                title={
-                  hasAccess
-                    ? hasFeature
-                      ? undefined
-                      : t('Your organization does not have access to this feature.')
-                    : t(
-                        'You must be an organization owner, manager or admin to configure data forwarding.'
-                      )
-                }
+                title={getCreateTooltip({hasAccess, hasFeature, hasAvailability: true})}
               >
                 {t('Set up your first Forwarder')}
               </LinkButton>

--- a/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function DataForwarderOnboarding({disabled}: {disabled: boolean}) {
+export function DataForwarderOnboarding({hasFeature}: {hasFeature: boolean}) {
   const organization = useOrganization();
 
   return (
@@ -29,16 +29,29 @@ export function DataForwarderOnboarding({disabled}: {disabled: boolean}) {
             {t('Works with Amazon SQS, Segment and Splunk.')}
           </Text>
           <Access access={['org:write']}>
-            <LinkButton
-              priority="primary"
-              to={`/settings/${organization.slug}/data-forwarding/setup/`}
-              onClick={() => {
-                trackAnalytics('data_forwarding.onboarding_cta_clicked', {organization});
-              }}
-              disabled={disabled}
-            >
-              {t('Setup Your First Forwarder')}
-            </LinkButton>
+            {({hasAccess}) => (
+              <LinkButton
+                priority="primary"
+                to={`/settings/${organization.slug}/data-forwarding/setup/`}
+                onClick={() => {
+                  trackAnalytics('data_forwarding.onboarding_cta_clicked', {
+                    organization,
+                  });
+                }}
+                disabled={!hasFeature || !hasAccess}
+                title={
+                  hasAccess
+                    ? hasFeature
+                      ? undefined
+                      : t('Your organization does not have access to this feature.')
+                    : t(
+                        'You must be an organization owner, manager or admin to configure data forwarding.'
+                      )
+                }
+              >
+                {t('Set up your first Forwarder')}
+              </LinkButton>
+            )}
           </Access>
         </Flex>
         <OversizedImage
@@ -51,6 +64,7 @@ export function DataForwarderOnboarding({disabled}: {disabled: boolean}) {
 }
 
 const OversizedImage = styled(Image)`
-  transform: translateX(8%) scale(1.1);
+  transform: translateX(8%) scale(1.3);
   flex: 2;
+  max-height: 300px;
 `;

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -18,6 +18,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DataForwarderOnboarding} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderOnboarding';
 import {DataForwarderRow} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderRow';
+import {getCreateTooltip} from 'sentry/views/settings/organizationDataForwarding/util/forms';
 import {useDataForwarders} from 'sentry/views/settings/organizationDataForwarding/util/hooks';
 import {
   DATA_FORWARDING_DOCS_URL,
@@ -34,7 +35,7 @@ export default function OrganizationDataForwarding() {
   } = useDataForwarders({
     params: {orgSlug: organization.slug},
   });
-  const canCreateForwarder =
+  const hasAvailability =
     dataForwarders.length < Object.values(DataForwarderProviderSlug).length;
 
   const pageContent = (
@@ -75,18 +76,8 @@ export default function OrganizationDataForwarding() {
                           organization,
                         });
                       }}
-                      disabled={!hasAccess || !canCreateForwarder || !hasFeature}
-                      title={
-                        canCreateForwarder
-                          ? hasFeature
-                            ? hasAccess
-                              ? undefined
-                              : t(
-                                  'You must be an organization owner, manager or admin to configure data forwarding.'
-                                )
-                            : t('This feature is not available for your organization')
-                          : t('Maximum data forwarders configured.')
-                      }
+                      disabled={!hasAccess || !hasAvailability || !hasFeature}
+                      title={getCreateTooltip({hasAvailability, hasAccess, hasFeature})}
                     >
                       {t('Setup a new Forwarder')}
                     </LinkButton>

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -64,30 +64,38 @@ export default function OrganizationDataForwarding() {
               </Stack>
               <Flex justify="end">
                 <Access access={['org:write']}>
-                  <LinkButton
-                    priority="primary"
-                    to={`/settings/${organization.slug}/data-forwarding/setup/`}
-                    icon={<IconAdd />}
-                    size="sm"
-                    onClick={() => {
-                      trackAnalytics('data_forwarding.add_forwarder_clicked', {
-                        organization,
-                      });
-                    }}
-                    disabled={!canCreateForwarder || !hasFeature}
-                    title={
-                      canCreateForwarder || !hasFeature
-                        ? undefined
-                        : t('Maximum data forwarders configured.')
-                    }
-                  >
-                    {t('Setup a new Forwarder')}
-                  </LinkButton>
+                  {({hasAccess}) => (
+                    <LinkButton
+                      priority="primary"
+                      to={`/settings/${organization.slug}/data-forwarding/setup/`}
+                      icon={<IconAdd />}
+                      size="sm"
+                      onClick={() => {
+                        trackAnalytics('data_forwarding.add_forwarder_clicked', {
+                          organization,
+                        });
+                      }}
+                      disabled={!hasAccess || !canCreateForwarder || !hasFeature}
+                      title={
+                        canCreateForwarder
+                          ? hasFeature
+                            ? hasAccess
+                              ? undefined
+                              : t(
+                                  'You must be an organization owner, manager or admin to configure data forwarding.'
+                                )
+                            : t('This feature is not available for your organization')
+                          : t('Maximum data forwarders configured.')
+                      }
+                    >
+                      {t('Setup a new Forwarder')}
+                    </LinkButton>
+                  )}
                 </Access>
               </Flex>
             </Fragment>
           ) : (
-            <DataForwarderOnboarding disabled={!hasFeature} />
+            <DataForwarderOnboarding hasFeature={hasFeature} />
           )}
         </Fragment>
       )}

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -20,13 +20,13 @@ export function getCreateTooltip(params: {
   hasAvailability: boolean;
   hasFeature: boolean;
 }): string | undefined {
+  if (!params.hasFeature) {
+    return t('This feature is not available for your organization');
+  }
   if (!params.hasAccess) {
     return t(
       'You must be an organization owner, manager or admin to configure data forwarding.'
     );
-  }
-  if (!params.hasFeature) {
-    return t('This feature is not available for your organization');
   }
   if (!params.hasAvailability) {
     return t('Maximum data forwarders configured.');

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -15,6 +15,25 @@ import {
   type DataForwarder,
 } from 'sentry/views/settings/organizationDataForwarding/util/types';
 
+export function getCreateTooltip(params: {
+  hasAccess: boolean;
+  hasAvailability: boolean;
+  hasFeature: boolean;
+}): string | undefined {
+  if (!params.hasAccess) {
+    return t(
+      'You must be an organization owner, manager or admin to configure data forwarding.'
+    );
+  }
+  if (!params.hasFeature) {
+    return t('This feature is not available for your organization');
+  }
+  if (!params.hasAvailability) {
+    return t('Maximum data forwarders configured.');
+  }
+  return undefined;
+}
+
 export function getDataForwarderFormGroups({
   provider,
   dataForwarder,


### PR DESCRIPTION
access is a bit cleaner, image is constrained and rather than hide the button entirely, just disable it so users know they need more perms

before:

<img width="1211" height="652" alt="image" src="https://github.com/user-attachments/assets/d93736e5-92a0-428c-a0f1-428f93d85789" />


after: 

<img width="1156" height="487" alt="image" src="https://github.com/user-attachments/assets/c4f7402a-8eba-4607-ae0d-6d6f75ed5e33" />
