### PR TITLE
fix(anomaly detection): don't allow enable anomaly detection on free/team plan

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -206,7 +206,10 @@ type ComponentHooks = {
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
-  'component:disabled-detector-alert-message': React.ComponentType<{
+  'component:disabled-detector-action': React.ComponentType<{
+    detector: import('sentry/types/workflowEngine/detectors').Detector;
+  }>;
+  'component:disabled-detector-alert': React.ComponentType<{
     detector: import('sentry/types/workflowEngine/detectors').Detector;
   }>;
   'component:disabled-member': () => React.ComponentType;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -206,6 +206,9 @@ type ComponentHooks = {
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
+  'component:disabled-detector-alert-message': React.ComponentType<{
+    detector: import('sentry/types/workflowEngine/detectors').Detector;
+  }>;
   'component:disabled-member': () => React.ComponentType;
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
   'component:enhanced-org-stats': () => React.ComponentType<OrganizationStatsProps>;

--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -51,12 +51,15 @@ export function DisableDetectorAction({detector}: {detector: Detector}) {
     return null;
   }
 
-  // Check if this is a metric detector without the required feature
-  const isMetricDetector = detector.type === 'metric_issue';
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'
   );
-  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+  const requiresUpgrade = isAnomalyDetector && !hasAnomalyDetectionFeature;
 
   // If it's a metric detector without the feature, disable the Enable button
   const isButtonDisabled = isUpdating || (requiresUpgrade && !detector.enabled);

--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -55,13 +55,13 @@ export function DisableDetectorAction({detector}: {detector: Detector}) {
   const isAnomalyDetector =
     detector.type === 'metric_issue' &&
     'config' in detector &&
-    detector.config?.detectionType === 'dynamic';
+    (detector as any).config?.detectionType === 'dynamic';
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'
   );
   const requiresUpgrade = isAnomalyDetector && !hasAnomalyDetectionFeature;
 
-  // If it's a metric detector without the feature, disable the Enable button
+  // If it's an anomaly detector without the feature, disable the Enable button
   const isButtonDisabled = isUpdating || (requiresUpgrade && !detector.enabled);
   const tooltipText =
     requiresUpgrade && !detector.enabled

--- a/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
@@ -1,4 +1,4 @@
-import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {MetricDetectorFixture, UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -73,5 +73,27 @@ describe('DisabledAlert', () => {
         })
       );
     });
