### PR TITLE
fix(killswitches): Always emit a metric if there is a match

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -317,7 +317,7 @@ def value_matches(
             decision = True
             break
 
-    if emit_metrics:
+    if emit_metrics or decision:
         # metrics can have a meaningful performance impact, so allow caller to opt out
         # TODO: re-evaluate after we make metric collection aysnc.
         metrics.incr(


### PR DESCRIPTION
Emitting a metric for every non-matched value is slow. But for the case
where we actually use the killswitch, we should always know how much we
dropped.
