### PR TITLE
feat(uptime): Add API endpoint for response capture retrieval

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -618,6 +618,9 @@ from sentry.uptime.endpoints.project_uptime_alert_checks_index import (
 )
 from sentry.uptime.endpoints.project_uptime_alert_details import ProjectUptimeAlertDetailsEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAlertIndexEndpoint
+from sentry.uptime.endpoints.project_uptime_response_capture import (
+    ProjectUptimeResponseCaptureEndpoint,
+)
 from sentry.uptime.endpoints.uptime_ips import UptimeIpsEndpoint
 from sentry.users.api.endpoints.authenticator_index import AuthenticatorIndexEndpoint
 from sentry.users.api.endpoints.user_authenticator_details import UserAuthenticatorDetailsEndpoint
@@ -3305,6 +3308,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/uptime/(?P<uptime_detector_id>[^/]+)/checks/$",
         ProjectUptimeAlertCheckIndexEndpoint.as_view(),
         name="sentry-api-0-project-uptime-alert-checks",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/uptime/(?P<uptime_detector_id>[^/]+)/response-captures/(?P<capture_id>[^/]+)/$",
+        ProjectUptimeResponseCaptureEndpoint.as_view(),
+        name="sentry-api-0-project-uptime-response-capture",
     ),
     # Tempest
     re_path(

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -28,6 +28,7 @@ from sentry.uptime.autodetect.result_handler import handle_onboarding_result
 from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
 from sentry.uptime.grouptype import UptimePacketValue
 from sentry.uptime.models import (
+    RESPONSE_BODY_SEPARATOR,
     UptimeResponseCapture,
     UptimeSubscription,
     UptimeSubscriptionRegion,
@@ -77,9 +78,6 @@ TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS = 30
 
 # The maximum number of missed checks we backfill, upon noticing a gap in our expected check results
 MAX_SYNTHETIC_MISSED_CHECKS = 100
-
-
-RESPONSE_BODY_SEPARATOR = b"\r\n\r\n---BODY---\r\n\r\n"
 
 
 def format_response_for_storage(

--- a/src/sentry/uptime/endpoints/project_uptime_response_capture.py
+++ b/src/sentry/uptime/endpoints/project_uptime_response_capture.py
@@ -11,10 +11,12 @@ from sentry.apidocs.parameters import GlobalParams, UptimeParams
 from sentry.models.files.file import File
 from sentry.models.project import Project
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
-from sentry.uptime.models import UptimeResponseCapture, get_uptime_subscription
+from sentry.uptime.models import (
+    RESPONSE_BODY_SEPARATOR,
+    UptimeResponseCapture,
+    get_uptime_subscription,
+)
 from sentry.workflow_engine.models import Detector
-
-RESPONSE_BODY_SEPARATOR = b"\r\n\r\n---BODY---\r\n\r\n"
 
 
 def parse_response_content(content: bytes) -> tuple[list[list[str]], bytes]:

--- a/src/sentry/uptime/endpoints/project_uptime_response_capture.py
+++ b/src/sentry/uptime/endpoints/project_uptime_response_capture.py
@@ -1,0 +1,98 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, UptimeParams
+from sentry.models.files.file import File
+from sentry.models.project import Project
+from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
+from sentry.uptime.models import UptimeResponseCapture, get_uptime_subscription
+from sentry.workflow_engine.models import Detector
+
+RESPONSE_BODY_SEPARATOR = b"\r\n\r\n---BODY---\r\n\r\n"
+
+
+def parse_response_content(content: bytes) -> tuple[list[list[str]], bytes]:
+    """
+    Parse the stored response content into headers and body.
+
+    The format is: headers (one per line), separator, body
+    """
+    if RESPONSE_BODY_SEPARATOR in content:
+        header_bytes, body = content.split(RESPONSE_BODY_SEPARATOR, 1)
+    else:
+        header_bytes = content
+        body = b""
+
+    headers: list[list[str]] = []
+    if header_bytes:
+        for line in header_bytes.decode("utf-8", errors="replace").split("\r\n"):
+            if ": " in line:
+                name, value = line.split(": ", 1)
+                headers.append([name, value])
+
+    return headers, body
+
+
+@region_silo_endpoint
+class ProjectUptimeResponseCaptureEndpoint(ProjectUptimeAlertEndpoint):
+    owner = ApiOwner.CRONS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve an Uptime Response Capture",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            UptimeParams.UPTIME_ALERT_ID,
+        ],
+        responses={
+            200: dict,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self,
+        request: Request,
+        project: Project,
+        uptime_detector: Detector,
+        capture_id: str,
+    ) -> Response:
+        """
+        Retrieve the HTTP response captured during an uptime check failure.
+        """
+        uptime_subscription = get_uptime_subscription(uptime_detector)
+
+        try:
+            capture = UptimeResponseCapture.objects.get(
+                id=capture_id,
+                uptime_subscription=uptime_subscription,
+            )
+        except (UptimeResponseCapture.DoesNotExist, ValueError):
+            raise ResourceDoesNotExist
+
+        try:
+            file = File.objects.get(pk=capture.file_id)
+            content = file.getfile().read()
+        except File.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        headers, body = parse_response_content(content)
+
+        return Response(
+            {
+                "id": str(capture.id),
+                "headers": headers,
+                "body": body.decode("utf-8", errors="replace"),
+                "bodySize": len(body),
+            }
+        )

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -32,6 +32,9 @@ from sentry.workflow_engine.types import DataSourceTypeHandler
 
 logger = logging.getLogger(__name__)
 
+# Separator used in UptimeResponseCapture file storage format.
+RESPONSE_BODY_SEPARATOR = b"\r\n\r\n---BODY---\r\n\r\n"
+
 SupportedHTTPMethodsLiteral = Literal["GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
 IntervalSecondsLiteral = Literal[60, 300, 600, 1200, 1800, 3600]
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -726,6 +726,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/checks/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/response-captures/$captureId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-feedback/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-issue/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-reports/'

--- a/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
@@ -73,7 +73,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
         self.get_error_response(
             self.organization.slug,
             self.project.slug,
-            self.detector.id,  # Wrong detector
+            self.detector.id,
             capture.id,
             status_code=404,
         )

--- a/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
@@ -1,0 +1,112 @@
+from io import BytesIO
+
+from sentry.models.files.file import File
+from sentry.testutils.cases import APITestCase, UptimeTestCase
+from sentry.uptime.models import UptimeResponseCapture
+
+
+class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
+    endpoint = "sentry-api-0-project-uptime-response-capture"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.uptime_subscription = self.create_uptime_subscription(url="https://example.com")
+        self.detector = self.create_uptime_detector(
+            uptime_subscription=self.uptime_subscription,
+            project=self.project,
+        )
+
+    def test_get_response_capture(self):
+        response_content = b"Content-Type: text/html\r\nX-Custom: value\r\n\r\n---BODY---\r\n\r\n<html>Error</html>"
+        file = File.objects.create(name="test-response", type="uptime.response")
+        file.putfile(BytesIO(response_content))
+
+        capture = UptimeResponseCapture.objects.create(
+            uptime_subscription=self.uptime_subscription,
+            file_id=file.id,
+            scheduled_check_time_ms=1234567890,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            capture.id,
+        )
+
+        assert response.data["id"] == str(capture.id)
+        assert response.data["headers"] == [
+            ["Content-Type", "text/html"],
+            ["X-Custom", "value"],
+        ]
+        assert response.data["body"] == "<html>Error</html>"
+        assert response.data["bodySize"] == len(b"<html>Error</html>")
+
+    def test_get_response_capture_not_found(self):
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            999999,
+            status_code=404,
+        )
+
+    def test_get_response_capture_wrong_detector(self):
+        """Capture belongs to a different detector's subscription."""
+        other_subscription = self.create_uptime_subscription(url="https://other.com")
+        other_detector = self.create_uptime_detector(
+            uptime_subscription=other_subscription,
+            project=self.project,
+        )
+
+        file = File.objects.create(name="test-response", type="uptime.response")
+        file.putfile(BytesIO(b"test"))
+
+        capture = UptimeResponseCapture.objects.create(
+            uptime_subscription=other_subscription,
+            file_id=file.id,
+            scheduled_check_time_ms=1234567890,
+        )
+
+        # Try to access capture using wrong detector
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,  # Wrong detector
+            capture.id,
+            status_code=404,
+        )
+
+        # Should work with correct detector
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            other_detector.id,
+            capture.id,
+        )
+
+    def test_get_response_capture_no_body(self):
+        response_content = b"Content-Type: text/html\r\nX-Custom: value"
+        file = File.objects.create(name="test-response", type="uptime.response")
+        file.putfile(BytesIO(response_content))
+
+        capture = UptimeResponseCapture.objects.create(
+            uptime_subscription=self.uptime_subscription,
+            file_id=file.id,
+            scheduled_check_time_ms=1234567890,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            capture.id,
+        )
+
+        assert response.data["headers"] == [
+            ["Content-Type", "text/html"],
+            ["X-Custom", "value"],
+        ]
+        assert response.data["body"] == ""
+        assert response.data["bodySize"] == 0


### PR DESCRIPTION
Add endpoint to fetch captured HTTP response data (headers + body) for uptime incidents. This allows the UI to display the response that caused a downtime detection, helping users debug why their endpoint failed.

Endpoint: GET /api/0/projects/{org}/{project}/uptime/{detector_id}/response-captures/{capture_id}/

This is part of the Uptime Response Capture feature - storing HTTP response data (body + headers) when downtime incidents are created to help users debug failures.

  PRs in this series:
  1. sentry-kafka-schemas: Schema changes
  2. uptime-checker: Response capture logic
  3. uptime-checker: Toggle handling
  4. sentry: UptimeResponseCapture model
  5. sentry: Toggle producer
  6. sentry: Consumer capture creation
  7. sentry: API endpoint ← this PR

<!-- Describe your PR here. -->