+  });
+
+  it('shows upgrade message for disabled metric detector without feature', () => {
+    const orgWithoutFeature = OrganizationFixture({
+      access: ['org:write', 'alerts:write'],
+      features: [],
+    });
+    const metricDetector = MetricDetectorFixture({
+      enabled: false,
+      projectId: project.id,
+    });
+
+    render(<DisabledAlert detector={metricDetector} message="Test message" />, {
+      organization: orgWithoutFeature,
+    });
+
+    expect(
+      screen.getByText(
+        /Anomaly detection is only available on Business and Enterprise plans/
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Enable'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
@@ -75,17 +75,18 @@ describe('DisabledAlert', () => {
     });
   });
 
-  it('shows upgrade message for disabled metric detector without feature', () => {
+  it('shows upgrade message for disabled anomaly detector without feature', () => {
     const orgWithoutFeature = OrganizationFixture({
       access: ['org:write', 'alerts:write'],
       features: [],
     });
-    const metricDetector = MetricDetectorFixture({
+    const anomalyDetector = MetricDetectorFixture({
       enabled: false,
       projectId: project.id,
+      config: {detectionType: 'dynamic'},
     });
 
-    render(<DisabledAlert detector={metricDetector} message="Test message" />, {
+    render(<DisabledAlert detector={anomalyDetector} message="Test message" />, {
       organization: orgWithoutFeature,
     });
 

--- a/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.spec.tsx
@@ -1,4 +1,4 @@
-import {MetricDetectorFixture, UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -73,28 +73,5 @@ describe('DisabledAlert', () => {
         })
       );
     });
-  });
-
-  it('shows upgrade message for disabled anomaly detector without feature', () => {
-    const orgWithoutFeature = OrganizationFixture({
-      access: ['org:write', 'alerts:write'],
-      features: [],
-    });
-    const anomalyDetector = MetricDetectorFixture({
-      enabled: false,
-      projectId: project.id,
-      config: {detectionType: 'dynamic'},
-    });
-
-    render(<DisabledAlert detector={anomalyDetector} message="Test message" />, {
-      organization: orgWithoutFeature,
-    });
-
-    expect(
-      screen.getByText(
-        /Anomaly detection is only available on Business and Enterprise plans/
-      )
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Enable'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/details/common/disabledAlert.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.tsx
@@ -1,8 +1,10 @@
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
@@ -17,6 +19,7 @@ type DisabledAlertProps = {
  * to enable it. The alert automatically hides when the detector is enabled.
  */
 export function DisabledAlert({detector, message}: DisabledAlertProps) {
+  const organization = useOrganization();
   const {mutate: updateDetector, isPending: isEnabling} = useUpdateDetector();
   const canEdit = useCanEditDetector({
     detectorType: detector.type,
@@ -30,6 +33,30 @@ export function DisabledAlert({detector, message}: DisabledAlertProps) {
   const handleEnable = () => {
     updateDetector({detectorId: detector.id, enabled: true});
   };
+
+  // Check if this is a metric (anomaly detection) detector without the required feature
+  const isMetricDetector = detector.type === 'metric_issue';
+  const hasAnomalyDetectionFeature = organization.features.includes(
+    'anomaly-detection-alerts'
+  );
+  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+
+  if (requiresUpgrade) {
+    return (
+      <Alert.Container>
+        <Alert variant="muted">
+          {tct(
+            'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
+            {
+              link: (
+                <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />
+              ),
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
 
   return (
     <Alert.Container>

--- a/static/app/views/detectors/components/details/common/disabledAlert.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import Hook from 'sentry/components/hook';
@@ -32,40 +34,37 @@ export function DisabledAlert({detector, message}: DisabledAlertProps) {
     updateDetector({detectorId: detector.id, enabled: true});
   };
 
-  // Check for getsentry upgrade message override
-  const UpgradeMessage = (
-    <Hook name="component:disabled-detector-alert-message" detector={detector} />
-  );
-
-  if (UpgradeMessage) {
-    return (
-      <Alert.Container>
-        <Alert variant="muted">{UpgradeMessage}</Alert>
-      </Alert.Container>
-    );
-  }
-
   return (
     <Alert.Container>
-      <Alert
-        variant="muted"
-        trailingItems={
-          <Button
-            size="xs"
-            icon={<IconPlay />}
-            onClick={handleEnable}
-            disabled={isEnabling || !canEdit}
-            aria-label={t('Enable')}
-            title={
-              canEdit ? undefined : t('You do not have permission to enable this monitor')
-            }
-          >
-            {t('Enable')}
-          </Button>
+      <Hook name="component:disabled-detector-alert" detector={detector}>
+        {({hooks}) =>
+          hooks.length > 0 ? (
+            <Fragment>{hooks as React.ReactNode}</Fragment>
+          ) : (
+            <Alert
+              variant="muted"
+              trailingItems={
+                <Button
+                  size="xs"
+                  icon={<IconPlay />}
+                  onClick={handleEnable}
+                  disabled={isEnabling || !canEdit}
+                  aria-label={t('Enable')}
+                  title={
+                    canEdit
+                      ? undefined
+                      : t('You do not have permission to enable this monitor')
+                  }
+                >
+                  {t('Enable')}
+                </Button>
+              }
+            >
+              {message}
+            </Alert>
+          )
         }
-      >
-        {message}
-      </Alert>
+      </Hook>
     </Alert.Container>
   );
 }

--- a/static/app/views/detectors/components/details/common/disabledAlert.tsx
+++ b/static/app/views/detectors/components/details/common/disabledAlert.tsx
@@ -34,12 +34,15 @@ export function DisabledAlert({detector, message}: DisabledAlertProps) {
     updateDetector({detectorId: detector.id, enabled: true});
   };
 
-  // Check if this is a metric (anomaly detection) detector without the required feature
-  const isMetricDetector = detector.type === 'metric_issue';
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'
   );
-  const requiresUpgrade = isMetricDetector && !hasAnomalyDetectionFeature;
+  const requiresUpgrade = isAnomalyDetector && !hasAnomalyDetectionFeature;
 
   if (requiresUpgrade) {
     return (

--- a/static/gsApp/components/anomalyDetectionDisableAction.tsx
+++ b/static/gsApp/components/anomalyDetectionDisableAction.tsx
@@ -1,0 +1,38 @@
+import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {t} from 'sentry/locale';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function AnomalyDetectionDisableAction({detector}: {detector: Detector}) {
+  const organization = useOrganization();
+
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
+
+  const hasAnomalyDetectionFeature = organization.features.includes(
+    'anomaly-detection-alerts'
+  );
+
+  // Only override for anomaly detectors without the feature
+  if (!isAnomalyDetector || hasAnomalyDetectionFeature) {
+    return null;
+  }
+
+  // For anomaly detectors without feature: disable the Enable button with tooltip
+  const isDisabled = !detector.enabled;
+  const tooltipText = isDisabled
+    ? t('Anomaly detection is only available on Business and Enterprise plans')
+    : undefined;
+
+  return (
+    <Tooltip title={tooltipText} disabled={!tooltipText}>
+      <Button size="sm" disabled>
+        {detector.enabled ? t('Disable') : t('Enable')}
+      </Button>
+    </Tooltip>
+  );
+}

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.spec.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.spec.tsx
@@ -3,16 +3,16 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {AnomalyDetectionDisabledAlertMessage} from './anomalyDetectionDisabledAlert';
+import {AnomalyDetectionDisabledAlert} from './anomalyDetectionDisabledAlert';
 
-describe('AnomalyDetectionDisabledAlertMessage', () => {
+describe('AnomalyDetectionDisabledAlert', () => {
   it('shows upgrade message for anomaly detector without feature', () => {
     const orgWithoutFeature = OrganizationFixture({features: []});
     const anomalyDetector = MetricDetectorFixture({
       config: {detectionType: 'dynamic'},
     });
 
-    render(<AnomalyDetectionDisabledAlertMessage detector={anomalyDetector} />, {
+    render(<AnomalyDetectionDisabledAlert detector={anomalyDetector} />, {
       organization: orgWithoutFeature,
     });
 
@@ -30,7 +30,7 @@ describe('AnomalyDetectionDisabledAlertMessage', () => {
     });
 
     const {container} = render(
-      <AnomalyDetectionDisabledAlertMessage detector={thresholdDetector} />,
+      <AnomalyDetectionDisabledAlert detector={thresholdDetector} />,
       {
         organization: orgWithoutFeature,
       }
@@ -48,7 +48,7 @@ describe('AnomalyDetectionDisabledAlertMessage', () => {
     });
 
     const {container} = render(
-      <AnomalyDetectionDisabledAlertMessage detector={anomalyDetector} />,
+      <AnomalyDetectionDisabledAlert detector={anomalyDetector} />,
       {
         organization: orgWithFeature,
       }

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.spec.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.spec.tsx
@@ -1,0 +1,59 @@
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {AnomalyDetectionDisabledAlertMessage} from './anomalyDetectionDisabledAlert';
+
+describe('AnomalyDetectionDisabledAlertMessage', () => {
+  it('shows upgrade message for anomaly detector without feature', () => {
+    const orgWithoutFeature = OrganizationFixture({features: []});
+    const anomalyDetector = MetricDetectorFixture({
+      config: {detectionType: 'dynamic'},
+    });
+
+    render(<AnomalyDetectionDisabledAlertMessage detector={anomalyDetector} />, {
+      organization: orgWithoutFeature,
+    });
+
+    expect(
+      screen.getByText(
+        /Anomaly detection is only available on Business and Enterprise plans/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('returns null for non-anomaly detectors', () => {
+    const orgWithoutFeature = OrganizationFixture({features: []});
+    const thresholdDetector = MetricDetectorFixture({
+      config: {detectionType: 'static'},
+    });
+
+    const {container} = render(
+      <AnomalyDetectionDisabledAlertMessage detector={thresholdDetector} />,
+      {
+        organization: orgWithoutFeature,
+      }
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when org has feature', () => {
+    const orgWithFeature = OrganizationFixture({
+      features: ['anomaly-detection-alerts'],
+    });
+    const anomalyDetector = MetricDetectorFixture({
+      config: {detectionType: 'dynamic'},
+    });
+
+    const {container} = render(
+      <AnomalyDetectionDisabledAlertMessage detector={anomalyDetector} />,
+      {
+        organization: orgWithFeature,
+      }
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -1,9 +1,10 @@
+import {Alert} from 'sentry/components/core/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {tct} from 'sentry/locale';
-import type {Detector, MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function AnomalyDetectionDisabledAlertMessage({detector}: {detector: Detector}) {
+export function AnomalyDetectionDisabledAlert({detector}: {detector: Detector}) {
   const organization = useOrganization();
 
   // Check if this is an anomaly detection detector without the required feature
@@ -16,14 +17,21 @@ export function AnomalyDetectionDisabledAlertMessage({detector}: {detector: Dete
     'anomaly-detection-alerts'
   );
 
+  // Only show for anomaly detectors without the feature
   if (!isAnomalyDetector || hasAnomalyDetectionFeature) {
     return null;
   }
 
-  return tct(
-    'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
-    {
-      link: <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />,
-    }
+  return (
+    <Alert variant="muted">
+      {tct(
+        'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
+        {
+          link: (
+            <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />
+          ),
+        }
+      )}
+    </Alert>
   );
 }

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -1,0 +1,29 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {tct} from 'sentry/locale';
+import type {Detector, MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function AnomalyDetectionDisabledAlertMessage({detector}: {detector: Detector}) {
+  const organization = useOrganization();
+
+  // Check if this is an anomaly detection detector without the required feature
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    (detector as MetricDetector).config?.detectionType === 'dynamic';
+
+  const hasAnomalyDetectionFeature = organization.features.includes(
+    'anomaly-detection-alerts'
+  );
+
+  if (!isAnomalyDetector || hasAnomalyDetectionFeature) {
+    return null;
+  }
+
+  return tct(
+    'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
+    {
+      link: <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />,
+    }
+  );
+}

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -10,7 +10,7 @@ export function AnomalyDetectionDisabledAlertMessage({detector}: {detector: Dete
   const isAnomalyDetector =
     detector.type === 'metric_issue' &&
     'config' in detector &&
-    (detector as MetricDetector).config?.detectionType === 'dynamic';
+    detector.config?.detectionType === 'dynamic';
 
   const hasAnomalyDetectionFeature = organization.features.includes(
     'anomaly-detection-alerts'

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -7,6 +7,7 @@ import type {Hooks} from 'sentry/types/hooks';
 
 import AiSetupConfiguration from 'getsentry/components/ai/aiSetupConfiguration';
 import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
+import {AnomalyDetectionDisabledAlertMessage} from 'getsentry/components/anomalyDetectionDisabledAlert';
 import CronsBillingBanner from 'getsentry/components/crons/cronsBillingBanner';
 import DashboardBanner from 'getsentry/components/dashboardBanner';
 import DataConsentBanner from 'getsentry/components/dataConsentBanner';
@@ -253,6 +254,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
   'component:metric-alert-quota-message': MetricAlertQuotaMessage,
   'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
+  'component:disabled-detector-alert-message': AnomalyDetectionDisabledAlertMessage,
 
   /**
    * Augment disable feature hooks for augmenting with upsell interfaces

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -7,7 +7,8 @@ import type {Hooks} from 'sentry/types/hooks';
 
 import AiSetupConfiguration from 'getsentry/components/ai/aiSetupConfiguration';
 import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
-import {AnomalyDetectionDisabledAlertMessage} from 'getsentry/components/anomalyDetectionDisabledAlert';
+import {AnomalyDetectionDisableAction} from 'getsentry/components/anomalyDetectionDisableAction';
+import {AnomalyDetectionDisabledAlert} from 'getsentry/components/anomalyDetectionDisabledAlert';
 import CronsBillingBanner from 'getsentry/components/crons/cronsBillingBanner';
 import DashboardBanner from 'getsentry/components/dashboardBanner';
 import DataConsentBanner from 'getsentry/components/dataConsentBanner';
@@ -254,7 +255,8 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
   'component:metric-alert-quota-message': MetricAlertQuotaMessage,
   'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
-  'component:disabled-detector-alert-message': AnomalyDetectionDisabledAlertMessage,
+  'component:disabled-detector-action': AnomalyDetectionDisableAction,
+  'component:disabled-detector-alert': AnomalyDetectionDisabledAlert,
 
   /**
    * Augment disable feature hooks for augmenting with upsell interfaces


### PR DESCRIPTION
Free/team plans can enable dynamic detectors that already exist on a project, which should not be possible. Changed banner to say "Anomaly detection is only available on Business and Enterprise plans. [Upgrade your plan](https://sentry.io/pricing/?referrer=anomaly-detection) to enable this monitor." and disabled `enable` button.

no `anomaly-detection-alerts`
<img width="1246" height="358" alt="image" src="https://github.com/user-attachments/assets/7dccb9aa-571d-4b18-9592-498f56fdb96a" />

with `anomaly-detection-alerts`
<img width="1247" height="306" alt="image" src="https://github.com/user-attachments/assets/abdbe0bb-8f4f-4b85-b229-fe78c9c713b2" />

