### PR TITLE
feat(rollout): Add sample rate option to `SafeRolloutComparator` to gate double reads

### DIFF
--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from sentry.options import all as all_options
 from sentry.testutils.helpers import override_options
@@ -20,6 +21,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         assert TestRolloutComparator._should_eval_option_name() in option_names
         assert TestRolloutComparator._callsite_allowlist_option_name() in option_names
         assert TestRolloutComparator._callsite_blocklist_option_name() in option_names
+        assert TestRolloutComparator._sample_rate_option_name() in option_names
 
     def test_return_as_expected(self) -> None:
         with override_options({TestRolloutComparator._should_eval_option_name(): False}):
@@ -29,6 +31,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_eval_option_name(): True,
                 TestRolloutComparator._callsite_blocklist_option_name(): ["test_blocked"],
+                TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_2") is True
@@ -41,3 +44,46 @@ class SafeRolloutComparatorTestCase(TestCase):
         ):
             assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
             assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_allowed") == "exp"
+
+    def test_eval_experimental_sample_rate(self) -> None:
+        with override_options(
+            {
+                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._callsite_blocklist_option_name(): [],
+                TestRolloutComparator._sample_rate_option_name(): 0.5,
+            }
+        ):
+            with patch("sentry.utils.rollout.random.random", return_value=0.3):
+                assert TestRolloutComparator.should_check_experiment("test_sampled_in") is True
+
+            with patch("sentry.utils.rollout.random.random", return_value=0.7):
+                assert TestRolloutComparator.should_check_experiment("test_sampled_out") is False
+
+            with patch("sentry.utils.rollout.random.random", return_value=0.5):
+                assert TestRolloutComparator.should_check_experiment("test_boundary") is False
+
+            with patch("sentry.utils.rollout.random.random", return_value=0.49999):
+                assert TestRolloutComparator.should_check_experiment("test_just_under") is True
+
+    def test_eval_experimental_respects_blocklist(self) -> None:
+        with override_options(
+            {
+                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._callsite_blocklist_option_name(): ["test_blocked"],
+                TestRolloutComparator._sample_rate_option_name(): 1.0,
+            }
+        ):
+            # Even with 100% sample rate, blocklisted callsites should be blocked
+            assert TestRolloutComparator.should_check_experiment("test_blocked") is False
+            # Non-blocklisted callsites should still work
+            assert TestRolloutComparator.should_check_experiment("test_not_blocked") is True
+
+    def test_eval_experimental_sample_rate_respects_eval_disabled(self) -> None:
+        with override_options(
+            {
+                TestRolloutComparator._should_eval_option_name(): False,
+                TestRolloutComparator._callsite_blocklist_option_name(): [],
+                TestRolloutComparator._sample_rate_option_name(): 1.0,
+            }
+        ):
+            assert TestRolloutComparator.should_check_experiment("test_disabled") is False


### PR DESCRIPTION
Adds a configurable sample rate to `SafeRolloutComparator` to limit the percentage of requests that perform double-reads during EAP migration. This allows us to collect representative metrics while reducing latency impact on high-traffic call sites.

- Adds new option `dynamic.saferollouts.{ROLLOUT_NAME}.eval_experimental_sample_rate` (Float, default 1.0)
- Updates `should_check_experiment()` to include random sampling based on the sample rate
- Default of 1.0 (100%) maintains backward compatibility with existing behavior

Rollout plan:

- [x] Deploy this PR
- [x] Set global sample rate to 10% (can tune this) for double-reads of EAP occurrences ([PR](https://github.com/getsentry/sentry-options-automator/pull/6261))
- [x] Enable double-reads for the `GroupEventsEndpoint` in S4S only to start ([PR](https://github.com/getsentry/sentry/pull/105969/))
- [x] Enable double-reads in DE ([PR](https://github.com/getsentry/sentry-options-automator/pull/6262))
- [x] Continue implementing more double-read paths