### PR TITLE
ref(dashboards): migrate errors to hook pattern

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.spec.tsx
@@ -1,17 +1,13 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ThemeFixture} from 'sentry-fixture/theme';
 import {UserFixture} from 'sentry-fixture/user';
-import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import type {Client} from 'sentry/api';
 import type {EventViewOptions} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
 
 const theme = ThemeFixture();
@@ -106,102 +102,6 @@ describe('ErrorsConfig', () => {
         pageStart: undefined,
         statsPeriod: '14d',
       });
-    });
-  });
-
-  describe('getEventsRequest', () => {
-    let api!: Client;
-    let organization!: ReturnType<typeof OrganizationFixture>;
-    let mockEventsRequest!: jest.Mock;
-
-    beforeEach(() => {
-      MockApiClient.clearMockResponses();
-
-      api = new MockApiClient();
-      organization = OrganizationFixture();
-
-      mockEventsRequest = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events/',
-        body: {
-          data: [],
-        },
-      });
-    });
-
-    it('makes a request to the errors dataset', () => {
-      const pageFilters = PageFiltersFixture();
-      const widget = WidgetFixture();
-
-      ErrorsConfig.getTableRequest!(
-        api,
-        widget,
-        {
-          fields: ['count()'],
-          aggregates: ['count()'],
-          columns: [],
-          conditions: '',
-          name: '',
-          orderby: '',
-        },
-        organization,
-        pageFilters
-      );
-
-      expect(mockEventsRequest).toHaveBeenCalledWith(
-        '/organizations/org-slug/events/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            dataset: DiscoverDatasets.ERRORS,
-          }),
-        })
-      );
-    });
-  });
-
-  describe('getSeriesRequest', () => {
-    let api!: Client;
-    let organization!: ReturnType<typeof OrganizationFixture>;
-    let mockEventsRequest!: jest.Mock;
-
-    beforeEach(() => {
-      MockApiClient.clearMockResponses();
-
-      api = new MockApiClient();
-      organization = OrganizationFixture();
-
-      mockEventsRequest = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events-stats/',
-        body: {
-          data: [],
-        },
-      });
-    });
-
-    it('makes a request to the errors dataset', () => {
-      const pageFilters = PageFiltersFixture();
-      const widget = WidgetFixture({
-        queries: [
-          {
-            fields: ['count()'],
-            aggregates: ['count()'],
-            columns: [],
-            conditions: '',
-            name: '',
-            orderby: '',
-          },
-        ],
-      });
-
-      ErrorsConfig.getSeriesRequest!(api, widget, 0, organization, pageFilters);
-
-      expect(mockEventsRequest).toHaveBeenCalledWith(
-        '/organizations/org-slug/events-stats/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            dataset: DiscoverDatasets.ERRORS,
-          }),
-        })
-      );
     });
   });
 });

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -183,7 +183,7 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     mepSetting,
     samplingMode,
     enabled: !isChartDisplay && !disabled && !propsLoading,
-    limit,
+    limit: limit ?? DEFAULT_TABLE_LIMIT,
     cursor,
   });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
