### PR TITLE
chore(preprod): [FE] Remove old platform references and only use apple for ios and mac apps

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -20,7 +20,7 @@ const baseBuild = {
   app_info: {
     app_id: 'com.example.app',
     name: 'Example App',
-    platform: 'ios' as Platform,
+    platform: 'apple' as Platform,
     build_number: '1',
     version: '1.0.0',
     date_added: '2024-01-01T00:00:00Z',

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -16,7 +16,6 @@ import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
-import {getPlatformIconFromPlatform} from 'sentry/views/preprod/utils/labelUtils';
 
 export function PreprodBuildsHeaderCells({
   showProjectColumn,
@@ -59,9 +58,7 @@ export function PreprodBuildsRowCells({
           <Flex direction="column" gap="xs">
             <Flex align="center" gap="2xs">
               {build.app_info?.platform && (
-                <PlatformIcon
-                  platform={getPlatformIconFromPlatform(build.app_info.platform)}
-                />
+                <PlatformIcon platform={build.app_info.platform} />
               )}
               <Container paddingLeft="xs">
                 <Text size="lg" bold>

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.spec.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.spec.tsx
@@ -34,7 +34,7 @@ describe('BuildCompareHeaderContent', () => {
           build_configuration: null,
           date_added: undefined,
           date_built: null,
-          platform: 'ios',
+          platform: 'apple',
         },
       }
     );
@@ -82,7 +82,7 @@ describe('BuildCompareHeaderContent', () => {
           build_configuration: null,
           date_added: undefined,
           date_built: null,
-          platform: 'ios',
+          platform: 'apple',
         },
       }
     );

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -21,7 +21,6 @@ import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
   getLabels,
-  getPlatformIconFromPlatform,
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
 import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
@@ -78,9 +77,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
           <Flex gap="sm" align="center">
             <InfoIcon>
               {buildDetails.app_info.platform ? (
-                <PlatformIcon
-                  platform={getPlatformIconFromPlatform(buildDetails.app_info.platform)}
-                />
+                <PlatformIcon platform={buildDetails.app_info.platform} />
               ) : null}
             </InfoIcon>
             <Text>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -24,7 +24,7 @@ interface AppSizeInsightsSidebarProps {
 }
 
 function getInsightsDocsUrl(platform?: Platform): string {
-  if (platform === 'apple' || platform === 'macos' || platform === 'ios') {
+  if (platform === 'apple') {
     return 'https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/insights/';
   }
   if (platform === 'android') {

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -117,7 +117,7 @@ export function openOptimizeImagesModal(platform?: Platform) {
   const title =
     platform === 'android'
       ? t('Optimize Images (Android)')
-      : platform === 'ios'
+      : platform === 'apple'
         ? t('Optimize Images (iOS)')
         : t('Optimize Images');
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -16,7 +16,6 @@ import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton
 import {type BuildDetailsAppInfo} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   getLabels,
-  getPlatformIconFromPlatform,
   getReadableArtifactTypeLabel,
   getReadableArtifactTypeTooltip,
   getReadablePlatformLabel,
@@ -55,9 +54,7 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
         <Flex gap="2xs" align="center">
           <InfoIcon>
             {props.appInfo.platform ? (
-              <PlatformIcon
-                platform={getPlatformIconFromPlatform(props.appInfo.platform)}
-              />
+              <PlatformIcon platform={props.appInfo.platform} />
             ) : null}
           </InfoIcon>
           <Text>

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -17,7 +17,7 @@ const mockBuildDetailsData: BuildDetailsApiResponse = {
     name: 'Test App',
     version: '1.0.0',
     build_number: '100',
-    platform: 'ios',
+    platform: 'apple',
     artifact_type: 0,
     build_configuration: 'Release',
     date_built: '2023-01-01T00:00:00Z',

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -122,7 +122,7 @@ export function InstallDetailsContent({
               <QuietZoneQRCode
                 aria-label={t('Install QR Code')}
                 value={
-                  installDetails.platform === 'ios' || installDetails.platform === 'apple'
+                  installDetails.platform === 'apple'
                     ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
                     : installDetails.install_url
                 }

--- a/static/app/views/preprod/install/buildInstallHeader.tsx
+++ b/static/app/views/preprod/install/buildInstallHeader.tsx
@@ -19,7 +19,6 @@ import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   getLabels,
-  getPlatformIconFromPlatform,
   getReadableArtifactTypeLabel,
   getReadableArtifactTypeTooltip,
   getReadablePlatformLabel,
@@ -106,9 +105,7 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
             <Tooltip title={t('Platform')}>
               <Flex gap="2xs" align="center">
                 <Flex align="center" justify="center" width="24px" height="24px">
-                  <PlatformIcon
-                    platform={getPlatformIconFromPlatform(appInfo.platform)}
-                  />
+                  <PlatformIcon platform={appInfo.platform} />
                 </Flex>
                 <Text size="sm" variant="muted">
                   {getReadablePlatformLabel(appInfo.platform)}

--- a/static/app/views/preprod/types/sharedTypes.ts
+++ b/static/app/views/preprod/types/sharedTypes.ts
@@ -1,1 +1,1 @@
-export type Platform = 'ios' | 'android' | 'macos' | 'apple';
+export type Platform = 'apple' | 'android';

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -10,21 +10,6 @@ import {
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 
-// Mapping of Launchpad platform to PlatformIcon platform
-// PlatformIcon definitions: https://sentry.sentry.io/stories/foundations/icons
-export function getPlatformIconFromPlatform(platform: Platform): 'apple' | 'android' {
-  switch (platform) {
-    case 'ios':
-    case 'macos':
-    case 'apple':
-      return 'apple';
-    case 'android':
-      return 'android';
-    default:
-      throw new Error(`Unsupported platform: ${platform}`);
-  }
-}
-
 export function getReadableArtifactTypeLabel(
   artifactType: BuildDetailsArtifactType | null
 ): string {
@@ -103,8 +88,6 @@ export function getLabels(
         installUnavailableTooltip: t('This app cannot be installed.'),
       };
     case 'apple':
-    case 'ios':
-    case 'macos':
     case undefined:
       return {
         installSizeLabel: t('Install Size'),
@@ -126,12 +109,8 @@ export function getReadablePlatformLabel(platform: Platform): string {
   switch (platform) {
     case 'apple':
       return 'Apple';
-    case 'ios':
-      return 'iOS';
     case 'android':
       return 'Android';
-    case 'macos':
-      return 'macOS';
     default:
       throw new Error(`Unknown platform: ${platform}`);
   }

--- a/static/app/views/preprod/utils/sharedTypesUtils.ts
+++ b/static/app/views/preprod/utils/sharedTypesUtils.ts
@@ -1,12 +1,7 @@
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 
 export function validatedPlatform(platform: unknown): Platform | undefined {
-  if (
-    platform === 'apple' ||
-    platform === 'ios' ||
-    platform === 'android' ||
-    platform === 'macos'
-  ) {
+  if (platform === 'apple' || platform === 'android') {
     return platform;
   }
   return undefined;


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
