### PR TITLE
fix(seer): Settings was not splitting repo name and repo owner properly

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
@@ -106,13 +106,13 @@ export default function AutofixRepositories({canWrite, preference, project}: Pro
 
             // Create new entry with defaults for newly added repos
             const orgRepo = repositories?.find(r => r.externalId === repoId);
-            const [owner] = (orgRepo?.name ?? '').split('/');
+            const [owner, name] = (orgRepo?.name || '/').split('/');
             return {
               organization_id: organization.id,
               external_id: repoId,
-              name: orgRepo?.name ?? '',
+              name: name ?? orgRepo?.name ?? '',
               owner: owner ?? '',
-              provider: orgRepo?.provider.id ?? '',
+              provider: orgRepo?.provider?.name?.toLowerCase() ?? '',
               integration_id: orgRepo?.integrationId,
               branch_name: '',
               instructions: '',


### PR DESCRIPTION
Matches logic from before: https://github.com/getsentry/sentry/blob/master/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx#L64-L76