### PR TITLE
feat(preprod): Add app size chart to Mobile Builds tab

### DIFF
--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import {parseAsString, useQueryState} from 'nuqs';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -23,6 +23,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {usePreprodBuildsAnalytics} from 'sentry/views/preprod/hooks/usePreprodBuildsAnalytics';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import {MobileBuildsChart} from './mobileBuildsChart';
 
 type Props = {
   organization: Organization;
@@ -176,16 +178,25 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
           onDocsClick={handleDocsClick}
         />
       ) : (
-        <PreprodBuildsTable
-          builds={builds}
-          display={activeDisplay}
-          isLoading={isLoadingBuilds}
-          error={buildsError}
-          pageLinks={pageLinks}
-          organizationSlug={organization.slug}
-          hasSearchQuery={hasSearchQuery}
-          showProjectColumn={showProjectColumn}
-        />
+        <Fragment>
+          {activeDisplay === PreprodBuildsDisplay.SIZE && (
+            <MobileBuildsChart
+              builds={builds}
+              isLoading={isLoadingBuilds}
+              organizationSlug={organization.slug}
+            />
+          )}
+          <PreprodBuildsTable
+            builds={builds}
+            display={activeDisplay}
+            isLoading={isLoadingBuilds}
+            error={buildsError}
+            pageLinks={pageLinks}
+            organizationSlug={organization.slug}
+            hasSearchQuery={hasSearchQuery}
+            showProjectColumn={showProjectColumn}
+          />
+        </Fragment>
       )}
     </Stack>
   );

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -240,7 +240,7 @@ export function MobileBuildsChart({
 
                 const rows = params
                   .map(param => {
-                    const value = (param.value as number[])[1];
+                    const value = (param.value as number[])[1]!;
                     const marker = typeof param.marker === 'string' ? param.marker : '';
                     return `<div><span class="tooltip-label">${marker}<strong>${param.seriesName}</strong></span> ${formatBytesBase10(value)}</div>`;
                   })

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import type {LineSeriesOption} from 'echarts';
+import type {LineSeriesOption, TooltipComponentFormatterCallbackParams} from 'echarts';
 import moment from 'moment-timezone';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
@@ -243,7 +243,7 @@ export function MobileBuildsChart({
               trigger: 'axis',
               valueFormatter: (value: number | string) =>
                 typeof value === 'number' ? formatBytesBase10(value) : value,
-              formatter: seriesParams => {
+              formatter: (seriesParams: TooltipComponentFormatterCallbackParams) => {
                 const params = Array.isArray(seriesParams)
                   ? seriesParams
                   : [seriesParams];
@@ -251,20 +251,14 @@ export function MobileBuildsChart({
                 if (!firstParam) {
                   return '';
                 }
-                const data = firstParam.data as {name: number; value: number} | undefined;
-                const timestamp = data?.name ?? 0;
+                const timestamp = (firstParam as {axisValue?: number}).axisValue ?? 0;
                 const formattedDate = moment(timestamp).format('MMM D, YYYY h:mm A');
 
                 const rows = params
                   .map(param => {
-                    const paramData = param.data as
-                      | {name: number; value: number}
-                      | undefined;
-                    const formattedValue = paramData
-                      ? formatBytesBase10(paramData.value)
-                      : '';
+                    const value = (param.value as number[])[1];
                     const marker = typeof param.marker === 'string' ? param.marker : '';
-                    return `<div><span class="tooltip-label">${marker}<strong>${param.seriesName}</strong></span> ${formattedValue}</div>`;
+                    return `<div><span class="tooltip-label">${marker}<strong>${param.seriesName}</strong></span> ${formatBytesBase10(value)}</div>`;
                   })
                   .join('');
 

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -35,34 +35,18 @@ interface MobileBuildsChartProps {
   organizationSlug: string;
 }
 
-interface SeriesKey {
-  appId: string | null;
-  buildConfiguration: string | null;
-  platform: string | null;
-}
-
 function getSeriesKey(build: BuildDetailsApiResponse): string {
   const {app_id, platform, build_configuration} = build.app_info;
   return `${app_id ?? 'unknown'}|${platform ?? 'unknown'}|${build_configuration ?? 'unknown'}`;
 }
 
-function getSeriesLabel(key: SeriesKey): string {
-  const parts = [
-    key.appId ?? 'Unknown App',
-    key.platform ?? 'Unknown',
-    key.buildConfiguration ?? 'Unknown',
-  ];
-  return parts.join(' | ');
-}
-
-function parseSeriesKey(key: string): SeriesKey {
-  const [appId, platform, buildConfiguration] = key.split('|');
-  return {
-    appId: !appId || appId === 'unknown' ? null : appId,
-    platform: !platform || platform === 'unknown' ? null : platform,
-    buildConfiguration:
-      !buildConfiguration || buildConfiguration === 'unknown' ? null : buildConfiguration,
-  };
+function getSeriesLabel(build: BuildDetailsApiResponse): string {
+  const {app_id, platform, build_configuration} = build.app_info;
+  return [
+    app_id ?? 'Unknown App',
+    platform ?? 'Unknown',
+    build_configuration ?? 'Unknown',
+  ].join(' | ');
 }
 
 export function MobileBuildsChart({
@@ -126,7 +110,7 @@ export function MobileBuildsChart({
 
       return {
         id: key,
-        seriesName: getSeriesLabel(parseSeriesKey(key)),
+        seriesName: getSeriesLabel(groupBuilds[0]!),
         data,
         symbol: 'circle',
         showSymbol: true,

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -20,7 +20,10 @@ import type {
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {isSizeInfoCompleted} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  getMainArtifactSizeMetric,
+  isSizeInfoCompleted,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
 export enum SizeMetric {
@@ -111,9 +114,7 @@ export function MobileBuildsChart({
           return;
         }
 
-        // Get the main artifact size metric (first one with MAIN_ARTIFACT type)
-        const sizeMetrics = build.size_info.size_metrics;
-        const mainMetric = sizeMetrics[0];
+        const mainMetric = getMainArtifactSizeMetric(build.size_info);
         if (!mainMetric) {
           return;
         }

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -278,7 +278,7 @@ export function MobileBuildsChart({
                 if (!firstParam) {
                   return '';
                 }
-                const timestamp = (firstParam as TooltipAxisParams).axisValue;
+                const timestamp = (firstParam as unknown as TooltipAxisParams).axisValue;
                 const formattedDate = moment(timestamp).format('MMM D, YYYY h:mm A');
 
                 const rows = params

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -1,0 +1,282 @@
+import {useCallback, useMemo, useState} from 'react';
+import type {LineSeriesOption} from 'echarts';
+import moment from 'moment-timezone';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {LineChart} from 'sentry/components/charts/lineChart';
+import TransitionChart from 'sentry/components/charts/transitionChart';
+import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Text} from 'sentry/components/core/text';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import type {
+  EChartClickHandler,
+  EChartLegendSelectChangeHandler,
+} from 'sentry/types/echarts';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {isSizeInfoCompleted} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+
+export enum SizeMetric {
+  INSTALL_SIZE = 'install_size',
+  DOWNLOAD_SIZE = 'download_size',
+}
+
+interface MobileBuildsChartProps {
+  builds: BuildDetailsApiResponse[];
+  isLoading: boolean;
+  organizationSlug: string;
+}
+
+interface SeriesKey {
+  appId: string | null;
+  buildConfiguration: string | null;
+  platform: string | null;
+}
+
+function getSeriesKey(build: BuildDetailsApiResponse): string {
+  const {app_id, platform, build_configuration} = build.app_info;
+  return `${app_id ?? 'unknown'}|${platform ?? 'unknown'}|${build_configuration ?? 'unknown'}`;
+}
+
+function getSeriesLabel(key: SeriesKey): string {
+  const parts = [
+    key.appId ?? 'Unknown App',
+    key.platform ?? 'Unknown',
+    key.buildConfiguration ?? 'Unknown',
+  ];
+  return parts.join(' | ');
+}
+
+function parseSeriesKey(key: string): SeriesKey {
+  const [appId, platform, buildConfiguration] = key.split('|');
+  return {
+    appId: appId === 'unknown' ? null : (appId ?? null),
+    platform: platform === 'unknown' ? null : (platform ?? null),
+    buildConfiguration:
+      buildConfiguration === 'unknown' ? null : (buildConfiguration ?? null),
+  };
+}
+
+export function MobileBuildsChart({
+  builds,
+  isLoading,
+  organizationSlug,
+}: MobileBuildsChartProps) {
+  const navigate = useNavigate();
+  const [metric, setMetric] = useState<SizeMetric>(SizeMetric.INSTALL_SIZE);
+  const [legendSelected, setLegendSelected] = useState<Record<string, boolean>>({});
+
+  // Group builds by (app_id, platform, build_configuration) and transform to chart series
+  // Also create a lookup map: seriesKey -> dataIndex -> build
+  const {series, seriesBuildLookup} = useMemo(() => {
+    const grouped = new Map<string, BuildDetailsApiResponse[]>();
+
+    // Filter to builds with completed size info and group them
+    for (const build of builds) {
+      if (!isSizeInfoCompleted(build.size_info)) {
+        continue;
+      }
+
+      const key = getSeriesKey(build);
+      const existing = grouped.get(key) ?? [];
+      existing.push(build);
+      grouped.set(key, existing);
+    }
+
+    // Map from seriesId -> dataIndex -> build for click lookup
+    const buildLookup = new Map<string, Map<number, BuildDetailsApiResponse>>();
+
+    // Transform grouped builds into chart series
+    const chartSeries = Array.from(grouped.entries()).map(([key, groupBuilds]) => {
+      // Sort builds by date for consistent line drawing
+      const sortedBuilds = [...groupBuilds].sort(
+        (a, b) =>
+          new Date(a.app_info.date_added ?? 0).getTime() -
+          new Date(b.app_info.date_added ?? 0).getTime()
+      );
+
+      const indexMap = new Map<number, BuildDetailsApiResponse>();
+      const data: Array<{name: number; value: number}> = [];
+
+      sortedBuilds.forEach(build => {
+        // Re-check isSizeInfoCompleted for TypeScript narrowing
+        if (!isSizeInfoCompleted(build.size_info)) {
+          return;
+        }
+
+        // Get the main artifact size metric (first one with MAIN_ARTIFACT type)
+        const sizeMetrics = build.size_info.size_metrics;
+        const mainMetric = sizeMetrics[0];
+        if (!mainMetric) {
+          return;
+        }
+
+        const sizeValue =
+          metric === SizeMetric.INSTALL_SIZE
+            ? mainMetric.install_size_bytes
+            : mainMetric.download_size_bytes;
+
+        const timestamp = new Date(build.app_info.date_added ?? 0).getTime();
+
+        data.push({
+          name: timestamp,
+          value: sizeValue,
+        });
+        indexMap.set(data.length - 1, build);
+      });
+
+      buildLookup.set(key, indexMap);
+
+      return {
+        id: key,
+        seriesName: getSeriesLabel(parseSeriesKey(key)),
+        data,
+        emphasis: {
+          focus: 'series',
+        } as LineSeriesOption['emphasis'],
+      };
+    });
+
+    return {series: chartSeries, seriesBuildLookup: buildLookup};
+  }, [builds, metric]);
+
+  const handleClick = useCallback<EChartClickHandler>(
+    params => {
+      const seriesId = params.seriesId;
+      const dataIndex = params.dataIndex;
+
+      if (seriesId === undefined || dataIndex === undefined) {
+        return;
+      }
+
+      const indexMap = seriesBuildLookup.get(seriesId);
+      if (!indexMap) {
+        return;
+      }
+
+      const build = indexMap.get(dataIndex);
+      if (!build) {
+        return;
+      }
+
+      const path = getSizeBuildPath({
+        organizationSlug,
+        projectId: build.project_id.toString(),
+        baseArtifactId: build.id,
+      });
+
+      if (path) {
+        navigate(path);
+      }
+    },
+    [seriesBuildLookup, organizationSlug, navigate]
+  );
+
+  const handleLegendSelectChanged = useCallback<EChartLegendSelectChangeHandler>(
+    params => {
+      setLegendSelected(params.selected);
+    },
+    []
+  );
+
+  if (isLoading) {
+    return (
+      <Panel>
+        <PanelBody withPadding>
+          <Placeholder height="24px" />
+          <Placeholder height="200px" />
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  if (series.length === 0) {
+    return null;
+  }
+
+  // Get min/max timestamps for x-axis
+  const allTimestamps = series.flatMap(s => s.data.map(d => d.name));
+  const minTime = Math.min(...allTimestamps);
+  const maxTime = Math.max(...allTimestamps);
+
+  return (
+    <Panel>
+      <PanelBody withPadding>
+        <Flex align="center" justify="between" marginBottom="md">
+          <Text bold>{t('App Size')}</Text>
+          <CompactSelect
+            size="xs"
+            value={metric}
+            options={[
+              {value: SizeMetric.INSTALL_SIZE, label: t('Install Size')},
+              {value: SizeMetric.DOWNLOAD_SIZE, label: t('Download Size')},
+            ]}
+            onChange={opt => setMetric(opt.value)}
+          />
+        </Flex>
+        <TransitionChart loading={isLoading} reloading={false}>
+          <TransparentLoadingMask visible={false} />
+          <LineChart
+            height={200}
+            grid={{left: '10px', right: '10px', top: '30px', bottom: '0px'}}
+            series={series}
+            legend={{
+              show: true,
+              top: 0,
+              left: 0,
+              selected: legendSelected,
+            }}
+            onLegendSelectChanged={handleLegendSelectChanged}
+            yAxis={{
+              type: 'value',
+              axisLabel: {
+                formatter: (value: number) => formatBytesBase10(value),
+              },
+            }}
+            xAxis={{
+              show: true,
+              min: minTime,
+              max: maxTime,
+              type: 'time',
+              axisLabel: {
+                formatter: (value: number) => moment(value).format('MMM D'),
+              },
+            }}
+            tooltip={{
+              trigger: 'axis',
+              valueFormatter: (value: number | string) =>
+                typeof value === 'number' ? formatBytesBase10(value) : value,
+              formatter: (seriesParams: any) => {
+                const params = Array.isArray(seriesParams)
+                  ? seriesParams
+                  : [seriesParams];
+                if (params.length === 0) {
+                  return '';
+                }
+                const timestamp = params[0]?.data?.[0] ?? params[0]?.name;
+                const formattedDate = moment(timestamp).format('MMM D, YYYY h:mm A');
+
+                const rows = params
+                  .map(
+                    (p: any) =>
+                      `<div><span class="tooltip-label">${p.marker}<strong>${p.seriesName}</strong></span> ${formatBytesBase10(p.data?.[1] ?? p.value)}</div>`
+                  )
+                  .join('');
+
+                return `<div class="tooltip-series">${rows}</div><div class="tooltip-footer">${formattedDate}</div>`;
+              },
+            }}
+            onClick={handleClick}
+          />
+        </TransitionChart>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -59,9 +59,10 @@ function getSeriesLabel(key: SeriesKey): string {
 function parseSeriesKey(key: string): SeriesKey {
   const [appId, platform, buildConfiguration] = key.split('|');
   return {
-    appId: appId === 'unknown' ? null : appId,
-    platform: platform === 'unknown' ? null : platform,
-    buildConfiguration: buildConfiguration === 'unknown' ? null : buildConfiguration,
+    appId: !appId || appId === 'unknown' ? null : appId,
+    platform: !platform || platform === 'unknown' ? null : platform,
+    buildConfiguration:
+      !buildConfiguration || buildConfiguration === 'unknown' ? null : buildConfiguration,
   };
 }
 

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -89,7 +89,7 @@ export function MobileBuildsChart({
   const [metric, setMetric] = useState<SizeMetric>(SizeMetric.INSTALL_SIZE);
   const [legendSelected, setLegendSelected] = useState<Record<string, boolean>>({});
 
-  const {series, seriesBuildLookup} = useMemo(() => {
+  const {series, seriesBuildLookup, minTime, maxTime} = useMemo(() => {
     const grouped = new Map<string, BuildDetailsApiResponse[]>();
 
     for (const build of builds) {
@@ -154,7 +154,14 @@ export function MobileBuildsChart({
       };
     });
 
-    return {series: chartSeries, seriesBuildLookup: buildLookup};
+    const allTimestamps = chartSeries.flatMap(s => s.data.map(d => d.name));
+
+    return {
+      series: chartSeries,
+      seriesBuildLookup: buildLookup,
+      minTime: allTimestamps.length > 0 ? Math.min(...allTimestamps) : 0,
+      maxTime: allTimestamps.length > 0 ? Math.max(...allTimestamps) : 0,
+    };
   }, [builds, metric]);
 
   const handleClick = useCallback<EChartClickHandler>(
@@ -207,13 +214,9 @@ export function MobileBuildsChart({
     );
   }
 
-  if (series.length === 0) {
+  if (series.length === 0 || (minTime === 0 && maxTime === 0)) {
     return null;
   }
-
-  const allTimestamps = series.flatMap(s => s.data.map(d => d.name));
-  const minTime = Math.min(...allTimestamps);
-  const maxTime = Math.max(...allTimestamps);
 
   return (
     <Panel>

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -100,6 +100,9 @@ export function MobileBuildsChart({
       const data: Array<{name: number; value: number}> = [];
 
       sortedBuilds.forEach(build => {
+        if (!isSizeInfoCompleted(build.size_info)) {
+          return;
+        }
         const mainMetric = getMainArtifactSizeMetric(build.size_info);
         if (!mainMetric) {
           return;


### PR DESCRIPTION
Add a line chart showing build size over time on the Mobile Builds tab when display mode is "Size". The chart groups data by (app_id, platform, build_configuration) with each group as a separate series.

Features:
- Toggle between Install Size and Download Size metrics
- Click data points to navigate to build details
- Legend selection persists across pagination
- X-axis shows formatted dates, Y-axis shows formatted byte sizes

<img width="2790" height="1586" alt="CleanShot 2026-02-03 at 10 13 00@2x" src="https://github.com/user-attachments/assets/02a43f16-25a4-47a8-be8b-c34ef75dd496" />


