### PR TITLE
feat(preprod): Fix platform_name handling

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -415,7 +415,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str]:
 
     Returns a dict with keys matching the filter key format:
     - git_head_ref: The git_head_ref name (from commit_comparison.head_ref)
-    - platform_name: "ios" or "android" (derived from artifact_type)
+    - platform_name: "apple" or "android" (derived from artifact_type)
     - app_id: The app ID (e.g., "com.example.app")
     - build_configuration_name: The build configuration name
     """
@@ -426,7 +426,7 @@ def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str]:
 
     if artifact.artifact_type is not None:
         if artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
-            context["platform_name"] = "ios"
+            context["platform_name"] = "apple"
         elif artifact.artifact_type in (
             PreprodArtifact.ArtifactType.AAB,
             PreprodArtifact.ArtifactType.APK,

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -501,7 +501,7 @@ class BuildsEndpointTest(APITestCase):
         assert data[0]["app_info"]["app_id"] == "pr123.app"
 
     @with_feature("organizations:preprod-frontend-routes")
-    def test_query_platform_name_ios(self) -> None:
+    def test_query_platform_name_apple(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
         self.create_preprod_artifact(

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -511,7 +511,7 @@ class BuildsEndpointTest(APITestCase):
             app_id="android.app", artifact_type=PreprodArtifact.ArtifactType.APK
         )
 
-        response = self._request({"query": "platform_name:ios"})
+        response = self._request({"query": "platform_name:apple"})
         self._assert_is_successful(response)
         data = response.json()
         assert len(data) == 1
@@ -552,7 +552,7 @@ class BuildsEndpointTest(APITestCase):
             app_id="android.aab", artifact_type=PreprodArtifact.ArtifactType.AAB
         )
 
-        response = self._request({"query": "platform_name:[ios,android]"})
+        response = self._request({"query": "platform_name:[apple,android]"})
         self._assert_is_successful(response)
         data = response.json()
         assert len(data) == 3
@@ -573,7 +573,7 @@ class BuildsEndpointTest(APITestCase):
             app_id="android.aab", artifact_type=PreprodArtifact.ArtifactType.AAB
         )
 
-        response = self._request({"query": "!platform_name:[ios]"})
+        response = self._request({"query": "!platform_name:[apple]"})
         self._assert_is_successful(response)
         data = response.json()
         assert len(data) == 2
@@ -867,7 +867,7 @@ class QuerysetForQueryTest(APITestCase):
             app_id="android.app", artifact_type=PreprodArtifact.ArtifactType.APK
         )
 
-        queryset = queryset_for_query("platform_name:ios", self.organization)
+        queryset = queryset_for_query("platform_name:apple", self.organization)
         results = list(queryset)
         assert len(results) == 1
         assert results[0].id == ios_artifact.id
@@ -939,7 +939,7 @@ class QuerysetForQueryTest(APITestCase):
         # Test multiple filters combined
         assert (
             artifact_matches_query(
-                artifact, "platform_name:ios git_head_ref:feature/test", self.organization
+                artifact, "platform_name:apple git_head_ref:feature/test", self.organization
             )
             is True
         )

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -63,7 +63,7 @@ class StatusCheckFiltersTest(TestCase):
 
         context = _get_artifact_filter_context(artifact)
 
-        assert context["platform_name"] == "ios"
+        assert context["platform_name"] == "apple"
         assert context["git_head_ref"] == "feature/test"
         assert context["app_id"] == "com.example.app"
         assert context["build_configuration_name"] == "Debug"
@@ -180,12 +180,12 @@ class StatusCheckFiltersTest(TestCase):
 
         context = _get_artifact_filter_context(artifact)
 
-        rule_ios_release = StatusCheckRule(
+        rule_apple_release = StatusCheckRule(
             id="rule1",
             metric="install_size",
             measurement="absolute",
             value=100 * 1024 * 1024,
-            filter_query="platform_name:ios build_configuration_name:Release",
+            filter_query="platform_name:apple build_configuration_name:Release",
         )
 
         rule_android_release = StatusCheckRule(
@@ -201,10 +201,10 @@ class StatusCheckFiltersTest(TestCase):
             metric="install_size",
             measurement="absolute",
             value=100 * 1024 * 1024,
-            filter_query="platform_name:ios build_configuration_name:Debug",
+            filter_query="platform_name:apple build_configuration_name:Debug",
         )
 
-        assert _rule_matches_artifact(rule_ios_release, context) is True
+        assert _rule_matches_artifact(rule_apple_release, context) is True
         assert _rule_matches_artifact(rule_android_release, context) is False
         assert _rule_matches_artifact(rule_ios_debug, context) is False
 
@@ -862,7 +862,7 @@ class StatusCheckFiltersTest(TestCase):
         )
 
         context = _get_artifact_filter_context(artifact)
-        assert context["platform_name"] == "ios"
+        assert context["platform_name"] == "apple"
         assert "build_configuration_name" not in context
 
         rule = StatusCheckRule(
@@ -870,7 +870,7 @@ class StatusCheckFiltersTest(TestCase):
             metric="install_size",
             measurement="absolute",
             value=100 * 1024 * 1024,
-            filter_query="platform_name:ios !build_configuration_name:Debug",
+            filter_query="platform_name:apple !build_configuration_name:Debug",
         )
 
         assert _rule_matches_artifact(rule, context) is False


### PR DESCRIPTION
Previously we had two issues:
- EAP and Postgres disagreed on the values for `platform_name` {`android`,`ios`} vs {`android`,`apple`} this caused issues with structured search (since EAP provides auto-fill but postgres backs the search.
- `platform_name` had a special implementation which was fragile.

Fix both of these  by adding another annotation which a) matches EAP and b) lets us treat `platform_name` as just another string.