### PR TITLE
feat(rate-limiter): Extend project argument to accept integer values

### DIFF
--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from sentry.models.project import Project
 from sentry.utils.services import Service
-
-if TYPE_CHECKING:
-    from sentry.models.project import Project
 
 
 class RateLimiter(Service):

--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -14,23 +14,25 @@ class RateLimiter(Service):
     window = 60
 
     def is_limited(
-        self, key: str, limit: int, project: Project | None = None, window: int | None = None
+        self, key: str, limit: int, project: Project | int | None = None, window: int | None = None
     ) -> bool:
         is_limited, _, _ = self.is_limited_with_value(key, limit, project=project, window=window)
         return is_limited
 
     def current_value(
-        self, key: str, project: Project | None = None, window: int | None = None
+        self, key: str, project: Project | int | None = None, window: int | None = None
     ) -> int:
         return 0
 
     def is_limited_with_value(
-        self, key: str, limit: int, project: Project | None = None, window: int | None = None
+        self, key: str, limit: int, project: Project | int | None = None, window: int | None = None
     ) -> tuple[bool, int, int]:
         return False, 0, 0
 
     def validate(self) -> None:
         raise NotImplementedError
 
-    def reset(self, key: str, project: Project | None = None, window: int | None = None) -> None:
+    def reset(
+        self, key: str, project: Project | int | None = None, window: int | None = None
+    ) -> None:
         return

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 import logging
 from time import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.conf import settings
 from redis.exceptions import RedisError
 
 from sentry.exceptions import InvalidConfiguration
+from sentry.models.project import Project
 from sentry.ratelimits.base import RateLimiter
 from sentry.utils import redis
 from sentry.utils.hashlib import md5_text
-
-if TYPE_CHECKING:
-    from sentry.models.project import Project
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -63,7 +63,7 @@ class RedisRateLimiter(RateLimiter):
 
         redis_key = f"rl:{key_hex}"
         if project_id is not None:
-            redis_key += f":{project.id}"
+            redis_key += f":{project_id}"
         redis_key += f":{bucket}"
 
         return redis_key


### PR DESCRIPTION
Presently, the rate-limiter expects a full Project model instance. This requires querying the database if a Project model instance is not already available.

If we accept a union of Project and integer we can accept project-ids without querying.