### PR TITLE
fix(ui): Delay checking frontend version for 10 minutes

### DIFF
--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import * as constants from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
@@ -23,14 +23,18 @@ function TestComponent() {
   );
 }
 
+const TEN_MINUTES = 10 * 60 * 1000;
+
 describe('FrontendVersionProvider', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     MockApiClient.clearMockResponses();
     ConfigStore.set('sentryMode', 'SAAS');
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   it('provides state="current" when server version matches current version', async () => {
@@ -47,6 +51,9 @@ describe('FrontendVersionProvider', () => {
         <TestComponent />
       </FrontendVersionProvider>
     );
+
+    // Advance past the initial delay before version checking starts
+    act(() => jest.advanceTimersByTime(TEN_MINUTES));
 
     expect(await screen.findByTestId('state')).toHaveTextContent('current');
     expect(await screen.findByTestId('deployed-version')).toHaveTextContent(commitSha);
@@ -68,6 +75,9 @@ describe('FrontendVersionProvider', () => {
         <TestComponent />
       </FrontendVersionProvider>
     );
+
+    // Advance past the initial delay before version checking starts
+    act(() => jest.advanceTimersByTime(TEN_MINUTES));
 
     expect(await screen.findByTestId('state')).toHaveTextContent('stale');
     expect(await screen.findByTestId('deployed-version')).toHaveTextContent(
@@ -92,6 +102,9 @@ describe('FrontendVersionProvider', () => {
         <TestComponent />
       </FrontendVersionProvider>
     );
+
+    // Advance past the initial delay before version checking starts
+    act(() => jest.advanceTimersByTime(TEN_MINUTES));
 
     expect(await screen.findByTestId('state')).toHaveTextContent('unknown');
     expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');


### PR DESCRIPTION
During rollouts i've seen that the frontend version checking can be annoying and moves the user back and forth between versions.

Prevents checking the version until the page has been alive for > 10 minutes
