### PR TITLE
feat(dashboards): Register Mobile Session Health prebuilt dashboard

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -74,6 +74,7 @@ class PrebuiltDashboardId(IntEnum):
     MOBILE_VITALS_SCREEN_LOADS = 10
     MOBILE_VITALS_SCREEN_RENDERING = 11
     BACKEND_OVERVIEW = 12
+    MOBILE_SESSION_HEALTH = 13
 
 
 class PrebuiltDashboard(TypedDict):
@@ -138,6 +139,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_OVERVIEW,
         "title": "Backend Overview",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_SESSION_HEALTH,
+        "title": "Mobile Session Health",
     },
 ]
 


### PR DESCRIPTION
## Summary

Register the Mobile Session Health prebuilt dashboard in the backend:

- Add `MOBILE_SESSION_HEALTH = 13` to the `PrebuiltDashboardId` enum
- Add dashboard entry to the `PREBUILT_DASHBOARDS` list with title "Mobile Session Health"

This is part of the mobile session health module migration to the dashboards platform.