### PR TITLE
fix(logs): Convert count() to count(message) when opening in explore

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -69,7 +69,7 @@ describe('getWidgetExploreUrl', () => {
     expectUrl(url).toMatch({
       path: '/organizations/org-slug/explore/logs/',
       params: [
-        ['aggregateField', '{"chartType":1,"yAxes":["count()"]}'],
+        ['aggregateField', '{"chartType":1,"yAxes":["count(message)"]}'],
         ['interval', '3h'],
         ['logsGroupBy', ''],
         ['mode', 'aggregate'],

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -13,7 +13,7 @@ import {
   isEquationAlias,
   parseFunction,
 } from 'sentry/utils/discover/fields';
-import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {AggregationKey, FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {decodeBoolean, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -26,6 +26,7 @@ import {
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import type {TabularRow} from 'sentry/views/dashboards/widgets/common/types';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getExploreMultiQueryUrl, getExploreUrl} from 'sentry/views/explore/utils';
@@ -161,6 +162,21 @@ function getChartType(displayType: DisplayType) {
   }
 
   return chartType;
+}
+
+/**
+ * Transforms yAxis values for logs context.
+ * In logs, `count()` without an argument is invalid - it must be `count(message)`.
+ *
+ * This function defensively handles the case where the widget only uses count() without
+ * an argument. We should remove this when we convert the dashboard widgets to use
+ * count(message) instead.
+ */
+function transformLogsYAxis(yAxis: string): string {
+  if (yAxis === `${AggregationKey.COUNT}()`) {
+    return `${AggregationKey.COUNT}(${OurLogKnownFieldKey.MESSAGE})`;
+  }
+  return yAxis;
 }
 
 function getAggregateArguments(yAxis: string): string[] {
@@ -318,13 +334,18 @@ function _getWidgetExploreUrl(
   };
 
   if (traceItemDataset === TraceItemDataset.LOGS) {
+    const logsVisualize = queryParams.visualize.map(v => ({
+      ...v,
+      yAxes: v.yAxes.map(transformLogsYAxis),
+    }));
+
     return getLogsUrl({
       organization: queryParams.organization,
       selection: queryParams.selection,
       query: queryParams.query,
       field: queryParams.field,
       groupBy: queryParams.groupBy,
-      aggregateFields: queryParams.visualize,
+      aggregateFields: logsVisualize,
       interval: queryParams.interval,
       mode: queryParams.mode,
       referrer: queryParams.referrer,


### PR DESCRIPTION
This is a small patch to convert `count()` in dashboard widgets to `count(message)` for logs. A more robust fix should be that we always encode `count(message)` for logs widgets, but since we aren't doing that at the moment and those widgets need migration/intervention, this is a quick fix to accommodate this navigation.

For logs, `count()` defaults to `count(log.body)` in the backend, which seems to have the same result, so using `count(message)` is the same as what the user would see.