### PR TITLE
ref(dashboards): Migrate mobileAppSize to React Query hooks

### DIFF
--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.spec.tsx
@@ -1,8 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {WidgetFixture} from 'sentry-fixture/widget';
 
 import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
-import {WidgetType} from 'sentry/views/dashboards/types';
 
 import {MobileAppSizeConfig} from './mobileAppSize';
 
@@ -129,92 +127,6 @@ describe('MobileAppSizeConfig', () => {
       expect(result[1]!.seriesName).toBe('android');
       expect(result[0]!.data).toHaveLength(2);
       expect(result[0]!.data[0]!.value).toBe(1000000);
-    });
-  });
-
-  describe('getSeriesRequest', () => {
-    it('makes request with correct dataset and yAxis', async () => {
-      const api = new MockApiClient();
-      const widget = WidgetFixture({
-        widgetType: WidgetType.PREPROD_APP_SIZE,
-        queries: [
-          {
-            conditions: 'app_id:com.example.app',
-            aggregates: ['max(install_size)'],
-            fields: ['max(install_size)'],
-            columns: [],
-            fieldAliases: [],
-            name: '',
-            orderby: '',
-          },
-        ],
-      });
-
-      const mockRequest = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-stats/`,
-        body: {
-          data: [[1609459200, [{count: 1000000}]]],
-          start: 1609459200,
-          end: 1609459200,
-          meta: {fields: {}},
-        },
-      });
-
-      await MobileAppSizeConfig.getSeriesRequest!(api, widget, 0, organization, {
-        datetime: {start: null, end: null, period: '14d', utc: false},
-        environments: [],
-        projects: [1],
-      });
-
-      expect(mockRequest).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/events-stats/`,
-        expect.objectContaining({
-          query: expect.objectContaining({
-            dataset: 'preprodSize',
-            yAxis: ['max(install_size)'],
-          }),
-        })
-      );
-    });
-
-    it('includes topEvents and field params when columns are specified', async () => {
-      const api = new MockApiClient();
-      const widget = WidgetFixture({
-        widgetType: WidgetType.PREPROD_APP_SIZE,
-        limit: 5,
-        queries: [
-          {
-            conditions: '',
-            aggregates: ['max(install_size)'],
-            fields: ['max(install_size)'],
-            columns: ['platform'],
-            fieldAliases: [],
-            name: '',
-            orderby: '',
-          },
-        ],
-      });
-
-      const mockRequest = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-stats/`,
-        body: {},
-      });
-
-      await MobileAppSizeConfig.getSeriesRequest!(api, widget, 0, organization, {
-        datetime: {start: null, end: null, period: '14d', utc: false},
-        environments: [],
-        projects: [1],
-      });
-
-      expect(mockRequest).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/events-stats/`,
-        expect.objectContaining({
-          query: expect.objectContaining({
-            topEvents: 5,
-            field: ['platform', 'max(install_size)'],
-          }),
-        })
-      );
     });
   });
 

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -1,5 +1,3 @@
-import {doEventsRequest} from 'sentry/actionCreators/events';
-import type {Client} from 'sentry/api';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
@@ -16,32 +14,30 @@ import type {
   AggregationOutputType,
   QueryFieldValue,
 } from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {AggregationKey} from 'sentry/utils/fields';
