### PR TITLE
feat(ai-insights): add platform icons to onboarding dropdown 

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -58,6 +58,10 @@ export interface PlatformOption<Value extends string = string> {
   items: Array<{
     label: string;
     value: Value;
+    /**
+     * Optional leading items to display before the label (e.g., icons)
+     */
+    leadingItems?: React.ReactNode;
   }>;
   /**
    * The name of the option

--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
@@ -28,11 +29,15 @@ type PlatformOptionsControlProps = {
 };
 
 function OptionControl({option, value, onChange, disabled}: OptionControlProps) {
+  const selectedItem = option.items.find(v => v.value === value) ?? option.items[0]!;
   return (
     <CompactSelect
       trigger={triggerProps => (
         <OverlayTrigger.Button {...triggerProps}>
-          {option.items.find(v => v.value === value)?.label ?? option.items[0]!.label}
+          <Flex align="center" gap="sm">
+            {selectedItem.leadingItems}
+            {selectedItem.label}
+          </Flex>
         </OverlayTrigger.Button>
       )}
       value={value}

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
 
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
@@ -48,6 +49,7 @@ import {getHasAiSpansFilter} from 'sentry/views/insights/pages/agents/utils/quer
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 
 import {
+  AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
   AgentIntegration,
   NODE_AGENT_INTEGRATIONS,
@@ -244,6 +246,9 @@ export function Onboarding() {
         ? PYTHON_AGENT_INTEGRATIONS.map(integration => ({
             label: AGENT_INTEGRATION_LABELS[integration],
             value: integration,
+            leadingItems: (
+              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
+            ),
           }))
         : (hasServerSideNode
             ? NODE_AGENT_INTEGRATIONS
@@ -253,6 +258,9 @@ export function Onboarding() {
           ).map(integration => ({
             label: AGENT_INTEGRATION_LABELS[integration],
             value: integration,
+            leadingItems: (
+              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
+            ),
           })),
     },
   };

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -26,6 +26,20 @@ export const AGENT_INTEGRATION_LABELS = {
   [AgentIntegration.MANUAL]: 'Other',
 };
 
+export const AGENT_INTEGRATION_ICONS: Record<AgentIntegration, string> = {
+  [AgentIntegration.OPENAI]: 'openai',
+  [AgentIntegration.OPENAI_AGENTS]: 'openai',
+  [AgentIntegration.ANTHROPIC]: 'anthropic',
+  [AgentIntegration.GOOGLE_GENAI]: 'gemini',
+  [AgentIntegration.LANGCHAIN]: 'langchain',
+  [AgentIntegration.LANGGRAPH]: 'langchain',
+  [AgentIntegration.LITTELLM]: 'litellm',
+  [AgentIntegration.MASTRA]: 'mastra',
+  [AgentIntegration.PYDANTIC_AI]: 'pydantic-ai',
+  [AgentIntegration.VERCEL_AI]: 'vercel',
+  [AgentIntegration.MANUAL]: 'default',
+};
+
 export const PYTHON_AGENT_INTEGRATIONS = [
   AgentIntegration.OPENAI_AGENTS,
   AgentIntegration.ANTHROPIC,


### PR DESCRIPTION
[TET-1816: Add icons to platform dropdowns in agent onboarding](https://linear.app/getsentry/issue/TET-1816/add-icons-to-platform-dropdowns-in-agent-onboarding)

<img width="689" height="728" alt="CleanShot 2026-01-27 at 10 48 09" src="https://github.com/user-attachments/assets/4fa9c1e9-51a9-4144-927d-fc38dd4d87c8" />

<img width="689" height="728" alt="image" src="https://github.com/user-attachments/assets/9af2a82a-97a4-4274-802c-c9c3a0d56621" />
