### PR TITLE
remove try cc cta button on subscription overview

### DIFF
--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
@@ -1,23 +1,16 @@
 import {cloneElement, Fragment, isValidElement} from 'react';
 
-import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconCodecov} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
-import {openCodecovModal} from 'getsentry/actionCreators/modal';
 import PartnerPlanEndingBanner from 'getsentry/components/partnerPlanEndingBanner';
 import type {Subscription} from 'getsentry/types';
-import {
-  getPlanIcon,
-  hasAccessToSubscriptionOverview,
-  hasPartnerMigrationFeature,
-} from 'getsentry/utils/billing';
+import {getPlanIcon, hasPartnerMigrationFeature} from 'getsentry/utils/billing';
 import {isDisabledByPartner} from 'getsentry/utils/partnerships';
 import PartnershipNote from 'getsentry/views/subscriptionPage/partnershipNote';
 
@@ -81,15 +74,6 @@ function SubscriptionHeader(props: Props) {
                 {t('Manage plan')}
               </LinkButton>
             )}
-            {hasAccessToSubscriptionOverview(subscription, organization) ? (
-              <Button
-                size="md"
-                icon={<IconCodecov />}
-                onClick={() => openCodecovModal({organization})}
-              >
-                {t('Try Codecov')}
-              </Button>
-            ) : null}
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
- remove the try cc cta button on subscription overview
- clean up unused imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the Codecov trial CTA from the subscription header.
> 
> - Deletes the `Try Codecov` button and its conditional rendering
> - Cleans up related unused imports (`Button`, `IconCodecov`, `openCodecovModal`, `hasAccessToSubscriptionOverview`)
> - Consolidates billing utils import to only `getPlanIcon` and `hasPartnerMigrationFeature`
> 
> Existing manage plan flow and other header content remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a00b63c11c51c5aba9ab7b2319f4bd3559c2c339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->