### PR TITLE
ref(ownership): Remove backwards compatibility logic for assignee existence cache

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -243,13 +243,10 @@ def handle_owner_assignment(job):
     assignee_exists = None
     if assignee_cache_value is not None:
         # Cache stores (value, timestamp) tuple for timestamp-based invalidation
-        if isinstance(assignee_cache_value, tuple):
-            cached_assignee_exists, assignee_debounce_time = assignee_cache_value
-            ownership_changed_at = GroupOwner.get_project_ownership_version(project.id)
-            if ownership_changed_at is None or ownership_changed_at < assignee_debounce_time:
-                assignee_exists = cached_assignee_exists
-        else:  # TODO(shashank): for backwards compatibility, remove this and the above tuple check once rolled out for 24hrs
-            assignee_exists = assignee_cache_value
+        cached_assignee_exists, assignee_debounce_time = assignee_cache_value
+        ownership_changed_at = GroupOwner.get_project_ownership_version(project.id)
+        if ownership_changed_at is None or ownership_changed_at < assignee_debounce_time:
+            assignee_exists = cached_assignee_exists
 
     if assignee_exists is None:
         assignee_exists = group.assignee_set.exists()


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/106479.

Closes [ID-1238](https://linear.app/getsentry/issue/ID-1238/cache-for-assignee-existence-check-uses-expensive-fan-out-invalidation).

It's been >24 hours since the PR above was deployed and the assignee existence cache values were migrated to the new format. We can therefore remove the backwards compatibility logic, since all cache values will now correctly be 2-tuples of `(assignee_exists, assignee_debounce_time)`.