### PR TITLE
chore(ACI): Add get_installation_by_uuid RPC method

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -92,6 +92,15 @@ class DatabaseBackedAppService(AppService):
             return None
         return install.organization_id
 
+    def get_installation_by_uuid(self, *, uuid: str) -> RpcSentryAppInstallation | None:
+        try:
+            install = SentryAppInstallation.objects.select_related("sentry_app").get(
+                uuid=uuid, status=SentryAppInstallationStatus.INSTALLED
+            )
+            return serialize_sentry_app_installation(install)
+        except SentryAppInstallation.DoesNotExist:
+            return None
+
     def get_sentry_app_by_slug(self, *, slug: str) -> RpcSentryApp | None:
         try:
             sentry_app = SentryApp.objects.get(slug=slug)

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -117,6 +117,14 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_installation_by_uuid(self, *, uuid: str) -> RpcSentryAppInstallation | None:
+        """
+        Get a sentryapp install by uuid
+        """
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_token(self, *, organization_id: int, provider: str) -> str | None:
         pass
 

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -240,6 +240,24 @@ def test_get_installation_org_id_by_token_id() -> None:
 
 @django_db_all(transaction=True)
 @all_silo_test
+def test_get_installation_by_uuid() -> None:
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    app = Factories.create_sentry_app(
+        name="demo-app",
+        user=user,
+        published=True,
+    )
+    install = Factories.create_sentry_app_installation(
+        organization=org,
+        slug=app.slug,
+    )
+    result = app_service.get_installation_by_uuid(uuid=install.uuid)
+    assert result.uuid == install.uuid
+
+
+@django_db_all(transaction=True)
+@all_silo_test
 def test_get_sentry_apps_for_organization() -> None:
     org = Factories.create_organization()
     other_org = Factories.create_organization()


### PR DESCRIPTION
In order to migrate the `Action`s with sentry app data to all have the sentry app id stored instead of some storing that and others storing the sentry all installation uuid, we need an RPC method to look up the installation by the one piece of information we have - the installation uuid. This model contains the sentry app id that we need to replace on the `Action` model later on.