### PR TITLE
fix(dashboards): Always auto-increment dashboard titles on conflict

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -574,9 +574,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
             return Response(serialize(dashboard, request.user), status=201)
         except IntegrityError:
-            duplicate = request.data.get("duplicate", False)
-
-            if not duplicate or retry >= MAX_RETRIES:
+            if retry >= MAX_RETRIES:
                 return Response("Dashboard title already taken", status=409)
 
             request.data["title"] = Dashboard.incremental_title(organization, request.data["title"])

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -47,8 +47,7 @@ export function fetchDashboards(api: Client, orgSlug: string) {
 export function createDashboard(
   api: Client,
   orgSlug: string,
-  newDashboard: DashboardDetails,
-  duplicate?: boolean
+  newDashboard: DashboardDetails
 ): Promise<DashboardDetails> {
   const {title, widgets, projects, environment, period, start, end, filters, utc} =
     newDashboard;
@@ -60,7 +59,6 @@ export function createDashboard(
       data: {
         title,
         widgets: widgets.map(widget => omit(widget, ['tempId'])).map(_enforceWidgetLimit),
-        duplicate,
         projects,
         environment,
         period,

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -69,15 +69,10 @@ function ImportDashboardFromFileModal({
     const dashboard = JSON.parse(dashboardData);
 
     try {
-      const newDashboard = await createDashboard(
-        api,
-        organization.slug,
-        {
-          ...dashboard,
-          widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
-        },
-        true
-      );
+      const newDashboard = await createDashboard(api, organization.slug, {
+        ...dashboard,
+        widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
+      });
 
       addSuccessMessage(`${dashboard.title} dashboard template successfully added`);
       loadDashboard(newDashboard.id);

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -831,12 +831,7 @@ class DashboardDetail extends Component<Props, State> {
             ...getCurrentPageFilters(location),
             filters: getDashboardFiltersFromURL(location) ?? modifiedDashboard.filters,
           };
-          createDashboard(
-            api,
-            organization.slug,
-            newModifiedDashboard,
-            this.isPreview
-          ).then(
+          createDashboard(api, organization.slug, newModifiedDashboard).then(
             (newDashboard: DashboardDetails) => {
               addSuccessMessage(t('Dashboard created'));
               trackAnalytics('dashboards2.create.complete', {organization});

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -33,8 +33,7 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
         const copiedDashboard = await createDashboard(
           api,
           organization.slug,
-          newDashboard,
-          true
+          newDashboard
         );
         trackAnalytics('dashboards_manage.duplicate', {
           organization,
@@ -75,8 +74,7 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
         const copiedDashboard = await createDashboard(
           api,
           organization.slug,
-          newDashboard,
-          true
+          newDashboard
         );
         onSuccess?.(copiedDashboard);
         addSuccessMessage(t('Dashboard duplicated'));

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -518,15 +518,10 @@ function ManageDashboards() {
 
     addLoadingMessage(t('Adding dashboard from template...'));
 
-    const newDashboard = await createDashboard(
-      api,
-      organization.slug,
-      {
-        ...dashboard,
-        widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
-      },
-      true
-    );
+    const newDashboard = await createDashboard(api, organization.slug, {
+      ...dashboard,
+      widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
+    });
     addSuccessMessage(`${dashboard.title} dashboard template successfully added.`);
     loadDashboard(newDashboard.id);
   }

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -182,7 +182,6 @@ describe('DashboardTable', () => {
         data: expect.objectContaining({
           title: 'Dashboard',
           widgets: [],
-          duplicate: true,
         }),
       })
     );

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1422,77 +1422,39 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         response = self.do_request("post", self.url, data={"malformed-data": "Dashboard from Post"})
         assert response.status_code == 400
 
-    def test_integrity_error(self) -> None:
+    def test_duplicate_title_auto_increments(self) -> None:
         response = self.do_request("post", self.url, data={"title": self.dashboard.title})
-        assert response.status_code == 409
-        assert response.data == "Dashboard title already taken"
-
-    def test_duplicate_dashboard(self) -> None:
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": self.dashboard.title, "duplicate": True},
-        )
         assert response.status_code == 201, response.data
         assert response.data["title"] == f"{self.dashboard.title} copy"
 
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": self.dashboard.title, "duplicate": True},
-        )
+        response = self.do_request("post", self.url, data={"title": self.dashboard.title})
         assert response.status_code == 201, response.data
         assert response.data["title"] == f"{self.dashboard.title} copy 1"
 
     def test_many_duplicate_dashboards(self) -> None:
         title = "My Awesome Dashboard"
 
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": title, "duplicate": True},
-        )
-
+        response = self.do_request("post", self.url, data={"title": title})
         assert response.status_code == 201, response.data
         assert response.data["title"] == "My Awesome Dashboard"
 
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": title, "duplicate": True},
-        )
-
+        response = self.do_request("post", self.url, data={"title": title})
         assert response.status_code == 201, response.data
         assert response.data["title"] == "My Awesome Dashboard copy"
 
         for i in range(1, 10):
-            response = self.do_request(
-                "post",
-                self.url,
-                data={"title": title, "duplicate": True},
-            )
-
+            response = self.do_request("post", self.url, data={"title": title})
             assert response.status_code == 201, response.data
             assert response.data["title"] == f"My Awesome Dashboard copy {i}"
 
     def test_duplicate_a_duplicate(self) -> None:
         title = "An Amazing Dashboard copy 3"
 
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": title, "duplicate": True},
-        )
-
+        response = self.do_request("post", self.url, data={"title": title})
         assert response.status_code == 201, response.data
         assert response.data["title"] == "An Amazing Dashboard copy 3"
 
-        response = self.do_request(
-            "post",
-            self.url,
-            data={"title": title, "duplicate": True},
-        )
-
+        response = self.do_request("post", self.url, data={"title": title})
         assert response.status_code == 201, response.data
         assert response.data["title"] == "An Amazing Dashboard copy 4"
 


### PR DESCRIPTION
Fixes a bug where creating a new dashboard with the default title ("Untitled Dashboard") would return a 409 error instead of auto-incrementing the title to "Untitled Dashboard copy" when an untitled dashboard already exists.

The backend has special auto-increment code, but it wasn't firing in this case, because the frontend was explicitly saying _not_ to auto-increment it. I looked through the codebase, and this is the only site where that happens. I cannot think of a good reason why this behaviour would be unwanted, so I removed the `duplicate` parameter altogether.

This is an alternative to https://github.com/getsentry/sentry/pull/106974

Fixes DAIN-1171