### PR TITLE
nit(alerts): force English time seen for consistency

### DIFF
--- a/src/sentry/integrations/time_utils.py
+++ b/src/sentry/integrations/time_utils.py
@@ -2,9 +2,8 @@ import time
 from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.utils.timesince import timesince
-from django.utils.translation import gettext as _
 
 from sentry.models.group import Group
 
@@ -31,11 +30,12 @@ def time_since(value: datetime) -> str | date:
     now = timezone.now()
     if value < (now - timedelta(days=5)):
         return value.date()
-    diff = timesince(value, now)
+    with translation.override("en"):
+        diff = timesince(value, now)
     if diff == timesince(now, now):
         return "Just now"
     if diff == "1 day":
-        return _("Yesterday")
+        return "Yesterday"
     return f"{diff} ago"
 
 

--- a/src/sentry/integrations/time_utils.py
+++ b/src/sentry/integrations/time_utils.py
@@ -32,11 +32,11 @@ def time_since(value: datetime) -> str | date:
         return value.date()
     with translation.override("en"):
         diff = timesince(value, now)
-    if diff == timesince(now, now):
-        return "Just now"
-    if diff == "1 day":
-        return "Yesterday"
-    return f"{diff} ago"
+        if diff == timesince(now, now):
+            return "Just now"
+        if diff == "1 day":
+            return "Yesterday"
+        return f"{diff} ago"
 
 
 def get_relative_time(


### PR DESCRIPTION
Slack notifications are currently sent with exactly one word in the translated language. Force timesince to be in English for consistency. Fixes [ISWF-1934](https://linear.app/getsentry/issue/ISWF-1934/slack-notifications-show-localized-first-seen-time-instead-of-english).