### PR TITLE
fix(code-review): add date_updated to update_fields

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repository_settings.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_settings.py
@@ -67,7 +67,7 @@ class OrganizationRepositorySettingsEndpoint(OrganizationEndpoint):
         updated_enabled_code_review = data.get("enabledCodeReview")
         updated_code_review_triggers = data.get("codeReviewTriggers")
 
-        update_fields = []
+        update_fields = ["date_updated"]
         if updated_enabled_code_review is not None:
             update_fields.append("enabled_code_review")
         if updated_code_review_triggers is not None:


### PR DESCRIPTION
followup to https://github.com/getsentry/sentry/pull/106977

Add `"date_updated"` to `update_fields` when bulk creating repo settings. Otherwise the value will not update.