### PR TITLE
feat(seer): add pre-autofix cache for slack workflow notifications

### DIFF
--- a/fixtures/seer/webhooks.py
+++ b/fixtures/seer/webhooks.py
@@ -1,9 +1,11 @@
 from sentry.sentry_apps.metrics import SentryAppEventType
 
 MOCK_RUN_ID = 123
+MOCK_GROUP_ID = 456
 MOCK_SEER_WEBHOOKS = {
     SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED: {
         "run_id": MOCK_RUN_ID,
+        "group_id": MOCK_GROUP_ID,
         "root_cause": {
             "description": "Test description",
             "steps": [{"title": "Step 1"}, {"title": "Step 2"}],
@@ -11,6 +13,7 @@ MOCK_SEER_WEBHOOKS = {
     },
     SentryAppEventType.SEER_SOLUTION_COMPLETED: {
         "run_id": MOCK_RUN_ID,
+        "group_id": MOCK_GROUP_ID,
         "solution": {
             "description": "Test description",
             "steps": [{"title": "Step 1"}, {"title": "Step 2"}],
@@ -18,6 +21,7 @@ MOCK_SEER_WEBHOOKS = {
     },
     SentryAppEventType.SEER_CODING_COMPLETED: {
         "run_id": MOCK_RUN_ID,
+        "group_id": MOCK_GROUP_ID,
         "changes": [
             {
                 "repo_name": "Test repo",
@@ -29,6 +33,7 @@ MOCK_SEER_WEBHOOKS = {
     },
     SentryAppEventType.SEER_PR_CREATED: {
         "run_id": MOCK_RUN_ID,
+        "group_id": MOCK_GROUP_ID,
         "pull_requests": [
             {
                 "pull_request": {

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -571,16 +571,15 @@ class SlackActionEndpoint(Endpoint):
     ) -> None:
         entrypoint = SlackEntrypoint(
             slack_request=slack_request,
+            action=action,
             group=group,
             organization_id=group.project.organization_id,
         )
-        stopping_point = entrypoint.set_autofix_stopping_point(action=action)
-        operator = SeerOperator(entrypoint=entrypoint)
-        operator.trigger_autofix(
+        SeerOperator(entrypoint=entrypoint).trigger_autofix(
             group=group,
             user=user,
-            stopping_point=stopping_point,
-            run_id=entrypoint.get_autofix_run_id(),
+            stopping_point=entrypoint.autofix_stopping_point,
+            run_id=entrypoint.autofix_run_id,
         )
 
     @classmethod

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -195,7 +195,7 @@ def _trigger_autofix_task(
         if run_id and features.has(
             "organizations:seer-slack-workflows", group.project.organization
         ):
-            SeerOperator.migrate_autofix_cache(group_id=group_id, run_id=run_id)
+            SeerOperator.autofix_cache.migrate(from_group_id=group_id, to_run_id=run_id)
 
 
 def _get_event(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -30,6 +30,7 @@ from sentry.seer.autofix.utils import (
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_seat_based_tier_enabled,
 )
+from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
@@ -171,23 +172,30 @@ def _trigger_autofix_task(
             user = AnonymousUser()
 
         # Route to explorer-based autofix if both feature flags are enabled
+        run_id: int | None = None
         if features.has("organizations:seer-explorer", group.organization) and features.has(
             "organizations:autofix-on-explorer", group.organization
         ):
-            trigger_autofix_explorer(
+            run_id = trigger_autofix_explorer(
                 group=group,
                 step=AutofixStep.ROOT_CAUSE,
                 run_id=None,
                 stopping_point=stopping_point,
             )
         else:
-            trigger_autofix(
+            response = trigger_autofix(
                 group=group,
                 event_id=event_id,
                 user=user,
                 auto_run_source=auto_run_source,
                 stopping_point=stopping_point,
             )
+            run_id = response.data.get("run_id")
+
+        if run_id and features.has(
+            "organizations:seer-slack-workflows", group.project.organization
+        ):
+            SeerOperator.migrate_autofix_cache(group_id=group_id, run_id=run_id)
 
 
 def _get_event(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -30,7 +30,7 @@ from sentry.seer.autofix.utils import (
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_seat_based_tier_enabled,
 )
-from sentry.seer.entrypoints.operator import SeerOperator
+from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
@@ -195,7 +195,7 @@ def _trigger_autofix_task(
         if run_id and features.has(
             "organizations:seer-slack-workflows", group.project.organization
         ):
-            SeerOperator.autofix_cache.migrate(from_group_id=group_id, to_run_id=run_id)
+            SeerOperatorAutofixCache.migrate(from_group_id=group_id, to_run_id=run_id)
 
 
 def _get_event(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -608,17 +608,12 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
         return {"success": False, "error": "Organization not found or not active"}
 
     if features.has("organizations:seer-slack-workflows", organization):
-        run_id = payload.get("run_id")
-        if not run_id:
-            logger.error("seer.webhook_run_id_not_found", extra={"payload": payload})
-        else:
-            process_autofix_updates.apply_async(
-                kwargs={
-                    "run_id": run_id,
-                    "event_type": sentry_app_event_type,
-                    "event_payload": payload,
-                }
-            )
+        process_autofix_updates.apply_async(
+            kwargs={
+                "event_type": sentry_app_event_type,
+                "event_payload": payload,
+            }
+        )
 
     if not features.has("organizations:seer-webhooks", organization):
         return {"success": False, "error": "Seer webhooks are not enabled for this organization"}

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -612,6 +612,7 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
             kwargs={
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
+                "organization_id": organization_id,
             }
         )
 

--- a/src/sentry/seer/entrypoints/cache.py
+++ b/src/sentry/seer/entrypoints/cache.py
@@ -100,7 +100,7 @@ class SeerOperatorAutofixCache[CachePayloadT]:
 
         # If we do have a run_id cache, we can delete the pre-autofix cache to prevent autofix
         # updates targeting all matching groups from being sent, limiting updates to just this run.
-        if cache_result["source"] == "run_id":
+        if group_id and cache_result["source"] == "run_id":
             cache.delete(
                 cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
             )

--- a/src/sentry/seer/entrypoints/cache.py
+++ b/src/sentry/seer/entrypoints/cache.py
@@ -24,11 +24,11 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         cache_payload = cache.get(cache_key)
         if not cache_payload:
             return None
-        return {
-            "payload": cache_payload,
-            "source": "group_id",
-            "key": cache_key,
-        }
+        return SeerOperatorCacheResult[CachePayloadT](
+            payload=cache_payload,
+            source="group_id",
+            key=cache_key,
+        )
 
     @classmethod
     def populate_pre_autofix_cache(
@@ -36,11 +36,11 @@ class SeerOperatorAutofixCache[CachePayloadT]:
     ) -> SeerOperatorCacheResult:
         cache_key = cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
         cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
-        return {
-            "payload": cache_payload,
-            "source": "group_id",
-            "key": cache_key,
-        }
+        return SeerOperatorCacheResult[CachePayloadT](
+            payload=cache_payload,
+            source="group_id",
+            key=cache_key,
+        )
 
     @classmethod
     def get_post_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
@@ -58,11 +58,11 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         cache_payload = cache.get(cache_key)
         if not cache_payload:
             return None
-        return {
-            "payload": cache_payload,
-            "source": "run_id",
-            "key": cache_key,
-        }
+        return SeerOperatorCacheResult[CachePayloadT](
+            payload=cache_payload,
+            source="run_id",
+            key=cache_key,
+        )
 
     @classmethod
     def populate_post_autofix_cache(
@@ -70,11 +70,11 @@ class SeerOperatorAutofixCache[CachePayloadT]:
     ) -> SeerOperatorCacheResult:
         cache_key = cls.get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
         cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
-        return {
-            "payload": cache_payload,
-            "source": "run_id",
-            "key": cache_key,
-        }
+        return SeerOperatorCacheResult[CachePayloadT](
+            payload=cache_payload,
+            source="run_id",
+            key=cache_key,
+        )
 
     @classmethod
     def get(

--- a/src/sentry/seer/entrypoints/cache.py
+++ b/src/sentry/seer/entrypoints/cache.py
@@ -1,0 +1,132 @@
+from sentry.seer.entrypoints.registry import entrypoint_registry
+from sentry.seer.entrypoints.types import SeerOperatorCacheResult
+from sentry.utils.cache import cache
+
+AUTOFIX_CACHE_TIMEOUT_SECONDS = 60 * 60 * 12  # 12 hours
+
+
+class SeerOperatorAutofixCache[CachePayloadT]:
+    """
+    A class for managing autofix cache payloads for the Seer Operator.
+    Do not use this class directly, instead use `SeerOperator.autofix_cache`.
+    """
+
+    @classmethod
+    def get_pre_autofix_cache_key(cls, *, entrypoint_key: str, group_id: int) -> str:
+        """
+        The group cache key is used to store entrypoint-specific cache payloads BEFORE an autofix
+        run has been started, thus requires a group_id. When an autofix run does start, Seer emits a
+        webhook with the run_id and group_id, so we can relocate the cache to the post-autofix key.
+        """
+        return f"seer:pre_autofix:{entrypoint_key}:{group_id}"
+
+    @classmethod
+    def get_pre_autofix_cache(
+        cls, *, entrypoint_key: str, group_id: int
+    ) -> SeerOperatorCacheResult | None:
+        cache_key = cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+        cache_payload = cache.get(cache_key)
+        if not cache_payload:
+            return None
+        return {
+            "payload": cache_payload,
+            "source": "group_id",
+            "key": cache_key,
+        }
+
+    @classmethod
+    def populate_pre_autofix_cache(
+        cls, *, entrypoint_key: str, group_id: int, cache_payload: CachePayloadT
+    ) -> None:
+        cache_key = cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+        cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
+        return {
+            "payload": cache_payload,
+            "source": "group_id",
+            "key": cache_key,
+        }
+
+    @classmethod
+    def get_post_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
+        """
+        The autofix cache key is used to store entrypoint-specific cache payloads AFTER an autofix
+        run has been started, thus requires a run_id.
+        """
+        return f"seer:post_autofix:{entrypoint_key}:{run_id}"
+
+    @classmethod
+    def get_post_autofix_cache(
+        cls, *, entrypoint_key: str, run_id: int
+    ) -> SeerOperatorCacheResult | None:
+        cache_key = cls.get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
+        cache_payload = cache.get(cache_key)
+        if not cache_payload:
+            return None
+        return {
+            "payload": cache_payload,
+            "source": "run_id",
+            "key": cache_key,
+        }
+
+    @classmethod
+    def get(
+        cls, *, entrypoint_key: str, group_id: int | None = None, run_id: int | None = None
+    ) -> SeerOperatorCacheResult | None:
+        if not group_id and not run_id:
+            raise ValueError("Either group_id or run_id must be provided.")
+
+        cache_result = None
+        if run_id:
+            cache_result = cls.get_post_autofix_cache(entrypoint_key=entrypoint_key, run_id=run_id)
+
+        # We prefer the run cache payload since it's more narrow
+        # A group can have multiple runs, and that means many threads to post updates to.
+        # A run has a single group, and (usually) a single thread to post updates to.
+        if group_id and not cache_result:
+            cache_result = cls.get_pre_autofix_cache(
+                entrypoint_key=entrypoint_key, group_id=group_id
+            )
+
+        if not cache_result:
+            return None
+
+        # If we do have a run_id cache, we can delete the pre-autofix cache to prevent autofix
+        # updates targeting all matching groups from being sent, limiting updates to just this run.
+        if cache_result["source"] == "run_id":
+            cache.delete(
+                cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+            )
+
+        return cache_result
+
+    @classmethod
+    def migrate(
+        cls,
+        *,
+        from_group_id: int,
+        to_run_id: int,
+        overwrite: bool = False,
+    ) -> None:
+        """
+        Migrate from a pre-autofix cache (keyed on group_id) to a post-autofix cache (keyed on run_id),
+        if one exists. If overwrite is True, any existing post-autofix cache will be overwritten.
+        """
+        for entrypoint_key in entrypoint_registry.registrations.keys():
+            pre_cache_result = cls.get_pre_autofix_cache(
+                entrypoint_key=entrypoint_key, group_id=from_group_id
+            )
+            post_cache_result = cls.get_post_autofix_cache(
+                entrypoint_key=entrypoint_key, run_id=to_run_id
+            )
+            # If we already have a post-autofix cache, and we're not overwriting, skip.
+            if not overwrite and post_cache_result:
+                continue
+            # If we don't have a pre-autofix cache, nothing to migrate, skip.
+            if not pre_cache_result:
+                continue
+            cache.set(
+                post_cache_result["key"],
+                pre_cache_result["payload"],
+                timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+            )
+            cache.delete(pre_cache_result["key"])

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -47,7 +47,7 @@ class SlackEntrypointCachePayload(TypedDict):
 @entrypoint_registry.register(key=SeerEntrypointKey.SLACK)
 class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
     key = SeerEntrypointKey.SLACK
-    autofix_stopping_point: AutofixStoppingPoint | None = None
+    autofix_stopping_point: AutofixStoppingPoint = AutofixStoppingPoint.ROOT_CAUSE
 
     def __init__(
         self,
@@ -66,7 +66,6 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         self.install = SlackIntegration(
             model=slack_request.integration, organization_id=organization_id
         )
-        self.action = action
         self.autofix_stopping_point = self.get_autofix_stopping_point_from_action(
             action=action, group_id=group.id
         )
@@ -381,7 +380,7 @@ def handle_prepare_autofix_update(
         group_id=group.id,
         group_link=group.get_absolute_url(),
     )
-    cache_result = SeerOperatorAutofixCache.populate_pre_autofix_cache(
+    cache_result = SeerOperatorAutofixCache[SlackEntrypointCachePayload].populate_pre_autofix_cache(
         entrypoint_key=str(SlackEntrypoint.key),
         group_id=group.id,
         cache_payload=cache_payload,

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -20,7 +20,7 @@ from sentry.notifications.platform.templates.seer import (
 from sentry.notifications.platform.types import NotificationData, NotificationProviderKey
 from sentry.notifications.utils.actions import BlockKitMessageAction
 from sentry.seer.autofix.utils import AutofixStoppingPoint
-from sentry.seer.entrypoints.operator import SeerOperator
+from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -378,7 +378,7 @@ def handle_prepare_autofix_update(
         group_id=group.id,
         group_link=group.get_absolute_url(),
     )
-    cache_result = SeerOperator.autofix_cache.populate_pre_autofix_cache(
+    cache_result = SeerOperatorAutofixCache.populate_pre_autofix_cache(
         entrypoint_key=str(SlackEntrypoint.key),
         group_id=group.id,
         cache_payload=cache_payload,

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -80,8 +80,9 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             )
         except ValueError:
             logger.warning(
-                "invalid_autofix_stopping_point",
+                "entrypoint.invalid_autofix_stopping_point",
                 extra={
+                    "entrypoint_key": self.key,
                     "stopping_point": action.value,
                     "action_id": action.action_id,
                     "group_id": self.group.id,
@@ -123,8 +124,9 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             )
         except (IntegrationError, TypeError, KeyError):
             logger.warning(
-                "slack.autofix.update_message_failed",
+                "entrypoint.update_message_failed",
                 extra={
+                    "entrypoint_key": SlackEntrypoint.key,
                     "channel_id": self.channel_id,
                     "message_ts": self.thread_ts,
                     "organization_id": self.organization_id,
@@ -171,6 +173,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         logging_ctx = {
             "event_type": event_type,
             "cache_payload": cache_payload,
+            "entrypoint_key": SlackEntrypoint.key,
         }
         integration = integration_service.get_integration(
             integration_id=cache_payload["integration_id"],
@@ -179,7 +182,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             status=ObjectStatus.ACTIVE,
         )
         if not integration:
-            logger.warning("integration_not_found", extra=logging_ctx)
+            logger.warning("entrypoint.integration_not_found", extra=logging_ctx)
             return
 
         install = SlackIntegration(

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -103,7 +103,6 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         )
 
     def on_trigger_autofix_success(self, *, run_id: int) -> None:
-
         _send_thread_update(
             install=self.install,
             channel_id=self.channel_id,
@@ -133,14 +132,31 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             )
 
     def create_autofix_cache_payload(self) -> SlackEntrypointCachePayload:
-        return SlackEntrypointCachePayload(
-            thread_ts=self.thread_ts,
-            channel_id=self.channel_id,
+        return SlackEntrypoint.create_autofix_cache_payload_manually(
+            group=self.group,
             organization_id=self.organization_id,
             integration_id=self.install.model.id,
-            project_id=self.group.project.id,
-            group_id=self.group.id,
-            group_link=self.group.get_absolute_url(),
+            thread_ts=self.thread_ts,
+            channel_id=self.channel_id,
+        )
+
+    @staticmethod
+    def create_autofix_cache_payload_manually(
+        *,
+        group: Group,
+        organization_id: int,
+        integration_id: int,
+        thread_ts: str,
+        channel_id: str,
+    ):
+        return SlackEntrypointCachePayload(
+            thread_ts=thread_ts,
+            channel_id=channel_id,
+            organization_id=organization_id,
+            integration_id=integration_id,
+            project_id=group.project_id,
+            group_id=group.id,
+            group_link=group.get_absolute_url(),
         )
 
     @staticmethod

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -150,7 +150,7 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         integration_id: int,
         thread_ts: str,
         channel_id: str,
-    ):
+    ) -> SlackEntrypointCachePayload:
         return SlackEntrypointCachePayload(
             thread_ts=thread_ts,
             channel_id=channel_id,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -52,8 +52,21 @@ class SeerOperator[CachePayloadT]:
         self.logging_ctx: dict[str, str] = {"entrypoint_key": str(entrypoint.key)}
 
     @classmethod
-    def get_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
+    def get_post_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
+        """
+        The autofix cache key is used to store entrypoint-specific cache payloads AFTER an autofix
+        run has been started, thus requires a run_id.
+        """
         return f"seer:autofix:{entrypoint_key}:{run_id}"
+
+    @classmethod
+    def get_pre_autofix_cache_key(cls, *, entrypoint_key: str, group_id: int) -> str:
+        """
+        The group cache key is used to store entrypoint-specific cache payloads BEFORE an autofix
+        run has been started, thus requires a group_id. When an autofix run does start, Seer emits a
+        webhook with the run_id and group_id, so we can relocate the cache to the post-autofix key.
+        """
+        return f"seer:group:{entrypoint_key}:{group_id}"
 
     def trigger_autofix(
         self,
@@ -130,12 +143,64 @@ class SeerOperator[CachePayloadT]:
         cache_payload = self.entrypoint.create_autofix_cache_payload()
 
         if cache_payload:
-            cache_key = self.get_autofix_cache_key(
-                entrypoint_key=str(self.entrypoint.key), run_id=run_id
+            cache_key = SeerOperator.populate_autofix_cache(
+                entrypoint_key=str(self.entrypoint.key),
+                cache_payload=cache_payload,
+                run_id=run_id,
             )
             self.logging_ctx["cache_key"] = cache_key
-            cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
         logger.info("operator.trigger_autofix_success", extra=self.logging_ctx)
+
+    @staticmethod
+    def populate_autofix_cache(
+        *,
+        entrypoint_key: str,
+        cache_payload: CachePayloadT,
+        group_id: int | None = None,
+        run_id: int | None = None,
+    ) -> str:
+        if (not group_id and not run_id) or (group_id and run_id):
+            raise ValueError("Either group_id or run_id must be provided, but not both.")
+
+        if group_id:
+            cache_key = SeerOperator.get_pre_autofix_cache_key(
+                entrypoint_key=entrypoint_key, group_id=group_id
+            )
+        else:
+            # mypy can't interpret the first conditional, so we assert here.
+            assert run_id is not None
+            cache_key = SeerOperator.get_post_autofix_cache_key(
+                entrypoint_key=entrypoint_key, run_id=run_id
+            )
+
+        cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
+        return cache_key
+
+    @staticmethod
+    def migrate_autofix_cache(
+        *,
+        group_id: int,
+        run_id: int,
+        overwrite: bool = False,
+    ) -> None:
+        """
+        Migrate from a pre-autofix cache (keyed on group_id) to a post-autofix cache (keyed on run_id),
+        if one exists. If overwrite is True, any existing post-autofix cache will be overwritten.
+        """
+        for entrypoint_key in entrypoint_registry.registrations.keys():
+            pre_cache_key = SeerOperator.get_pre_autofix_cache_key(
+                entrypoint_key=entrypoint_key, group_id=group_id
+            )
+            pre_cache_payload = cache.get(pre_cache_key)
+            post_cache_key = SeerOperator.get_post_autofix_cache_key(
+                entrypoint_key=entrypoint_key, run_id=run_id
+            )
+            post_cache_payload = cache.get(post_cache_key)
+            if not overwrite and post_cache_payload:
+                continue
+            if not pre_cache_payload:
+                continue
+            cache.set(post_cache_key, pre_cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
 
 
 @instrumented_task(
@@ -145,22 +210,43 @@ class SeerOperator[CachePayloadT]:
     retry=None,
 )
 def process_autofix_updates(
-    run_id: int, event_type: SentryAppEventType, event_payload: dict[str, Any]
+    *, event_type: SentryAppEventType, event_payload: dict[str, Any]
 ) -> None:
     """
-    Use the registry to iterate over all entrypoints and check if this run_id has been cached.
-    If so, call the entrypoint's handler with the payload it had previously cached.
+    Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
+    has a cache. If so, call the entrypoint's handler with the payload it had previously cached.
     """
-    logging_ctx = {"event_type": event_type, "run_id": run_id}
+
+    run_id = event_payload.get("run_id")
+    group_id = event_payload.get("group_id")
+    logging_ctx = {"event_type": event_type, "run_id": run_id, "group_id": group_id}
+
+    if not run_id and not group_id:
+        logger.error("operator.missing_identifiers", extra=logging_ctx)
+        return
 
     if event_type not in SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS:
         logger.info("operator.skipping_update", extra=logging_ctx)
         return
 
     for entrypoint_key, entrypoint_cls in entrypoint_registry.registrations.items():
-        cache_key = SeerOperator.get_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
-        logging_ctx["cache_key"] = cache_key
-        cache_payload = cache.get(cache_key)
+        if group_id:
+            pre_cache_key = SeerOperator.get_pre_autofix_cache_key(
+                entrypoint_key=entrypoint_key, group_id=group_id
+            )
+            logging_ctx["pre_cache_key"] = pre_cache_key
+            group_cache_payload = cache.get(pre_cache_key)
+        if run_id:
+            post_cache_key = SeerOperator.get_post_autofix_cache_key(
+                entrypoint_key=entrypoint_key, run_id=run_id
+            )
+            logging_ctx["post_cache_key"] = post_cache_key
+            run_cache_payload = cache.get(post_cache_key)
+
+        # We prefer the run cache payload since it's more narrow
+        # A group can have multiple runs, and that means many threads to post updates to.
+        # A run has a single group, and (usually) a single thread to post updates to.
+        cache_payload = run_cache_payload or group_cache_payload
         if not cache_payload:
             logger.info("operator.no_cache_payload", extra=logging_ctx)
             continue

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -46,8 +46,6 @@ class SeerOperator[CachePayloadT]:
     It does this to ensure all entrypoints have consistent behavior and responses.
     """
 
-    autofix_cache: SeerOperatorAutofixCache[CachePayloadT]
-
     def __init__(self, entrypoint: SeerEntrypoint[CachePayloadT]):
         self.entrypoint = entrypoint
         self.logging_ctx: dict[str, str] = {"entrypoint_key": str(entrypoint.key)}
@@ -127,12 +125,12 @@ class SeerOperator[CachePayloadT]:
         cache_payload = self.entrypoint.create_autofix_cache_payload()
 
         if cache_payload:
-            cache_key = self.autofix_cache.populate_autofix_cache(
+            cache_result = SeerOperatorAutofixCache.populate_post_autofix_cache(
                 entrypoint_key=str(self.entrypoint.key),
                 cache_payload=cache_payload,
                 run_id=run_id,
             )
-            self.logging_ctx["cache_key"] = cache_key
+            self.logging_ctx["cache_key"] = cache_result["key"]
         logger.info("operator.trigger_autofix_success", extra=self.logging_ctx)
 
 
@@ -169,7 +167,7 @@ def process_autofix_updates(
         return
 
     for entrypoint_key, entrypoint_cls in entrypoint_registry.registrations.items():
-        cache_result = SeerOperator.autofix_cache.get(
+        cache_result = SeerOperatorAutofixCache.get(
             entrypoint_key=entrypoint_key, group_id=group_id, run_id=run_id
         )
         if not cache_result:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -201,6 +201,7 @@ class SeerOperator[CachePayloadT]:
             if not pre_cache_payload:
                 continue
             cache.set(post_cache_key, pre_cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
+            cache.delete(pre_cache_key)
 
 
 @instrumented_task(

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, TypedDict
 
 from sentry.sentry_apps.metrics import SentryAppEventType
 
@@ -59,3 +59,9 @@ class SeerEntrypoint[CachePayloadT](Protocol):
         updates are being received, so leverage the cached payload to persist any state.
         """
         ...
+
+
+class SeerOperatorCacheResult(TypedDict):
+    payload: dict[str, Any]
+    source: Literal["group_id", "run_id"]
+    key: str

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -61,7 +61,7 @@ class SeerEntrypoint[CachePayloadT](Protocol):
         ...
 
 
-class SeerOperatorCacheResult(TypedDict):
-    payload: dict[str, Any]
+class SeerOperatorCacheResult[CachePayloadT](TypedDict):
+    payload: CachePayloadT
     source: Literal["group_id", "run_id"]
     key: str

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1010,7 +1010,6 @@ class TestSeerRpcMethods(APITestCase):
         assert result["success"]
         mock_process_autofix_updates.apply_async.assert_called_once_with(
             kwargs={
-                "run_id": event_payload["run_id"],
                 "event_type": SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
                 "event_payload": event_payload,
             },

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1012,6 +1012,7 @@ class TestSeerRpcMethods(APITestCase):
             kwargs={
                 "event_type": SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
                 "event_payload": event_payload,
+                "organization_id": self.organization.id,
             },
         )
         mock_broadcast.assert_called_once()

--- a/tests/sentry/seer/entrypoints/test_cache.py
+++ b/tests/sentry/seer/entrypoints/test_cache.py
@@ -1,0 +1,221 @@
+from typing import TypedDict
+from unittest.mock import patch
+
+from fixtures.seer.webhooks import MOCK_GROUP_ID, MOCK_RUN_ID
+from sentry.seer.entrypoints.cache import AUTOFIX_CACHE_TIMEOUT_SECONDS, SeerOperatorAutofixCache
+from sentry.seer.entrypoints.types import SeerEntrypointKey
+from sentry.testutils.cases import TestCase
+
+
+class MockCachePayload(TypedDict):
+    thread_id: str
+
+
+class SeerOperatorAutofixCacheTest(TestCase):
+    def setUp(self):
+        self.entrypoint_key = str(SeerEntrypointKey.SLACK)
+        self.pre_cache_key = SeerOperatorAutofixCache.get_pre_autofix_cache_key(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
+        )
+        self.post_cache_key = SeerOperatorAutofixCache.get_post_autofix_cache_key(
+            entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
+        )
+
+    def test_get_pre_autofix_cache_key(self):
+        assert self.pre_cache_key == f"seer:pre_autofix:{self.entrypoint_key}:{MOCK_GROUP_ID}"
+
+    def test_get_post_autofix_cache_key(self):
+        assert self.post_cache_key == f"seer:post_autofix:{self.entrypoint_key}:{MOCK_RUN_ID}"
+
+    @patch("sentry.seer.entrypoints.cache.cache.set")
+    def test_populate_pre_autofix_cache(self, mock_cache_set):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        result = SeerOperatorAutofixCache.populate_pre_autofix_cache(
+            entrypoint_key=self.entrypoint_key,
+            cache_payload=pre_cache_payload,
+            group_id=MOCK_GROUP_ID,
+        )
+        mock_cache_set.assert_called_once_with(
+            self.pre_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+        assert result["key"] == self.pre_cache_key
+        assert result["source"] == "group_id"
+        assert result["payload"] == pre_cache_payload
+
+    @patch("sentry.seer.entrypoints.cache.cache.set")
+    def test_populate_post_autofix_cache(self, mock_cache_set):
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        result = SeerOperatorAutofixCache.populate_post_autofix_cache(
+            entrypoint_key=self.entrypoint_key,
+            cache_payload=post_cache_payload,
+            run_id=MOCK_RUN_ID,
+        )
+        mock_cache_set.assert_called_once_with(
+            self.post_cache_key,
+            post_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+        assert result["key"] == self.post_cache_key
+        assert result["source"] == "run_id"
+        assert result["payload"] == post_cache_payload
+
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_pre_autofix_cache(self, mock_cache_get):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        mock_cache_get.return_value = pre_cache_payload
+
+        result = SeerOperatorAutofixCache.get_pre_autofix_cache(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
+        )
+
+        mock_cache_get.assert_called_once_with(self.pre_cache_key)
+        assert result is not None
+        assert result["key"] == self.pre_cache_key
+        assert result["source"] == "group_id"
+        assert result["payload"] == pre_cache_payload
+
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_pre_autofix_cache_miss(self, mock_cache_get):
+        mock_cache_get.return_value = None
+
+        result = SeerOperatorAutofixCache.get_pre_autofix_cache(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
+        )
+
+        assert result is None
+
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_post_autofix_cache(self, mock_cache_get):
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        mock_cache_get.return_value = post_cache_payload
+
+        result = SeerOperatorAutofixCache.get_post_autofix_cache(
+            entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
+        )
+
+        mock_cache_get.assert_called_once_with(self.post_cache_key)
+        assert result is not None
+        assert result["key"] == self.post_cache_key
+        assert result["source"] == "run_id"
+        assert result["payload"] == post_cache_payload
+
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_post_autofix_cache_miss(self, mock_cache_get):
+        mock_cache_get.return_value = None
+
+        result = SeerOperatorAutofixCache.get_post_autofix_cache(
+            entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
+        )
+
+        assert result is None
+
+    @patch("sentry.seer.entrypoints.cache.cache.delete")
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_prefers_post_cache_and_deletes_pre_cache(self, mock_cache_get, mock_cache_delete):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            post_cache_payload if k == self.post_cache_key else pre_cache_payload
+        )
+
+        result = SeerOperatorAutofixCache.get(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID
+        )
+
+        assert result is not None
+        assert result["source"] == "run_id"
+        assert result["payload"] == post_cache_payload
+        mock_cache_delete.assert_called_once_with(self.pre_cache_key)
+
+    @patch("sentry.seer.entrypoints.cache.cache.delete")
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_falls_back_to_pre_cache(self, mock_cache_get, mock_cache_delete):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            pre_cache_payload if k == self.pre_cache_key else None
+        )
+
+        result = SeerOperatorAutofixCache.get(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID
+        )
+
+        assert result is not None
+        assert result["source"] == "group_id"
+        assert result["payload"] == pre_cache_payload
+        mock_cache_delete.assert_not_called()
+
+    @patch("sentry.seer.entrypoints.cache.cache.get")
+    def test_get_all_cache_miss(self, mock_cache_get):
+        mock_cache_get.return_value = None
+
+        result = SeerOperatorAutofixCache.get(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID
+        )
+
+        assert result is None
+
+
+class SeerOperatorAutofixCacheMigrateTest(TestCase):
+    def setUp(self):
+        self.entrypoint_key = str(SeerEntrypointKey.SLACK)
+        self.pre_cache_key = SeerOperatorAutofixCache.get_pre_autofix_cache_key(
+            entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
+        )
+        self.post_cache_key = SeerOperatorAutofixCache.get_post_autofix_cache_key(
+            entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
+        )
+
+    @patch.dict(
+        "sentry.seer.entrypoints.cache.entrypoint_registry.registrations",
+        {SeerEntrypointKey.SLACK: None},
+    )
+    @patch("sentry.seer.entrypoints.cache.cache")
+    def test_migrate(self, mock_cache):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        mock_cache.get.side_effect = lambda k: (
+            pre_cache_payload if k == self.pre_cache_key else None
+        )
+        SeerOperatorAutofixCache.migrate(from_group_id=MOCK_GROUP_ID, to_run_id=MOCK_RUN_ID)
+        mock_cache.set.assert_called_once_with(
+            self.post_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+        mock_cache.delete.assert_called_once_with(self.pre_cache_key)
+
+    @patch.dict(
+        "sentry.seer.entrypoints.cache.entrypoint_registry.registrations",
+        {SeerEntrypointKey.SLACK: None},
+    )
+    @patch("sentry.seer.entrypoints.cache.cache")
+    def test_migrate_full_miss(self, mock_cache):
+        mock_cache.get.side_effect = lambda k: None
+        SeerOperatorAutofixCache.migrate(from_group_id=MOCK_GROUP_ID, to_run_id=MOCK_RUN_ID)
+        mock_cache.set.assert_not_called()
+
+    @patch.dict(
+        "sentry.seer.entrypoints.cache.entrypoint_registry.registrations",
+        {SeerEntrypointKey.SLACK: None},
+    )
+    @patch("sentry.seer.entrypoints.cache.cache")
+    def test_migrate_overwrite(self, mock_cache):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        mock_cache.get.side_effect = lambda k: (
+            post_cache_payload if k == self.post_cache_key else pre_cache_payload
+        )
+        # No overwrite by default
+        SeerOperatorAutofixCache.migrate(from_group_id=MOCK_GROUP_ID, to_run_id=MOCK_RUN_ID)
+        mock_cache.set.assert_not_called()
+        # With overwrite, the post cache should be set
+        SeerOperatorAutofixCache.migrate(
+            from_group_id=MOCK_GROUP_ID, to_run_id=MOCK_RUN_ID, overwrite=True
+        )
+        mock_cache.set.assert_called_once_with(
+            self.post_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+        mock_cache.delete.assert_called_once_with(self.pre_cache_key)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -2,9 +2,10 @@ import uuid
 from typing import Any, TypedDict
 from unittest.mock import ANY, Mock, patch
 
+import pytest
 from rest_framework.response import Response
 
-from fixtures.seer.webhooks import MOCK_RUN_ID
+from fixtures.seer.webhooks import MOCK_GROUP_ID, MOCK_RUN_ID
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.operator import (
     AUTOFIX_CACHE_TIMEOUT_SECONDS,
@@ -17,7 +18,7 @@ from sentry.testutils.cases import TestCase
 
 
 class MockCachePayload(TypedDict):
-    thread_id: uuid.UUID
+    thread_id: str
 
 
 class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
@@ -26,7 +27,7 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
     key = SeerEntrypointKey.SLACK
 
     def __init__(self):
-        self.thread_id = uuid.uuid4()
+        self.thread_id = str(uuid.uuid4())
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
@@ -50,23 +51,21 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
 
 
 class SeerOperatorTest(TestCase):
-
     def setUp(self):
         self.entrypoint = MockEntrypoint()
         self.operator = SeerOperator(self.entrypoint)
-
-    def _cache_get_side_effect(self, cache_key: str):
-        if cache_key == SeerOperator.get_post_autofix_cache_key(
-            entrypoint_key=self.entrypoint.key, run_id=MOCK_RUN_ID
-        ):
-            return {"thread_id": self.entrypoint.thread_id}
-        return None
-
-    def test_get_autofix_cache_key(self):
-        cache_key = SeerOperator.get_post_autofix_cache_key(
+        self.pre_cache_key = SeerOperator.get_pre_autofix_cache_key(
+            entrypoint_key=self.entrypoint.key, group_id=MOCK_GROUP_ID
+        )
+        self.post_cache_key = SeerOperator.get_post_autofix_cache_key(
             entrypoint_key=self.entrypoint.key, run_id=MOCK_RUN_ID
         )
-        assert cache_key == f"seer:autofix:{self.entrypoint.key}:{MOCK_RUN_ID}"
+
+    def test_get_pre_autofix_cache_key(self):
+        assert self.pre_cache_key == f"seer:pre_autofix:{self.entrypoint.key}:{MOCK_GROUP_ID}"
+
+    def test_get_post_autofix_cache_key(self):
+        assert self.post_cache_key == f"seer:post_autofix:{self.entrypoint.key}:{MOCK_RUN_ID}"
 
     @patch(
         "sentry.seer.entrypoints.operator.update_autofix",
@@ -136,72 +135,196 @@ class SeerOperatorTest(TestCase):
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch("sentry.seer.entrypoints.operator.cache.set")
-    def test_trigger_autofix_cache_payload(self, mock_cache_set, _mock_trigger_autofix_helper):
-        mock_cache_set.reset_mock()
+    def test_trigger_autofix_creates_cache_payload(
+        self, mock_cache_set, _mock_trigger_autofix_helper
+    ):
         self.operator.trigger_autofix(
             group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
         )
         mock_cache_set.assert_called_with(
-            self.operator.get_post_autofix_cache_key(
-                entrypoint_key=self.entrypoint.key, run_id=MOCK_RUN_ID
-            ),
+            self.post_cache_key,
             self.entrypoint.create_autofix_cache_payload(),
             timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
         )
 
-    @patch("sentry.seer.entrypoints.operator.logger.info")
-    def test_process_autofix_updates_ignore_non_seer_events(self, mock_logger_info):
-        process_autofix_updates(
-            event_type=SentryAppEventType.ISSUE_CREATED,
-            event_payload={"run_id": MOCK_RUN_ID},
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    def test_populate_autofix_cache_group_id(self, mock_cache_set):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        self.operator.populate_autofix_cache(
+            entrypoint_key=self.entrypoint.key,
+            cache_payload=pre_cache_payload,
+            group_id=MOCK_GROUP_ID,
         )
-        mock_logger_info.assert_called_once_with("operator.skipping_update", extra=ANY)
+        mock_cache_set.assert_called_once_with(
+            self.pre_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    def test_populate_autofix_cache_run_id(self, mock_cache_set):
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        self.operator.populate_autofix_cache(
+            entrypoint_key=self.entrypoint.key,
+            cache_payload=post_cache_payload,
+            run_id=MOCK_RUN_ID,
+        )
+        mock_cache_set.assert_called_once_with(
+            self.post_cache_key,
+            post_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    def test_populate_autofix_cache_both(self, mock_cache_set):
+        with pytest.raises(
+            ValueError, match="Either group_id or run_id must be provided, but not both."
+        ):
+            SeerOperator.populate_autofix_cache(
+                entrypoint_key=self.entrypoint.key,
+                cache_payload=self.entrypoint.create_autofix_cache_payload(),
+                group_id=MOCK_GROUP_ID,
+                run_id=MOCK_RUN_ID,
+            )
+        mock_cache_set.assert_not_called()
 
     @patch.dict(
         "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
         {MockEntrypoint.key: MockEntrypoint},
     )
-    @patch("sentry.seer.entrypoints.operator.logger.info")
-    @patch("sentry.seer.entrypoints.operator.cache.get", return_value=None)
-    def test_process_autofix_updates_cache_miss(self, mock_cache_get, mock_logger_info):
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    @patch("sentry.seer.entrypoints.operator.cache.get")
+    def test_migrate_autofix_cache(self, mock_cache_get, mock_cache_set):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            pre_cache_payload if k == self.pre_cache_key else None
+        )
+        SeerOperator.migrate_autofix_cache(group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID)
+        mock_cache_set.assert_called_once_with(
+            self.post_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+
+    @patch.dict(
+        "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+        {MockEntrypoint.key: MockEntrypoint},
+    )
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    @patch("sentry.seer.entrypoints.operator.cache.get")
+    def test_migrate_autofix_cache_full_miss(self, mock_cache_get, mock_cache_set):
+        mock_cache_get.side_effect = lambda k: None
+        SeerOperator.migrate_autofix_cache(group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID)
+        mock_cache_set.assert_not_called()
+
+    @patch.dict(
+        "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+        {MockEntrypoint.key: MockEntrypoint},
+    )
+    @patch("sentry.seer.entrypoints.operator.cache.set")
+    @patch("sentry.seer.entrypoints.operator.cache.get")
+    def test_migrate_autofix_cache_overwrite(self, mock_cache_get, mock_cache_set):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            post_cache_payload if k == self.post_cache_key else pre_cache_payload
+        )
+        # No overwrite by default
+        SeerOperator.migrate_autofix_cache(group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID)
+        mock_cache_set.assert_not_called()
+        # With overwrite, the post cache should be set
+        SeerOperator.migrate_autofix_cache(
+            group_id=MOCK_GROUP_ID, run_id=MOCK_RUN_ID, overwrite=True
+        )
+        mock_cache_set.assert_called_once_with(
+            self.post_cache_key,
+            pre_cache_payload,
+            timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS,
+        )
+
+    @patch.dict(
+        "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+        {MockEntrypoint.key: MockEntrypoint},
+    )
+    @patch("sentry.seer.entrypoints.operator.logger")
+    def test_process_autofix_updates_early_exits(self, mock_logger):
         process_autofix_updates(
             event_type=SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
+            event_payload={},
+        )
+        mock_logger.warning.assert_called_once_with("operator.missing_identifiers", extra=ANY)
+
+        process_autofix_updates(
+            event_type=SentryAppEventType.ISSUE_CREATED,
             event_payload={"run_id": MOCK_RUN_ID},
         )
-        mock_cache_get.assert_called_once_with(
-            SeerOperator.get_post_autofix_cache_key(
-                entrypoint_key=self.entrypoint.key, run_id=MOCK_RUN_ID
-            ),
-        )
-        mock_logger_info.assert_called_once_with("operator.no_cache_payload", extra=ANY)
+        mock_logger.info.assert_called_once_with("operator.skipping_update", extra=ANY)
 
     @patch("sentry.seer.entrypoints.operator.cache.get")
-    def test_process_autofix_updates(self, mock_cache_get):
-        # XXX: cache.get() is used everywhere, so side-effect to only affect our callsite
-        mock_cache_get.side_effect = self._cache_get_side_effect
+    def test_process_autofix_updates_all_cache_hit(self, mock_cache_get):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            post_cache_payload if k == self.post_cache_key else pre_cache_payload
+        )
         mock_entrypoint_cls = Mock(spec=SeerEntrypoint)
         event_type = SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED
-        event_payload = {"run_id": MOCK_RUN_ID, "imagine": "this was typesafe"}
+        event_payload = {"run_id": MOCK_RUN_ID, "group_id": MOCK_GROUP_ID}
 
         with patch.dict(
             "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
             {MockEntrypoint.key: mock_entrypoint_cls},
         ):
             process_autofix_updates(event_type=event_type, event_payload=event_payload)
-            mock_cache_get.assert_called_once_with(
-                SeerOperator.get_post_autofix_cache_key(
-                    entrypoint_key=self.entrypoint.key, run_id=MOCK_RUN_ID
-                ),
-            )
-            mock_entrypoint_cls.on_autofix_update.assert_called_once_with(
-                event_type=event_type,
-                event_payload=event_payload,
-                cache_payload=self.entrypoint.create_autofix_cache_payload(),
-            )
+
+        mock_entrypoint_cls.on_autofix_update.assert_called_once_with(
+            event_type=event_type,
+            event_payload=event_payload,
+            # If both caches are hit, post should be used
+            cache_payload=post_cache_payload,
+        )
+
+    @patch("sentry.seer.entrypoints.operator.logger")
+    @patch("sentry.seer.entrypoints.operator.cache.get")
+    def test_process_autofix_updates_all_cache_miss(self, mock_cache_get, mock_logger):
+        mock_cache_get.side_effect = lambda k: None
+        mock_entrypoint_cls = Mock(spec=SeerEntrypoint)
+        event_type = SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED
+        event_payload = {"run_id": MOCK_RUN_ID, "group_id": MOCK_GROUP_ID}
+
+        with patch.dict(
+            "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+            {MockEntrypoint.key: mock_entrypoint_cls},
+        ):
+            process_autofix_updates(event_type=event_type, event_payload=event_payload)
+
+        mock_entrypoint_cls.on_autofix_update.assert_not_called()
+        mock_logger.info.assert_called_once_with("operator.no_cache_payload", extra=ANY)
+
+    @patch("sentry.seer.entrypoints.operator.cache.get")
+    def test_process_autofix_updates_pre_cache_hit(self, mock_cache_get):
+        pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
+        mock_cache_get.side_effect = lambda k: (
+            pre_cache_payload if k == self.pre_cache_key else None
+        )
+        mock_entrypoint_cls = Mock(spec=SeerEntrypoint)
+        event_type = SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED
+        event_payload = {"run_id": MOCK_RUN_ID, "group_id": MOCK_GROUP_ID}
+
+        with patch.dict(
+            "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+            {MockEntrypoint.key: mock_entrypoint_cls},
+        ):
+            process_autofix_updates(event_type=event_type, event_payload=event_payload)
+
+        mock_entrypoint_cls.on_autofix_update.assert_called_once_with(
+            event_type=event_type,
+            event_payload=event_payload,
+            cache_payload=pre_cache_payload,
+        )
 
     @patch("sentry.seer.entrypoints.operator.update_autofix")
     def test_solution_stopping_point_continues_to_code_changes(self, mock_update_autofix):
-        """Verify that SOLUTION stopping point sends payload that continues to CODE_CHANGES."""
         mock_update_autofix.return_value = Response({"run_id": MOCK_RUN_ID}, status=202)
 
         self.operator.trigger_autofix(


### PR DESCRIPTION
adds pre-autofix caching so slack issue alert notifications can store entrypoint data before autofix runs. when autofix triggers later, the cache migrates from group_id to run_id keying.

this enables slack thread updates for alerts that auto-trigger autofix, not just manual slack button triggers.

Refs ISWF-1179 and ISWF-1157