### PR TITLE
fix(conversations): Fix cache pollution during project transitions

### DIFF
--- a/static/app/views/insights/pages/conversations/components/agentSelector.tsx
+++ b/static/app/views/insights/pages/conversations/components/agentSelector.tsx
@@ -58,7 +58,13 @@ export function AgentSelector() {
     }
   }, [projectKey, setQueryStates]);
 
-  const selectedAgents = useMemo(() => urlAgents ?? [], [urlAgents]);
+  const selectedAgents = useMemo(() => {
+    // Prevent cache pollution during project transitions
+    if (prevProjectKey.current !== projectKey) {
+      return [];
+    }
+    return urlAgents ?? [];
+  }, [urlAgents, projectKey]);
 
   const [searchQuery, setSearchQuery] = useState<string>('');
 


### PR DESCRIPTION
When switching from Project A to Project B, the selected agents from Project A were briefly leaking into Project B's options cache. This happened because selectedAgents still returned the old URL values before the reset effect cleared them, and those got cached under the new project's key.
Now we return an empty array during the transition so stale agents don't pollute the wrong project's cache.


**Before**

https://github.com/user-attachments/assets/de4a4f03-c3d5-4172-8b71-8bab896f3c3e



**After**


https://github.com/user-attachments/assets/29e2bd00-f843-4bb3-9494-8f4933478fae

