### PR TITLE
fix(uptime): Handle overflow for long monitor names

### DIFF
--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -59,6 +59,7 @@ export const Heading = styled(
   text-overflow: ${p => (p.ellipsis ? 'ellipsis' : undefined)};
   white-space: ${p => (p.wrap ? p.wrap : p.ellipsis ? 'nowrap' : undefined)};
   text-wrap: ${p => p.textWrap ?? undefined};
+  word-break: ${p => p.wordBreak ?? undefined};
 
   font-family: ${p => p.theme.font.family[p.monospace ? 'mono' : 'sans']};
   font-weight: ${p => p.theme.font.weight[p.monospace ? 'mono' : 'sans'].medium};

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -158,7 +158,7 @@ function DetailsLink(props: LinkProps) {
 }
 
 function Name(props: {children: React.ReactNode}) {
-  return <Heading {...props} as="h3" size="lg" />;
+  return <Heading {...props} as="h3" size="lg" wordBreak="break-word" />;
 }
 
 function Details(props: {children: React.ReactNode}) {


### PR DESCRIPTION
## Summary
- Adds `wordBreak="break-word"` to the monitor name heading in the uptime overview
- This properly wraps long unbroken strings (like URLs) instead of causing horizontal overflow

Fixes NEW-604

## Test plan
- [ ] Create/view an uptime monitor with a long URL or unbroken string as the name
- [ ] Verify the name wraps properly instead of overflowing horizontally