### PR TITLE
chore(ACI): Add 'beta' warning to ACI endpoints

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -157,7 +157,7 @@ OPENAPI_TAGS = [
     {
         "name": "Monitors",
         "x-sidebar-name": "Monitors & Alerts",
-        "description": "⚠️ These endpoints are currently in **beta**. They are supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.",
+        "description": "⚠️ These endpoints are currently in **beta** and may be subject to change. They are supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.",
         "x-display-description": True,
         "externalDocs": {
             "description": "Found an error? Let us know.",

--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -157,8 +157,8 @@ OPENAPI_TAGS = [
     {
         "name": "Monitors",
         "x-sidebar-name": "Monitors & Alerts",
-        "description": "Endpoints for Monitors and Alerts",
-        "x-display-description": False,
+        "description": "⚠️ These endpoints are currently in **beta**. They are supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.",
+        "x-display-description": True,
         "externalDocs": {
             "description": "Found an error? Let us know.",
             "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/monitors/&template=api_error_template.md",

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -115,6 +115,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization: Organization, detector: Detector):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Return details on an individual monitor
         """
         serialized_detector = serialize(
@@ -142,6 +144,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def put(self, request: Request, organization: Organization, detector: Detector) -> Response:
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Update an existing monitor
         """
         if not can_edit_detector(detector, request):
@@ -192,6 +196,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def delete(self, request: Request, organization: Organization, detector: Detector):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Delete a monitor
         """
         if not can_delete_detector(detector, request):

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -115,7 +115,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization: Organization, detector: Detector):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Return details on an individual monitor
         """
@@ -144,7 +144,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def put(self, request: Request, organization: Organization, detector: Detector) -> Response:
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Update an existing monitor
         """
@@ -196,7 +196,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     )
     def delete(self, request: Request, organization: Organization, detector: Detector):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Delete a monitor
         """

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -256,7 +256,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization: Organization) -> Response:
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         List an Organization's Monitors
         """
@@ -317,7 +317,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def post(self, request: Request, organization: Organization) -> Response:
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Create a Monitor for a project
         """
@@ -403,7 +403,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def put(self, request: Request, organization: Organization) -> Response:
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Bulk enable or disable an Organization's Monitors
         """
@@ -481,7 +481,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request: Request, organization: Organization) -> Response:
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Bulk delete Monitors for a given organization
         """

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -256,6 +256,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization: Organization) -> Response:
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         List an Organization's Monitors
         """
         if not request.user.is_authenticated:
@@ -315,6 +317,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def post(self, request: Request, organization: Organization) -> Response:
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Create a Monitor for a project
         """
         detector_type = request.data.get("type")
@@ -372,7 +376,6 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Mutate an Organization's Monitors",
-        description=("Currently supports bulk enabling/disabling Monitors."),
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
@@ -400,6 +403,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def put(self, request: Request, organization: Organization) -> Response:
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Bulk enable or disable an Organization's Monitors
         """
         if not request.user.is_authenticated:
@@ -476,6 +481,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request: Request, organization: Organization) -> Response:
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Bulk delete Monitors for a given organization
         """
         if not request.user.is_authenticated:

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -60,7 +60,7 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def get(self, request: Request, organization: Organization, workflow: Workflow):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Returns an alert.
         """
@@ -89,7 +89,7 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def put(self, request: Request, organization: Organization, workflow: Workflow):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Updates an alert.
         """
@@ -155,7 +155,7 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def delete(self, request: Request, organization: Organization, workflow: Workflow):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Deletes an alert.
         """

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -60,6 +60,8 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def get(self, request: Request, organization: Organization, workflow: Workflow):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Returns an alert.
         """
         serialized_workflow = serialize(
@@ -87,6 +89,8 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def put(self, request: Request, organization: Organization, workflow: Workflow):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Updates an alert.
         """
         validator = WorkflowValidator(
@@ -151,6 +155,8 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     )
     def delete(self, request: Request, organization: Organization, workflow: Workflow):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Deletes an alert.
         """
         RegionScheduledDeletion.schedule(workflow, days=0, actor=request.user)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -221,7 +221,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def get(self, request, organization):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Returns a list of alerts for a given organization
         """
@@ -307,7 +307,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def post(self, request, organization):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Creates an alert for an organization
         """
@@ -364,7 +364,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def put(self, request, organization):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Bulk enable or disable alerts for a given Organization
         """
@@ -425,7 +425,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request, organization):
         """
-        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
 
         Bulk delete alerts for a given organization
         """

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -221,6 +221,8 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def get(self, request, organization):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Returns a list of alerts for a given organization
         """
         sort_by = SortByParam.parse(request.GET.get("sortBy", "id"), SORT_COL_MAP)
@@ -305,6 +307,8 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def post(self, request, organization):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Creates an alert for an organization
         """
         validator = WorkflowValidator(
@@ -333,7 +337,6 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Mutate an Organization's Alerts",
-        description=("Currently supports bulk enabling/disabling alerts."),
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             WorkflowParams.QUERY,
@@ -361,6 +364,8 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def put(self, request, organization):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Bulk enable or disable alerts for a given Organization
         """
         if not (
@@ -420,6 +425,8 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     )
     def delete(self, request, organization):
         """
+        ⚠️ This endpoint is currently in **beta**. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
         Bulk delete alerts for a given organization
         """
         if not (


### PR DESCRIPTION
Add a warning that the new endpoints may not have a UI attached to them yet (for users not in LA as of now).


Example of a single endpoint:
<img width="1143" height="634" alt="Screenshot 2026-01-26 at 1 16 45 PM" src="https://github.com/user-attachments/assets/f83c235c-a419-4a67-b2ed-cc60e77b113e" />

Warning on the main page for these endpoints:
<img width="1312" height="614" alt="Screenshot 2026-01-26 at 1 32 21 PM" src="https://github.com/user-attachments/assets/f97aaeef-3dc6-4279-88fc-9ff860ffe42b" />
