### PR TITLE
fix(aci): Use open period to set query bounds on metric issue

### DIFF
--- a/static/app/views/detectors/hooks/useOpenPeriods.tsx
+++ b/static/app/views/detectors/hooks/useOpenPeriods.tsx
@@ -10,6 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 type CommonParams = {
   cursor?: string;
   end?: string | null;
+  eventId?: string;
   limit?: number;
   start?: string | null;
   statsPeriod?: string | null;
@@ -51,4 +52,26 @@ export function useOpenPeriods(
       ...options,
     }
   );
+}
+
+export function useEventOpenPeriod(
+  params: {
+    eventId: string;
+    groupId: string;
+  },
+  options: Partial<UseApiQueryOptions<GroupOpenPeriod[]>> = {}
+) {
+  const query = useOpenPeriods(
+    {
+      groupId: params.groupId,
+      eventId: params.eventId,
+      limit: 1,
+    },
+    options
+  );
+
+  return {
+    ...query,
+    openPeriod: query.data?.[0] ?? null,
+  };
 }

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -344,7 +344,7 @@ export function EventDetailsContent({
         </Fragment>
       )}
       <ErrorBoundary customComponent={() => null}>
-        <MetricDetectorTriggeredSection event={event} />
+        <MetricDetectorTriggeredSection group={group} event={event} />
       </ErrorBoundary>
       <EventHydrationDiff event={event} group={group} />
       <EventReplay event={event} group={group} projectSlug={project.slug} />

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -17,6 +17,8 @@ describe('MetricDetectorTriggeredSection', () => {
     conditionResult: true,
   };
   const dataSource = SnubaQueryDataSourceFixture();
+  const openPeriodStartDate = '2024-01-01T00:00:00Z';
+  const openPeriodEndDate = '2024-01-01T00:05:00.000Z';
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -31,6 +33,19 @@ describe('MetricDetectorTriggeredSection', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
       body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [
+        {
+          id: '101',
+          start: openPeriodStartDate,
+          end: openPeriodEndDate,
+          isOpen: false,
+          eventId: 'event-1',
+          activities: [],
+        },
+      ],
     });
   });
 
@@ -136,18 +151,17 @@ describe('MetricDetectorTriggeredSection', () => {
   });
 
   it('renders contributing issues section for errors dataset', async () => {
-    const eventDateCreated = '2024-01-01T00:00:00Z';
     // Start date is eventDateCreated minus the timeWindow (60 seconds) minus 1 extra minute
     const startDate = '2023-12-31T23:58:00.000Z';
-    const endDate = '2017-10-17T02:41:20.000Z'; // Mocked time in test env
 
     const contributingIssuesMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
       body: [GroupFixture()],
     });
