### PR TITLE
fix(dashboards): create widget queries for new mobile app size hooks

### DIFF
--- a/static/app/views/dashboards/widgetCard/mobileAppSizeWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/mobileAppSizeWidgetQueries.tsx
@@ -1,0 +1,44 @@
+import type {PageFilters} from 'sentry/types/core';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+
+import {useMobileAppSizeSeriesQuery} from './hooks/useMobileAppSizeWidgetQuery';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+
+type MobileAppSizeWidgetQueriesProps = {
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
+  widget: Widget;
+  dashboardFilters?: DashboardFilters;
+  limit?: number;
+  onDataFetchStart?: () => void;
+  onDataFetched?: () => void;
+  selection?: PageFilters;
+};
+
+function MobileAppSizeWidgetQueries({
+  children,
+  widget,
+  dashboardFilters,
+  selection: propsSelection,
+}: MobileAppSizeWidgetQueriesProps) {
+  const organization = useOrganization();
+  const hookPageFilters = usePageFilters();
+  const pageFilters = propsSelection ?? hookPageFilters.selection;
+
+  const result = useMobileAppSizeSeriesQuery({
+    widget,
+    organization,
+    pageFilters,
+    dashboardFilters,
+    enabled: true,
+  });
+
+  return getDynamicText({
+    value: children(result),
+    fixed: <div />,
+  });
+}
+
+export default MobileAppSizeWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/mobileAppSizeWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/mobileAppSizeWidgetQueries.tsx
@@ -2,18 +2,15 @@ import type {PageFilters} from 'sentry/types/core';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {MobileAppSizeConfig} from 'sentry/views/dashboards/datasetConfig/mobileAppSize';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 
-import {useMobileAppSizeSeriesQuery} from './hooks/useMobileAppSizeWidgetQuery';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 type MobileAppSizeWidgetQueriesProps = {
   children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
   widget: Widget;
   dashboardFilters?: DashboardFilters;
-  limit?: number;
-  onDataFetchStart?: () => void;
-  onDataFetched?: () => void;
   selection?: PageFilters;
 };
 
