### PR TITLE
feat(preprod): Add drilldown to clean up treemap

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -213,12 +213,10 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       height: `calc(100% - 22px)`,
       width: '100%',
       top: '22px',
-      // Very mysteriously this controls the initial breadcrumbs:
-      // https://github.com/apache/echarts/blob/6f305b497adc47fa2987a450d892d09741342c56/src/chart/treemap/TreemapView.ts#L665
-      // If truthy the root is selected else the 'middle' node is selected.
-      // It has to be set to large number to avoid problems caused by
-      // leafDepth's main use - controlling how many layers to render.
-      leafDepth: 100000,
+      // Controls how many levels deep to render at once.
+      // Users can click on nodes to drill down into deeper levels.
+      // The breadcrumb shows the current path and allows navigating back up.
+      leafDepth: 3,
       breadcrumb: {
         show: true,
         left: '0',

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -216,7 +216,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       // Controls how many levels deep to render at once.
       // Users can click on nodes to drill down into deeper levels.
       // The breadcrumb shows the current path and allows navigating back up.
-      leafDepth: 3,
+      leafDepth: 4,
       breadcrumb: {
         show: true,
         left: '0',


### PR DESCRIPTION
Before
<img width="2177" height="1048" alt="Screenshot 2026-01-27 at 10 29 25 AM" src="https://github.com/user-attachments/assets/aa75d7b9-8c6e-49a7-9131-1b35c619803f" />


After
<img width="2186" height="1093" alt="Screenshot 2026-01-27 at 10 30 31 AM" src="https://github.com/user-attachments/assets/b59e2551-9779-416c-b316-951cd290d9e4" />
