### PR TITLE
chore(preprod): Execute create_preprod_status_check_task immediately for user approval case

### DIFF
--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -174,9 +174,7 @@ def handle_preprod_check_run_event(
         amount=approvals_created,
     )
 
-    create_preprod_status_check_task.apply_async(
-        kwargs={
-            "preprod_artifact_id": artifact.id,
-            "caller": "github_approve_webhook",
-        }
+    create_preprod_status_check_task(
+        preprod_artifact_id=artifact.id,
+        caller="github_approve_webhook",
     )


### PR DESCRIPTION
While testing the approval via status check flow, i noticed it would take 30s for the status check to update after clicking "approve". It's most likely bcuz of this unnecessary task delay.

This should make approvals feel more snappy