### PR TITLE
fix(search): Support IN operator for semver release.version filters

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -300,7 +300,7 @@ OPERATOR_NEGATION_MAP = {
     "IN": "NOT IN",
     "NOT IN": "IN",
 }
-OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
+OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact", "IN": "in"}
 
 # This is a unicode character from the reserved space of unicode characters, see:
 # https://en.wikipedia.org/wiki/Private_Use_Areas for more details.

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1702,8 +1702,70 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             release_2_g_1,
         ]
 
-        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_BUILD_ALIAS}:[124]")
-        assert response.status_code == 400, response.content
+        # Test IN operator with multiple builds
+        response = self.get_response(
+            sort_by="date", limit=10, query=f"{SEMVER_BUILD_ALIAS}:[123,124]"
+        )
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.data] == [
+            release_1_g_1,
+            release_1_g_2,
+            release_2_g_1,
+        ]
+
+    def test_semver_version_in(self) -> None:
+        """Test IN operator for release.version with multiple semver versions."""
+        release_1 = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test@1.2.4")
+        release_3 = self.create_release(version="test@1.2.5")
+
+        release_1_g_1 = self.store_event(
+            data={
+                "timestamp": before_now(minutes=1).isoformat(),
+                "fingerprint": ["group-1"],
+                "release": release_1.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_2_g_1 = self.store_event(
+            data={
+                "timestamp": before_now(minutes=2).isoformat(),
+                "fingerprint": ["group-2"],
+                "release": release_2.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_3_g_1 = self.store_event(
+            data={
+                "timestamp": before_now(minutes=3).isoformat(),
+                "fingerprint": ["group-3"],
+                "release": release_3.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        self.login_as(user=self.user)
+
+        # Test IN operator with multiple versions
+        response = self.get_response(
+            sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:[1.2.3,1.2.5]"
+        )
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.data] == [
+            release_1_g_1,
+            release_3_g_1,
+        ]
+
+        # Test IN operator with single version
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:[1.2.4]")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.data] == [
+            release_2_g_1,
+        ]
+
+        # Test IN operator with no matching versions
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:[9.9.9]")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.data] == []
 
     def test_aggregate_stats_regression_test(self) -> None:
         self.store_event(

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -399,12 +399,6 @@ class SemverBuildFilterConverterTest(BaseSemverConverterTest):
         with pytest.raises(ValueError, match="organization_id is a required param"):
             _semver_filter_converter(filter, key, {"something": 1})  # type: ignore[arg-type]  # intentionally bad data
 
-        filter = SearchFilter(SearchKey(key), "IN", SearchValue("sentry"))
-        with pytest.raises(
-            InvalidSearchQuery, match="Invalid operation 'IN' for semantic version filter."
-        ):
-            _semver_filter_converter(filter, key, {"organization_id": 1})
-
     def test_empty(self) -> None:
         self.run_test("=", "test", "IN", [SEMVER_EMPTY_RELEASE])
 
@@ -434,11 +428,11 @@ class ParseSemverTest(unittest.TestCase):
             match=INVALID_SEMVER_MESSAGE,
         ):
             assert parse_semver("hello", ">") is None
-        with pytest.raises(
-            InvalidSearchQuery,
-            match="Invalid operation 'IN' for semantic version filter.",
-        ):
-            assert parse_semver("1.2.3.4", "IN") is None
+
+    def test_in_operator(self) -> None:
+        # IN operator is valid and should return a SemverFilter
+        result = parse_semver("1.2.3.4", "IN")
+        assert result == SemverFilter("in", [1, 2, 3, 4, 1, ""])
 
     def test_normal(self) -> None:
         self.run_test("1", ">", SemverFilter("gt", [1, 0, 0, 0, 1, ""]))


### PR DESCRIPTION
When users select multiple release versions via checkboxes in the Issues page search bar, the frontend generates a query like `release.version:[1.2.3,1.2.4]` with an IN operator. Previously this raised "Invalid operation 'IN' for semantic version filter" because the semver filter converters didn't handle the IN operator.

This change adds support for the IN operator with list values in:
- `_semver_filter_converter` and `semver_filter_converter`: iterate through each version in the list, query matching releases for each, and combine results
- `_semver_build_filter_converter` and `semver_build_filter_converter`: pass the list directly to `filter_by_semver_build`
- `filter_by_semver_build`: accept a sequence of builds and use `build_number__in` / `build_code__in` for the query

Fixes https://github.com/getsentry/sentry/issues/76286