-import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import type {
+  DatasetConfig,
+  SearchBarData,
+  SearchBarDataProviderProps,
+  WidgetBuilderSearchBarProps,
+} from 'sentry/views/dashboards/datasetConfig/base';
+import {handleOrderByReset} from 'sentry/views/dashboards/datasetConfig/base';
+import {getTimeseriesSortOptions} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
+import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {isEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
+import {
+  useMobileAppSizeSeriesQuery,
+  useMobileAppSizeTableQuery,
+} from 'sentry/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 import {useTraceItemSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-
-import {getSeriesRequestData} from './utils/getSeriesRequestData';
-import type {
-  DatasetConfig,
-  SearchBarData,
-  SearchBarDataProviderProps,
-  WidgetBuilderSearchBarProps,
-} from './base';
-import {handleOrderByReset} from './base';
-import {getTimeseriesSortOptions} from './errorsAndTransactions';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   name: '',
@@ -233,32 +229,8 @@ export const MobileAppSizeConfig: DatasetConfig<
   getGroupByFieldOptions,
   getTimeseriesSortOptions: (organization, widgetQuery, tags) =>
     getTimeseriesSortOptions(organization, widgetQuery, tags, getPrimaryFieldOptions),
-  getSeriesRequest: (
-    api: Client,
-    widget: Widget,
-    queryIndex: number,
-    organization: Organization,
-    pageFilters: PageFilters,
-    _onDemandControlContext?: OnDemandControlContext,
-    referrer?: string,
-    _mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
-  ) => {
-    const requestData = getSeriesRequestData(
-      widget,
-      queryIndex,
-      organization,
-      pageFilters,
-      DiscoverDatasets.PREPROD_SIZE,
-      referrer
-    );
-
-    if (samplingMode) {
-      requestData.sampling = samplingMode;
-    }
-
-    return doEventsRequest<true>(api, requestData);
-  },
+  useSeriesQuery: useMobileAppSizeSeriesQuery,
+  useTableQuery: useMobileAppSizeTableQuery,
   transformTable: (
     data: TableData,
     _widgetQuery: WidgetQuery,

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -43,7 +43,6 @@ function applyDashboardFilters(
 
     filtered.queries.forEach(query => {
       if (dashboardFilterConditions) {
-        // If there is no base query, there's no need to add parens
         if (query.conditions && !skipParens) {
           query.conditions = `(${query.conditions})`;
         }
@@ -54,11 +53,9 @@ function applyDashboardFilters(
     processedWidget = filtered;
   }
 
-  // Clean widget to remove empty/invalid fields before API request
   return cleanWidgetForRequest(processedWidget);
 }
 
-// Stable empty array to prevent infinite rerenders
 const EMPTY_ARRAY: any[] = [];
 
 /**
@@ -80,13 +77,11 @@ export function useMobileAppSizeSeriesQuery(
   const {queue} = useWidgetQueryQueue();
   const prevRawDataRef = useRef<MobileAppSizeSeriesResponse[] | undefined>(undefined);
 
-  // Apply dashboard filters
   const filteredWidget = useMemo(
     () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
   );
 
-  // Build query keys for all widget queries
   const queryKeys = useMemo(() => {
     const keys = filteredWidget.queries.map((_, queryIndex) => {
       const requestData = getSeriesRequestData(
@@ -98,12 +93,10 @@ export function useMobileAppSizeSeriesQuery(
         getReferrer(filteredWidget.displayType)
       );
 
-      // Add sampling mode if provided
       if (samplingMode) {
         requestData.sampling = samplingMode;
       }
 
-      // Transform requestData into proper query params
       const {
         organization: _org,
         includeAllArgs: _includeAllArgs,
@@ -125,7 +118,6 @@ export function useMobileAppSizeSeriesQuery(
         queryParams.end = getUtcDateString(queryParams.end);
       }
 
-      // Build the API query key for events-stats endpoint
       return [
         `/organizations/${organization.slug}/events-stats/`,
         {
@@ -137,7 +129,6 @@ export function useMobileAppSizeSeriesQuery(
     return keys;
   }, [filteredWidget, organization, pageFilters, samplingMode]);
 
-  // Create stable queryFn that uses queue
   const createQueryFn = useCallback(
     () =>
       async (context: any): Promise<ApiResult<MobileAppSizeSeriesResponse>> => {
@@ -155,7 +146,6 @@ export function useMobileAppSizeSeriesQuery(
           });
         }
 
-        // Fallback: call directly if queue not available
         return fetchDataQuery<MobileAppSizeSeriesResponse>(context);
       },
     [queue]
@@ -213,19 +203,16 @@ export function useMobileAppSizeSeriesQuery(
       const responseData = q.data[0];
       rawData[requestIndex] = responseData;
 
-      // Use the config's transformSeries method
       const transformedResult = MobileAppSizeConfig.transformSeries!(
         responseData,
         filteredWidget.queries[requestIndex]!,
         organization
       );
 
-      // Maintain color consistency
       transformedResult.forEach((result: Series, resultIndex: number) => {
         timeseriesResults[requestIndex * transformedResult.length + resultIndex] = result;
       });
 
-      // Get result types from config
       const resultTypes = MobileAppSizeConfig.getSeriesResultType?.(
         responseData,
         filteredWidget.queries[requestIndex]!
@@ -236,7 +223,6 @@ export function useMobileAppSizeSeriesQuery(
       }
     });
 
-    // Check if rawData is the same as before to prevent unnecessary rerenders
     let finalRawData = rawData;
     if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
@@ -245,7 +231,6 @@ export function useMobileAppSizeSeriesQuery(
       }
     }
 
-    // Store current rawData for next comparison
     if (finalRawData !== prevRawDataRef.current) {
       prevRawDataRef.current = finalRawData;
     }

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -1,0 +1,278 @@
+import {useCallback, useMemo, useRef} from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+import type {ApiResult} from 'sentry/api';
+import type {Series} from 'sentry/types/echarts';
+import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
+import {getUtcDateString} from 'sentry/utils/dates';
+import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useQueries} from 'sentry/utils/queryClient';
+import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
+import {MobileAppSizeConfig} from 'sentry/views/dashboards/datasetConfig/mobileAppSize';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {dashboardFiltersToString} from 'sentry/views/dashboards/utils';
+import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {
+  cleanWidgetForRequest,
+  getReferrer,
+} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+
+type MobileAppSizeSeriesResponse = EventsStats | MultiSeriesEventsStats;
+
+/**
+ * Helper to apply dashboard filters and clean widget for API request
+ */
+function applyDashboardFilters(
+  widget: Widget,
+  dashboardFilters?: DashboardFilters,
+  skipParens?: boolean
+): Widget {
+  let processedWidget = widget;
+
+  // Apply dashboard filters if provided
+  if (dashboardFilters) {
+    const filtered = cloneDeep(widget);
+    const dashboardFilterConditions = dashboardFiltersToString(
+      dashboardFilters,
+      filtered.widgetType
+    );
+
+    filtered.queries.forEach(query => {
+      if (dashboardFilterConditions) {
+        // If there is no base query, there's no need to add parens
+        if (query.conditions && !skipParens) {
+          query.conditions = `(${query.conditions})`;
+        }
+        query.conditions = query.conditions + ` ${dashboardFilterConditions}`;
+      }
+    });
+
+    processedWidget = filtered;
+  }
+
+  // Clean widget to remove empty/invalid fields before API request
+  return cleanWidgetForRequest(processedWidget);
+}
+
+// Stable empty array to prevent infinite rerenders
+const EMPTY_ARRAY: any[] = [];
+
+/**
+ * Hook for fetching MobileAppSize widget series data (charts) using React Query.
+ */
+export function useMobileAppSizeSeriesQuery(
+  params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled = true,
+    dashboardFilters,
+    skipDashboardFilterParens,
+    samplingMode,
+  } = params;
+
+  const {queue} = useWidgetQueryQueue();
+  const prevRawDataRef = useRef<MobileAppSizeSeriesResponse[] | undefined>(undefined);
+
+  // Apply dashboard filters
+  const filteredWidget = useMemo(
+    () => applyDashboardFilters(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  // Build query keys for all widget queries
+  const queryKeys = useMemo(() => {
+    const keys = filteredWidget.queries.map((_, queryIndex) => {
+      const requestData = getSeriesRequestData(
+        filteredWidget,
+        queryIndex,
+        organization,
+        pageFilters,
+        DiscoverDatasets.PREPROD_SIZE,
+        getReferrer(filteredWidget.displayType)
+      );
+
+      // Add sampling mode if provided
+      if (samplingMode) {
+        requestData.sampling = samplingMode;
+      }
+
+      // Transform requestData into proper query params
+      const {
+        organization: _org,
+        includeAllArgs: _includeAllArgs,
+        includePrevious: _includePrevious,
+        generatePathname: _generatePathname,
+        period,
+        ...restParams
+      } = requestData;
+
+      const queryParams = {
+        ...restParams,
+        ...(period ? {statsPeriod: period} : {}),
+      };
+
+      if (queryParams.start) {
+        queryParams.start = getUtcDateString(queryParams.start);
+      }
+      if (queryParams.end) {
+        queryParams.end = getUtcDateString(queryParams.end);
+      }
+
+      // Build the API query key for events-stats endpoint
+      return [
+        `/organizations/${organization.slug}/events-stats/`,
+        {
+          method: 'GET' as const,
+          query: queryParams,
+        },
+      ] satisfies ApiQueryKey;
+    });
+    return keys;
+  }, [filteredWidget, organization, pageFilters, samplingMode]);
+
+  // Create stable queryFn that uses queue
+  const createQueryFn = useCallback(
+    () =>
+      async (context: any): Promise<ApiResult<MobileAppSizeSeriesResponse>> => {
+        // If queue is available, wrap the API call to go through the queue
+        if (queue) {
+          return new Promise((resolve, reject) => {
+            const fetchFnRef = {
+              current: () =>
+                fetchDataQuery<MobileAppSizeSeriesResponse>(context).then(
+                  resolve,
+                  reject
+                ),
+            };
+            queue.addItem({fetchDataRef: fetchFnRef});
+          });
+        }
+
+        // Fallback: call directly if queue not available
+        return fetchDataQuery<MobileAppSizeSeriesResponse>(context);
+      },
+    [queue]
+  );
+
+  // Check if organization has the async queue feature
+  const hasQueueFeature = organization.features.includes(
+    'visibility-dashboards-async-queue'
+  );
+
+  const queryResults = useQueries({
+    queries: queryKeys.map(queryKey => ({
+      queryKey,
+      queryFn: createQueryFn(),
+      staleTime: 0,
+      enabled,
+      // Retry on 429 status codes up to 10 times, unless queue handles it
+      retry: hasQueueFeature
+        ? false
+        : (failureCount: number, error: any) => {
+            // Retry up to 10 times on rate limit errors
+            if (error?.status === 429 && failureCount < 10) {
+              return true;
+            }
+            return false;
+          },
+      placeholderData: (previousData: unknown) => previousData,
+    })),
+  });
+
+  const transformedData = (() => {
+    const isFetching = queryResults.some(q => q?.isFetching);
+    const allHaveData = queryResults.every(q => q?.data?.[0]);
+    const error = queryResults.find(q => q?.error)?.error as any;
+    const errorMessage = error?.responseJSON?.detail || error?.message;
+
+    if (!allHaveData || isFetching) {
+      const loading = isFetching || !errorMessage;
+      return {
+        loading,
+        errorMessage,
+        rawData: EMPTY_ARRAY,
+      };
+    }
+
+    const timeseriesResults: Series[] = [];
+    const timeseriesResultsTypes: Record<string, AggregationOutputType> = {};
+    const rawData: MobileAppSizeSeriesResponse[] = [];
+
+    queryResults.forEach((q, requestIndex) => {
+      if (!q?.data?.[0]) {
+        return;
+      }
+
+      const responseData = q.data[0];
+      rawData[requestIndex] = responseData;
+
+      // Use the config's transformSeries method
+      const transformedResult = MobileAppSizeConfig.transformSeries!(
+        responseData,
+        filteredWidget.queries[requestIndex]!,
+        organization
+      );
+
+      // Maintain color consistency
+      transformedResult.forEach((result: Series, resultIndex: number) => {
+        timeseriesResults[requestIndex * transformedResult.length + resultIndex] = result;
+      });
+
+      // Get result types from config
+      const resultTypes = MobileAppSizeConfig.getSeriesResultType?.(
+        responseData,
+        filteredWidget.queries[requestIndex]!
+      );
+
+      if (resultTypes) {
+        Object.assign(timeseriesResultsTypes, resultTypes);
+      }
+    });
+
+    // Check if rawData is the same as before to prevent unnecessary rerenders
+    let finalRawData = rawData;
+    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+      const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
+      if (allSame) {
+        finalRawData = prevRawDataRef.current;
+      }
+    }
+
+    // Store current rawData for next comparison
+    if (finalRawData !== prevRawDataRef.current) {
+      prevRawDataRef.current = finalRawData;
+    }
+
+    return {
+      loading: false,
+      errorMessage: undefined,
+      timeseriesResults,
+      timeseriesResultsTypes,
+      rawData: finalRawData,
+    };
+  })();
+
+  return transformedData;
+}
+
+/**
+ * MobileAppSize doesn't have table support, so this is a placeholder
+ * that returns empty data. This is needed for API compatibility.
+ */
+export function useMobileAppSizeTableQuery(
+  _params: WidgetQueryParams & {skipDashboardFilterParens?: boolean}
+): HookWidgetQueryResult {
+  return {
+    loading: false,
+    errorMessage: undefined,
+    tableResults: [],
+    rawData: EMPTY_ARRAY,
+  };
+}


### PR DESCRIPTION
Migrates the mobileAppSize dataset configuration from Promise-based API calls to React Query hook-based data fetching. The `useSeriesQuery` and `useTableQuery` will replace the old `getSeriesRequest` and `getTableRequest` in the config.

There's some duplication here between other dataset hooks, the plan is to extract shared functionality once all datasets are migrated. 