### PR TITLE
ref(code-review): add reaction logs to webhook handlers

### DIFF
--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -25,8 +25,6 @@ class Log(enum.StrEnum):
     NOT_ENABLED = "github.webhook.issue_comment.not-enabled"
     NOT_REVIEW_COMMAND = "github.webhook.issue_comment.not-review-command"
     NOT_PR_COMMENT = "github.webhook.issue_comment.not-pr-comment"
-    MISSING_INTEGRATION = "github.webhook.issue_comment.missing-integration"
-    REACTION_FAILED = "github.webhook.issue_comment.reaction-failed"
 
 
 class GitHubIssueCommentAction(enum.StrEnum):

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -25,6 +25,8 @@ class Log(enum.StrEnum):
     NOT_ENABLED = "github.webhook.issue_comment.not-enabled"
     NOT_REVIEW_COMMAND = "github.webhook.issue_comment.not-review-command"
     NOT_PR_COMMENT = "github.webhook.issue_comment.not-pr-comment"
+    MISSING_INTEGRATION = "github.webhook.issue_comment.missing-integration"
+    REACTION_FAILED = "github.webhook.issue_comment.reaction-failed"
 
 
 class GitHubIssueCommentAction(enum.StrEnum):
@@ -94,6 +96,7 @@ def handle_issue_comment_event(
             repo=repo,
             pr_number=str(pr_number) if pr_number else None,
             comment_id=str(comment_id),
+            extra=extra,
         )
 
     target_commit_sha = _get_target_commit_sha(github_event, event, repo, integration)

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -32,6 +32,8 @@ class Log(enum.StrEnum):
     MISSING_PULL_REQUEST = "github.webhook.pull_request.missing-pull-request"
     MISSING_ACTION = "github.webhook.pull_request.missing-action"
     UNSUPPORTED_ACTION = "github.webhook.pull_request.unsupported-action"
+    MISSING_INTEGRATION = "github.webhook.pull_request.missing-integration"
+    REACTION_FAILED = "github.webhook.pull_request.reaction-failed"
 
 
 class PullRequestAction(enum.StrEnum):
@@ -155,6 +157,7 @@ def handle_pull_request_event(
             repo=repo,
             pr_number=str(pr_number),
             comment_id=None,
+            extra=extra,
         )
 
     from .task import schedule_task

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -32,8 +32,6 @@ class Log(enum.StrEnum):
     MISSING_PULL_REQUEST = "github.webhook.pull_request.missing-pull-request"
     MISSING_ACTION = "github.webhook.pull_request.missing-action"
     UNSUPPORTED_ACTION = "github.webhook.pull_request.unsupported-action"
-    MISSING_INTEGRATION = "github.webhook.pull_request.missing-integration"
-    REACTION_FAILED = "github.webhook.pull_request.reaction-failed"
 
 
 class PullRequestAction(enum.StrEnum):

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -798,6 +798,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         self.mock_client.create_issue_reaction.assert_not_called()
@@ -821,6 +822,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         self.mock_client.delete_issue_reaction.assert_not_called()
@@ -842,6 +844,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number=None,
             comment_id="123456",
+            extra={},
         )
 
         self.mock_client.delete_issue_reaction.assert_not_called()
@@ -865,6 +868,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         assert self.mock_client.delete_issue_reaction.call_count == 2
@@ -890,6 +894,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id="123456",
+            extra={},
         )
 
         assert self.mock_client.delete_issue_reaction.call_count == 2
