### PR TITLE
feat(preprod): Add descriptions for preprod search attributes

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2515,7 +2515,7 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   build_configuration_name: {
-    desc: t('The name of the build configuration'),
+    desc: t('The name of the build configuration (e.g., Debug, Release)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -2535,32 +2535,32 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   git_head_ref: {
-    desc: t('The Git branch or tag name of the HEAD commit'),
+    desc: t('The Git branch of the HEAD commit associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_base_ref: {
-    desc: t('The Git branch or tag name of the base commit for comparison'),
+    desc: t('The Git branch of the base commit for comparison associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_head_sha: {
-    desc: t('The Git SHA of the HEAD commit'),
+    desc: t('The Git SHA of the HEAD commit associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_base_sha: {
-    desc: t('The Git SHA of the base commit for comparison'),
+    desc: t('The Git SHA of the base commit for comparison associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_head_repo_name: {
-    desc: t('The repository name for the HEAD commit'),
+    desc: t('The repository name for the HEAD commit associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_pr_number: {
-    desc: t('The pull request number associated with this build'),
+    desc: t('The pull request number associated with a build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2503,6 +2503,69 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   },
 };
 
+const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
+  app_id: {
+    desc: t('The bundle identifier of the application.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  app_name: {
+    desc: t('The display name of the application.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  build_configuration_name: {
+    desc: t('The name of the build configuration.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  platform_name: {
+    desc: t('The platform the build targets.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  build_number: {
+    desc: t('The build number assigned to this build.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  build_version: {
+    desc: t('The version string of the build.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_head_ref: {
+    desc: t('The Git branch or tag name of the HEAD commit.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_base_ref: {
+    desc: t('The Git branch or tag name of the base commit for comparison.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_head_sha: {
+    desc: t('The Git SHA of the HEAD commit.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_base_sha: {
+    desc: t('The Git SHA of the base commit for comparison.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_head_repo_name: {
+    desc: t('The repository name for the HEAD commit.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  git_pr_number: {
+    desc: t('The pull request number associated with this build.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+};
+
 const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   ...LOG_AGGREGATION_FIELDS,
   ...EVENT_FIELD_DEFINITIONS,
@@ -3388,6 +3451,27 @@ export const getFieldDefinition = (
       }
       return null;
     case 'preprod':
+      if (PREPROD_FIELD_DEFINITIONS[key]) {
+        return PREPROD_FIELD_DEFINITIONS[key];
+      }
+      if (SPAN_FIELD_DEFINITIONS[key]) {
+        return SPAN_FIELD_DEFINITIONS[key];
+      }
+
+      if (kind === FieldKind.MEASUREMENT) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.NUMBER};
+      }
+
+      if (kind === FieldKind.TAG) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.STRING};
+      }
+
+      if (kind === FieldKind.BOOLEAN) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
+      }
+
+      return null;
+
     case 'span':
       if (SPAN_FIELD_DEFINITIONS[key]) {
         return SPAN_FIELD_DEFINITIONS[key];

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2505,62 +2505,62 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
 
 const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   app_id: {
-    desc: t('The bundle identifier of the application.'),
+    desc: t('The bundle identifier of the application'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   app_name: {
-    desc: t('The display name of the application.'),
+    desc: t('The display name of the application'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   build_configuration_name: {
-    desc: t('The name of the build configuration.'),
+    desc: t('The name of the build configuration'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   platform_name: {
-    desc: t('The platform the build targets.'),
+    desc: t('The platform the build targets'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   build_number: {
-    desc: t('The build number assigned to this build.'),
+    desc: t('The build number assigned to this build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   build_version: {
-    desc: t('The version string of the build.'),
+    desc: t('The version string of the build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_head_ref: {
-    desc: t('The Git branch or tag name of the HEAD commit.'),
+    desc: t('The Git branch or tag name of the HEAD commit'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_base_ref: {
-    desc: t('The Git branch or tag name of the base commit for comparison.'),
+    desc: t('The Git branch or tag name of the base commit for comparison'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_head_sha: {
-    desc: t('The Git SHA of the HEAD commit.'),
+    desc: t('The Git SHA of the HEAD commit'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_base_sha: {
-    desc: t('The Git SHA of the base commit for comparison.'),
+    desc: t('The Git SHA of the base commit for comparison'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_head_repo_name: {
-    desc: t('The repository name for the HEAD commit.'),
+    desc: t('The repository name for the HEAD commit'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   git_pr_number: {
-    desc: t('The pull request number associated with this build.'),
+    desc: t('The pull request number associated with this build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },


### PR DESCRIPTION
Add human-readable descriptions for preprod field definitions so they display in the smart search dropdown when users hover over filter keys.

PR
<img width="2288" height="980" alt="CleanShot 2026-01-27 at 15 42 48@2x" src="https://github.com/user-attachments/assets/a804013a-3722-4339-bd59-882b9653522e" />

Prod
<img width="2708" height="1577" alt="CleanShot 2026-01-27 at 15 43 55@2x" src="https://github.com/user-attachments/assets/04b837dd-eadd-4795-8abd-4be17171255e" />
