### PR TITLE
perf(SearchQueryBuilder): Cache sizing div in useAutosizeInput, reduce ref calls

### DIFF
--- a/static/app/components/core/input/useAutosizeInput.tsx
+++ b/static/app/components/core/input/useAutosizeInput.tsx
@@ -16,11 +16,35 @@ interface UseAutosizeInputOptions {
   value?: React.InputHTMLAttributes<HTMLInputElement>['value'] | undefined;
 }
 
+function createSizingDiv() {
+  const sizingDiv = document.createElement('div');
+  sizingDiv.style.whiteSpace = 'pre';
+  sizingDiv.style.width = 'auto';
+  sizingDiv.style.height = '0';
+  sizingDiv.style.position = 'fixed';
+  sizingDiv.style.pointerEvents = 'none';
+  sizingDiv.style.opacity = '0';
+  sizingDiv.style.zIndex = '-1';
+  return sizingDiv;
+}
+
 export function useAutosizeInput(
   options?: UseAutosizeInputOptions
 ): React.RefCallback<HTMLInputElement> {
   const enabled = options?.enabled ?? true;
   const sourceRef = useRef<HTMLInputElement | null>(null);
+  // Cache the sizing div per hook instance to avoid create/destroy on every resize
+  const sizingDivRef = useRef<HTMLDivElement | null>(null);
+
+  // Cleanup sizing div on unmount
+  useLayoutEffect(() => {
+    return () => {
+      if (sizingDivRef.current?.parentNode) {
+        sizingDivRef.current.parentNode.removeChild(sizingDivRef.current);
+        sizingDivRef.current = null;
+      }
+    };
+  }, []);
 
   // A controlled input value change does not trigger a change event,
   // so we need to manually observe the value...
@@ -30,13 +54,13 @@ export function useAutosizeInput(
     }
 
     if (sourceRef.current) {
-      resize(sourceRef.current);
+      resize(sourceRef.current, sizingDivRef);
     }
   }, [options?.value, enabled]);
 
   const onInputChange = useCallback((_event: any) => {
     if (sourceRef.current) {
-      resize(sourceRef.current);
+      resize(sourceRef.current, sizingDivRef);
     }
   }, []);
 
