### PR TITLE
fix(anomaly detection): don't allow enable anomaly detection on free/team plan

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -12,6 +12,7 @@ import type {DataCategory} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import type {
   useDefaultMaxPickableDays,
   useMaxPickableDays,
@@ -206,8 +207,9 @@ type ComponentHooks = {
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
+  'component:disabled-detector-action': React.ComponentType<{detector: Detector}>;
   'component:disabled-detector-alert': React.ComponentType<{
-    detector: import('sentry/types/workflowEngine/detectors').Detector;
+    detector: Detector;
     message: string;
   }>;
   'component:disabled-member': () => React.ComponentType;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -206,6 +206,10 @@ type ComponentHooks = {
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
+  'component:disabled-detector-alert': React.ComponentType<{
+    detector: import('sentry/types/workflowEngine/detectors').Detector;
+    message: string;
+  }>;
   'component:disabled-member': () => React.ComponentType;
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
   'component:enhanced-org-stats': () => React.ComponentType<OrganizationStatsProps>;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -207,8 +207,8 @@ type ComponentHooks = {
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
-  'component:disabled-detector-action': React.ComponentType<{detector: Detector}>;
-  'component:disabled-detector-alert': React.ComponentType<{
+  'component:disabled-detector-action': () => React.ComponentType<{detector: Detector}>;
+  'component:disabled-detector-alert': () => React.ComponentType<{
     detector: Detector;
     message: string;
   }>;

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -1,5 +1,5 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
-import Hook from 'sentry/components/hook';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -15,6 +15,11 @@ import {
   makeMonitorTypePathname,
 } from 'sentry/views/detectors/pathnames';
 import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
+
+const HookedDisableDetectorAction = HookOrDefault({
+  hookName: 'component:disabled-detector-action',
+  defaultComponent: DisableDetectorAction,
+});
 
 type DetectorDetailsHeaderProps = {
   detector: Detector;
@@ -59,15 +64,7 @@ function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
   return (
     <DetailLayout.Actions>
       <MonitorFeedbackButton />
-      <Hook name="component:disabled-detector-action" detector={detector}>
-        {({hooks}) =>
-          hooks.length > 0 ? (
-            (hooks as React.ReactNode)
-          ) : (
-            <DisableDetectorAction detector={detector} />
-          )
-        }
-      </Hook>
+      <HookedDisableDetectorAction detector={detector} />
       <EditDetectorAction detector={detector} />
     </DetailLayout.Actions>
   );

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -1,13 +1,11 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import Hook from 'sentry/components/hook';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  DisableDetectorAction,
-  EditDetectorAction,
-} from 'sentry/views/detectors/components/details/common/actions';
+import {EditDetectorAction} from 'sentry/views/detectors/components/details/common/actions';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {
   makeMonitorBasePathname,
@@ -58,7 +56,7 @@ function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
   return (
     <DetailLayout.Actions>
       <MonitorFeedbackButton />
-      <DisableDetectorAction detector={detector} />
+      <Hook name="component:disabled-detector-action" detector={detector} />
       <EditDetectorAction detector={detector} />
     </DetailLayout.Actions>
   );

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -5,7 +5,10 @@ import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
-import {EditDetectorAction} from 'sentry/views/detectors/components/details/common/actions';
+import {
+  DisableDetectorAction,
+  EditDetectorAction,
+} from 'sentry/views/detectors/components/details/common/actions';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {
   makeMonitorBasePathname,
@@ -56,7 +59,15 @@ function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
   return (
     <DetailLayout.Actions>
       <MonitorFeedbackButton />
-      <Hook name="component:disabled-detector-action" detector={detector} />
+      <Hook name="component:disabled-detector-action" detector={detector}>
+        {({hooks}) =>
+          hooks.length > 0 ? (
+            (hooks as React.ReactNode)
+          ) : (
+            <DisableDetectorAction detector={detector} />
+          )
+        }
+      </Hook>
       <EditDetectorAction detector={detector} />
     </DetailLayout.Actions>
   );

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -1,11 +1,11 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import Hook from 'sentry/components/hook';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
-import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
@@ -45,7 +45,8 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
-          <DisabledAlert
+          <Hook
+            name="component:disabled-detector-alert"
             detector={detector}
             message={t('This monitor is disabled and not creating issues.')}
           />

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -1,5 +1,5 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Hook from 'sentry/components/hook';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -19,6 +19,11 @@ import {
 import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+
+const HookedDisabledDetectorAlert = HookOrDefault({
+  hookName: 'component:disabled-detector-alert',
+  defaultComponent: DisabledAlert,
+});
 
 type MetricDetectorDetailsProps = {
   detector: MetricDetector;
@@ -46,22 +51,10 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
-          <Hook
-            name="component:disabled-detector-alert"
+          <HookedDisabledDetectorAlert
             detector={detector}
             message={t('This monitor is disabled and not creating issues.')}
-          >
-            {({hooks}) =>
-              hooks.length > 0 ? (
-                (hooks as React.ReactNode)
-              ) : (
-                <DisabledAlert
-                  detector={detector}
-                  message={t('This monitor is disabled and not creating issues.')}
-                />
-              )
-            }
-          </Hook>
+          />
           {detectorDataset === DetectorDataset.TRANSACTIONS && (
             <TransactionsDatasetWarning />
           )}

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -6,6 +6,7 @@ import type {Project} from 'sentry/types/project';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
@@ -49,7 +50,18 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
             name="component:disabled-detector-alert"
             detector={detector}
             message={t('This monitor is disabled and not creating issues.')}
-          />
+          >
+            {({hooks}) =>
+              hooks.length > 0 ? (
+                (hooks as React.ReactNode)
+              ) : (
+                <DisabledAlert
+                  detector={detector}
+                  message={t('This monitor is disabled and not creating issues.')}
+                />
+              )
+            }
+          </Hook>
           {detectorDataset === DetectorDataset.TRANSACTIONS && (
             <TransactionsDatasetWarning />
           )}

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -21,7 +21,7 @@ export function AnomalyDetectionDisabledAlert({
 
   const hasFeature = organization.features.includes('anomaly-detection-alerts');
 
-  // For anomaly detectors without feature, show upgrade message without Enable button
+  // For anomaly detectors without feature, show upgrade message only when disabled
   if (isAnomalyDetector && !hasFeature) {
     if (detector.enabled) {
       return null;

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -23,6 +23,9 @@ export function AnomalyDetectionDisabledAlert({
 
   // For anomaly detectors without feature, show upgrade message without Enable button
   if (isAnomalyDetector && !hasFeature) {
+    if (detector.enabled) {
+      return null;
+    }
     return (
       <Alert.Container>
         <Alert variant="muted">

--- a/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
+++ b/static/gsApp/components/anomalyDetectionDisabledAlert.tsx
@@ -1,0 +1,44 @@
+import {Alert} from 'sentry/components/core/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {tct} from 'sentry/locale';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
+
+export function AnomalyDetectionDisabledAlert({
+  detector,
+  message,
+}: {
+  detector: Detector;
+  message: string;
+}) {
+  const organization = useOrganization();
+
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
+
+  const hasFeature = organization.features.includes('anomaly-detection-alerts');
+
+  // For anomaly detectors without feature, show upgrade message without Enable button
+  if (isAnomalyDetector && !hasFeature) {
+    return (
+      <Alert.Container>
+        <Alert variant="muted">
+          {tct(
+            'Anomaly detection is only available on Business and Enterprise plans. [link:Upgrade your plan] to enable this monitor.',
+            {
+              link: (
+                <ExternalLink href="https://sentry.io/pricing/?referrer=anomaly-detection" />
+              ),
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
+
+  // Otherwise show default message with Enable button
+  return <DisabledAlert detector={detector} message={message} />;
+}

--- a/static/gsApp/components/disabledDetectorAction.tsx
+++ b/static/gsApp/components/disabledDetectorAction.tsx
@@ -1,5 +1,6 @@
 import {Button} from '@sentry/scraps/button';
 
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -16,9 +17,11 @@ export function DisabledDetectorAction({detector}: {detector: Detector}) {
 
   if (isAnomalyDetector && !hasFeature) {
     return (
-      <Button size="sm" disabled>
-        {t('Enable')}
-      </Button>
+      <Tooltip title={t('Upgrade your plan to enable this monitor.')} isHoverable>
+        <Button size="sm" disabled>
+          {t('Enable')}
+        </Button>
+      </Tooltip>
     );
   }
 

--- a/static/gsApp/components/disabledDetectorAction.tsx
+++ b/static/gsApp/components/disabledDetectorAction.tsx
@@ -1,0 +1,26 @@
+import {Button} from '@sentry/scraps/button';
+
+import {t} from 'sentry/locale';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+import {DisableDetectorAction} from 'sentry/views/detectors/components/details/common/actions';
+
+export function DisabledDetectorAction({detector}: {detector: Detector}) {
+  const organization = useOrganization();
+  const isAnomalyDetector =
+    detector.type === 'metric_issue' &&
+    'config' in detector &&
+    detector.config?.detectionType === 'dynamic';
+
+  const hasFeature = organization.features.includes('anomaly-detection-alerts');
+
+  if (isAnomalyDetector && !hasFeature) {
+    return (
+      <Button size="sm" disabled>
+        {detector.enabled ? t('Disable') : t('Enable')}
+      </Button>
+    );
+  }
+
+  return <DisableDetectorAction detector={detector} />;
+}

--- a/static/gsApp/components/disabledDetectorAction.tsx
+++ b/static/gsApp/components/disabledDetectorAction.tsx
@@ -17,7 +17,7 @@ export function DisabledDetectorAction({detector}: {detector: Detector}) {
   if (isAnomalyDetector && !hasFeature) {
     return (
       <Button size="sm" disabled>
-        {detector.enabled ? t('Disable') : t('Enable')}
+        {t('Enable')}
       </Button>
     );
   }

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -73,6 +73,7 @@ import rawTrackAnalyticsEvent from 'getsentry/utils/rawTrackAnalyticsEvent';
 import trackMetric from 'getsentry/utils/trackMetric';
 
 import {CodecovSettingsLink} from './components/codecovSettingsLink';
+import {DisabledDetectorAction} from './components/disabledDetectorAction';
 import PrimaryNavigationQuotaExceeded from './components/navBillingStatus';
 import OpenInDiscoverBtn from './components/openInDiscoverBtn';
 import {
@@ -254,6 +255,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
   'component:metric-alert-quota-message': MetricAlertQuotaMessage,
   'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
+  'component:disabled-detector-action': DisabledDetectorAction,
   'component:disabled-detector-alert': AnomalyDetectionDisabledAlert,
 
   /**

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -7,6 +7,7 @@ import type {Hooks} from 'sentry/types/hooks';
 
 import AiSetupConfiguration from 'getsentry/components/ai/aiSetupConfiguration';
 import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
+import {AnomalyDetectionDisabledAlert} from 'getsentry/components/anomalyDetectionDisabledAlert';
 import CronsBillingBanner from 'getsentry/components/crons/cronsBillingBanner';
 import DashboardBanner from 'getsentry/components/dashboardBanner';
 import DataConsentBanner from 'getsentry/components/dataConsentBanner';
@@ -253,6 +254,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
   'component:metric-alert-quota-message': MetricAlertQuotaMessage,
   'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
+  'component:disabled-detector-alert': AnomalyDetectionDisabledAlert,
 
   /**
    * Augment disable feature hooks for augmenting with upsell interfaces

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -255,8 +255,8 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
   'component:metric-alert-quota-message': MetricAlertQuotaMessage,
   'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
-  'component:disabled-detector-action': DisabledDetectorAction,
-  'component:disabled-detector-alert': AnomalyDetectionDisabledAlert,
+  'component:disabled-detector-action': () => DisabledDetectorAction,
+  'component:disabled-detector-alert': () => AnomalyDetectionDisabledAlert,
 
   /**
    * Augment disable feature hooks for augmenting with upsell interfaces


### PR DESCRIPTION
Free/team plans can enable dynamic detectors that already exist on a project, which should not be possible. Changed banner to say "Anomaly detection is only available on Business and Enterprise plans. [Upgrade your plan](https://sentry.io/pricing/?referrer=anomaly-detection) to enable this monitor." and disabled `enable` button.

no `anomaly-detection-alerts`
<img width="1246" height="358" alt="image" src="https://github.com/user-attachments/assets/7dccb9aa-571d-4b18-9592-498f56fdb96a" />

with `anomaly-detection-alerts`
<img width="1247" height="306" alt="image" src="https://github.com/user-attachments/assets/abdbe0bb-8f4f-4b85-b229-fe78c9c713b2" />

Follow up to https://github.com/getsentry/getsentry/pull/19219