### PR TITLE
feat(preprod): Add NOT_RAN to SizeAnalysisState

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_size.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_size.py
@@ -97,10 +97,6 @@ def do_put(
             metrics.state = put.state
             metrics.error_code = put.error_code
             metrics.error_message = put.error_message
-        case PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN:
-            metrics.state = put.state
-            metrics.error_code = put.error_code
-            metrics.error_message = put.error_message
         case PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING:
             metrics.state = put.state
         case PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING:

--- a/src/sentry/preprod/api/endpoints/project_preprod_size.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_size.py
@@ -97,6 +97,10 @@ def do_put(
             metrics.state = put.state
             metrics.error_code = put.error_code
             metrics.error_message = put.error_message
+        case PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN:
+            metrics.state = put.state
+            metrics.error_code = put.error_code
+            metrics.error_message = put.error_message
         case PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING:
             metrics.state = put.state
         case PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING:

--- a/src/sentry/preprod/api/models/launchpad.py
+++ b/src/sentry/preprod/api/models/launchpad.py
@@ -32,8 +32,13 @@ class PutSizePending(BaseModel):
     )
 
 
-# Missing SizeAnalysisState.COMPLETED is on purpose. The only way to mark
-# a size metrics as successful is via the assemble endpoint.
+# Missing SizeAnalysisState.COMPLETED and SizeAnalysisState.NOT_STARTED
+# is on purpose.
+# COMPLETED: The only way to mark a size metrics as successful is via
+# the assemble endpoint.
+# NOT_STARTED: Is launchpad is talking to us about SizeAnalysis then it
+# was started.
+
 PutSize = Annotated[
     PutSizeFailed | PutSizePending | PutSizeProcessing,
     Field(discriminator="state"),

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -126,8 +126,16 @@ class SizeInfoFailed(BaseModel):
     error_message: str
 
 
+class SizeInfoNotRan(BaseModel):
+    state: Literal[PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN] = (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN
+    )
+    error_code: int
+    error_message: str
+
+
 SizeInfo = Annotated[
-    SizeInfoPending | SizeInfoProcessing | SizeInfoCompleted | SizeInfoFailed,
+    SizeInfoPending | SizeInfoProcessing | SizeInfoCompleted | SizeInfoFailed | SizeInfoNotRan,
     Field(discriminator="state"),
 ]
 
@@ -264,6 +272,12 @@ def to_size_info(
             if error_code is None or error_message is None:
                 raise ValueError("FAILED state requires both error_code and error_message")
             return SizeInfoFailed(error_code=error_code, error_message=error_message)
+        case PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN:
+            error_code = main_metric.error_code
+            error_message = main_metric.error_message
+            if error_code is None or error_message is None:
+                raise ValueError("NOT_RAN state requires both error_code and error_message")
+            return SizeInfoNotRan(error_code=error_code, error_message=error_message)
         case _:
             raise ValueError(f"Unknown SizeAnalysisState {main_metric.state}")
 

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -520,6 +520,8 @@ class PreprodArtifactSizeMetrics(DefaultFieldsModel):
         """Size analysis completed successfully."""
         FAILED = 3
         """Size analysis failed. See error_code and error_message for details."""
+        NOT_RAN = 4
+        """Size analysis not ran. See error_code and error_message for details."""
 
         @classmethod
         def as_choices(cls) -> tuple[tuple[int, str], ...]:
@@ -528,6 +530,7 @@ class PreprodArtifactSizeMetrics(DefaultFieldsModel):
                 (cls.PROCESSING, "processing"),
                 (cls.COMPLETED, "completed"),
                 (cls.FAILED, "failed"),
+                (cls.NOT_RAN, "not_ran"),
             )
 
     class ErrorCode(IntEnum):
@@ -539,6 +542,10 @@ class PreprodArtifactSizeMetrics(DefaultFieldsModel):
         """The artifact type is not supported for size analysis."""
         PROCESSING_ERROR = 3
         """An error occurred during size analysis processing."""
+        NO_QUOTA = 4
+        """NOT_RAN state: No quota available."""
+        SKIPPED = 5
+        """NOT_RAN state: Size analysis was not requested on this build."""
 
         @classmethod
         def as_choices(cls) -> tuple[tuple[int, str], ...]:
@@ -547,6 +554,8 @@ class PreprodArtifactSizeMetrics(DefaultFieldsModel):
                 (cls.TIMEOUT, "timeout"),
                 (cls.UNSUPPORTED_ARTIFACT, "unsupported_artifact"),
                 (cls.PROCESSING_ERROR, "processing_error"),
+                (cls.NO_QUOTA, "no_quota"),
+                (cls.SKIPPED, "skipped"),
             )
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -64,6 +64,8 @@ def format_status_check_messages(
                             analyzed_count += 1
                         case PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED:
                             errored_count += 1
+                        case PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN:
+                            errored_count += 1
                         case _:
                             raise ValueError(f"Unknown size analysis state: {metrics.state}")
 


### PR DESCRIPTION
Now we can not run size analysis for two legitimate reasons:
- Not having enough quota
- Skipping size because we only want to run build distribution

It's important to be able to tell these apart in the UI.
Currently we don't create a `PreprodArtifactSizeMetrics` row in this case which
makes them hard to tell apart.

This adds a new state for the row: `NOT_RAN` and also two new 'error' states:
- NO_QUOTA
- SKIPPED

We make a new top level state to be able to easily tell this case apart from real failures
but reuse error_code and error_message rather than introduce two new columns.
