### PR TITLE
fix(aci): Route all metric issue notifications to the metric alert handler

### DIFF
--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,5 +1,6 @@
 import logging
 
+from sentry import options
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
@@ -48,7 +49,9 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
 
     # Route all metric issues to metric alert handler regardless of detector type.
     # This ensures that metric issue notifications will always display metric alert charts.
-    if invocation.event_data.group.type == MetricIssue.type_id:
+    if invocation.event_data.group.type == MetricIssue.type_id and options.get(
+        "workflow_engine.notifications.metric_issue_to_metric_alert_registry"
+    ):
         return execute_via_metric_alert_handler(invocation)
 
     try:

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -22,9 +22,12 @@ def should_fire_workflow_actions(org: Organization, type_id: int) -> bool:
 def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
     """
     Generic "notification action handler" this method will lookup which registry
-    to send the notification to, based on the type of detector that created it.
+    to send the notification to, based on the group type or detector type.
 
-    This currently only supports the following detector types: 'error', 'metric_issue'
+    All metric issues are routed to the metric alert handler
+    regardless of detector type to ensure rich context is provided.
+
+    For other group types, routing is based on the detector type.
 
     If an `Activity` model for a `Group` is provided in the event data
     it will send an activity notification instead.
@@ -42,6 +45,11 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
         ):
             return execute_via_metric_alert_handler(invocation)
         return invocation.event_data.event.send_notification()
+
+    # Route all metric issues to metric alert handler regardless of detector type.
+    # This ensures that metric issue notifications will always display metric alert charts.
+    if invocation.event_data.group.type == MetricIssue.type_id:
+        return execute_via_metric_alert_handler(invocation)
 
     try:
         handler = group_type_notification_registry.get(invocation.detector.type)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3470,6 +3470,13 @@ register(
 )
 
 register(
+    "workflow_engine.notifications.metric_issue_to_metric_alert_registry",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "workflow_engine.num_cohorts",
     type=Int,
     default=1,

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -12,6 +12,7 @@ from sentry.notifications.notification_action.group_type_notification_registry.h
 )
 from sentry.notifications.notification_action.grouptype import SendTestNotification
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import Action
@@ -110,6 +111,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         execute_via_group_type_registry(invocation)
         mock_execute_metric_alert_handler.assert_called_once_with(invocation)
 
+    @override_options({"workflow_engine.notifications.metric_issue_to_metric_alert_registry": True})
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_metric_alert_handler")
     def test_metric_issue_routes_to_metric_alert_handler_regardless_of_detector_type(
         self, mock_execute_metric_alert_handler

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -15,8 +15,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 class TestNotificationActionHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         super().setUp()
-        self.project = self.create_project()
-        self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
@@ -26,8 +24,7 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
     )
     def test_execute_error_group_type(self, mock_registry_get: mock.MagicMock) -> None:
         """Test that execute calls correct handler for ErrorGroupType"""
-        self.detector.type = ErrorGroupType.slug
-        self.detector.save()
+        error_detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
 
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
@@ -35,18 +32,21 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         notification_uuid = str(uuid.uuid4())
         self.action.trigger(self.event_data, notification_uuid=notification_uuid)
 
+        # Should call the grouptype notification registry
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
         assert mock_handler.handle_workflow_action.call_count == 1
         invocation = mock_handler.handle_workflow_action.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
-        assert invocation.detector == self.detector
+        assert invocation.detector == error_detector
 
     @mock.patch(
-        "sentry.notifications.notification_action.registry.group_type_notification_registry.get"
+        "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
     )
-    def test_execute_metric_alert_type(self, mock_registry_get: mock.MagicMock) -> None:
+    def test_execute_metric_alert_type(
+        self, mock_metric_alert_handler_registry_get: mock.MagicMock
+    ) -> None:
         """Test that execute calls correct handler for MetricIssue"""
         self.detector.type = MetricIssue.slug
         self.detector.config = {"threshold_period": 1, "detection_type": "static"}
@@ -68,13 +68,14 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         self.event_data = WorkflowEventData(event=group_event, group=group)
 
         mock_handler = mock.Mock()
-        mock_registry_get.return_value = mock_handler
+        mock_metric_alert_handler_registry_get.return_value = mock_handler
 
         self.action.trigger(self.event_data, notification_uuid=str(uuid.uuid4()))
 
-        mock_registry_get.assert_called_once_with(MetricIssue.slug)
-        assert mock_handler.handle_workflow_action.call_count == 1
-        invocation = mock_handler.handle_workflow_action.call_args[0][0]
+        # Because it is a metric group type, it skips the grouptype notification registry and should call the metric alert handler registry
+        mock_metric_alert_handler_registry_get.assert_called_once_with(Action.Type.DISCORD)
+        assert mock_handler.invoke_legacy_registry.call_count == 1
+        invocation = mock_handler.invoke_legacy_registry.call_args[0][0]
         assert isinstance(invocation, ActionInvocation)
         assert invocation.event_data == self.event_data
         assert invocation.action == self.action
@@ -93,10 +94,18 @@ class TestNotificationActionHandler(MetricAlertHandlerBase):
         mock_execute_via_issue_alert_handler: mock.MagicMock,
     ) -> None:
         """Test that execute does nothing when we can't find the detector"""
+        detector = self.create_detector(project=self.project)
+        group, _, group_event = self.create_group_event(
+            occurrence=self.build_occurrence(evidence_data={"detector_id": detector.id}),
+        )
+        event_data = WorkflowEventData(
+            event=group_event,
+            group=group,
+        )
 
-        self.action.trigger(self.event_data, notification_uuid=str(uuid.uuid4()))
+        self.action.trigger(event_data, notification_uuid=str(uuid.uuid4()))
 
         mock_logger.warning.assert_called_once_with(
             "group_type_notification_registry.get.NoRegistrationExistsError",
-            extra={"detector_id": self.detector.id, "action_id": self.action.id},
+            extra={"detector_id": detector.id, "action_id": self.action.id},
         )


### PR DESCRIPTION
Closes ISWF-1952

We have an issue where, if we turn on metric issues, issue alerts will start triggering for those issues. Those notifications will use the issue alert registry, which means that it will look totally different (it won't display the chart, for one). This is because the detector type determines which registry we use. If we can force metric issue notifications to use the metric alert registry, my thinking is that notifications will look normal again.