### PR TITLE
chore(autofix): control with seer explorer flag on frontend

### DIFF
--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -135,8 +135,8 @@ function DrawerNavigator({
 /**
  * Explorer-based Seer Drawer component.
  *
- * This is the new UI for Autofix when both seer-explorer and autofix-on-explorer
- * feature flags are enabled. It uses the Explorer agent for all analysis instead
+ * This is the new UI for Autofix when seer-explorer is enabled.
+ * It uses the Explorer agent for all analysis instead
  * of the legacy Celery pipeline.
  */
 export function ExplorerSeerDrawer({

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -212,10 +212,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
   }
 
   // Route to Explorer-based drawer if both feature flags are enabled
-  if (
-    organization.features.includes('seer-explorer') &&
-    organization.features.includes('autofix-on-explorer')
-  ) {
+  if (organization.features.includes('seer-explorer')) {
     return (
       <ExplorerSeerDrawer
         group={group}
@@ -520,9 +517,7 @@ export const useOpenSeerDrawer = ({
       return;
     }
 
-    const isExplorerVersion =
-      organization.features.includes('seer-explorer') &&
-      organization.features.includes('autofix-on-explorer');
+    const isExplorerVersion = organization.features.includes('seer-explorer');
 
     openDrawer(() => <SeerDrawer group={group} project={project} event={event} />, {
       ariaLabel: t('Seer drawer'),

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -116,11 +116,9 @@ export default function SeerSection({
 
   const organization = useOrganization();
   const removeConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
-  const isExplorerEnabled =
-    organization.features.includes('seer-explorer') &&
-    organization.features.includes('autofix-on-explorer');
+  const isExplorerEnabled = organization.features.includes('seer-explorer');
 
-  // Get explorer artifacts when autofix-on-explorer is enabled
+  // Get explorer artifacts when autofix on explorer is enabled
   const {runState: explorerRunState} = useExplorerAutofix(group.id, {
     enabled: isExplorerEnabled,
   });


### PR DESCRIPTION
Removing usage of `autofix-on-explorer` flag so that both explorer and the explorer-based autofix are enabled/disabled together.