-
     const event = EventFixture({
-      dateCreated: eventDateCreated,
+      dateCreated: openPeriodStartDate,
+      eventID: 'event-1',
+      groupID: '123',
       occurrence: {
         id: '1',
         eventId: 'event-1',
@@ -180,7 +194,7 @@ describe('MetricDetectorTriggeredSection', () => {
         query: expect.objectContaining({
           query: 'issue.type:error event.type:error is:unresolved',
           start: startDate,
-          end: endDate,
+          end: openPeriodEndDate,
         }),
       })
     );
@@ -239,7 +253,7 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2017-10-17T02%3A41%3A20.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
+      '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
     );
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import {SnubaQueryDataSourceFixture} from 'sentry-fixture/detectors';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
@@ -19,6 +20,12 @@ describe('MetricDetectorTriggeredSection', () => {
   const dataSource = SnubaQueryDataSourceFixture();
   const openPeriodStartDate = '2024-01-01T00:00:00Z';
   const openPeriodEndDate = '2024-01-01T00:05:00.000Z';
+  const defaultGroup = GroupFixture();
+  const defaultEvent = EventFixture();
+  const defaultProps: ComponentProps<typeof MetricDetectorTriggeredSection> = {
+    group: defaultGroup,
+    event: defaultEvent,
+  };
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -54,7 +61,9 @@ describe('MetricDetectorTriggeredSection', () => {
       occurrence: null,
     });
 
-    const {container} = render(<MetricDetectorTriggeredSection event={event} />);
+    const {container} = render(
+      <MetricDetectorTriggeredSection {...defaultProps} event={event} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -78,7 +87,7 @@ describe('MetricDetectorTriggeredSection', () => {
       },
     });
 
-    render(<MetricDetectorTriggeredSection event={event} />);
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
 
     expect(screen.getByRole('region', {name: 'Message'})).toBeInTheDocument();
     expect(screen.getByText('Subtitle')).toBeInTheDocument();
@@ -103,7 +112,9 @@ describe('MetricDetectorTriggeredSection', () => {
       },
     });
 
-    const {container} = render(<MetricDetectorTriggeredSection event={event} />);
+    const {container} = render(
+      <MetricDetectorTriggeredSection {...defaultProps} event={event} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -127,7 +138,7 @@ describe('MetricDetectorTriggeredSection', () => {
       },
     });
 
-    render(<MetricDetectorTriggeredSection event={event} />);
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
 
     // Check sections exist by aria-label
     expect(await screen.findByRole('region', {name: 'Message'})).toBeInTheDocument();
@@ -180,7 +191,7 @@ describe('MetricDetectorTriggeredSection', () => {
       },
     });
 
-    render(<MetricDetectorTriggeredSection event={event} />);
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
 
     await waitFor(() => {
       expect(
@@ -239,7 +250,7 @@ describe('MetricDetectorTriggeredSection', () => {
       },
     });
 
-    render(<MetricDetectorTriggeredSection event={event} />);
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
 
     // Check that the boolean logic error alert is shown
     expect(

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -19,6 +19,7 @@ import {treeResultLocator} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, EventOccurrence} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
 import type {
   MetricCondition,
   MetricDetectorConfig,
@@ -59,6 +60,7 @@ interface MetricDetectorEvidenceData {
 
 interface MetricDetectorTriggeredSectionProps {
   event: Event;
+  group: Group;
 }
 
 function isMetricDetectorEvidenceData(
@@ -254,16 +256,16 @@ function OpenInDestinationButton({
 }
 
 function TriggeredConditionDetails({
+  evidenceData,
   eventDateCreated,
   eventId,
-  evidenceData,
   groupId,
   projectId,
 }: {
   eventDateCreated: string | undefined;
-  eventId: string | undefined;
+  eventId: string;
   evidenceData: MetricDetectorEvidenceData;
-  groupId: string | undefined;
+  groupId: string;
   projectId: string | number;
 }) {
   const {conditions, dataSources, value} = evidenceData;
@@ -271,13 +273,10 @@ function TriggeredConditionDetails({
   const snubaQuery = dataSource?.queryObj?.snubaQuery;
   const triggeredCondition = conditions[0];
   const [fallbackEndDate] = useState(() => new Date().toISOString());
-  const {openPeriod, isLoading: isOpenPeriodLoading} = useEventOpenPeriod(
-    {
-      groupId: groupId ?? '',
-      eventId: eventId ?? '',
-    },
-    {enabled: Boolean(groupId && eventId)}
-  );
+  const {openPeriod, isLoading: isOpenPeriodLoading} = useEventOpenPeriod({
+    groupId,
+    eventId,
+  });
   const endDate = openPeriod?.end ?? fallbackEndDate;
 
   if (!triggeredCondition || !snubaQuery || !eventDateCreated) {
@@ -389,6 +388,7 @@ const GroupListWrapper = styled('div')`
 `;
 
 export function MetricDetectorTriggeredSection({
+  group,
   event,
 }: MetricDetectorTriggeredSectionProps) {
   const evidenceData = event.occurrence?.evidenceData;
@@ -410,7 +410,7 @@ export function MetricDetectorTriggeredSection({
           evidenceData={evidenceData}
           eventDateCreated={event.dateCreated}
           eventId={event.eventID}
-          groupId={event.groupID}
+          groupId={group.id}
           projectId={event.projectID}
         />
       </ErrorBoundary>


### PR DESCRIPTION
Closes ISWF-908

Now that we can fetch open periods by event ID, this adds a `useEventOpenPeriod()` hook and uses it in the metric issue to inform the end date of the interval. For example, if you are looking at an event that went from 1pm-3pm, the contributing issues section will only show issues from that time period. Also, the "open in explore" button will apply that same time range.