@@ -913,6 +918,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         mock_record_error.assert_called_once_with(
@@ -943,6 +949,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         mock_record_error.assert_called_once_with(
@@ -967,6 +974,7 @@ class AddEyesReactionTest(TestCase):
             repo=self.repo,
             pr_number="42",
             comment_id=None,
+            extra={},
         )
 
         mock_record_error.assert_called_once_with(

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -801,9 +801,7 @@ class AddEyesReactionTest(TestCase):
         )
 
         self.mock_client.create_issue_reaction.assert_not_called()
-        mock_logger.warning.assert_called_once_with(
-            "github.webhook.pull_request.missing-integration", extra={}
-        )
+        mock_logger.warning.assert_called_once_with("github.webhook.missing-integration", extra={})
 
     def test_adds_eyes_to_pr(self) -> None:
         self.mock_client.get_issue_reactions.return_value = [
@@ -918,9 +916,7 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_logger.warning.assert_called_once_with(
-            "github.webhook.pull_request.reaction-failed", extra={}
-        )
+        mock_logger.warning.assert_called_once_with("github.webhook.reaction-failed", extra={})
         self.mock_client.create_issue_reaction.assert_called_once_with(
             self.repo.name, "42", GitHubReaction.EYES
         )
@@ -947,9 +943,7 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_logger.warning.assert_called_once_with(
-            "github.webhook.pull_request.reaction-failed", extra={}
-        )
+        mock_logger.warning.assert_called_once_with("github.webhook.reaction-failed", extra={})
         self.mock_client.create_issue_reaction.assert_called_once_with(
             self.repo.name, "42", GitHubReaction.EYES
         )
@@ -970,6 +964,4 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_logger.warning.assert_called_once_with(
-            "github.webhook.pull_request.reaction-failed", extra={}
-        )
+        mock_logger.warning.assert_called_once_with("github.webhook.reaction-failed", extra={})

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -8,7 +8,6 @@ from urllib3.exceptions import HTTPError
 
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.webhook_types import GithubWebhookType
-from sentry.seer.code_review.metrics import CodeReviewErrorType
 from sentry.seer.code_review.utils import (
     ClientError,
     delete_existing_reactions_and_add_eyes_reaction,
@@ -788,8 +787,8 @@ class AddEyesReactionTest(TestCase):
             name="owner/repo",
         )
 
-    @patch("sentry.seer.code_review.utils.record_webhook_handler_error")
-    def test_records_error_when_integration_is_none(self, mock_record_error: MagicMock) -> None:
+    @patch("sentry.seer.code_review.utils.logger")
+    def test_logs_warning_when_integration_is_none(self, mock_logger: MagicMock) -> None:
         delete_existing_reactions_and_add_eyes_reaction(
             github_event=GithubWebhookType.PULL_REQUEST,
             github_event_action=PullRequestAction.OPENED.value,
@@ -802,10 +801,8 @@ class AddEyesReactionTest(TestCase):
         )
 
         self.mock_client.create_issue_reaction.assert_not_called()
-        mock_record_error.assert_called_once_with(
-            GithubWebhookType.PULL_REQUEST,
-            PullRequestAction.OPENED.value,
-            CodeReviewErrorType.MISSING_INTEGRATION,
+        mock_logger.warning.assert_called_once_with(
+            "github.webhook.pull_request.missing-integration", extra={}
         )
 
     def test_adds_eyes_to_pr(self) -> None:
@@ -904,9 +901,9 @@ class AddEyesReactionTest(TestCase):
             self.repo.name, "123456", GitHubReaction.EYES
         )
 
-    @patch("sentry.seer.code_review.utils.record_webhook_handler_error")
-    def test_records_error_and_adds_eyes_when_get_reactions_fails(
-        self, mock_record_error: MagicMock
+    @patch("sentry.seer.code_review.utils.logger")
+    def test_logs_warning_and_adds_eyes_when_get_reactions_fails(
+        self, mock_logger: MagicMock
     ) -> None:
         self.mock_client.get_issue_reactions.side_effect = Exception("API Error")
 
@@ -921,18 +918,16 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_record_error.assert_called_once_with(
-            GithubWebhookType.PULL_REQUEST,
-            PullRequestAction.OPENED.value,
-            CodeReviewErrorType.REACTION_FAILED,
+        mock_logger.warning.assert_called_once_with(
+            "github.webhook.pull_request.reaction-failed", extra={}
         )
         self.mock_client.create_issue_reaction.assert_called_once_with(
             self.repo.name, "42", GitHubReaction.EYES
         )
 
-    @patch("sentry.seer.code_review.utils.record_webhook_handler_error")
-    def test_records_error_and_adds_eyes_when_delete_reaction_fails(
-        self, mock_record_error: MagicMock
+    @patch("sentry.seer.code_review.utils.logger")
+    def test_logs_warning_and_adds_eyes_when_delete_reaction_fails(
+        self, mock_logger: MagicMock
     ) -> None:
         self.mock_client.get_issue_reactions.return_value = [
             {"id": 1, "user": {"login": "other-user"}, "content": "hooray"},
@@ -952,17 +947,15 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_record_error.assert_called_once_with(
-            GithubWebhookType.PULL_REQUEST,
-            PullRequestAction.OPENED.value,
-            CodeReviewErrorType.REACTION_FAILED,
+        mock_logger.warning.assert_called_once_with(
+            "github.webhook.pull_request.reaction-failed", extra={}
         )
         self.mock_client.create_issue_reaction.assert_called_once_with(
             self.repo.name, "42", GitHubReaction.EYES
         )
 
-    @patch("sentry.seer.code_review.utils.record_webhook_handler_error")
-    def test_records_error_when_create_reaction_fails(self, mock_record_error: MagicMock) -> None:
+    @patch("sentry.seer.code_review.utils.logger")
+    def test_logs_warning_when_create_reaction_fails(self, mock_logger: MagicMock) -> None:
         self.mock_client.get_issue_reactions.return_value = []
         self.mock_client.create_issue_reaction.side_effect = Exception("API Error")
 
@@ -977,8 +970,6 @@ class AddEyesReactionTest(TestCase):
             extra={},
         )
 
-        mock_record_error.assert_called_once_with(
-            GithubWebhookType.PULL_REQUEST,
-            PullRequestAction.OPENED.value,
-            CodeReviewErrorType.REACTION_FAILED,
+        mock_logger.warning.assert_called_once_with(
+            "github.webhook.pull_request.reaction-failed", extra={}
         )


### PR DESCRIPTION
Add logs to the webhook handlers when adding or removing reactions on a PR or comment.