### PR TITLE
truncate urls longer than 200 characters when adding them to the event from request interface

### DIFF
--- a/src/sentry/plugins/sentry_urls/models.py
+++ b/src/sentry/plugins/sentry_urls/models.py
@@ -1,4 +1,5 @@
 import sentry
+from sentry.constants import MAX_TAG_VALUE_LENGTH
 from sentry.plugins.bases.tag import TagPlugin
 
 
@@ -22,4 +23,7 @@ class UrlsPlugin(TagPlugin):
             return []
         if not http.url:
             return []
-        return [http.url]
+        url = http.url
+        if len(url) > MAX_TAG_VALUE_LENGTH:
+            url = url[: MAX_TAG_VALUE_LENGTH - 3] + "..."
+        return [url]

--- a/tests/sentry/plugins/sentry_urls/test_models.py
+++ b/tests/sentry/plugins/sentry_urls/test_models.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock
+
+from sentry.constants import MAX_TAG_VALUE_LENGTH
+from sentry.plugins.sentry_urls.models import UrlsPlugin
+from sentry.testutils.cases import TestCase
+
+
+class UrlsPluginTest(TestCase):
+    def setUp(self):
+        self.plugin = UrlsPlugin()
+
+    def test_get_tag_values_with_short_url(self):
+        """URLs under MAX_TAG_VALUE_LENGTH should be returned as-is."""
+        url = "https://example.com/path/to/page"
+        event = Mock()
+        event.interfaces = {"request": Mock(url=url)}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert result == [url]
+
+    def test_get_tag_values_truncates_long_url(self):
+        """URLs exceeding MAX_TAG_VALUE_LENGTH should be truncated with '...'."""
+        # Create a URL that exceeds the limit
+        url = "https://example.com/" + "a" * 300
+        assert len(url) > MAX_TAG_VALUE_LENGTH
+
+        event = Mock()
+        event.interfaces = {"request": Mock(url=url)}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert len(result) == 1
+        assert len(result[0]) == MAX_TAG_VALUE_LENGTH
+        assert result[0].endswith("...")
+        # Verify the truncated content is correct (minus the "...")
+        assert result[0][:-3] == url[: MAX_TAG_VALUE_LENGTH - 3]
+
+    def test_get_tag_values_url_exactly_at_limit(self):
+        """URLs exactly at MAX_TAG_VALUE_LENGTH should be returned as-is."""
+        url = "https://example.com/" + "a" * (MAX_TAG_VALUE_LENGTH - len("https://example.com/"))
+        assert len(url) == MAX_TAG_VALUE_LENGTH
+
+        event = Mock()
+        event.interfaces = {"request": Mock(url=url)}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert result == [url]
+        assert "..." not in result[0]
+
+    def test_get_tag_values_no_request_interface(self):
+        """Events without a request interface should return empty list."""
+        event = Mock()
+        event.interfaces = {}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert result == []
+
+    def test_get_tag_values_no_url(self):
+        """Events with request interface but no URL should return empty list."""
+        event = Mock()
+        event.interfaces = {"request": Mock(url=None)}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert result == []
+
+    def test_get_tag_values_empty_url(self):
+        """Events with empty URL should return empty list."""
+        event = Mock()
+        event.interfaces = {"request": Mock(url="")}
+
+        result = self.plugin.get_tag_values(event)
+
+        assert result == []
+

--- a/tests/sentry/plugins/sentry_urls/test_models.py
+++ b/tests/sentry/plugins/sentry_urls/test_models.py
@@ -75,4 +75,3 @@ class UrlsPluginTest(TestCase):
         result = self.plugin.get_tag_values(event)
 
         assert result == []
-


### PR DESCRIPTION
this PR adds some truncation logic for long URLs which were previously omitted entirely

here's the resulting url tag after truncation: `"https://example.com/api/v1/very-long-path-segment-with-many-characters/very-long-path-segment-with-many-characters/very-long-path-segment-with-many-characters/very-long-path-segment-with-many-chara..."`

When generated from this script:
```
const Sentry = require('@sentry/node');

// Generate a 400 character URL (characters in the path, not query string)
const baseUrl = 'https://example.com/api/v1/';
const pathSegment = 'very-long-path-segment-with-many-characters/';
// Calculate how many segments we need to reach 400 characters
const targetLength = 400;
const currentLength = baseUrl.length;
const segmentLength = pathSegment.length;
const segmentsNeeded = Math.ceil((targetLength - currentLength) / segmentLength);
const longPath = pathSegment.repeat(segmentsNeeded);
const longUrl = baseUrl + longPath.slice(0, targetLength - currentLength) + 'endpoint';

// Initialize Sentry with the provided DSN
Sentry.init({
  dsn: 'http://some-dsn@dev.getsentry.net:8000/1',
  // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring
  tracesSampleRate: 1.0,
  // Modify events before they are sent to add request interface
  beforeSend(event) {
    // Add request interface with a 400 character URL
    event.request = {
      url: longUrl,
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',
        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
      },
      query_string: longUrl.split('?')[1] || '',
    };

    console.log(`Request URL length: ${event.request.url.length} characters`);
    return event;
  },
});

// Send a test error to Sentry
try {
  throw new Error('This is a test error sent to Sentry!');
} catch (error) {
  Sentry.captureException(error);
  console.log('Error sent to Sentry successfully!');
}

// Give Sentry time to send the event before the script exits
setTimeout(() => {
  console.log('Script completed.');
  process.exit(0);
}, 2000);
```

As part of response to this feedback here: https://x.com/tim_nolet/status/2008955053646991863 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds length guard for URL tags extracted from request interface.
> 
> - `UrlsPlugin.get_tag_values` now truncates `request.url` to `MAX_TAG_VALUE_LENGTH`, appending `...` when exceeded
> - New tests cover short URLs, truncation behavior (including exact length), and cases with missing/empty request URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea2f3792a252723f4a3c473594a3bf647812d36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->