### PR TITLE
chore(ownership): Retry `code_owners_auto_sync` task on `Commit.DoesNotExist` silently

### DIFF
--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -21,7 +21,7 @@ from sentry.taskworker.retry import Retry
     processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
 )
-@retry(on=(Commit.DoesNotExist,))
+@retry(on_silent=(Commit.DoesNotExist,))
 def code_owners_auto_sync(commit_id: int, **kwargs: Any) -> None:
     from django.db.models import BooleanField, Case, Exists, OuterRef, Subquery, When
 

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -21,7 +21,7 @@ from sentry.taskworker.retry import Retry
     processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
 )
-@retry(on_silent=(Commit.DoesNotExist,))
+@retry(on=(), on_silent=(Commit.DoesNotExist,))
 def code_owners_auto_sync(commit_id: int, **kwargs: Any) -> None:
     from django.db.models import BooleanField, Case, Exists, OuterRef, Subquery, When
 


### PR DESCRIPTION
Resolves [ID-1184](https://linear.app/getsentry/issue/ID-1184/code-owners-sync-fails-to-find-commits). Resolves [SENTRY-54BK](https://sentry.sentry.io/issues/6879879123/?project=1). Resolves [SENTRY-5BRW](https://sentry.sentry.io/issues/6985264366?project=1). 

When retrying this task on `Commit.DoesNotExist`, do not capture the exception in Sentry. Only capture an issue when all of the retries fail.