### PR TITLE
chore(preprod): Limit feature filter search keys

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -16,6 +16,20 @@ import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSet
 import {useFeatureFilter} from './useFeatureFilter';
 
 const EXAMPLE_BUILDS_COUNT = 5;
+const FEATURE_FILTER_ALLOWED_KEYS = [
+  'app_id',
+  'app_name',
+  'build_configuration_name',
+  'platform_name',
+  'build_number',
+  'build_version',
+  'git_head_ref',
+  'git_base_ref',
+  'git_head_sha',
+  'git_base_sha',
+  'git_head_repo_name',
+  'git_pr_number',
+];
 
 interface FeatureFilterProps {
   settingsReadKey: string;
@@ -91,6 +105,7 @@ export function FeatureFilter({
           <PreprodSearchBar
             initialQuery={localQuery}
             projects={[Number(project.id)]}
+            allowedKeys={FEATURE_FILTER_ALLOWED_KEYS}
             onChange={handleQueryChange}
             onSearch={handleSearch}
             searchSource="preprod_feature_filter"


### PR DESCRIPTION
Restrict the preprod feature filter search bar to build metadata fields.

PR
<img width="2754" height="1016" alt="CleanShot 2026-01-26 at 16 47 03@2x" src="https://github.com/user-attachments/assets/fdc0ceba-1ec9-4f32-b0cc-e693d5ca05b3" />


prod
<img width="2884" height="1234" alt="CleanShot 2026-01-26 at 16 48 03@2x" src="https://github.com/user-attachments/assets/270c6f10-449a-4d99-a153-47e181e4169f" />


Refs EME-760