### PR TITLE
Update Jira search to v3 endpoints

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -33,7 +33,7 @@ class JiraCloudClient(ApiClient):
     PRIORITIES_URL = "/rest/api/2/priority"
     PROJECTS_PAGINATED_URL = "/rest/api/2/project/search"
     PROJECT_URL = "/rest/api/2/project"
-    SEARCH_URL = "/rest/api/2/search/jql/"
+    SEARCH_URL = "/rest/api/3/search/jql"
     VERSIONS_URL = "/rest/api/2/project/%s/versions"
     USERS_URL = "/rest/api/2/user/assignable/search"
     USER_URL = "/rest/api/2/user"

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -30,7 +30,7 @@ class JiraSearchEndpointTest(APITestCase):
     def test_issue_search_text(self) -> None:
         responses.add(
             responses.GET,
-            "https://example.atlassian.net/rest/api/2/search/jql/",
+            "https://example.atlassian.net/rest/api/3/search/jql",
             body=StubService.get_stub_json("jira", "search_response.json"),
             content_type="json",
         )
@@ -53,7 +53,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         responses.add_callback(
             responses.GET,
-            "https://example.atlassian.net/rest/api/2/search/jql/",
+            "https://example.atlassian.net/rest/api/3/search/jql",
             callback=responder,
         )
         org = self.organization
@@ -73,7 +73,7 @@ class JiraSearchEndpointTest(APITestCase):
     def test_issue_search_error(self) -> None:
         responses.add(
             responses.GET,
-            "https://example.atlassian.net/rest/api/2/search/jql/",
+            "https://example.atlassian.net/rest/api/3/search/jql",
             status=500,
             body="Totally broken",
         )

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -330,7 +330,7 @@ class JiraPluginTest(TestCase):
         self._setup_autocomplete_jira()
         responses.add(
             responses.GET,
-            "https://getsentry.atlassian.net/rest/api/2/search/",
+            "https://getsentry.atlassian.net/rest/api/3/search/jql",
             json={"issues": [issue_response]},
         )
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

We are selfhosting sentry.

When I want to link a Sentry issue to an existing Jira issue, when searching, nothing appears. The endpoint in Sentry gives us a 400 with this:
```
{
    "detail": "Error Communicating with Jira (HTTP 410): 
               The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. 
               A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046"
}
```

So it looks like the endpoints were removed on the 1st of May, 2025 (?): [Atlassian developer changelog](https://developer.atlassian.com/changelog/#CHANGE-2046)

This PR should fix issue: https://github.com/getsentry/sentry/issues/102667 (but I had no ability to test it ;-/ )


I "made" this fix but have no idea how to build everything by my self to check if now everything works. I just found wrong API endpoints and updated them.

Propably sentry employe will know what to do next.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
