### PR TITLE
Seer webhook payload default

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3901,12 +3901,10 @@ register(
 )
 
 # Controls whether to validate webhook payloads with Pydantic before sending to Seer
-# This is disabled by default to avoid potential issues with enum key serialization
-# until the validation is fully tested and deployed
 register(
     "seer.code_review.validate_webhook_payload",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Enables `seer.code_review.validate_webhook_payload` by default to ensure Pydantic validation of webhook payloads sent to Seer. This improves data consistency, proper enum key serialization, and verifies the presence of required fields.

Existing tests are robust and handle this change correctly using `@override_options`. The option remains configurable via the options-automator.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1769520034064479?thread_ts=1769520034.064479&cid=D09259VQFAP)

<a href="https://cursor.com/background-agent?bcId=bc-414d024a-b88d-4c1a-a4d7-961000f89d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-414d024a-b88d-4c1a-a4d7-961000f89d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