@@ -27,7 +24,7 @@ function MobileAppSizeWidgetQueries({
   const hookPageFilters = usePageFilters();
   const pageFilters = propsSelection ?? hookPageFilters.selection;
 
-  const result = useMobileAppSizeSeriesQuery({
+  const result = MobileAppSizeConfig.useSeriesQuery!({
     widget,
     organization,
     pageFilters,

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -148,9 +148,6 @@ export function WidgetCardDataLoader({
       <MobileAppSizeWidgetQueries
         widget={widget}
         selection={selection}
-        limit={tableItemLimit}
-        onDataFetchStart={onDataFetchStart}
-        onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
       >
         {props => <Fragment>{children({...props})}</Fragment>}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -12,6 +12,7 @@ import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQu
 import TraceMetricsWidgetQueries from 'sentry/views/dashboards/widgetCard/traceMetricsWidgetQueries';
 
 import IssueWidgetQueries from './issueWidgetQueries';
+import MobileAppSizeWidgetQueries from './mobileAppSizeWidgetQueries';
 import ReleaseWidgetQueries from './releaseWidgetQueries';
 import WidgetQueries from './widgetQueries';
 
@@ -139,6 +140,21 @@ export function WidgetCardDataLoader({
       >
         {props => <Fragment>{children({...props})}</Fragment>}
       </TraceMetricsWidgetQueries>
+    );
+  }
+
+  if (widget.widgetType === WidgetType.PREPROD_APP_SIZE) {
+    return (
+      <MobileAppSizeWidgetQueries
+        widget={widget}
+        selection={selection}
+        limit={tableItemLimit}
+        onDataFetchStart={onDataFetchStart}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+      >
+        {props => <Fragment>{children({...props})}</Fragment>}
+      </MobileAppSizeWidgetQueries>
     );
   }
 


### PR DESCRIPTION
I'm seeing these errors after some of the recent dashboard hook changes, it looks like some of the hook dependency arrays are changing and I saw other products have these query widgets which solve the issue.

<img width="404" height="78" alt="Screenshot 2026-01-27 at 7 00 22 PM" src="https://github.com/user-attachments/assets/9bc7276d-c649-4fdc-a219-e9323e2bd246" />

```
The final argument passed to useMemo changed size between renders. The order and size of this array must remain constant.

Previous: [[object Object], [object Object], [object Object]]
Incoming: [[object Object], [object Object], [object Object], ]
eval @ console.js:47
areHookInputsEqual @ react-dom-client.development.js:4283
updateMemo @ react-dom-client.development.js:5090
useMemo @ react-dom-client.development.js:14064
exports.useMemo @ react.development.js:800
useMobileAppSizeSeriesQuery @ useMobileAppSizeWidgetQuery.tsx:85
useGenericWidgetQueries @ genericWidgetQueries.tsx:162
WidgetQueriesWithOnDemandControl @ widgetQueries.tsx:64
react_stack_bottom_frame @ react-dom-client.development.js:13635
renderWithHooks @ react-dom-client.development.js:4299
updateFunctionComponent @ react-dom-client.development.js:5752
beginWork @ react-dom-client.development.js:6333
runWithFiberInDEV @ react-dom-client.development.js:721
performUnitOfWork @ react-dom-client.development.js:8729
workLoopSync @ react-dom-client.development.js:8623
renderRootSync @ react-dom-client.development.js:8607
performWorkOnRoot @ react-dom-client.development.js:8272
performSyncWorkOnRoot @ react-dom-client.development.js:9377
flushSyncWorkAcrossRoots_impl @ react-dom-client.development.js:9293
processRootScheduleInMicrotask @ react-dom-client.development.js:9314
eval @ react-dom-client.development.js:9388Understand this error

console.js:47 TypeError: Cannot read properties of undefined (reading 'length')
    at areHookInputsEqual (react-dom-client.development.js:4283:38)
    at updateEffectImpl (react-dom-client.development.js:4978:50)
    at Object.useEffect (react-dom-client.development.js:14041:13)
    at exports.useEffect (react.development.js:780:36)
    at useGenericWidgetQueries (genericWidgetQueries.tsx:202:1)
    at WidgetQueriesWithOnDemandControl (widgetQueries.tsx:64:1)
    at Object.react_stack_bottom_frame (react-dom-client.development.js:13635:24)
    at renderWithHooks (react-dom-client.development.js:4299:24)
    at updateFunctionComponent (react-dom-client.development.js:5752:21)
    at beginWork (react-dom-client.development.js:6333:24)
    at runWithFiberInDEV (react-dom-client.development.js:721:74)
    at performUnitOfWork (react-dom-client.development.js:8729:97)
    at workLoopSync (react-dom-client.development.js:8623:40)
    at renderRootSync (react-dom-client.development.js:8607:13)
    at performWorkOnRoot (react-dom-client.development.js:8272:47)
    at performSyncWorkOnRoot (react-dom-client.development.js:9377:9)
    at flushSyncWorkAcrossRoots_impl (react-dom-client.development.js:9293:316)
    at processRootScheduleInMicrotask (react-dom-client.development.js:9314:106)
    at eval (react-dom-client.development.js:9388:158)Caused by: React ErrorBoundary Error: Cannot read properties of undefined (reading 'length')
    at WidgetQueriesWithOnDemandControl (widgetQueries.tsx:43:1)
    at WidgetQueries (widgetQueries.tsx:85:1)
    at WidgetCardDataLoader (widgetCardDataLoader.tsx:55:1)
    at WidgetCardChartContainer (widgetCardChartContainer.tsx:63:1)
    at ErrorBoundary (errorBoundary.tsx:50:1)
    at div (<anonymous>)
    at VisualizationWrapper (emotion-element-489459f2.browser.development.esm.js:123:59)
    at div (<anonymous>)
    at Frame (emotion-element-489459f2.browser.development.esm.js:123:59)
    at WidgetLayout (widget.tsx:71:1)
    at WidgetFrame (widgetFrame.tsx:35:1)
    at VisuallyCompleteWithData (index.tsx:133:1)
    at ErrorBoundary (errorBoundary.tsx:50:1)
    at WidgetCard (index.tsx:134:1)
    at WithSentryRouterWrapper (withSentryRouter.tsx:17:1)
    at WithPageFilters (withPageFilters.tsx:21:1)
    at Wrapper (withOrganization.tsx:18:1)
    at WithApi (withApi.tsx:24:1)
    at WidgetPreview (widgetPreview.tsx:37:1)
    at div (<anonymous>)
    at MotionDOMComponent (index.mjs:64:53)
    at SampleWidgetCard (emotion-element-489459f2.browser.development.esm.js:123:59)
    at div (<anonymous>)
    at DraggableWidgetContainer (emotion-element-489459f2.browser.development.esm.js:123:59)
    at MEPDataProvider (metricsEnhancedPerformanceDataContext.tsx:27:1)
    at MEPSettingProvider (metricsEnhancedSetting.tsx:76:1)
    at MetricsDataSwitcher (metricsDataSwitcher.tsx:33:1)
    at MetricsCardinalityProvider (metricsCardinality.tsx:50:1)
    at DashboardsMEPProvider (dashboardsMEPContext.tsx:18:1)
    at WidgetPreviewContainer (newWidgetBuilder.tsx:264:1)
    at div (<anonymous>)
    at eval (container.tsx:226:1)
    at Flex (emotion-element-489459f2.browser.development.esm.js:123:59)
    at DndContext (core.esm.js:2634:11)
    at div (<anonymous>)
    at WidgetBuilderContainer (emotion-element-489459f2.browser.development.esm.js:123:59)
    at div (<anonymous>)
    at ContainerWithoutSidebar (emotion-element-489459f2.browser.development.esm.js:123:59)
    at TraceItemAttributeProvider (traceItemAttributeContext.tsx:52:1)
    at TraceItemAttributeProviderFromDataset (newWidgetBuilder.tsx:72:1)
    at CustomMeasurementsProvider (customMeasurementsProvider.tsx:51:1)
    at WidgetBuilderStateProvider (widgetBuilderContext.tsx:18:1)
    at UrlParamBatchProvider (urlParamBatchContext.tsx:14:1)
    at WidgetBuilderProvider (widgetBuilderContext.tsx:27:1)
    at PresenceChild (PresenceChild.mjs:18:26)
    at AnimatePresence (index.mjs:56:28)
    at WidgetBuilderV2 (newWidgetBuilder.tsx:113:1)
    at MEPDataProvider (metricsEnhancedPerformanceDataContext.tsx:27:1)
    at MEPSettingProvider (metricsEnhancedSetting.tsx:76:1)
    at MetricsDataSwitcher (metricsDataSwitcher.tsx:33:1)
    at MetricsCardinalityProvider (metricsCardinality.tsx:50:1)
    at section (<anonymous>)
    at Container (emotion-element-489459f2.browser.development.esm.js:123:59)
    at Main (thirds.tsx:161:1)
    at div (<anonymous>)
    at Body (emotion-element-489459f2.browser.development.esm.js:123:59)
    at NoProjectMessage (noProjectMessage.tsx:23:1)
    at MetricsResultsMetaProvider (metricsEnhancedPerformanceDataContext.tsx:81:1)
    at OnDemandControlProvider (onDemandControl.tsx:33:1)
    at main (<anonymous>)
    at Page (emotion-element-489459f2.browser.development.esm.js:123:59)
    at PageFiltersContainer (container.tsx:53:1)
    at SentryDocumentTitle (index.tsx:26:1)
    at DashboardDetail (detail.tsx:191:1)
    at DashboardDetailWithInjectedProps (detail.tsx:1383:1)
    at ErrorBoundary (errorBoundary.tsx:50:1)
    at SentryDocumentTitle (index.tsx:26:1)
    at OrgDashboards (orgDashboards.tsx:40:1)
    at Feature (feature.tsx:134:1)
    at Wrapper (withConfig.tsx:20:1)
    at Wrapper (withProject.tsx:17:1)
    at Wrapper (withOrganization.tsx:18:1)
    at DashboardBasicFeature (view.tsx:73:1)
    at ViewEditDashboard (view.tsx:23:1)
    at Suspense (<anonymous>)
    at ErrorBoundary (lazyLoad.tsx:85:1)
    at LazyLoad (lazyLoad.tsx:54:1)
    at ErrorHandler (errorHandler.tsx:11:1)
    at RouteLazyLoad (<anonymous>)
    at WithDomainRedirectWrapper (withDomainRedirect.tsx:40:1)
    at RenderedRoute (index.js:614:11)
    at RenderedRoute (index.js:614:11)
    at RenderedRoute (index.js:614:11)
    at Outlet (index.js:1323:28)
    at ErrorBoundary (errorBoundary.tsx:50:1)
    at OrganizationDetailsBody (body.tsx:105:1)
    at AppBodyContent (appBodyContent.tsx:17:1)
    at div (<anonymous>)
    at eval (container.tsx:226:1)
    at Flex (emotion-element-489459f2.browser.development.esm.js:123:59)
    at StackComponent.target (stack.tsx:19:1)
    at StackComponent (emotion-element-489459f2.browser.development.esm.js:123:59)
    at div (<anonymous>)
    at AppContainer (emotion-element-489459f2.browser.development.esm.js:123:59)
    at NavContextProvider (context.tsx:46:1)
    at AppLayout (index.tsx:69:1)
    at GlobalDrawer (index.tsx:110:1)
    at OrganizationContainer (organizationContainer.tsx:44:1)
    at SentryDocumentTitle (index.tsx:26:1)
    at OrganizationLayout (index.tsx:37:1)
    at ErrorHandler (errorHandler.tsx:11:1)
    at RenderedRoute (index.js:614:11)
    at Outlet (index.js:1323:28)
    at ErrorBoundary (errorBoundary.tsx:50:1)
    at ExplorerPanelProvider (useExplorerPanel.tsx:27:1)
    at DemoToursProvider (demoTours.tsx:116:1)
    at div (<anonymous>)
    at MainContainer (emotion-element-489459f2.browser.development.esm.js:123:59)
    at GlobalFeedbackForm (useFeedbackForm.tsx:118:1)
    at AsyncSDKIntegrationContextProvider (asyncSDKIntegrationProvider.tsx:18:1)
    at OrganizationContextProvider (organizationContext.tsx:52:1)
    at RouteAnalyticsContextProvider (routeAnalyticsContextProvider.tsx:40:1)
    at LastKnownRouteContextProvider (lastKnownRouteContextProvider.tsx:20:1)
    at TimezoneProvider (timezoneProvider.tsx:29:1)
    at UserTimezoneProvider (timezoneProvider.tsx:38:1)
    at App (index.tsx:50:1)
    at ErrorHandler (errorHandler.tsx:11:1)
    at RenderedRoute (index.js:614:11)
    at Outlet (index.js:1323:28)
    at SentryLinkBehaviorProvider (link.tsx:13:1)
    at SentryTrackingProvider (tracking.tsx:6:1)
    at ScrapsProviders (index.tsx:4:1)
    at $ea8dcbcb9ea1b556$export$323e4fc2fa4753fb (openLink.mjs:38:21)
    at ProvideAriaRouter (provideAriaRouter.tsx:12:1)
    at component (<anonymous>)
    at RenderedRoute (index.js:614:11)
    at RenderErrorBoundary (index.js:562:9)
    at DataRoutes (index.js:897:11)
    at Router (index.js:1349:21)
    at RouterProvider (index.js:650:11)
    at CommandPaletteProvider (context.tsx:75:1)
    at eval (context-B9lexhKS.js:128:15)
    at ThemeProvider (emotion-element-489459f2.browser.development.esm.js:155:41)
    at ThemeAndStyleProvider (themeAndStyleProvider.tsx:43:1)
    at FrontendVersionProvider (frontendVersionContext.tsx:82:1)
    at DocumentTitleManager (documentTitleManager.tsx:25:1)
    at QueryClientProvider (QueryClientProvider.js:28:11)
    at PersistQueryClientProvider (PersistQueryClientProvider.js:18:11)
    at AppQueryClientProvider (appQueryClient.tsx:37:1)
    at Main (main.tsx:27:1)

The above error occurred in the <WidgetQueriesWithOnDemandControl> component.
```