### PR TITLE
feat(code_review): Retry task up to five times

### DIFF
--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 PREFIX = "seer.code_review.task"
-MAX_RETRIES = 3
+MAX_RETRIES = 5
 DELAY_BETWEEN_RETRIES = 60  # 1 minute
 RETRYABLE_ERRORS = (HTTPError,)
 METRICS_PREFIX = "seer.code_review.task"

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -51,7 +51,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
             "Without this, the task will fail immediately despite times=3."
         )
 
-        assert task.retry._times == 3, "Task should retry 3 times"
+        assert task.retry._times == 5, "Task should retry 5 times"
         assert task.retry._delay == 60, "Task should delay 60 seconds between retries"
 
         from urllib3.exceptions import MaxRetryError
@@ -382,7 +382,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
 
         mock_request.side_effect = MaxRetryError(None, "test", reason="Connection failed")  # type: ignore[arg-type]
 
-        # With MAX_RETRIES=3, there are 2 delays between 3 attempts: (3-1) * 60s = 120s
+        # With MAX_RETRIES=5, there are 4 delays between 5 attempts: (5-1) * 60s = 240s
         enqueued_at_str = (
             datetime.now(timezone.utc)
             - timedelta(seconds=DELAY_BETWEEN_RETRIES * (MAX_RETRIES - 1))
@@ -414,9 +414,9 @@ class ProcessGitHubWebhookEventTest(TestCase):
         assert "tags" in call_kwargs
         assert "status" in call_kwargs["tags"]
 
-        # With MAX_RETRIES=3, there are 2 delays: (3-1) * 60s = 120s
-        # Allow tolerance for test execution time (3 attempts add overhead)
-        expected_latency_ms = (MAX_RETRIES - 1) * DELAY_BETWEEN_RETRIES * 1000  # 120,000ms
+        # With MAX_RETRIES=5, there are 4 delays: (5-1) * 60s = 240s
+        # Allow tolerance for test execution time (5 attempts add overhead)
+        expected_latency_ms = (MAX_RETRIES - 1) * DELAY_BETWEEN_RETRIES * 1000  # 240,000ms
         assert (
             expected_latency_ms - 1000 <= call_args[1] <= expected_latency_ms + 5000
         ), f"Expected latency ~{expected_latency_ms}ms, got {call_args[1]}ms"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Increases the `MAX_RETRIES` for the `seer.code_review.task` from 3 to 5.

This change enhances the resilience of the code review webhook processing against transient failures by allowing more retry attempts. Related test assertions and expected latency calculations have been updated accordingly.

---
Linear Issue: [CW-647](https://linear.app/getsentry/issue/CW-647/retry-the-task-5-times)

<a href="https://cursor.com/background-agent?bcId=bc-8550a5ec-b27a-4ff4-bd9a-2d08da5695be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8550a5ec-b27a-4ff4-bd9a-2d08da5695be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

