### PR TITLE
feat(aci): Add pagination and event ID links to open period list

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -998,6 +998,7 @@ export interface GroupOpenPeriod {
   activities: GroupOpenPeriodActivity[];
   duration: string;
   end: string;
+  eventId: string | null;
   id: string;
   isOpen: boolean;
   lastChecked: string;

--- a/static/app/views/detectors/hooks/useOpenPeriods.tsx
+++ b/static/app/views/detectors/hooks/useOpenPeriods.tsx
@@ -47,6 +47,7 @@ export function useOpenPeriods(
     makeOpenPeriodsQueryKey({orgSlug: organization.slug, ...params}),
     {
       staleTime: 0,
+      retry: false,
       ...options,
     }
   );

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -1,15 +1,18 @@
 import {useState} from 'react';
+import {Link} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
-import LoadingError from 'sentry/components/loadingError';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
+import {getShortEventId} from 'sentry/utils/events';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTable';
@@ -17,31 +20,26 @@ import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTabl
 interface OpenPeriodDisplayData {
   duration: React.ReactNode;
   end: React.ReactNode;
+  eventId: React.ReactNode;
   start: React.ReactNode;
   title: React.ReactNode;
 }
 
 // TODO(snigdha): make this work for the old UI
-// TODO(snigdha): support pagination
 function IssueOpenPeriodsList() {
+  const organization = useOrganization();
+  const location = useLocation();
   const [now] = useState(() => new Date());
   const params = useParams<{groupId: string}>();
   const {
-    data: openPeriods,
+    data: openPeriods = [],
     isPending,
-    isError,
-    refetch,
+    error,
+    getResponseHeader,
   } = useOpenPeriods({
     groupId: params.groupId,
+    cursor: location.query?.cursor as string | undefined,
   });
-
-  if (isError) {
-    return <LoadingError onRetry={refetch} />;
-  }
-
-  if (isPending) {
-    return <LoadingIndicator />;
-  }
 
   const getDuration = (start: Date, end?: Date) => {
     const duration = end
@@ -57,6 +55,15 @@ function IssueOpenPeriodsList() {
 
     return {
       title: <DateTime date={startDate} />,
+      eventId: period.eventId ? (
+        <Link
+          to={`/organizations/${organization.slug}/issues/${params.groupId}/events/${period.eventId}/`}
+        >
+          {getShortEventId(period.eventId)}
+        </Link>
+      ) : (
+        '—'
+      ),
       start: <DateTime date={startDate} />,
       end: endDate ? <DateTime date={endDate} /> : '—',
       duration: getDuration(startDate, endDate),
@@ -75,13 +82,31 @@ function IssueOpenPeriodsList() {
     return <AlignLeft>{dataRow[column]}</AlignLeft>;
   };
 
+  const links = parseLinkHeader(getResponseHeader?.('Link') ?? '');
+  const totalCount = getResponseHeader?.('X-Hits') ?? undefined;
+  const previousDisabled = links.previous?.results === false;
+  const nextDisabled = links.next?.results === false;
+
   return (
-    <EventListTable title={t('All Open Periods')} pagination={{enabled: false}}>
+    <EventListTable
+      title={t('All Open Periods')}
+      pagination={{
+        enabled: true,
+        links,
+        paginatorType: 'offset',
+        pageCount: openPeriods.length,
+        totalCount,
+        previousDisabled,
+        nextDisabled,
+        tableUnits: t('open periods'),
+      }}
+    >
       <GridEditable
         isLoading={isPending}
         data={data}
+        error={error}
         columnOrder={[
-          {key: 'title', width: COL_WIDTH_UNDEFINED, name: t('Title')},
+          {key: 'eventId', width: COL_WIDTH_UNDEFINED, name: t('Event ID')},
           {key: 'start', width: COL_WIDTH_UNDEFINED, name: t('Start')},
           {key: 'end', width: COL_WIDTH_UNDEFINED, name: t('End')},
           {key: 'duration', width: COL_WIDTH_UNDEFINED, name: t('Duration')},
@@ -100,4 +125,5 @@ const AlignLeft = styled('span')`
   text-align: left;
   width: 100%;
 `;
+
 export default IssueOpenPeriodsList;

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -22,7 +22,6 @@ interface OpenPeriodDisplayData {
   end: React.ReactNode;
   eventId: React.ReactNode;
   start: React.ReactNode;
-  title: React.ReactNode;
 }
 
 // TODO(snigdha): make this work for the old UI
@@ -54,7 +53,6 @@ function IssueOpenPeriodsList() {
     const endDate = period.end ? new Date(period.end) : undefined;
 
     return {
-      title: <DateTime date={startDate} />,
       eventId: period.eventId ? (
         <Link
           to={`/organizations/${organization.slug}/issues/${params.groupId}/events/${period.eventId}/`}

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -110,6 +110,7 @@ export function EventList({group}: EventListProps) {
                   pageCount={pageEventsCount}
                   totalCount={totalEventsCount}
                   tableUnits={t('events')}
+                  paginatorType="cursor"
                 />
               </HeaderItem>
               <HeaderItem>

--- a/static/app/views/issueDetails/streamline/eventListTable.tsx
+++ b/static/app/views/issueDetails/streamline/eventListTable.tsx
@@ -42,6 +42,10 @@ interface EventListTableProps {
      */
     pageCount?: number;
     /**
+     * Which type of pagination implementation is used by the API.
+     */
+    paginatorType?: 'offset' | 'cursor';
+    /**
      * Whether the previous page link is disabled
      */
     previousDisabled?: boolean;
@@ -71,6 +75,7 @@ export function EventListTable({children, pagination, title}: EventListTableProp
     previousDisabled,
     tableUnits = 'events',
     enabled: isPaginationEnabled = true,
+    paginatorType = 'cursor',
   } = pagination ?? {};
 
   const hasHeader = title !== undefined || isPaginationEnabled;
@@ -87,6 +92,7 @@ export function EventListTable({children, pagination, title}: EventListTableProp
                   pageCount={pageCount}
                   totalCount={totalCount}
                   tableUnits={tableUnits}
+                  paginatorType={paginatorType}
                 />
               </HeaderItem>
               <HeaderItem>
@@ -230,31 +236,43 @@ export const PaginationButton = styled(LinkButton)`
 
 export function PaginationText({
   pageCount = 0,
+  paginatorType,
   totalCount,
   tableUnits,
 }: {
   pageCount: Required<EventListTableProps>['pagination']['pageCount'];
+  paginatorType: NonNullable<EventListTableProps['pagination']>['paginatorType'];
   tableUnits: Required<EventListTableProps>['pagination']['tableUnits'];
   totalCount: Required<EventListTableProps>['pagination']['totalCount'];
 }) {
   const location = useLocation();
   const currentCursor = parseCursor(location.query?.cursor);
-  const start = Math.max(currentCursor?.offset ?? 1, 1);
 
   if (pageCount === 0) {
     return null;
   }
 
+  const isOffsetPagination = paginatorType === 'offset';
+
+  const start =
+    isOffsetPagination && currentCursor
+      ? currentCursor.offset * currentCursor.value + 1
+      : Math.max((currentCursor?.offset ?? 0) + 1, 1);
+  const end =
+    isOffsetPagination && currentCursor
+      ? currentCursor.offset * currentCursor.value + pageCount
+      : (currentCursor?.offset ?? 0) + pageCount;
+
   return defined(totalCount)
     ? tct('Showing [start]-[end] of [count] matching [tableUnits]', {
         start: start.toLocaleString(),
-        end: ((currentCursor?.offset ?? 0) + pageCount).toLocaleString(),
+        end: end.toLocaleString(),
         count: totalCount.toLocaleString(),
         tableUnits,
       })
     : tct('Showing [start]-[end] matching [tableUnits]', {
         start: start.toLocaleString(),
-        end: ((currentCursor?.offset ?? 0) + pageCount).toLocaleString(),
+        end: end.toLocaleString(),
         tableUnits,
       });
 }


### PR DESCRIPTION
Closes ISWF-1929
Closes ISWF-1932

Before:

<img width="1026" height="248" alt="CleanShot 2026-01-26 at 13 38 58" src="https://github.com/user-attachments/assets/ce6d14bd-964a-4c1d-b435-9ca6cd3f7fbe" />

After:

<img width="1037" height="259" alt="CleanShot 2026-01-26 at 13 38 38" src="https://github.com/user-attachments/assets/85675871-be51-46c4-9cdf-088ba5ede23b" />