@@ -1,0 +1,467 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import {DisplayType} from 'sentry/views/dashboards/types';
+
+import {useErrorsSeriesQuery, useErrorsTableQuery} from './useErrorsWidgetQuery';
+
+jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
+  useWidgetQueryQueue: () => ({queue: null}),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({children}: {children: React.ReactNode}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useErrorsSeriesQuery', () => {
+  const organization = OrganizationFixture();
+  const pageFilters = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(pageFilters);
+  });
+
+  it('makes a request to the errors dataset', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1, [{count: 100}]],
+          [2, [{count: 200}]],
+        ],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.ERRORS,
+          }),
+        })
+      );
+    });
+  });
+
+  it('formats Date objects in query parameters', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const startDate = new Date('2026-01-14T00:00:00.000Z');
+    const endDate = new Date('2026-01-21T00:00:00.000Z');
+
+    const pageFiltersWithDates = PageFiltersFixture({
+      datetime: {
+        start: startDate,
+        end: endDate,
+        period: null,
+        utc: true,
+      },
+    });
+
+    PageFiltersStore.onInitializeUrlState(pageFiltersWithDates);
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1, [{count: 100}]],
+          [2, [{count: 200}]],
+        ],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsSeriesQuery({
+          widget,
+          organization,
+          pageFilters: pageFiltersWithDates,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            start: '2026-01-14T00:00:00',
+            end: '2026-01-21T00:00:00',
+          }),
+        })
+      );
+    });
+  });
+
+  it('applies dashboard filters correctly', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'browser.name:chrome',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [[1, [{count: 100}]]],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          dashboardFilters: {
+            release: ['1.0.0'],
+          },
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: expect.stringContaining('release:"1.0.0"'),
+          }),
+        })
+      );
+    });
+  });
+
+  it('handles multiple widget queries', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: 'query1',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+        {
+          name: 'query2',
+          fields: ['count_unique(user)'],
+          aggregates: ['count_unique(user)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest1 = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [[1, [{count: 100}]]],
+      },
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          const yAxis = Array.isArray(options.query.yAxis)
+            ? options.query.yAxis[0]
+            : options.query.yAxis;
+          return yAxis === 'count()';
+        },
+      ],
+    });
+
+    const mockRequest2 = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [[1, [{count: 50}]]],
+      },
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          const yAxis = Array.isArray(options.query.yAxis)
+            ? options.query.yAxis[0]
+            : options.query.yAxis;
+          return yAxis === 'count_unique(user)';
+        },
+      ],
+    });
+
+    renderHook(
+      () =>
+        useErrorsSeriesQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest1).toHaveBeenCalled();
+    });
+    expect(mockRequest2).toHaveBeenCalled();
+  });
+});
+
+describe('useErrorsTableQuery', () => {
+  const organization = OrganizationFixture();
+  const pageFilters = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(pageFilters);
+  });
+
+  it('makes a request to the errors dataset', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{count: 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.ERRORS,
+          }),
+        })
+      );
+    });
+  });
+
+  it('adds timestamp field when trace column is present', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['trace', 'count()'],
+          aggregates: ['count()'],
+          columns: ['trace'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{trace: 'abc123', count: 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: expect.arrayContaining(['trace', 'count()', 'max(timestamp)']),
+          }),
+        })
+      );
+    });
+  });
+
+  it('applies dashboard filters correctly', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'browser.name:chrome',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{count: 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          dashboardFilters: {
+            release: ['1.0.0'],
+          },
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: expect.stringContaining('release:"1.0.0"'),
+          }),
+        })
+      );
+    });
+  });
+
+  it('handles cursor pagination', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: 'test',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{count: 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useErrorsTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+          cursor: '0:10:0',
+          limit: 50,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            cursor: '0:10:0',
+            per_page: 50,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -1,0 +1,413 @@
+import {useCallback, useMemo, useRef} from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+import type {ApiResult} from 'sentry/api';
+import type {Series} from 'sentry/types/echarts';
+import type {
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+} from 'sentry/types/organization';
+import {getUtcDateString} from 'sentry/utils/dates';
+import type {
+  EventsTableData,
+  TableData,
+  TableDataWithTitle,
+} from 'sentry/utils/discover/discoverQuery';
+import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useQueries} from 'sentry/utils/queryClient';
+import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
+import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {
+  dashboardFiltersToString,
+  eventViewFromWidget,
+} from 'sentry/views/dashboards/utils';
+import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {
+  cleanWidgetForRequest,
+  getReferrer,
+} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+
+type ErrorsSeriesResponse =
+  | EventsStats
+  | MultiSeriesEventsStats
+  | GroupedMultiSeriesEventsStats;
+type ErrorsTableResponse = TableData | EventsTableData;
+
+/**
+ * Helper to apply dashboard filters and clean widget for API request
+ */
+function applyDashboardFilters(
+  widget: Widget,
+  dashboardFilters?: DashboardFilters,
+  skipParens?: boolean
+): Widget {
+  let processedWidget = widget;
+
+  if (dashboardFilters) {
+    const filtered = cloneDeep(widget);
+    const dashboardFilterConditions = dashboardFiltersToString(
+      dashboardFilters,
+      filtered.widgetType
+    );
+
+    filtered.queries.forEach(query => {
+      if (dashboardFilterConditions) {
+        if (query.conditions && !skipParens) {
+          query.conditions = `(${query.conditions})`;
+        }
+        query.conditions = query.conditions + ` ${dashboardFilterConditions}`;
+      }
+    });
+
+    processedWidget = filtered;
+  }
+
+  return cleanWidgetForRequest(processedWidget);
+}
+
+const EMPTY_ARRAY: any[] = [];
+
+export function useErrorsSeriesQuery(
+  params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled = true,
+    dashboardFilters,
+    skipDashboardFilterParens,
+  } = params;
+
+  const {queue} = useWidgetQueryQueue();
+  const prevRawDataRef = useRef<ErrorsSeriesResponse[] | undefined>(undefined);
+
+  const filteredWidget = useMemo(
+    () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  const queryKeys = useMemo(() => {
+    const keys = filteredWidget.queries.map((_, queryIndex) => {
+      const requestData = getSeriesRequestData(
+        filteredWidget,
+        queryIndex,
+        organization,
+        pageFilters,
+        DiscoverDatasets.ERRORS,
+        getReferrer(filteredWidget.displayType)
+      );
+
+      const {
+        organization: _org,
+        includeAllArgs: _includeAllArgs,
+        includePrevious: _includePrevious,
+        generatePathname: _generatePathname,
+        period,
+        ...restParams
+      } = requestData;
+
+      const queryParams = {
+        ...restParams,
+        ...(period ? {statsPeriod: period} : {}),
+      };
+
+      if (queryParams.start) {
+        queryParams.start = getUtcDateString(queryParams.start);
+      }
+      if (queryParams.end) {
+        queryParams.end = getUtcDateString(queryParams.end);
+      }
+
+      return [
+        `/organizations/${organization.slug}/events-stats/`,
+        {
+          method: 'GET' as const,
+          query: queryParams,
+        },
+      ] satisfies ApiQueryKey;
+    });
+    return keys;
+  }, [filteredWidget, organization, pageFilters]);
+
+  const createQueryFn = useCallback(
+    () =>
+      async (context: any): Promise<ApiResult<ErrorsSeriesResponse>> => {
+        if (queue) {
+          return new Promise((resolve, reject) => {
+            const fetchFnRef = {
+              current: () =>
+                fetchDataQuery<ErrorsSeriesResponse>(context).then(resolve, reject),
+            };
+            queue.addItem({fetchDataRef: fetchFnRef});
+          });
+        }
+
+        return fetchDataQuery<ErrorsSeriesResponse>(context);
+      },
+    [queue]
+  );
+
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const queryResults = useQueries({
+    queries: queryKeys.map(queryKey => ({
+      queryKey,
+      queryFn: createQueryFn(),
+      staleTime: 0,
+      enabled,
+      retry: hasQueueFeature
+        ? false
+        : (failureCount: number, error: any) => {
+            if (error?.status === 429 && failureCount < 10) {
+              return true;
+            }
+            return false;
+          },
+      placeholderData: (previousData: unknown) => previousData,
+    })),
+  });
+
+  const transformedData = (() => {
+    const isFetching = queryResults.some(q => q?.isFetching);
+    const allHaveData = queryResults.every(q => q?.data?.[0]);
+    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+
+    if (!allHaveData || isFetching) {
+      const loading = isFetching || !errorMessage;
+      return {
+        loading,
+        errorMessage,
+        rawData: EMPTY_ARRAY,
+      };
+    }
+
+    const timeseriesResults: Series[] = [];
+    const rawData: ErrorsSeriesResponse[] = [];
+
+    queryResults.forEach((q, requestIndex) => {
+      if (!q?.data?.[0]) {
+        return;
+      }
+
+      const responseData = q.data[0];
+      rawData[requestIndex] = responseData;
+
+      const transformedResult = ErrorsConfig.transformSeries!(
+        responseData,
+        filteredWidget.queries[requestIndex]!,
+        organization
+      );
+
+      transformedResult.forEach((result: Series, resultIndex: number) => {
+        timeseriesResults[requestIndex * transformedResult.length + resultIndex] = result;
+      });
+    });
+
+    let finalRawData = rawData;
+    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+      const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
+      if (allSame) {
+        finalRawData = prevRawDataRef.current;
+      }
+    }
+
+    if (finalRawData !== prevRawDataRef.current) {
+      prevRawDataRef.current = finalRawData;
+    }
+
+    return {
+      loading: false,
+      errorMessage: undefined,
+      timeseriesResults,
+      rawData: finalRawData,
+    };
+  })();
+
+  return transformedData;
+}
+
+export function useErrorsTableQuery(
+  params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled = true,
+    cursor,
+    limit,
+    dashboardFilters,
+    skipDashboardFilterParens,
+  } = params;
+
+  const {queue} = useWidgetQueryQueue();
+  const prevRawDataRef = useRef<ErrorsTableResponse[] | undefined>(undefined);
+
+  const filteredWidget = useMemo(
+    () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  const queryKeys = useMemo(() => {
+    return filteredWidget.queries.map(query => {
+      const modifiedQuery = cloneDeep(query);
+
+      if (
+        modifiedQuery.aggregates.length &&
+        modifiedQuery.columns.includes('trace') &&
+        !modifiedQuery.aggregates.includes('max(timestamp)') &&
+        !modifiedQuery.columns.includes('timestamp')
+      ) {
+        modifiedQuery.aggregates.push('max(timestamp)');
+      } else if (
+        modifiedQuery.columns.includes('trace') &&
+        !modifiedQuery.columns.includes('timestamp')
+      ) {
+        modifiedQuery.columns.push('timestamp');
+      }
+
+      const eventView = eventViewFromWidget('', modifiedQuery, pageFilters);
+
+      const requestParams: DiscoverQueryRequestParams = {
+        per_page: limit,
+        cursor,
+        referrer: getReferrer(filteredWidget.displayType),
+        dataset: DiscoverDatasets.ERRORS,
+      };
+
+      if (modifiedQuery.orderby) {
+        requestParams.sort =
+          typeof modifiedQuery.orderby === 'string'
+            ? [modifiedQuery.orderby]
+            : modifiedQuery.orderby;
+      }
+
+      const queryParams = {
+        ...eventView.generateQueryStringObject(),
+        ...requestParams,
+      };
+
+      const baseQueryKey: ApiQueryKey = [
+        `/organizations/${organization.slug}/events/`,
+        {
+          method: 'GET' as const,
+          query: queryParams,
+        },
+      ];
+
+      return baseQueryKey;
+    });
+  }, [filteredWidget, organization, pageFilters, cursor, limit]);
+
+  const createQueryFnTable = useCallback(
+    () =>
+      async (context: any): Promise<ApiResult<ErrorsTableResponse>> => {
+        if (queue) {
+          return new Promise((resolve, reject) => {
+            const fetchFnRef = {
+              current: () =>
+                fetchDataQuery<ErrorsTableResponse>(context).then(resolve, reject),
+            };
+            queue.addItem({fetchDataRef: fetchFnRef});
+          });
+        }
+        return fetchDataQuery<ErrorsTableResponse>(context);
+      },
+    [queue]
+  );
+
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const queryResults = useQueries({
+    queries: queryKeys.map(queryKey => ({
+      queryKey,
+      queryFn: createQueryFnTable(),
+      staleTime: 0,
+      enabled,
+      retry: hasQueueFeature
+        ? false
+        : (failureCount: number, error: any) => {
+            if (error?.status === 429 && failureCount < 10) {
+              return true;
+            }
+            return false;
+          },
+    })),
+  });
+
+  const transformedData = (() => {
+    const isFetching = queryResults.some(q => q?.isFetching);
+    const allHaveData = queryResults.every(q => q?.data?.[0]);
+    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+
+    if (!allHaveData || isFetching) {
+      const loading = isFetching || !errorMessage;
+      return {
+        loading,
+        errorMessage,
+        rawData: EMPTY_ARRAY,
+      };
+    }
+
+    const tableResults: TableDataWithTitle[] = [];
+    const rawData: ErrorsTableResponse[] = [];
+    let responsePageLinks: string | undefined;
+
+    queryResults.forEach((q, i) => {
+      if (!q?.data?.[0]) {
+        return;
+      }
+
+      const responseData = q.data[0];
+      const responseMeta = q.data[2];
+      rawData[i] = responseData;
+
+      const transformedDataItem: TableDataWithTitle = {
+        ...ErrorsConfig.transformTable(
+          responseData,
+          filteredWidget.queries[i]!,
+          organization,
+          pageFilters
+        ),
+        title: filteredWidget.queries[i]?.name ?? '',
+      };
+
+      tableResults.push(transformedDataItem);
+
+      responsePageLinks = responseMeta?.getResponseHeader('Link') ?? undefined;
+    });
+
+    let finalRawData = rawData;
+    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+      const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
+      if (allSame) {
+        finalRawData = prevRawDataRef.current;
+      }
+    }
+
+    if (finalRawData !== prevRawDataRef.current) {
+      prevRawDataRef.current = finalRawData;
+    }
+
+    return {
+      loading: false,
+      errorMessage: undefined,
+      tableResults,
+      pageLinks: responsePageLinks,
+      rawData: finalRawData,
+    };
+  })();
+
+  return transformedData;
+}


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/106524 but for errors dataset

A lot of copy/paste from spans/transactions/metrics dataset hooks. I'll extract shared logic in future PRs