### PR TITLE
feat(spans-buffer): Use separate redirect table for SET implementation

### DIFF
--- a/src/sentry/scripts/spans/add-buffer-set.lua
+++ b/src/sentry/scripts/spans/add-buffer-set.lua
@@ -47,7 +47,7 @@ local start_time_ms = get_time_ms()
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
-local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
+local main_redirect_key = string.format("span-buf:ssr:{%s}", project_and_trace)
 
 -- Navigates the tree up to the highest level parent span we can find. Such
 -- span is needed to know the segment we need to merge the subsegment into.


### PR DESCRIPTION
When we enabled `write_to_set` , the comparison metrics between SET and ZSET showed differences because both implementations shared the same ZSET redirect table `span-buf:sr:...`.

- SET now uses its own redirect table (`span-buf:ssr:...`) instead of sharing with ZSET.                
- Added a unit test to verify both tables are created with equivalent mappings and are cleaned up.
