### PR TITLE
Agent selection local storage

### DIFF
--- a/static/app/views/insights/pages/conversations/components/agentSelector.tsx
+++ b/static/app/views/insights/pages/conversations/components/agentSelector.tsx
@@ -49,14 +49,18 @@ export function AgentSelector() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Reset when project changes
+  // Reset and restore when project changes
   const prevProjectKey = useRef(projectKey);
   useEffect(() => {
     if (prevProjectKey.current !== projectKey) {
       prevProjectKey.current = projectKey;
-      setQueryStates({[AGENT_URL_PARAM]: null, [TableUrlParams.CURSOR]: null});
+      // Restore stored agents for the new project selection, or clear if none stored
+      setQueryStates({
+        [AGENT_URL_PARAM]: storedAgents.length > 0 ? storedAgents : null,
+        [TableUrlParams.CURSOR]: null,
+      });
     }
-  }, [projectKey, setQueryStates]);
+  }, [projectKey, setQueryStates, storedAgents]);
 
   const selectedAgents = useMemo(() => urlAgents ?? [], [urlAgents]);
 


### PR DESCRIPTION
Fixes an issue where the AI Conversations agent selector did not restore previously saved agent selections from local storage when the project context changed.

Previously, the agent selection was only restored on initial page load. This PR updates the `useEffect` hook that listens for project changes to explicitly restore the `storedAgents` from local storage for the newly selected project(s), leveraging the existing project-scoped local storage key.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C0AB1UJFZ4K/p1769525714385079?thread_ts=1769525714.385079&cid=C0AB1UJFZ4K)

<a href="https://cursor.com/background-agent?bcId=bc-21075765-ac13-4c8d-855b-49154be37e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21075765-ac13-4c8d-855b-49154be37e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

