### PR TITLE
ref(llm-detection): Add span count validation before sending traces to Seer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -687,6 +687,7 @@ class Referrer(StrEnum):
     ISSUES_SUSPECT_TAGS_QUERY_ERROR_COUNTS = "issues.suspect_tags.query_error_counts"
     ISSUES_LLM_ISSUE_DETECTION_TRANSACTION = "issues.llm_issue_detection.transaction"
     ISSUES_LLM_ISSUE_DETECTION_TRACE = "issues.llm_issue_detection.trace"
+    ISSUES_LLM_ISSUE_DETECTION_SPAN_COUNT = "issues.llm_issue_detection.span_count"
 
     INSIGHTS_MOBILE_HAS_TTFDCONFIGURED = "insights.mobile.hasTTFDConfigured"
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -32,7 +32,7 @@ SEER_ANALYZE_ISSUE_ENDPOINT_PATH = "/v1/automation/issue-detection/analyze"
 SEER_TIMEOUT_S = 10
 START_TIME_DELTA_MINUTES = 60
 TRANSACTION_BATCH_SIZE = 50
-TRACES_TO_SEND_TO_SEER = 20
+NUM_TRANSACTIONS_TO_PROCESS = 10
 TRACE_PROCESSING_TTL_SECONDS = 7200
 # Character limit for LLM-generated fields to protect against abuse.
 # Word limits are enforced by Seer's prompt (see seer/automation/issue_detection/analyze.py).
@@ -267,10 +267,10 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     if skipped:
         sentry_sdk.metrics.count("llm_issue_detection.trace.skipped", skipped)
 
-    # Take up to TRACES_TO_SEND_TO_SEER unprocessed traces
+    # Take up to NUM_TRANSACTIONS_TO_PROCESS
     traces_to_send: list[TraceMetadata] = [
         t for t in evidence_traces if t.trace_id in unprocessed_ids
-    ][:TRACES_TO_SEND_TO_SEER]
+    ][:NUM_TRANSACTIONS_TO_PROCESS]
 
     if not traces_to_send:
         return


### PR DESCRIPTION
**Note:** This PR is being merged into parent branch `ID-1151`. It depends on additional changes that are not yet merged. Full cutover will happen when all pieces are ready. Tech spec [here](https://www.notion.so/sentry/Add-Create-Issue-Occurrence-RPC-Method-2e78b10e4b5d8021a518c43e2090769b?source=copy_link)

Moves span count validation from Seer to Sentry to eliminate wasted RPC calls.

Previously, Seer would receive trace IDs, fetch full trace data via RPC (2 calls per trace), then check if the span count was valid. Traces outside this range were rejected after the fetch.

By validating span counts in Sentry first, we can query counts for all candidate traces in a single Snuba call, then only send pre-validated traces to Seer. This reduces RPC calls per detection run.

## Changes

- Add `get_valid_trace_ids_by_span_count()` to count spans for multiple traces in one query
- Filter traces inside `get_project_top_transaction_traces_for_llm_detection` using the same snuba_params already constructed for trace fetching
- Add `ISSUES_LLM_ISSUE_DETECTION_SPAN_COUNT` referrer for query attribution
- Only send traces to seer that it should analyze
