### PR TITLE
fix(issue-details): Show Seer tour copy only when Seer is available

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -55,11 +55,13 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
   const issueTypeConfig = getConfigForIssueType(group, group.project);
   const isBottomSidebar = useMedia(`(max-width: ${theme.breakpoints.lg})`);
   const shouldDisplaySidebar = isSidebarOpen || isBottomSidebar;
-  const showSeerSection =
-    (organization.features.includes('gen-ai-features') &&
-      issueTypeConfig.issueSummary.enabled &&
-      !organization.hideAiFeatures) ||
-    issueTypeConfig.resources;
+  // Check if Seer (AI features) will be shown - must match SeerSection's logic
+  // SeerSection shows "Seer" title when the issue type supports it AND AI features are allowed
+  const hasSeerFeatures =
+    organization.features.includes('gen-ai-features') &&
+    !organization.hideAiFeatures &&
+    (issueTypeConfig.issueSummary.enabled || issueTypeConfig.autofix);
+  const showSeerSection = hasSeerFeatures || issueTypeConfig.resources;
 
   if (!shouldDisplaySidebar) {
     return null;
@@ -70,9 +72,9 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       tourContext={IssueDetailsTourContext}
       id={IssueDetailsTour.SIDEBAR}
       demoTourId={DemoTourStep.ISSUES_DETAIL_SIDEBAR}
-      title={showSeerSection ? t('Automate root cause') : t('Share updates')}
+      title={hasSeerFeatures ? t('Automate root cause') : t('Share updates')}
       description={
-        showSeerSection
+        hasSeerFeatures
           ? tct(
               'Use [link:Seer] to investigate this issue faster. You can also add comments for your team and link tickets to track progress.',
               {


### PR DESCRIPTION
## Summary
- Fixes a mismatch between tour guidance and the actual sidebar UI
- The sidebar tour step was showing "Automate root cause" and mentioning Seer even when only Resources were visible (no AI features enabled)
- Now the tour copy only mentions Seer when AI features are actually enabled, falling back to the collaboration-focused "Share updates" copy otherwise

## Test plan
- [ ] Test with AI features disabled: tour should show "Share updates" title and collaboration description
- [ ] Test with AI features enabled: tour should show "Automate root cause" title and Seer description