### PR TITLE
fix(alerts): improve alerts list UX for downgraded plans

### DIFF
--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -7,6 +7,7 @@ import {
   addMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
+import {Alert} from 'sentry/components/core/alert/alert';
 import {Link} from 'sentry/components/core/link';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -177,6 +178,7 @@ export default function AlertRulesList() {
   };
 
   const hasEditAccess = organization.access.includes('alerts:write');
+  const hasIncidentsFeature = organization.features.includes('incidents');
 
   const ruleList = ruleListResponse.filter(defined);
   const projectsFromResults = uniq(
@@ -210,6 +212,11 @@ export default function AlertRulesList() {
         <Layout.Body>
           <Layout.Main width="full">
             <DataConsentBanner source="alerts" />
+            {!hasIncidentsFeature && (
+              <Alert variant="warning" system>
+                Placeholder Text
+              </Alert>
+            )}
             <FilterBar
               location={location}
               onChangeFilter={handleChangeFilter}

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -178,7 +178,7 @@ export default function AlertRulesList() {
   };
 
   const hasEditAccess = organization.access.includes('alerts:write');
-  const hasIncidentsFeature = organization.features.includes('incidents');
+  const hasMetricAlerts = organization.features.includes('incidents');
 
   const ruleList = ruleListResponse.filter(defined);
   const projectsFromResults = uniq(
@@ -212,10 +212,10 @@ export default function AlertRulesList() {
         <Layout.Body>
           <Layout.Main width="full">
             <DataConsentBanner source="alerts" />
-            {!hasIncidentsFeature && (
-              <Alert variant="warning" system>
-                Placeholder Text
-              </Alert>
+            {!hasMetricAlerts && (
+              <Alert.Container>
+                <Alert variant="danger">Placeholder Text</Alert>
+              </Alert.Container>
             )}
             <FilterBar
               location={location}
@@ -304,6 +304,7 @@ export default function AlertRulesList() {
                           onOwnerChange={handleOwnerChange}
                           onDelete={handleDeleteRule}
                           hasEditAccess={hasEditAccess}
+                          hasMetricAlerts={hasMetricAlerts}
                         />
                       );
                     })

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -178,9 +178,12 @@ export default function AlertRulesList() {
   };
 
   const hasEditAccess = organization.access.includes('alerts:write');
-  const hasMetricAlerts = organization.features.includes('incidents');
+  const hasMetricAlertsFeature = organization.features.includes('incidents');
 
   const ruleList = ruleListResponse.filter(defined);
+  const hasAnyMetricAlerts = ruleList.some(
+    rule => rule.type === CombinedAlertType.METRIC
+  );
   const projectsFromResults = uniq(
     ruleList.flatMap(rule =>
       rule.type === CombinedAlertType.UPTIME
@@ -212,9 +215,12 @@ export default function AlertRulesList() {
         <Layout.Body>
           <Layout.Main width="full">
             <DataConsentBanner source="alerts" />
-            {!hasMetricAlerts && (
+            {!hasMetricAlertsFeature && hasAnyMetricAlerts && (
               <Alert.Container>
-                <Alert variant="danger">Placeholder Text</Alert>
+                <Alert variant="danger">
+                  Your metric alerts have been disabled. Upgrade your plan to re-enable
+                  them.
+                </Alert>
               </Alert.Container>
             )}
             <FilterBar
@@ -304,7 +310,7 @@ export default function AlertRulesList() {
                           onOwnerChange={handleOwnerChange}
                           onDelete={handleDeleteRule}
                           hasEditAccess={hasEditAccess}
-                          hasMetricAlerts={hasMetricAlerts}
+                          hasMetricAlerts={hasMetricAlertsFeature}
                         />
                       );
                     })

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -129,7 +129,7 @@ function RuleListRow({
     : true;
 
   const isMetricAlert = rule.type === CombinedAlertType.METRIC;
-  const isMetricAlertDisabled = isMetricAlert && !hasMetricAlerts;
+  const shouldDisableAlertRule = isMetricAlert && !hasMetricAlerts;
 
   const activeActions = {
     [CombinedAlertType.ISSUE]: ['edit', 'duplicate', 'delete'],
@@ -284,7 +284,7 @@ function RuleListRow({
       <AlertNameWrapper isIssueAlert={isIssueAlert(rule)}>
         <AlertNameAndStatus>
           <AlertName>
-            {isMetricAlertDisabled ? (
+            {shouldDisableAlertRule ? (
               <Tooltip
                 skipWrapper
                 title={t(
@@ -364,7 +364,7 @@ function RuleListRow({
             if (!hasAccess || !canEdit) {
               disabledKeys.push('delete');
             }
-            if (isMetricAlertDisabled) {
+            if (shouldDisableAlertRule) {
               disabledKeys.push('edit', 'duplicate');
             }
             return (

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -44,6 +44,7 @@ import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/has
 
 type Props = {
   hasEditAccess: boolean;
+  hasMetricAlerts: boolean;
   onDelete: (projectId: string, rule: CombinedAlerts) => void;
   onOwnerChange: (projectId: string, rule: CombinedAlerts, ownerValue: string) => void;
   organization: Organization;
@@ -60,6 +61,7 @@ function RuleListRow({
   onDelete,
   onOwnerChange,
   hasEditAccess,
+  hasMetricAlerts,
 }: Props) {
   const {teams: userTeams} = useUserTeams();
   const [assignee, setAssignee] = useState<string>('');
@@ -125,6 +127,9 @@ function RuleListRow({
   const canEdit = ownerActor?.id
     ? userTeams.some(team => team.id === ownerActor.id)
     : true;
+
+  const isMetricAlert = rule.type === CombinedAlertType.METRIC;
+  const isMetricAlertDisabled = isMetricAlert && !hasMetricAlerts;
 
   const activeActions = {
     [CombinedAlertType.ISSUE]: ['edit', 'duplicate', 'delete'],
@@ -279,9 +284,22 @@ function RuleListRow({
       <AlertNameWrapper isIssueAlert={isIssueAlert(rule)}>
         <AlertNameAndStatus>
           <AlertName>
-            <Link to={ruleUrl()}>
-              {rule.name} {titleBadge}
-            </Link>
+            {isMetricAlertDisabled ? (
+              <Tooltip
+                skipWrapper
+                title={t(
+                  'This metric alert is not available. Your organization does not have access to this feature.'
+                )}
+              >
+                <DisabledAlertName>
+                  {rule.name} {titleBadge}
+                </DisabledAlertName>
+              </Tooltip>
+            ) : (
+              <Link to={ruleUrl()}>
+                {rule.name} {titleBadge}
+              </Link>
+            )}
           </AlertName>
           <AlertIncidentDate>
             <AlertLastIncidentActivationInfo rule={rule} />
@@ -341,19 +359,28 @@ function RuleListRow({
       </Flex>
       <ActionsColumn>
         <Access access={['alerts:write']}>
-          {({hasAccess}) => (
-            <DropdownMenu
-              items={actions}
-              position="bottom-end"
-              triggerProps={{
-                'aria-label': t('Actions'),
-                size: 'xs',
-                icon: <IconEllipsis />,
-                showChevron: false,
-              }}
-              disabledKeys={hasAccess && canEdit ? [] : ['delete']}
-            />
-          )}
+          {({hasAccess}) => {
+            const disabledKeys: string[] = [];
+            if (!hasAccess || !canEdit) {
+              disabledKeys.push('delete');
+            }
+            if (isMetricAlertDisabled) {
+              disabledKeys.push('edit', 'duplicate');
+            }
+            return (
+              <DropdownMenu
+                items={actions}
+                position="bottom-end"
+                triggerProps={{
+                  'aria-label': t('Actions'),
+                  size: 'xs',
+                  icon: <IconEllipsis />,
+                  showChevron: false,
+                }}
+                disabledKeys={disabledKeys}
+              />
+            );
+          }}
         </Access>
       </ActionsColumn>
     </ErrorBoundary>
@@ -427,6 +454,11 @@ const MarginLeft = styled('div')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   margin: 0;
   margin-right: ${space(1.5)};
+`;
+
+const DisabledAlertName = styled('span')`
+  color: ${p => p.theme.tokens.content.disabled};
+  cursor: not-allowed;
 `;
 
 export default RuleListRow;


### PR DESCRIPTION
Solution for [ISWF-1931](https://linear.app/getsentry/issue/ISWF-1931/404-error-for-alerts-not-part-of-current-subscription-plan). If an organization has alert rules that they created before downgrading, then display a warning banner and prevent clicking on or taking edit/duplicate actions on the alerts. Hopefully this is less confusing than the alerts being clickable but the details page giving a 404.

<img width="1281" height="584" alt="Screenshot 2026-01-26 at 2 59 10 PM" src="https://github.com/user-attachments/assets/a3145084-ee3b-428f-b86d-54947b4970c4" />

