### PR TITLE
chore(preprod): Show distribution table in settings

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -5,6 +5,7 @@ import {Text} from 'sentry/components/core/text';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
@@ -37,6 +38,7 @@ interface FeatureFilterProps {
   successMessage: string;
   title: string;
   children?: React.ReactNode;
+  display?: PreprodBuildsDisplay;
 }
 
 export function FeatureFilter({
@@ -44,6 +46,7 @@ export function FeatureFilter({
   successMessage,
   settingsReadKey,
   settingsWriteKey,
+  display,
   children,
 }: FeatureFilterProps) {
   const organization = useOrganization();
@@ -123,6 +126,7 @@ export function FeatureFilter({
             error={!!buildsQuery.error}
             organizationSlug={organization.slug}
             hasSearchQuery={!!localQuery}
+            display={display}
           />
         </Stack>
       </PanelBody>

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -5,6 +5,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -56,6 +57,7 @@ export default function PreprodSettings() {
             settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
             title={t('Build Distribution')}
             successMessage={t('Distribution filter updated')}
+            display={PreprodBuildsDisplay.DISTRIBUTION}
           >
             <Text>
               {t(


### PR DESCRIPTION
Render the distribution builds view in the Build Distribution feature filter instead of defaulting to the size table so the settings preview matches its feature.

PR
<img width="2794" height="1224" alt="CleanShot 2026-01-27 at 11 57 19@2x" src="https://github.com/user-attachments/assets/bba0e6b1-ef7e-49a9-901e-37a499648ebd" />


Prod
<img width="2742" height="1382" alt="CleanShot 2026-01-27 at 11 57 49@2x" src="https://github.com/user-attachments/assets/1f16ef52-1824-477b-b80e-74f1b4ce6266" />



Refs EME-778