### PR TITLE
feat(oauth): Add Authorization Server Metadata endpoint (RFC 8414)

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.project import Project
 from sentry.utils import json
-from sentry.utils.http import get_origins
+from sentry.utils.http import absolute_uri, get_origins
 from sentry.web.client_config import get_client_config
 from sentry.web.frontend.base import all_silo_view, region_silo_view
 from sentry.web.helpers import render_to_response
@@ -98,6 +98,42 @@ def mcp_json(request):
         return HttpResponse(status=404)
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
+    """
+    OAuth 2.0 Authorization Server Metadata endpoint per RFC 8414.
+
+    Returns JSON metadata document describing the authorization server's
+    configuration, supported grant types, PKCE methods, and endpoints.
+    """
+    # Build sorted scopes list for consistent output
+    scopes = sorted(settings.SENTRY_SCOPES)
+
+    metadata = {
+        "issuer": absolute_uri("/"),
+        "authorization_endpoint": absolute_uri("/oauth/authorize/"),
+        "token_endpoint": absolute_uri("/oauth/token/"),
+        "userinfo_endpoint": absolute_uri("/oauth/userinfo/"),
+        "device_authorization_endpoint": absolute_uri("/oauth/device/code/"),
+        "response_types_supported": ["code"],
+        "grant_types_supported": [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ],
+        "scopes_supported": scopes,
+    }
+
+    return HttpResponse(json.dumps(metadata), content_type="application/json")
 
 
 @region_silo_view

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1266,6 +1266,11 @@ urlpatterns += [
         api.mcp_json,
         name="sentry-mcp-json",
     ),
+    re_path(
+        r"^\.well-known/oauth-authorization-server$",
+        api.oauth_authorization_server_metadata,
+        name="sentry-oauth-authorization-server-metadata",
+    ),
     # Force a 404 of favicon.ico.
     # This url is commonly requested by browsers, and without
     # blocking this, it was treated as a 200 OK for a react page view.

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -747,3 +747,64 @@ class McpJsonTest(TestCase):
         assert response.status_code == 200
         assert "max-age=3600" in response["Cache-Control"]
         assert "public" in response["Cache-Control"]
+
+
+class OAuthAuthorizationServerMetadataTest(TestCase):
+    @cached_property
+    def path(self) -> str:
+        return reverse("sentry-oauth-authorization-server-metadata")
+
+    def test_metadata_response(self) -> None:
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+
+        data = json.loads(response.content)
+
+        # RFC 8414 required fields
+        assert "issuer" in data
+        assert "authorization_endpoint" in data
+        assert "token_endpoint" in data
+
+        assert data["authorization_endpoint"].endswith("/oauth/authorize/")
+        assert data["token_endpoint"].endswith("/oauth/token/")
+        assert data["userinfo_endpoint"].endswith("/oauth/userinfo/")
+        assert data["device_authorization_endpoint"].endswith("/oauth/device/code/")
+
+        assert data["grant_types_supported"] == [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ]
+
+        # OAuth 2.1 only allows "code" response type
+        assert data["response_types_supported"] == ["code"]
+
+        # S256 only per security best practices
+        assert data["code_challenge_methods_supported"] == ["S256"]
+
+        assert data["token_endpoint_auth_methods_supported"] == [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ]
+
+        assert "scopes_supported" in data
+        assert data["scopes_supported"] == sorted(data["scopes_supported"])
+        assert "openid" in data["scopes_supported"]
+        assert "org:read" in data["scopes_supported"]
+        assert "project:read" in data["scopes_supported"]
+
+    def test_cache_control(self) -> None:
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+
+    def test_issuer_matches_server(self) -> None:
+        response = self.client.get(self.path)
+        data = json.loads(response.content)
+
+        assert data["issuer"] == "http://testserver/"


### PR DESCRIPTION
Add `/.well-known/oauth-authorization-server` discovery endpoint per RFC 8414 that returns JSON metadata describing the OAuth authorization server's configuration.

This enables OAuth clients to automatically discover Sentry's supported capabilities without hardcoding configuration, improving interoperability and supporting OAuth 2.1 compliance.

The metadata document includes:
- Issuer identifier and all OAuth endpoint URLs (authorize, token, userinfo, device code)
- Supported grant types: `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`
- PKCE support with S256 only (per security best practices)
- Token endpoint authentication methods: `client_secret_basic`, `client_secret_post`, `none`
- All available scopes from `SENTRY_SCOPES`

Response is cached for 1 hour with public cache headers.

Refs #99002