@@ -45,7 +69,7 @@ export function useAutosizeInput(
       if (!enabled || !element) {
         sourceRef.current?.removeEventListener('input', onInputChange);
       } else {
-        resize(element);
+        resize(element, sizingDivRef);
         element.addEventListener('input', onInputChange);
       }
 
@@ -57,29 +81,26 @@ export function useAutosizeInput(
   return autosizingCallbackRef;
 }
 
-function createSizingDiv(referenceStyles: CSSStyleDeclaration) {
-  const sizingDiv = document.createElement('div');
-  sizingDiv.style.whiteSpace = 'pre';
-  sizingDiv.style.width = 'auto';
-  sizingDiv.style.height = '0';
-  sizingDiv.style.position = 'fixed';
-  sizingDiv.style.pointerEvents = 'none';
-  sizingDiv.style.opacity = '0';
-  sizingDiv.style.zIndex = '-1';
-
-  sizingDiv.style.fontSize = referenceStyles.fontSize;
-  sizingDiv.style.fontWeight = referenceStyles.fontWeight;
-  sizingDiv.style.fontFamily = referenceStyles.fontFamily;
-
-  return sizingDiv;
-}
-
-function resize(input: HTMLInputElement) {
+function resize(
+  input: HTMLInputElement,
+  sizingDivRef: React.MutableRefObject<HTMLDivElement | null>
+) {
   const computedStyles = getComputedStyle(input);
 
-  const sizingDiv = createSizingDiv(computedStyles);
+  // Lazily create and attach the sizing div
+  if (!sizingDivRef.current) {
+    sizingDivRef.current = createSizingDiv();
+    document.body.appendChild(sizingDivRef.current);
+  }
+
+  const sizingDiv = sizingDivRef.current;
+
+  // Update font styles to match the input
+  sizingDiv.style.fontSize = computedStyles.fontSize;
+  sizingDiv.style.fontWeight = computedStyles.fontWeight;
+  sizingDiv.style.fontFamily = computedStyles.fontFamily;
+
   sizingDiv.innerText = input.value || input.placeholder;
-  document.body.appendChild(sizingDiv);
 
   const newTotalInputSize =
     sizingDiv.offsetWidth +
@@ -89,6 +110,5 @@ function resize(input: HTMLInputElement) {
     parseInt(computedStyles.borderWidth ?? 0, 10) * 2 +
     1; // Add 1px to account for cursor width in Safari
 
-  document.body.removeChild(sizingDiv);
   input.style.width = `${newTotalInputSize}px`;
 }

--- a/static/app/components/core/input/useAutosizeInput.tsx
+++ b/static/app/components/core/input/useAutosizeInput.tsx
@@ -16,7 +16,7 @@ interface UseAutosizeInputOptions {
   value?: React.InputHTMLAttributes<HTMLInputElement>['value'] | undefined;
 }
 
-function createSizingDiv() {
+function createSizingDiv(input: HTMLInputElement) {
   const sizingDiv = document.createElement('div');
   sizingDiv.style.whiteSpace = 'pre';
   sizingDiv.style.width = 'auto';
@@ -25,6 +25,12 @@ function createSizingDiv() {
   sizingDiv.style.pointerEvents = 'none';
   sizingDiv.style.opacity = '0';
   sizingDiv.style.zIndex = '-1';
+
+  // Initialize font styles to match the input once at creation.
+  const computedStyles = getComputedStyle(input);
+  sizingDiv.style.fontSize = computedStyles.fontSize;
+  sizingDiv.style.fontWeight = computedStyles.fontWeight;
+  sizingDiv.style.fontFamily = computedStyles.fontFamily;
   return sizingDiv;
 }
 
@@ -89,16 +95,13 @@ function resize(
 
   // Lazily create and attach the sizing div
   if (!sizingDivRef.current) {
-    sizingDivRef.current = createSizingDiv();
+    sizingDivRef.current = createSizingDiv(input);
     document.body.appendChild(sizingDivRef.current);
   }
 
   const sizingDiv = sizingDivRef.current;
 
-  // Update font styles to match the input
-  sizingDiv.style.fontSize = computedStyles.fontSize;
-  sizingDiv.style.fontWeight = computedStyles.fontWeight;
-  sizingDiv.style.fontFamily = computedStyles.fontFamily;
+  // Font styles are set when the sizing div is created
 
   sizingDiv.innerText = input.value || input.placeholder;
 

--- a/static/app/components/core/input/useAutosizeInput.tsx
+++ b/static/app/components/core/input/useAutosizeInput.tsx
@@ -16,7 +16,11 @@ interface UseAutosizeInputOptions {
   value?: React.InputHTMLAttributes<HTMLInputElement>['value'] | undefined;
 }
 
-function createSizingDiv(input: HTMLInputElement) {
+function createSizingDiv(computedStyles: {
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+}) {
   const sizingDiv = document.createElement('div');
   sizingDiv.style.whiteSpace = 'pre';
   sizingDiv.style.width = 'auto';
@@ -27,7 +31,6 @@ function createSizingDiv(input: HTMLInputElement) {
   sizingDiv.style.zIndex = '-1';
 
   // Initialize font styles to match the input once at creation.
-  const computedStyles = getComputedStyle(input);
   sizingDiv.style.fontSize = computedStyles.fontSize;
   sizingDiv.style.fontWeight = computedStyles.fontWeight;
   sizingDiv.style.fontFamily = computedStyles.fontFamily;
@@ -95,14 +98,11 @@ function resize(
 
   // Lazily create and attach the sizing div
   if (!sizingDivRef.current) {
-    sizingDivRef.current = createSizingDiv(input);
+    sizingDivRef.current = createSizingDiv(computedStyles);
     document.body.appendChild(sizingDivRef.current);
   }
 
   const sizingDiv = sizingDivRef.current;
-
-  // Font styles are set when the sizing div is created
-
   sizingDiv.innerText = input.value || input.placeholder;
 
   const newTotalInputSize =

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -584,17 +584,27 @@ export function SearchQueryBuilderCombobox<
   }, [inputRef, popoverRef, isOpen, customMenu]);
 
   const autosizeInput = useAutosizeInput({value: inputValue});
+
+  // Memoize the merged ref to avoid calling callback refs on every render.
+  // mergeRefs creates a new function each call, which causes React to call
+  // old ref with null and new ref with element on every render.
+  const mergedInputRef = useMemo(
+    () =>
+      mergeRefs(
+        ref,
+        inputRef,
+        autosizeInput,
+        triggerProps.ref as React.Ref<HTMLInputElement>
+      ),
+    [ref, autosizeInput, triggerProps.ref]
+  );
+
   return (
     <Flex align="stretch" width="100%" height="100%" position="relative">
       <UnstyledInput
         {...inputProps}
         size="md"
-        ref={mergeRefs(
-          ref,
-          inputRef,
-          autosizeInput,
-          triggerProps.ref as React.Ref<HTMLInputElement>
-        )}
+        ref={mergedInputRef}
         type="text"
         placeholder={placeholder}
         onClick={handleInputClick}


### PR DESCRIPTION
Two optimizations to reduce render overhead in SearchQueryBuilder:

  ### 1. Cache sizing div in useAutosizeInput

  Previously, `resize()` created a new div, appended it to `document.body`, measured it, and removed it on every call. This caused significant overhead in components with frequent resizes.

  Now the sizing div is lazily created once per hook instance and reused for the lifetime of the component, with cleanup on unmount.

  ### 2. Memoize merged refs in combobox

  `mergeRefs()` returns a new function on every call. When passed directly to a ref prop, React sees a different callback ref each render, causing it to call the old ref with `null` and the new ref with the element—triggering unmount/remount behavior on every render, scroll, or window resize.

  ## Performance

  **SearchQueryBuilder test suite (225 tests):**

  | Metric | Baseline | After | Improvement |
  |--------|----------|-------|-------------|
  | Median timing | 19.7s | 18.3s | **-7%** |
  | App-code time | 1351ms | 1138ms | **-16%** |
  | useAutosizeInput.tsx | 46.8ms | <35ms | dropped out of top 30 |
  | useOverlay.tsx | 102ms | 70ms | **-32ms** |
  | menuListItem.tsx | 117ms | 98ms | **-19ms** |

prod build trace before

<img width="295" height="251" alt="image" src="https://github.com/user-attachments/assets/6a97fe40-e1d3-45ff-8f65-fde942ddc36e" />


after

<img width="332" height="330" alt="image" src="https://github.com/user-attachments/assets/19a9a638-653d-4a86-8255-068ded16df83" />
