### PR TITLE
chore(preprod): Move preprod settings to be gated by correct feature flag

### DIFF
--- a/static/app/views/preprod/buildList/buildList.tsx
+++ b/static/app/views/preprod/buildList/buildList.tsx
@@ -78,7 +78,7 @@ export default function BuildList() {
           <Layout.Title>Builds</Layout.Title>
           <Layout.HeaderActions>
             {projects.length === 1 && (
-              <Feature features="organizations:preprod-issues">
+              <Feature features="organizations:preprod-frontend-routes">
                 <LinkButton
                   size="sm"
                   icon={<IconSettings />}

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -141,7 +141,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/mobile-builds/`,
           title: t('Mobile Builds'),
-          show: () => !!organization?.features?.includes('preprod-issues'),
+          show: () => !!organization?.features?.includes('preprod-frontend-routes'),
           badge: () => 'beta',
           description: t('Size analysis and build distribution configuration.'),
         },

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -40,32 +40,34 @@ export default function PreprodSettings() {
         </TextBlock>
         <Stack gap="lg">
           <StatusCheckRules />
-          <FeatureFilter
-            settingsWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
-            settingsReadKey={SIZE_ENABLED_QUERY_READ_KEY}
-            title={t('Size Analysis')}
-            successMessage={t('Size filter updated')}
-          >
-            <Text>
-              {t(
-                "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
-              )}
-            </Text>
-          </FeatureFilter>
-          <Feature features="organizations:preprod-build-distribution">
+          <Feature features="organizations:preprod-issues">
             <FeatureFilter
-              settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-              settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-              title={t('Build Distribution')}
-              successMessage={t('Distribution filter updated')}
-              display={PreprodBuildsDisplay.DISTRIBUTION}
+              settingsWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
+              settingsReadKey={SIZE_ENABLED_QUERY_READ_KEY}
+              title={t('Size Analysis')}
+              successMessage={t('Size filter updated')}
             >
               <Text>
                 {t(
-                  'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
+                  "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
                 )}
               </Text>
             </FeatureFilter>
+            <Feature features="organizations:preprod-build-distribution">
+              <FeatureFilter
+                settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+                settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+                title={t('Build Distribution')}
+                successMessage={t('Distribution filter updated')}
+                display={PreprodBuildsDisplay.DISTRIBUTION}
+              >
+                <Text>
+                  {t(
+                    'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
+                  )}
+                </Text>
+              </FeatureFilter>
+            </Feature>
           </Feature>
         </Stack>
       </Feature>

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -23,7 +23,7 @@ const DISTRIBUTION_ENABLED_QUERY_WRITE_KEY = 'preprodDistributionEnabledQuery';
 export default function PreprodSettings() {
   return (
     <Fragment>
-      <Feature features="organizations:preprod-issues" renderDisabled>
+      <Feature features="organizations:preprod-frontend-routes" renderDisabled>
         <SentryDocumentTitle title={t('Mobile Builds')} />
         <SettingsPageHeader
           title={t('Mobile Builds')}
@@ -52,19 +52,21 @@ export default function PreprodSettings() {
               )}
             </Text>
           </FeatureFilter>
-          <FeatureFilter
-            settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-            settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-            title={t('Build Distribution')}
-            successMessage={t('Distribution filter updated')}
-            display={PreprodBuildsDisplay.DISTRIBUTION}
-          >
-            <Text>
-              {t(
-                'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
-              )}
-            </Text>
-          </FeatureFilter>
+          <Feature features="organizations:preprod-build-distribution">
+            <FeatureFilter
+              settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+              settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+              title={t('Build Distribution')}
+              successMessage={t('Distribution filter updated')}
+              display={PreprodBuildsDisplay.DISTRIBUTION}
+            >
+              <Text>
+                {t(
+                  'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
+                )}
+              </Text>
+            </FeatureFilter>
+          </Feature>
         </Stack>
       </Feature>
     </Fragment>


### PR DESCRIPTION
Close https://linear.app/getsentry/issue/EME-748/move-settings-out-of-feature-flag-for-ga

made sure the build distribution section is still hidden according to it's own FF