### PR TITLE
test(discover): Remove usage of `deprecatedRouterMocks` from `QueryList` component tests

### DIFF
--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -89,10 +89,7 @@ describe('Discover > QueryList', () => {
         renderPrebuilt={false}
         location={location}
         refetchSavedQueries={refetchSavedQueries}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     expect(screen.getByText('No saved queries match that filter')).toBeInTheDocument();


### PR DESCRIPTION
Removing this usage of `deprecatedRouterMocks`.