### PR TITLE
fix(dashboards): select the first supported display type if unsupported

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -890,6 +890,30 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.displayType).toBe(DisplayType.TABLE);
     });
 
+    it('resets display type to first supported type when switching to dataset with limited display types', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {dataset: WidgetType.TRANSACTIONS, displayType: DisplayType.TABLE},
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.displayType).toBe(DisplayType.TABLE);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.PREPROD_APP_SIZE,
+        });
+      });
+
+      // PREPROD_APP_SIZE only supports LINE, so TABLE should be reset to LINE
+      expect(result.current.state.displayType).toBe(DisplayType.LINE);
+    });
+
     it('resets the fields, yAxis, query, and sort when the dataset is switched', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -370,20 +370,26 @@ function useWidgetBuilderState(): {
           break;
         }
         case BuilderStateAction.SET_DATASET: {
-          setDataset(action.payload, options);
+          const config = getDatasetConfig(action.payload);
 
           let nextDisplayType = displayType;
           if (action.payload === WidgetType.ISSUE) {
             // Issues only support table display type
-            setDisplayType(DisplayType.TABLE, options);
             nextDisplayType = DisplayType.TABLE;
+          } else if (
+            nextDisplayType &&
+            !config.supportedDisplayTypes.includes(nextDisplayType) &&
+            config.supportedDisplayTypes.length > 0
+          ) {
+            // If the current display type is not supported by the new dataset,
+            // reset to the first supported display type. This can happen when switching
+            // between datasets in the UI
+            nextDisplayType = config.supportedDisplayTypes[0];
           }
 
-          const config = getDatasetConfig(action.payload);
-          setFields(
-            config.defaultWidgetQuery.fields?.map(field => explodeField({field})),
-            options
-          );
+          setDataset(action.payload, options);
+          setDisplayType(nextDisplayType, options);
+
           if (isChartDisplayType(nextDisplayType)) {
             setFields([], options);
             setYAxis(


### PR DESCRIPTION
Resolves EME-785

The root cause of the issue is that the Table visualization should not be selectable for the Mobile Builds dataset since it's not part of our `supportedDisplayTypes: [DisplayType.LINE]`. But currently you can trigger this bug by selecting Table on another dataset and then switch over to Mobile Builds. Rather than trying to update our dataset config to support some of the table methods, it seemed like a better UX to have the dashboard switch the selected visualization to one that's actually supported.