### PR TITLE
feat(issue-details): Update onboarding tour copy and welcome modal

### DIFF
--- a/static/app/components/tours/startTour.tsx
+++ b/static/app/components/tours/startTour.tsx
@@ -94,6 +94,7 @@ const Header = styled('div')`
 const Description = styled('div')`
   font-size: ${p => p.theme.font.size.md};
   color: ${p => p.theme.tokens.content.primary};
+  white-space: pre-line;
 `;
 
 export const startTourModalCss = css`

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -78,7 +78,7 @@ function useIssueDetailsPromoModal() {
             }}
             header={t('Welcome to Issue Details')}
             description={t(
-              "New around here? Tour the issue experience - we promise you'll be less confused."
+              "This is where you'll come every time something breaks. It shows what happened, why it happened, and what to do next.\n\nNew here? Take a tour - we promise you'll be less confused."
             )}
             onDismissTour={() => {
               handleEndTour();

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -76,7 +76,7 @@ function useIssueDetailsPromoModal() {
               src: issueDetailsPreview,
               alt: t('Preview of the issue details experience'),
             }}
-            header={t('Welcome to Issue Details')}
+            header={t('Welcome to issue details')}
             description={t(
               "This is where you'll come every time something breaks. It shows what happened, why it happened, and what to do next.\n\nNew here? Take a tour - we promise you'll be less confused."
             )}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -113,7 +113,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
             id={IssueDetailsTour.FILTERS}
             title={t('Narrow your focus')}
             description={t(
-              'Filtering data to a specific environment, timeframe, tag value, or user can speed up debugging.'
+              'Filter to a specific environment, timeframe, tag value, or user to speed up debugging.'
             )}
             position="bottom-start"
           >

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -216,9 +216,9 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
       <TourElement<IssueDetailsTour>
         tourContext={IssueDetailsTourContext}
         id={IssueDetailsTour.NAVIGATION}
-        title={t('Compare different examples')}
+        title={t('Compare events')}
         description={t(
-          'You can quickly navigate between different examples in this issue to find their similarities (and differences).'
+          'Review the events associated with an issue. Compare the first, latest, or recommended event to see what changed.'
         )}
       >
         <NavigationWrapper>

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -62,7 +62,7 @@ export function GroupDetailsLayout({
             tourContext={IssueDetailsTourContext}
             title={t('See overall impact')}
             description={t(
-              'Frequency over time, total affected users, and where it occurs (environment, release, device, browser, and more).'
+              'Here you’ll see aggregate metrics like frequency over time, total affected users, and where it occurs (environment, release, device, etc.).'
             )}
             position="bottom"
           >

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -60,9 +60,9 @@ export function GroupDetailsLayout({
             id={IssueDetailsTour.AGGREGATES}
             demoTourId={DemoTourStep.ISSUES_AGGREGATES}
             tourContext={IssueDetailsTourContext}
-            title={t('View data in aggregate')}
+            title={t('See overall impact')}
             description={t(
-              'The top section of the page always displays data in aggregate, including trends over time or tag value distributions.'
+              'Frequency over time, total affected users, and where it occurs (environment, release, device, browser, and more).'
             )}
             position="bottom"
           >
@@ -72,9 +72,9 @@ export function GroupDetailsLayout({
             id={IssueDetailsTour.EVENT_DETAILS}
             demoTourId={DemoTourStep.ISSUES_EVENT_DETAILS}
             tourContext={IssueDetailsTourContext}
-            title={t('Explore details')}
+            title={t('Investigate the issue')}
             description={t(
-              'Here we capture everything we know about this data example, like context, trace, breadcrumbs, replay, and tags.'
+              'See all the issue context including the stack trace, tags, screenshots and connected replays, logs, and traces.'
             )}
             position="top"
           >

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -62,7 +62,7 @@ export function GroupDetailsLayout({
             tourContext={IssueDetailsTourContext}
             title={t('See overall impact')}
             description={t(
-              'Here you’ll see aggregate metrics like frequency over time, total affected users, and where it occurs (environment, release, device, etc.).'
+              "Here you'll see aggregate metrics like frequency over time, total affected users, and where it occurs (environment, release, device, etc.)."
             )}
             position="bottom"
           >

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -70,7 +70,7 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       tourContext={IssueDetailsTourContext}
       id={IssueDetailsTour.SIDEBAR}
       demoTourId={DemoTourStep.ISSUES_DETAIL_SIDEBAR}
-      title={t('Automate root cause')}
+      title={showSeerSection ? t('Automate root cause') : t('Share updates')}
       description={
         showSeerSection
           ? tct(
@@ -81,7 +81,9 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
                 ),
               }
             )
-          : t('Add comments for your team and link tickets to track progress.')
+          : t(
+              'Leave a comment for a teammate or link your favorite ticketing system - this area helps you collaborate and track progress on the issue.'
+            )
       }
       position={isBottomSidebar ? 'top' : 'left-start'}
     >

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -55,6 +55,11 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
   const issueTypeConfig = getConfigForIssueType(group, group.project);
   const isBottomSidebar = useMedia(`(max-width: ${theme.breakpoints.lg})`);
   const shouldDisplaySidebar = isSidebarOpen || isBottomSidebar;
+  const showSeerSection =
+    (organization.features.includes('gen-ai-features') &&
+      issueTypeConfig.issueSummary.enabled &&
+      !organization.hideAiFeatures) ||
+    issueTypeConfig.resources;
 
   if (!shouldDisplaySidebar) {
     return null;
@@ -66,21 +71,24 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       id={IssueDetailsTour.SIDEBAR}
       demoTourId={DemoTourStep.ISSUES_DETAIL_SIDEBAR}
       title={t('Automate root cause')}
-      description={tct(
-        'Use [link:Seer] to investigate this issue faster. You can also add comments for your team and link tickets to track progress.',
-        {
-          link: <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />,
-        }
-      )}
+      description={
+        showSeerSection
+          ? tct(
+              'Use [link:Seer] to investigate this issue faster. You can also add comments for your team and link tickets to track progress.',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />
+                ),
+              }
+            )
+          : t('Add comments for your team and link tickets to track progress.')
+      }
       position={isBottomSidebar ? 'top' : 'left-start'}
     >
       <Side>
         <FirstLastSeenSection group={group} />
         <StyledBreak />
-        {((organization.features.includes('gen-ai-features') &&
-          issueTypeConfig.issueSummary.enabled &&
-          !organization.hideAiFeatures) ||
-          issueTypeConfig.resources) && (
+        {showSeerSection && (
           <ErrorBoundary mini>
             <SeerSection group={group} project={project} event={event} />
           </ErrorBoundary>

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -2,10 +2,12 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {ExternalLink} from '@sentry/scraps/link';
+
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import * as SidebarSection from 'sentry/components/sidebarSection';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, TeamParticipant, UserParticipant} from 'sentry/types/group';
@@ -63,9 +65,12 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       tourContext={IssueDetailsTourContext}
       id={IssueDetailsTour.SIDEBAR}
       demoTourId={DemoTourStep.ISSUES_DETAIL_SIDEBAR}
-      title={t('Share updates')}
-      description={t(
-        'Leave a comment for a teammate or link your favorite ticketing system - this area helps you collaborate and track progress on the issue.'
+      title={t('Automate root cause')}
+      description={tct(
+        'Use [link:Seer] to investigate this issue faster. You can also add comments for your team and link tickets to track progress.',
+        {
+          link: <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />,
+        }
       )}
       position={isBottomSidebar ? 'top' : 'left-start'}
     >


### PR DESCRIPTION
## Summary
- Updates welcome modal description to better explain what Issue Details is
- Adds support for newlines in StartTourModal descriptions (`white-space: pre-line`)
- Revises tour step copy for clarity:
  - "See overall impact" (aggregate data)
  - "Investigate the issue" (event details)
  - "Compare events" (navigation)
  - "Narrow your focus" (filters)
  - "Automate root cause" (Seer sidebar)

## Test plan
- [ ] Navigate to issue details as a new user (or clear tour state)
- [ ] Verify welcome modal shows description with line break
- [ ] Step through the tour and verify updated copy on each step