### PR TITLE
fix(billing): Hide issue fixes and scans in stats page for non-legacy Seer orgs

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -460,9 +460,9 @@ describe('OrganizationStats', () => {
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
   });
 
-  it('shows Seer categories when seer-billing feature flag is enabled', async () => {
+  it('shows Seer categories for old usage-based Seer plan (seer-added)', async () => {
     const newOrg = OrganizationFixture({
-      features: ['team-insights', 'seer-billing'],
+      features: ['team-insights', 'seer-billing', 'seer-added'],
     });
 
     render(<OrganizationStats />, {
@@ -477,6 +477,20 @@ describe('OrganizationStats', () => {
   it('does not show Seer categories when seer-billing feature flag is disabled', async () => {
     const newOrg = OrganizationFixture({
       features: ['team-insights'],
+    });
+
+    render(<OrganizationStats />, {
+      organization: newOrg,
+    });
+
+    await userEvent.click(await screen.findByText('Category'));
+    expect(screen.queryByRole('option', {name: 'Issue Fixes'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Issue Scans'})).not.toBeInTheDocument();
+  });
+
+  it('does not show Seer categories for seat-based Seer plan', async () => {
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'seer-billing', 'seat-based-seer-enabled'],
     });
 
     render(<OrganizationStats />, {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -263,7 +263,10 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
         return !organization.features.includes('spans-usage-tracking');
       }
       if ([DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER].includes(opt.value)) {
-        return organization.features.includes('seer-billing');
+        return (
+          organization.features.includes('seer-billing') &&
+          organization.features.includes('seer-added')
+        );
       }
       if ([DataCategory.LOG_BYTE].includes(opt.value)) {
         return organization.features.includes('ourlogs-enabled');


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-2011/hide-issue-fixes-and-scans-in-stats-page-for-seat-based-seer

Only include issue fixes and scans from stats page if `seer-added` flag is included. `seer-added` is the flag used to represent orgs currently paying for legacy Seer.

Note: this doesn't include stats in _admin stats. We'll still show all data category stats there.