### PR TITLE
feat(attribute-breakdown) Add custom cell actions

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -8,6 +8,9 @@ import {
 
 import {closeModal} from 'sentry/actionCreators/modal';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 
 import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
 
@@ -30,6 +33,31 @@ const stubProps = {
   CloseButton: stubEl,
   closeModal: mockCloseModal,
 };
+
+const defaultQueryParams = new ReadableQueryParams({
+  aggregateCursor: '',
+  aggregateFields: [],
+  aggregateSortBys: [],
+  cursor: '',
+  extrapolate: false,
+  fields: [],
+  mode: Mode.SAMPLES,
+  query: '',
+  sortBys: [],
+});
+
+function Wrapper({children}: {children?: React.ReactNode}) {
+  return (
+    <QueryParamsContextProvider
+      isUsingDefaultFields
+      queryParams={defaultQueryParams}
+      setQueryParams={() => {}}
+      shouldManageFields={false}
+    >
+      {children}
+    </QueryParamsContextProvider>
+  );
+}
 
 describe('AttributeBreakdownViewerModal', () => {
   beforeEach(() => {
@@ -60,7 +88,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -73,7 +102,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       // Total values: 500 + 300 + 200 = 1000, cohortCount = 1000 => 100%
@@ -87,7 +117,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -100,7 +131,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       // Table should have column headers
@@ -127,7 +159,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={cohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('cell', {name: '25%'})).toBeInTheDocument();
@@ -141,7 +174,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={cohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -158,7 +192,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
@@ -195,7 +230,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -209,7 +245,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       // Cohort 1: (500 + 300) / 800 = 100%
@@ -225,7 +262,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -239,7 +277,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       // Table should have column headers
@@ -262,7 +301,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       // Table should have attribute values
@@ -279,7 +319,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={0}
           cohort2Total={0}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -298,7 +339,8 @@ describe('AttributeBreakdownViewerModal', () => {
           }}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
@@ -324,7 +366,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -347,7 +390,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -364,7 +408,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -387,7 +432,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -411,7 +457,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -442,7 +489,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');
@@ -483,7 +531,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={800}
           cohort2Total={750}
-        />
+        />,
+        {additionalWrapper: Wrapper}
       );
 
       const cells = screen.getAllByRole('cell');

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -1,8 +1,20 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {closeModal} from 'sentry/actionCreators/modal';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 
-import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
+import {AttributeBreakdownViewerModal} from './attributeBreakdownViewerModal';
+
+jest.mock('sentry/actionCreators/modal');
 
 jest.mock('echarts-for-react/lib/core', () => {
   return jest.fn(({style}) => {
@@ -12,15 +24,30 @@ jest.mock('echarts-for-react/lib/core', () => {
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
+const mockCloseModal = jest.mocked(closeModal);
+
+const organization = OrganizationFixture();
+const selection = PageFiltersFixture();
+
 const stubProps = {
   Header: stubEl,
   Footer: stubEl as ModalRenderProps['Footer'],
   Body: stubEl as ModalRenderProps['Body'],
   CloseButton: stubEl,
-  closeModal: () => undefined,
+  closeModal: mockCloseModal,
+  selection,
 };
 
 describe('AttributeBreakdownViewerModal', () => {
+  beforeEach(() => {
+    mockCloseModal.mockClear();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(() => Promise.resolve()),
+      },
+    });
+  });
+
   describe('single mode', () => {
     const mockAttributeDistribution = {
       attributeName: 'browser.name',
@@ -283,6 +310,207 @@ describe('AttributeBreakdownViewerModal', () => {
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
       expect(screen.queryByText('echarts mock')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('cell actions', () => {
+    const mockAttributeDistribution = {
+      attributeName: 'browser.name',
+      values: [
+        {label: 'Chrome', value: 500},
+        {label: 'Firefox', value: 300},
+      ],
+    };
+
+    const mockCohortCount = 1000;
+
+    it('allows cell actions for Value column', async () => {
+      render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      // First cell should be the Value column (Chrome)
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      // Verify all expected menu items are present
+      expect(await screen.findByText('View span samples')).toBeInTheDocument();
+      expect(screen.getByText('Add to filter')).toBeInTheDocument();
+      expect(screen.getByText('Exclude from filter')).toBeInTheDocument();
+      expect(screen.getByText('Copy to clipboard')).toBeInTheDocument();
+    });
+
+    it('does not allow cell actions for non-Value columns', () => {
+      render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      // Count column should be the second cell (500)
+      const countCell = cells[1]!;
+      // Non-Value columns should not have action buttons
+      expect(within(countCell).queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('navigates correctly when OPEN_ROW_IN_EXPLORE action is triggered', async () => {
+      const {router} = render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      const menuOption = await screen.findByText('View span samples');
+      await userEvent.click(menuOption);
+
+      await waitFor(() => expect(router.location.pathname).toContain('/explore/traces/'));
+      expect(router.location.query.query).toContain('browser.name:Chrome');
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    it('navigates with attribute_breakdowns table when ADD action is triggered', async () => {
+      const {router} = render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      const menuOption = await screen.findByText('Add to filter');
+      await userEvent.click(menuOption);
+
+      await waitFor(() => expect(router.location.pathname).toContain('/explore/traces/'));
+      expect(router.location.query.table).toBe('attribute_breakdowns');
+      expect(router.location.query.query).toContain('browser.name:Chrome');
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    it('navigates with negated filter when EXCLUDE action is triggered', async () => {
+      const {router} = render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      const menuOption = await screen.findByText('Exclude from filter');
+      await userEvent.click(menuOption);
+
+      await waitFor(() => expect(router.location.pathname).toContain('/explore/traces/'));
+      expect(router.location.query.table).toBe('attribute_breakdowns');
+      expect(router.location.query.query).toContain('!browser.name:Chrome');
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    it('copies value to clipboard when COPY_TO_CLIPBOARD action is triggered', async () => {
+      const writeTextMock = jest.fn(() => Promise.resolve());
+      Object.assign(navigator, {
+        clipboard: {
+          writeText: writeTextMock,
+        },
+      });
+
+      render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="single"
+          attributeDistribution={mockAttributeDistribution}
+          cohortCount={mockCohortCount}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      const menuOption = await screen.findByText('Copy to clipboard');
+      await userEvent.click(menuOption);
+
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalledWith('Chrome');
+      });
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    it('works correctly in comparison mode', async () => {
+      const mockAttribute = {
+        attributeName: 'browser.name',
+        cohort1: [
+          {label: 'Chrome', value: 500},
+          {label: 'Firefox', value: 300},
+        ],
+        cohort2: [
+          {label: 'Chrome', value: 400},
+          {label: 'Firefox', value: 350},
+        ],
+        order: {
+          rrf: 0.5,
+          rrr: 0.3,
+        },
+      };
+
+      const {router} = render(
+        <AttributeBreakdownViewerModal
+          {...stubProps}
+          mode="comparison"
+          attribute={mockAttribute}
+          cohort1Total={800}
+          cohort2Total={750}
+        />,
+        {organization}
+      );
+
+      const cells = screen.getAllByRole('cell');
+      const valueCell = cells[0]!;
+      const valueCellButton = within(valueCell).getByRole('button');
+      await userEvent.click(valueCellButton);
+
+      const menuOption = await screen.findByText('View span samples');
+      await userEvent.click(menuOption);
+
+      await waitFor(() => expect(router.location.pathname).toContain('/explore/traces/'));
+      expect(router.location.query.query).toContain('browser.name:Chrome');
+      expect(mockCloseModal).toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -12,7 +12,7 @@ import {
 import {closeModal} from 'sentry/actionCreators/modal';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 
-import {AttributeBreakdownViewerModal} from './attributeBreakdownViewerModal';
+import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
 
 jest.mock('sentry/actionCreators/modal');
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -1,6 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
-
 import {
   render,
   screen,
@@ -26,16 +23,12 @@ const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</d
 
 const mockCloseModal = jest.mocked(closeModal);
 
-const organization = OrganizationFixture();
-const selection = PageFiltersFixture();
-
 const stubProps = {
   Header: stubEl,
   Footer: stubEl as ModalRenderProps['Footer'],
   Body: stubEl as ModalRenderProps['Body'],
   CloseButton: stubEl,
   closeModal: mockCloseModal,
-  selection,
 };
 
 describe('AttributeBreakdownViewerModal', () => {
@@ -331,8 +324,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -355,8 +347,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -373,8 +364,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -397,8 +387,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -422,8 +411,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -454,8 +442,7 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -496,8 +483,7 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={800}
           cohort2Total={750}
-        />,
-        {organization}
+        />
       );
 
       const cells = screen.getAllByRole('cell');

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -20,7 +20,7 @@ import type {
   TabularData,
 } from 'sentry/views/dashboards/widgets/common/types';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
-import {Actions, copyToClipboard} from 'sentry/views/discover/table/cellAction';
+import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
@@ -389,7 +389,6 @@ export default function AttributeBreakdownViewerModal(props: Props) {
                   closeModal();
                   return;
                 case Actions.COPY_TO_CLIPBOARD:
-                  copyToClipboard(value);
                   closeModal();
                   return;
                 default:

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -274,11 +274,11 @@ export default function AttributeBreakdownViewerModal(props: Props) {
       ...computedData.tableData,
       data: computedData.tableData.data.slice(0, CHART_MAX_SERIES_LENGTH),
     };
-    const query =
+    const chartQuery =
       computedData.mode === 'comparison'
         ? COMPARISON_MODE_CHART_QUERY
         : SINGLE_MODE_CHART_QUERY;
-    return transformTableToCategoricalSeries(query, slicedTableData);
+    return transformTableToCategoricalSeries(chartQuery, slicedTableData);
   }, [computedData.tableData, computedData.mode]);
 
   const hasPlottableValues = useMemo(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -22,6 +22,7 @@ import type {
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
@@ -247,6 +248,7 @@ function PopulationIndicatorComponent({
 export default function AttributeBreakdownViewerModal(props: Props) {
   const {Header, Body, mode} = props;
   const {selection} = usePageFilters();
+  const query = useQueryParamsQuery();
 
   const theme = useTheme();
   const navigate = useNavigate();
@@ -351,39 +353,39 @@ export default function AttributeBreakdownViewerModal(props: Props) {
             tableData={computedData.tableData}
             columns={computedData.tableColumns}
             onTriggerCellAction={(action, value) => {
-              const query = new MutableSearch('');
+              const search = new MutableSearch(query ?? '');
               switch (action) {
                 case Actions.OPEN_ROW_IN_EXPLORE:
-                  query.addFilterValue(computedData.attributeName, `${value}`);
+                  search.addFilterValue(computedData.attributeName, `${value}`);
                   navigate(
                     getExploreUrl({
                       organization,
                       selection,
-                      query: query.formatString(),
+                      query: search.formatString(),
                     })
                   );
                   closeModal();
                   return;
                 case Actions.ADD:
-                  query.addFilterValue(computedData.attributeName, `${value}`);
+                  search.addFilterValue(computedData.attributeName, `${value}`);
                   navigate(
                     getExploreUrl({
                       organization,
                       selection,
                       table: 'attribute_breakdowns',
-                      query: query.formatString(),
+                      query: search.formatString(),
                     })
                   );
                   closeModal();
                   return;
                 case Actions.EXCLUDE:
-                  query.addFilterValue(`!${computedData.attributeName}`, `${value}`);
+                  search.addFilterValue(`!${computedData.attributeName}`, `${value}`);
                   navigate(
                     getExploreUrl({
                       organization,
                       selection,
                       table: 'attribute_breakdowns',
-                      query: query.formatString(),
+                      query: search.formatString(),
                     })
                   );
                   closeModal();

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -5,9 +5,13 @@ import styled from '@emotion/styled';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {closeModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {t} from 'sentry/locale';
 import {transformTableToCategoricalSeries} from 'sentry/utils/categoricalTimeSeries/transformTableToCategoricalSeries';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {CategoricalSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization';
 import {Bars} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/plottables/bars';
@@ -16,7 +20,9 @@ import type {
   TabularData,
 } from 'sentry/views/dashboards/widgets/common/types';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
+import {Actions, copyToClipboard} from 'sentry/views/discover/table/cellAction';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
 import {CHART_MAX_SERIES_LENGTH, COHORT_2_COLOR, MODAL_CHART_HEIGHT} from './constants';
@@ -240,7 +246,11 @@ function PopulationIndicatorComponent({
 
 export default function AttributeBreakdownViewerModal(props: Props) {
   const {Header, Body, mode} = props;
+
   const theme = useTheme();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
 
   const primaryColor = theme.chart.getColorPalette(0)?.[0];
   const secondaryColor = COHORT_2_COLOR;
@@ -341,6 +351,63 @@ export default function AttributeBreakdownViewerModal(props: Props) {
             scrollable
             tableData={computedData.tableData}
             columns={computedData.tableColumns}
+            onTriggerCellAction={(action, value) => {
+              const query = new MutableSearch('');
+              switch (action) {
+                case Actions.OPEN_ROW_IN_EXPLORE:
+                  query.addFilterValue(computedData.attributeName, `${value}`);
+                  navigate(
+                    getExploreUrl({
+                      organization,
+                      selection,
+                      query: query.formatString(),
+                    })
+                  );
+                  closeModal();
+                  return;
+                case Actions.ADD:
+                  query.addFilterValue(computedData.attributeName, `${value}`);
+                  navigate(
+                    getExploreUrl({
+                      organization,
+                      selection,
+                      table: 'attribute_breakdowns',
+                      query: query.formatString(),
+                    })
+                  );
+                  closeModal();
+                  return;
+                case Actions.EXCLUDE:
+                  query.addFilterValue(`!${computedData.attributeName}`, `${value}`);
+                  navigate(
+                    getExploreUrl({
+                      organization,
+                      selection,
+                      table: 'attribute_breakdowns',
+                      query: query.formatString(),
+                    })
+                  );
+                  closeModal();
+                  return;
+                case Actions.COPY_TO_CLIPBOARD:
+                  copyToClipboard(value);
+                  closeModal();
+                  return;
+                default:
+                  return;
+              }
+            }}
+            allowedCellActions={cellInfo => {
+              if (cellInfo.column.key === t('Value')) {
+                return [
+                  Actions.OPEN_ROW_IN_EXPLORE,
+                  Actions.EXCLUDE,
+                  Actions.ADD,
+                  Actions.COPY_TO_CLIPBOARD,
+                ];
+              }
+              return [];
+            }}
           />
         </Flex>
       </Body>

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -246,12 +246,11 @@ function PopulationIndicatorComponent({
 
 export default function AttributeBreakdownViewerModal(props: Props) {
   const {Header, Body, mode} = props;
+  const {selection} = usePageFilters();
 
   const theme = useTheme();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
-
   const primaryColor = theme.chart.getColorPalette(0)?.[0];
   const secondaryColor = COHORT_2_COLOR;
 


### PR DESCRIPTION
This PR updates the attribute viewer modal to add in cell actions for the value column. The actions include: `View span samples`, `Copy to clipboard`, `Add to filter`, and `Exclude from filter`.

Ticket: EXP-733

Example:

<img width="935" height="653" alt="Screenshot 2026-01-27 at 09 01 40" src="https://github.com/user-attachments/assets/c7178537-856a-47f8-8854-299d3288c882" />