### PR TITLE
feat(uptime): Add API endpoints to delete response captures

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -617,6 +617,9 @@ from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAler
 from sentry.uptime.endpoints.project_uptime_response_capture import (
     ProjectUptimeResponseCaptureEndpoint,
 )
+from sentry.uptime.endpoints.project_uptime_response_captures_index import (
+    ProjectUptimeResponseCapturesIndexEndpoint,
+)
 from sentry.uptime.endpoints.uptime_ips import UptimeIpsEndpoint
 from sentry.users.api.endpoints.authenticator_index import AuthenticatorIndexEndpoint
 from sentry.users.api.endpoints.user_authenticator_details import UserAuthenticatorDetailsEndpoint
@@ -3298,6 +3301,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/uptime/(?P<uptime_detector_id>[^/]+)/response-captures/(?P<capture_id>[^/]+)/$",
         ProjectUptimeResponseCaptureEndpoint.as_view(),
         name="sentry-api-0-project-uptime-response-capture",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/uptime/(?P<uptime_detector_id>[^/]+)/response-captures/$",
+        ProjectUptimeResponseCapturesIndexEndpoint.as_view(),
+        name="sentry-api-0-project-uptime-response-captures-index",
     ),
     # Tempest
     re_path(

--- a/src/sentry/uptime/endpoints/project_uptime_response_captures_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_response_captures_index.py
@@ -1,0 +1,56 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, UptimeParams
+from sentry.models.project import Project
+from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
+from sentry.uptime.models import UptimeResponseCapture, get_uptime_subscription
+from sentry.workflow_engine.models import Detector
+
+
+@region_silo_endpoint
+class ProjectUptimeResponseCapturesIndexEndpoint(ProjectUptimeAlertEndpoint):
+    owner = ApiOwner.CRONS
+    publish_status = {
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    @extend_schema(
+        operation_id="Delete All Uptime Response Captures",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            UptimeParams.UPTIME_ALERT_ID,
+        ],
+        responses={
+            200: dict,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def delete(
+        self,
+        request: Request,
+        project: Project,
+        uptime_detector: Detector,
+    ) -> Response:
+        """
+        Delete all captured HTTP responses for an uptime monitor.
+        """
+        uptime_subscription = get_uptime_subscription(uptime_detector)
+
+        # Delete each capture individually to trigger File cleanup via delete() override
+        deleted_count = 0
+        for capture in UptimeResponseCapture.objects.filter(
+            uptime_subscription=uptime_subscription
+        ):
+            capture.delete()
+            deleted_count += 1
+
+        return Response({"deletedCount": deleted_count})

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -724,6 +724,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/checks/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/response-captures/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/response-captures/$captureId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-feedback/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-issue/'

--- a/tests/sentry/uptime/endpoints/test_project_uptime_response_captures_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_response_captures_index.py
@@ -1,0 +1,92 @@
+from io import BytesIO
+
+from sentry.models.files.file import File
+from sentry.testutils.cases import APITestCase, UptimeTestCase
+from sentry.uptime.models import UptimeResponseCapture
+
+
+class ProjectUptimeResponseCapturesIndexEndpointTest(APITestCase, UptimeTestCase):
+    endpoint = "sentry-api-0-project-uptime-response-captures-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.uptime_subscription = self.create_uptime_subscription(url="https://example.com")
+        self.detector = self.create_uptime_detector(
+            uptime_subscription=self.uptime_subscription,
+            project=self.project,
+        )
+
+    def test_delete_all_response_captures(self):
+        files = [
+            File.objects.create(name=f"test-response-{i}", type="uptime.response") for i in range(3)
+        ]
+        for i, file in enumerate(files):
+            file.putfile(BytesIO(f"test content {i}".encode()))
+
+        captures = UptimeResponseCapture.objects.bulk_create(
+            [
+                UptimeResponseCapture(
+                    uptime_subscription=self.uptime_subscription,
+                    file_id=file.id,
+                    scheduled_check_time_ms=1234567890 + i,
+                )
+                for i, file in enumerate(files)
+            ]
+        )
+
+        file_ids = [f.id for f in files]
+        capture_ids = [c.id for c in captures]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            method="delete",
+            status_code=200,
+        )
+
+        assert response.data["deletedCount"] == 3
+        assert UptimeResponseCapture.objects.filter(id__in=capture_ids).count() == 0
+        assert File.objects.filter(id__in=file_ids).count() == 0
+
+    def test_delete_all_response_captures_empty(self):
+        """Deleting when there are no captures should succeed."""
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            method="delete",
+            status_code=200,
+        )
+        assert response.data["deletedCount"] == 0
+
+    def test_delete_only_affects_own_subscription(self):
+        """Deleting captures should not affect other subscriptions."""
+        file1 = File.objects.create(name="test-response-1", type="uptime.response")
+        file1.putfile(BytesIO(b"test content 1"))
+        capture1 = UptimeResponseCapture.objects.create(
+            uptime_subscription=self.uptime_subscription,
+            file_id=file1.id,
+            scheduled_check_time_ms=1234567890,
+        )
+        other_subscription = self.create_uptime_subscription(url="https://other.com")
+        file2 = File.objects.create(name="test-response-2", type="uptime.response")
+        file2.putfile(BytesIO(b"test content 2"))
+        capture2 = UptimeResponseCapture.objects.create(
+            uptime_subscription=other_subscription,
+            file_id=file2.id,
+            scheduled_check_time_ms=1234567890,
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.detector.id,
+            method="delete",
+            status_code=200,
+        )
+        assert response.data["deletedCount"] == 1
+        assert not UptimeResponseCapture.objects.filter(id=capture1.id).exists()
+        assert not File.objects.filter(id=file1.id).exists()
+        assert UptimeResponseCapture.objects.filter(id=capture2.id).exists()
+        assert File.objects.filter(id=file2.id).exists()


### PR DESCRIPTION
Add endpoints for users to delete captured HTTP responses from uptime check failures:
- DELETE single capture by ID
- DELETE all captures for a monitor

<!-- Describe your PR here. -->