### PR TITLE
feat(performance-detectors): Use config from Workflow Engine Detectors if available and enabled

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -573,6 +573,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:project-detail-apple-app-hang-rate", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable supergroup RCA embedding generation from autofix explorer runs
     manager.add("projects:supergroup-embeddings-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
+    manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
     # fmt: on
 
     # Partner oauth

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -202,6 +202,20 @@ def detect_performance_problems(
 
 
 class SettingsMode(IntEnum):
+    """
+    Performance detection settings modes for gradual migration from ProjectOptions to WFE Detectors.
+
+    LEGACY: Use system defaults + well-known defaults + ProjectOption values.
+            Traditional behavior, no WFE Detector involvement.
+
+    COMPARE: Generate both legacy and WFE settings, log differences for monitoring,
+             return legacy settings. Used to detect config drift during migration.
+
+    WFE: Hybrid mode combining WFE Detector configs with ProjectOptions.
+         For detectors with WFE Detector objects: use WFE config (falls back to system defaults).
+         For detectors without WFE Detector objects: use ProjectOptions.
+    """
+
     LEGACY = 0
     COMPARE = 1
     WFE = 2
@@ -213,11 +227,6 @@ def get_merged_settings(
 ) -> dict[str | Any, Any]:
     """
     Get performance detection settings based on the specified mode.
-
-    Modes:
-    - LEGACY: Use system defaults + well-known defaults + ProjectOption values
-    - COMPARE: Generate both legacy and WFE settings, log differences, return legacy
-    - WFE: Use system defaults + well-known defaults + WFE Detector configs
 
     Returns a dict with all performance detection settings.
     """

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -284,7 +284,7 @@ def get_merged_settings(
     default_project_settings = (
         projectoptions.get_well_known_default(
             "sentry:performance_issue_settings",
-            project=project.id,
+            project=project,
         )
         if project
         else {}

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import sentry_sdk
 
-from sentry import nodestore, options, projectoptions
+from sentry import features, nodestore, options, projectoptions
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -5,6 +5,7 @@ import logging
 import random
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Any
 
 import sentry_sdk
@@ -19,6 +20,7 @@ from sentry.utils import metrics
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.safe import get_path
+from sentry.workflow_engine.models import Detector
 
 from .base import DetectorType, PerformanceDetector
 from .detectors.consecutive_db_detector import ConsecutiveDBSpanDetector
@@ -35,6 +37,8 @@ from .detectors.slow_db_query_detector import SlowDBQueryDetector
 from .detectors.sql_injection_detector import SQLInjectionDetector
 from .detectors.uncompressed_asset_detector import UncompressedAssetSpanDetector
 from .performance_problem import PerformanceProblem
+
+logger = logging.getLogger(__name__)
 
 INTEGRATIONS_OF_INTEREST = [
     "django",
@@ -197,10 +201,26 @@ def detect_performance_problems(
     return []
 
 
-# Merges system defaults, with default project settings and saved project settings.
+class SettingsMode(IntEnum):
+    LEGACY = 0
+    COMPARE = 1
+    WFE = 2
+
+
 def get_merged_settings(
-    project_id: int | None = None, project: Project | None = None
+    project: Project | None = None,
+    settings_mode: SettingsMode = SettingsMode.LEGACY,
 ) -> dict[str | Any, Any]:
+    """
+    Get performance detection settings based on the specified mode.
+
+    Modes:
+    - LEGACY: Use system defaults + well-known defaults + ProjectOption values
+    - COMPARE: Generate both legacy and WFE settings, log differences, return legacy
+    - WFE: Use system defaults + well-known defaults + WFE Detector configs
+
+    Returns a dict with all performance detection settings.
+    """
     system_settings = {
         "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
         "n_plus_one_db_duration_threshold": options.get(
@@ -269,49 +289,145 @@ def get_merged_settings(
     default_project_settings = (
         projectoptions.get_well_known_default(
             "sentry:performance_issue_settings",
-            project=project_id,
+            project=project.id,
         )
-        if project_id
+        if project
         else {}
     )
 
     project_option_settings = (
         ProjectOption.objects.get_value(
-            project_id, "sentry:performance_issue_settings", default_project_settings
+            project.id, "sentry:performance_issue_settings", default_project_settings
         )
-        if project_id
+        if project
         else DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
     )
 
-    project_settings = {
+    legacy_settings = {
+        **system_settings,
         **default_project_settings,
         **project_option_settings,
-    }  # Merge saved project settings into default so updating the default to add new settings works in the future.
+    }
 
-    # WFE Detector config handling:
-    # When a WFE Detector exists for a detector type, it fully owns that detector's config.
-    # Values come from Detector.config, falling back to system defaults (not ProjectOptions).
-    # When no WFE Detector exists, ProjectOptions are used with system defaults as fallback.
-    if project and features.has("projects:workflow-engine-performance-detectors", project):
-        wfe_configs = _get_wfe_detector_configs(project)
+    # If feature flag is disabled, always use LEGACY mode because we can't decide check the feature
+    # flag without a Project.
+    # TODO: WFE config should fall back to DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS without a Project.
+    if not project or not features.has("projects:workflow-engine-performance-detectors", project):
+        settings_mode = SettingsMode.LEGACY
 
-        for detector_type, wfe_config in wfe_configs.items():
-            mapping = PERFORMANCE_DETECTOR_CONFIG_MAPPINGS[detector_type]
+    if settings_mode == SettingsMode.LEGACY:
+        return legacy_settings
 
-            # detection_enabled comes from Detector.enabled
-            project_settings[mapping.detection_enabled_key] = wfe_config["detection_enabled"]
+    assert project is not None
 
-            # For each config field: use WFE value if present, otherwise clear so system default applies
-            for field_name, field_mapping in mapping.config_fields.items():
-                if field_mapping.hardcoded_value is not None:
-                    continue
+    # Get WFE-specific settings (analogous to project_option_settings)
+    wfe_option_settings, wfe_managed_keys = _build_wfe_settings(project)
+
+    # Build complete WFE settings by merging in order
+    wfe_settings = {**system_settings, **default_project_settings, **wfe_option_settings}
+
+    if settings_mode == SettingsMode.COMPARE:
+        # Compare and log differences, but return legacy settings
+        _log_settings_diff(project, wfe_managed_keys, legacy=legacy_settings, wfe=wfe_settings)
+        return legacy_settings
+    elif settings_mode == SettingsMode.WFE:
+        # Build hybrid settings with clear priority:
+        # 1. Base: system + well-known defaults
+        # 2. For unmanaged keys: use project_option_settings
+        # 3. For managed keys: use wfe_option_settings (if specified, else base)
+        hybrid_settings = {**system_settings, **default_project_settings}
+
+        # Apply project options only for keys NOT managed by WFE
+        for key, value in project_option_settings.items():
+            if key not in wfe_managed_keys:
+                hybrid_settings[key] = value
+
+        # Apply WFE options for managed keys (overwrites base if specified)
+        hybrid_settings.update(wfe_option_settings)
+
+        return hybrid_settings
+
+    # Unreachable: all modes should be handled above
+    raise ValueError(f"Unknown settings_mode: {settings_mode}")
+
+
+def _build_wfe_settings(
+    project: Project,
+) -> tuple[dict[str, Any], set[str]]:
+    """
+    Build WFE-specific settings (Detector.config-derived version of sentry:performance_issue_settings).
+    The returned settings dict will only contain keys that are managed by WFE Detectors.
+
+    Returns:
+        - wfe_option_settings: Dict with only WFE-specified config values
+        - wfe_managed_keys: Set of all setting keys managed by WFE; wfe_option_setings keys are a subset of this
+    """
+    wfe_option_settings: dict[str, Any] = {}
+    wfe_managed_keys: set[str] = set()
+    wfe_configs = _get_wfe_detector_configs(project)
+
+    # Generate settings only for detectors that have WFE Detector objects
+    for detector_type, wfe_config in wfe_configs.items():
+        mapping = PERFORMANCE_DETECTOR_CONFIG_MAPPINGS[detector_type]
+
+        # All Detectors provide a detection_enabled key.
+        wfe_managed_keys.add(mapping.detection_enabled_key)
+        wfe_option_settings[mapping.detection_enabled_key] = wfe_config["detection_enabled"]
+
+        # For each config field: only set if present in WFE config
+        for field_name, field_mapping in mapping.config_fields.items():
+            if field_mapping.hardcoded_value is None:
+                # Track this key as WFE-managed
+                option_key = field_mapping.project_option_key
+                wfe_managed_keys.add(option_key)
+
                 if field_name in wfe_config:
-                    project_settings[field_mapping.project_option_key] = wfe_config[field_name]
-                else:
-                    # Remove ProjectOption value so system default is used
-                    project_settings.pop(field_mapping.project_option_key, None)
+                    # TODO: Consider using None so we don't have to track managed keys.
+                    wfe_option_settings[option_key] = wfe_config[field_name]
 
-    return {**system_settings, **project_settings}
+    return wfe_option_settings, wfe_managed_keys
+
+
+def _log_settings_diff(
+    project: Project,
+    wfe_managed_keys: set[str],
+    *,
+    legacy: dict[str, Any],
+    wfe: dict[str, Any],
+) -> None:
+    """
+    Compare legacy and WFE settings and log any differences.
+
+    Only compares keys that are managed by WFE Detectors (detectors that have
+    WFE Detector objects). This avoids noise from detectors that haven't been
+    migrated yet.
+
+    This is used in COMPARE mode to monitor config drift between
+    ProjectOption-based settings and WFE Detector-based settings.
+    """
+    differences: dict[str, dict[str, Any]] = {}
+
+    # Only compare keys that are managed by WFE Detectors
+    for key in wfe_managed_keys:
+        legacy_value = legacy.get(key)
+        wfe_value = wfe.get(key)
+
+        if legacy_value != wfe_value:
+            differences[key] = {
+                "legacy": legacy_value,
+                "wfe": wfe_value,
+            }
+
+    if differences:
+        logger.info(
+            "performance_detector.settings_diff",
+            extra={
+                "project_id": project.id,
+                "organization_id": project.organization_id,
+                "differences": differences,
+                "diff_count": len(differences),
+            },
+        )
 
 
 def _get_wfe_detector_configs(project: Project) -> dict[DetectorType, dict[str, Any]]:
@@ -324,35 +440,27 @@ def _get_wfe_detector_configs(project: Project) -> dict[DetectorType, dict[str, 
     When a WFE Detector exists, its config is always used (regardless of enabled state).
     The Detector.enabled field controls detection_enabled, not whether we use WFE config.
     """
-    from sentry.workflow_engine.models.detector import Detector
-
-    # Get all WFE detector types we care about
+    # Get all WFE detector types we can map.
     wfe_types = [
         mapping.wfe_detector_type for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
     ]
 
-    # Query all detectors for this project (regardless of enabled state)
-    # When a WFE Detector exists, it's the source of truth for config
-    detectors = Detector.objects.filter(
+    # Per DetectorType configs
+    wfe_configs: dict[DetectorType, dict[str, Any]] = {}
+    for detector in Detector.objects.filter(
         project=project,
         type__in=wfe_types,
-    )
-
-    # Build config dict keyed by DetectorType
-    wfe_configs: dict[DetectorType, dict[str, Any]] = {}
-    for detector in detectors:
+    ):
         # Map WFE detector type to our DetectorType enum
         detector_type = WFE_DETECTOR_TYPE_TO_CONFIG_MAPPING.get(detector.type)
         if not detector_type:
             continue
 
         # Store raw Detector.config plus detection_enabled from Detector.enabled
-        config: dict[str, Any] = {
+        wfe_configs[detector_type] = {
             "detection_enabled": detector.enabled,
             **detector.config,  # Include all fields from Detector.config
         }
-
-        wfe_configs[detector_type] = config
 
     return wfe_configs
 
@@ -361,11 +469,11 @@ def _get_wfe_detector_configs(project: Project) -> dict[DetectorType, dict[str, 
 # Duration thresholds are in milliseconds.
 # Allowed span ops are allowed span prefixes. (eg. 'http' would work for a span with 'http.client' as its op)
 def get_detection_settings(
-    project_id: int | None = None,
-    organization: Organization | None = None,
     project: Project | None = None,
+    organization: Organization | None = None,
+    settings_mode: SettingsMode = SettingsMode.LEGACY,
 ) -> dict[DetectorType, dict[str, Any]]:
-    settings = get_merged_settings(project_id, project)
+    settings = get_merged_settings(project, settings_mode)
 
     return {
         DetectorType.SLOW_DB_QUERY: {
@@ -483,7 +591,7 @@ def _detect_performance_problems(
     organization = project.organization
 
     with sentry_sdk.start_span(op="function", name="get_detection_settings"):
-        detection_settings = get_detection_settings(project.id, organization, project)
+        detection_settings = get_detection_settings(project)
 
     # The performance detectors expect the span list to be ordered/flattened in the way they
     # are structured in the tree. This is an implicit assumption in the performance detectors.

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import random
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import sentry_sdk
@@ -48,6 +49,72 @@ INTEGRATIONS_OF_INTEREST = [
 SDKS_OF_INTEREST = [
     "sentry.javascript.node",
 ]
+
+
+@dataclass(frozen=True)
+class ConfigFieldMapping:
+    """Maps a config field between WFE Detector.config and ProjectOption settings."""
+
+    project_option_key: str  # Key in get_merged_settings() result
+    hardcoded_value: Any | None = None  # If set, this is a constant value (not from config)
+
+
+@dataclass(frozen=True)
+class PerformanceDetectorConfigMapping:
+    """Complete mapping for a single performance detector type."""
+
+    settings_key: DetectorType  # e.g., DetectorType.SLOW_DB_QUERY
+    wfe_detector_type: str  # GroupType slug (e.g., "performance_slow_db_query")
+    detection_enabled_key: str  # ProjectOption key for detection_enabled fallback
+    config_fields: dict[str, ConfigFieldMapping]  # WFE field name -> mapping
+
+
+# Mapping from DetectorType to WFE Detector configuration
+PERFORMANCE_DETECTOR_CONFIG_MAPPINGS: dict[DetectorType, PerformanceDetectorConfigMapping] = {
+    DetectorType.SLOW_DB_QUERY: PerformanceDetectorConfigMapping(
+        settings_key=DetectorType.SLOW_DB_QUERY,
+        wfe_detector_type="performance_slow_db_query",
+        detection_enabled_key="slow_db_queries_detection_enabled",
+        config_fields={
+            "duration_threshold": ConfigFieldMapping(
+                project_option_key="slow_db_query_duration_threshold",
+            ),
+            "allowed_span_ops": ConfigFieldMapping(
+                project_option_key="",
+                hardcoded_value=["db"],
+            ),
+        },
+    ),
+    DetectorType.LARGE_HTTP_PAYLOAD: PerformanceDetectorConfigMapping(
+        settings_key=DetectorType.LARGE_HTTP_PAYLOAD,
+        wfe_detector_type="performance_large_http_payload",
+        detection_enabled_key="large_http_payload_detection_enabled",
+        config_fields={
+            "payload_size_threshold": ConfigFieldMapping(
+                project_option_key="large_http_payload_size_threshold",
+            ),
+            "filtered_paths": ConfigFieldMapping(
+                project_option_key="large_http_payload_filtered_paths",
+            ),
+            "minimum_span_duration": ConfigFieldMapping(
+                project_option_key="",
+                hardcoded_value=100,
+            ),
+        },
+    ),
+    DetectorType.QUERY_INJECTION: PerformanceDetectorConfigMapping(
+        settings_key=DetectorType.QUERY_INJECTION,
+        wfe_detector_type="query_injection_vulnerability",
+        detection_enabled_key="db_query_injection_detection_enabled",
+        config_fields={},  # No configurable fields beyond detection_enabled
+    ),
+}
+
+# Reverse lookup: WFE detector type -> DetectorType
+WFE_DETECTOR_TYPE_TO_CONFIG_MAPPING: dict[str, DetectorType] = {
+    mapping.wfe_detector_type: mapping.settings_key
+    for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
+}
 
 
 class EventPerformanceProblem:
@@ -131,7 +198,9 @@ def detect_performance_problems(
 
 
 # Merges system defaults, with default project settings and saved project settings.
-def get_merged_settings(project_id: int | None = None) -> dict[str | Any, Any]:
+def get_merged_settings(
+    project_id: int | None = None, project: Project | None = None
+) -> dict[str | Any, Any]:
     system_settings = {
         "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
         "n_plus_one_db_duration_threshold": options.get(
@@ -219,16 +288,84 @@ def get_merged_settings(project_id: int | None = None) -> dict[str | Any, Any]:
         **project_option_settings,
     }  # Merge saved project settings into default so updating the default to add new settings works in the future.
 
+    # WFE Detector config handling:
+    # When a WFE Detector exists for a detector type, it fully owns that detector's config.
+    # Values come from Detector.config, falling back to system defaults (not ProjectOptions).
+    # When no WFE Detector exists, ProjectOptions are used with system defaults as fallback.
+    if project and features.has("projects:workflow-engine-performance-detectors", project):
+        wfe_configs = _get_wfe_detector_configs(project)
+
+        for detector_type, wfe_config in wfe_configs.items():
+            mapping = PERFORMANCE_DETECTOR_CONFIG_MAPPINGS[detector_type]
+
+            # detection_enabled comes from Detector.enabled
+            project_settings[mapping.detection_enabled_key] = wfe_config["detection_enabled"]
+
+            # For each config field: use WFE value if present, otherwise clear so system default applies
+            for field_name, field_mapping in mapping.config_fields.items():
+                if field_mapping.hardcoded_value is not None:
+                    continue
+                if field_name in wfe_config:
+                    project_settings[field_mapping.project_option_key] = wfe_config[field_name]
+                else:
+                    # Remove ProjectOption value so system default is used
+                    project_settings.pop(field_mapping.project_option_key, None)
+
     return {**system_settings, **project_settings}
+
+
+def _get_wfe_detector_configs(project: Project) -> dict[DetectorType, dict[str, Any]]:
+    """
+    Fetch WFE Detector configs for performance detectors.
+
+    Returns a dict mapping DetectorType to config values from Detector.config
+    that should be used INSTEAD OF ProjectOption values for that detector.
+
+    When a WFE Detector exists, its config is always used (regardless of enabled state).
+    The Detector.enabled field controls detection_enabled, not whether we use WFE config.
+    """
+    from sentry.workflow_engine.models.detector import Detector
+
+    # Get all WFE detector types we care about
+    wfe_types = [
+        mapping.wfe_detector_type for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
+    ]
+
+    # Query all detectors for this project (regardless of enabled state)
+    # When a WFE Detector exists, it's the source of truth for config
+    detectors = Detector.objects.filter(
+        project=project,
+        type__in=wfe_types,
+    )
+
+    # Build config dict keyed by DetectorType
+    wfe_configs: dict[DetectorType, dict[str, Any]] = {}
+    for detector in detectors:
+        # Map WFE detector type to our DetectorType enum
+        detector_type = WFE_DETECTOR_TYPE_TO_CONFIG_MAPPING.get(detector.type)
+        if not detector_type:
+            continue
+
+        # Store raw Detector.config plus detection_enabled from Detector.enabled
+        config: dict[str, Any] = {
+            "detection_enabled": detector.enabled,
+            **detector.config,  # Include all fields from Detector.config
+        }
+
+        wfe_configs[detector_type] = config
+
+    return wfe_configs
 
 
 # Gets the thresholds to perform performance detection.
 # Duration thresholds are in milliseconds.
 # Allowed span ops are allowed span prefixes. (eg. 'http' would work for a span with 'http.client' as its op)
 def get_detection_settings(
-    project_id: int | None = None, organization: Organization | None = None
+    project_id: int | None = None,
+    organization: Organization | None = None,
+    project: Project | None = None,
 ) -> dict[DetectorType, dict[str, Any]]:
-    settings = get_merged_settings(project_id)
+    settings = get_merged_settings(project_id, project)
 
     return {
         DetectorType.SLOW_DB_QUERY: {
@@ -346,7 +483,7 @@ def _detect_performance_problems(
     organization = project.organization
 
     with sentry_sdk.start_span(op="function", name="get_detection_settings"):
-        detection_settings = get_detection_settings(project.id, organization)
+        detection_settings = get_detection_settings(project.id, organization, project)
 
     # The performance detectors expect the span list to be ordered/flattened in the way they
     # are structured in the tree. This is an implicit assumption in the performance detectors.

--- a/src/sentry/tasks/web_vitals_issue_detection.py
+++ b/src/sentry/tasks/web_vitals_issue_detection.py
@@ -97,7 +97,7 @@ def dispatch_detection_for_project_ids(
             continue
 
         # Check if web vitals detection is enabled in the project's performance issue settings
-        performance_settings = get_merged_settings(project.id)
+        performance_settings = get_merged_settings(project)
         if not performance_settings.get("web_vitals_detection_enabled", False):
             results[project.id] = {"success": False, "reason": "web_vitals_detection_not_enabled"}
             continue
@@ -234,7 +234,7 @@ def get_highest_opportunity_page_vitals_for_project(
     start_time = end_time - timedelta(**start_time_delta)
 
     # Get the samples count threshold from performance issue settings
-    performance_settings = get_merged_settings(project.id)
+    performance_settings = get_merged_settings(project)
     samples_count_threshold = performance_settings.get(
         "web_vitals_count", DEFAULT_SAMPLES_COUNT_THRESHOLD
     )

--- a/tests/sentry/issue_detection/test_consecutive_db_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_db_detector.py
@@ -248,7 +248,7 @@ class ConsecutiveDbDetectorTest(TestCase):
         event = self.create_issue_event()
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = ConsecutiveDBSpanDetector(
             settings[ConsecutiveDBSpanDetector.settings_key], event
         )
@@ -261,7 +261,7 @@ class ConsecutiveDbDetectorTest(TestCase):
             value={"consecutive_db_queries_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = ConsecutiveDBSpanDetector(
             settings[ConsecutiveDBSpanDetector.settings_key], event
         )

--- a/tests/sentry/issue_detection/test_consecutive_http_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_http_detector.py
@@ -367,7 +367,7 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         project = self.create_project()
         event = self.create_issue_event()
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = ConsecutiveHTTPSpanDetector(
             settings[ConsecutiveHTTPSpanDetector.settings_key], event
         )
@@ -380,7 +380,7 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
             value={"consecutive_http_spans_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = ConsecutiveHTTPSpanDetector(
             settings[ConsecutiveHTTPSpanDetector.settings_key], event
         )

--- a/tests/sentry/issue_detection/test_db_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_db_main_thread_detector.py
@@ -54,7 +54,7 @@ class DBMainThreadDetectorTest(TestCase):
         event = get_event("db-on-main-thread/db-on-main-thread")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
@@ -65,7 +65,7 @@ class DBMainThreadDetectorTest(TestCase):
             value={"db_on_main_thread_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
@@ -57,7 +57,7 @@ class FileIOMainThreadDetectorTest(TestCase):
         event = get_event("file-io-on-main-thread/file-io-on-main-thread")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
@@ -68,7 +68,7 @@ class FileIOMainThreadDetectorTest(TestCase):
             value={"file_io_on_main_thread_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -82,7 +82,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event = create_event(spans)
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = LargeHTTPPayloadDetector(
             settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
         )
@@ -95,7 +95,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             value={"large_http_payload_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = LargeHTTPPayloadDetector(
             settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
         )

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -314,7 +314,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             key="sentry:performance_issue_settings",
             value={"large_http_payload_filtered_paths": "/api/0/organizations/download/"},
         )
-        settings = get_detection_settings(project, organization=self.organization)
+        settings = get_detection_settings(project)
         spans = [
             create_span(
                 "http.client",
@@ -343,7 +343,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             key="sentry:performance_issue_settings",
             value={"large_http_payload_filtered_paths": "/api/0/organizations/user"},
         )
-        settings = get_detection_settings(project, organization=self.organization)
+        settings = get_detection_settings(project)
         spans = [
             create_span(
                 "http.client",

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -314,7 +314,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             key="sentry:performance_issue_settings",
             value={"large_http_payload_filtered_paths": "/api/0/organizations/download/"},
         )
-        settings = get_detection_settings(project.id, organization=self.organization)
+        settings = get_detection_settings(project, organization=self.organization)
         spans = [
             create_span(
                 "http.client",
@@ -343,7 +343,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             key="sentry:performance_issue_settings",
             value={"large_http_payload_filtered_paths": "/api/0/organizations/user"},
         )
-        settings = get_detection_settings(project.id, organization=self.organization)
+        settings = get_detection_settings(project, organization=self.organization)
         spans = [
             create_span(
                 "http.client",

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -248,7 +248,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project_id=project.id)
+        settings = get_detection_settings(project)
         assert self.find_problems(event, settings) == []
 
         # Total duration exceeds the threshold
@@ -258,7 +258,7 @@ class MNPlusOneDBDetectorTest(TestCase):
             value={"n_plus_one_db_duration_threshold": 100},
         )
 
-        settings = get_detection_settings(project_id=project.id)
+        settings = get_detection_settings(project)
         assert len(self.find_problems(event, settings)) == 1
 
     @patch("sentry.issue_detection.detectors.mn_plus_one_db_span_detector.metrics")

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -219,7 +219,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = self.detector(settings[self.detector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
@@ -230,7 +230,7 @@ class MNPlusOneDBDetectorTest(TestCase):
             value={"n_plus_one_db_queries_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = self.detector(settings[self.detector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
@@ -404,7 +404,7 @@ class NPlusOneDbSettingTest(TestCase):
         event = get_event("n-plus-one-db/n-plus-one-in-django-index-view-activerecord")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
@@ -415,7 +415,7 @@ class NPlusOneDbSettingTest(TestCase):
             value={"n_plus_one_db_queries_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -704,3 +704,186 @@ class EventPerformanceProblemTest(TestCase):
 )
 def test_total_span_time(spans: list[Span], duration: float) -> None:
     assert total_span_time(spans) == pytest.approx(duration, 0.01)
+
+
+@pytest.mark.django_db
+class WFEDetectorConfigTest(TestCase):
+    """Tests for WFE Detector config resolution in get_detection_settings"""
+
+    def test_wfe_detector_enabled_uses_wfe_config(self):
+        """When WFE Detector exists and is enabled, should use WFE config"""
+        from sentry.workflow_engine.models.detector import Detector
+
+        project = self.create_project()
+
+        # Create a WFE Detector for SlowDB with custom config
+        Detector.objects.create(
+            project=project,
+            type="performance_slow_db_query",
+            name="Test SlowDB Detector",
+            enabled=True,
+            config={"duration_threshold": 5000},  # Custom threshold (5s)
+        )
+
+        with self.feature("projects:workflow-engine-performance-detectors"):
+            settings = get_detection_settings(
+                project_id=project.id,
+                organization=project.organization,
+                project=project,
+            )
+
+        # Should use WFE config values
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
+        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]
+        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
+
+    def test_wfe_detector_disabled_still_uses_wfe_config(self):
+        """When WFE Detector exists but is disabled, should still use WFE config (not legacy)"""
+        from sentry.workflow_engine.models.detector import Detector
+
+        project = self.create_project()
+
+        # Create a disabled WFE Detector with custom threshold
+        Detector.objects.create(
+            project=project,
+            type="performance_slow_db_query",
+            name="Test SlowDB Detector",
+            enabled=False,
+            config={"duration_threshold": 5000},
+        )
+
+        # Set legacy config - this should be ignored since WFE Detector exists
+        projectoptions.set(
+            project,
+            "sentry:performance_issue_settings",
+            {
+                "slow_db_queries_detection_enabled": True,
+                "slow_db_query_duration_threshold": 2000,
+            },
+        )
+
+        with self.feature("projects:workflow-engine-performance-detectors"):
+            settings = get_detection_settings(
+                project_id=project.id,
+                organization=project.organization,
+                project=project,
+            )
+
+        # Should use WFE config values, NOT legacy config
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
+        # detection_enabled comes from Detector.enabled (False)
+        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is False
+
+    def test_no_wfe_detector_uses_legacy_config(self):
+        """When no WFE Detector exists, should use legacy config"""
+        project = self.create_project()
+
+        # Set legacy config
+        projectoptions.set(
+            project,
+            "sentry:performance_issue_settings",
+            {
+                "slow_db_queries_detection_enabled": True,
+                "slow_db_query_duration_threshold": 2000,
+            },
+        )
+
+        with self.feature("projects:workflow-engine-performance-detectors"):
+            settings = get_detection_settings(
+                project_id=project.id,
+                organization=project.organization,
+                project=project,
+            )
+
+        # Should use legacy settings
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 2000
+        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
+
+    def test_wfe_detector_missing_field_uses_system_default_not_project_option(self):
+        """When WFE Detector exists but is missing a field, use system default (not ProjectOption)"""
+        from sentry.workflow_engine.models.detector import Detector
+
+        project = self.create_project()
+
+        # Set a ProjectOption value that should be IGNORED when WFE Detector exists
+        projectoptions.set(
+            project,
+            "sentry:performance_issue_settings",
+            {"slow_db_query_duration_threshold": 2000},  # Custom ProjectOption value
+        )
+
+        # Create a WFE Detector with empty config (missing duration_threshold)
+        Detector.objects.create(
+            project=project,
+            type="performance_slow_db_query",
+            name="Test SlowDB Detector",
+            enabled=True,
+            config={},  # No duration_threshold specified
+        )
+
+        with self.feature("projects:workflow-engine-performance-detectors"):
+            settings = get_detection_settings(
+                project_id=project.id,
+                organization=project.organization,
+                project=project,
+            )
+
+        # Should use system default (1000), NOT ProjectOption value (2000)
+        # because WFE Detector exists and owns this detector's config
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
+        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
+
+    def test_wfe_detector_partial_config_uses_wfe_values_and_system_defaults(self):
+        """WFE Detector with partial config uses its values + system defaults"""
+        from sentry.workflow_engine.models.detector import Detector
+
+        project = self.create_project()
+
+        # Create a WFE Detector with duration_threshold specified
+        Detector.objects.create(
+            project=project,
+            type="performance_slow_db_query",
+            name="Test SlowDB Detector",
+            enabled=True,
+            config={"duration_threshold": 5000},
+        )
+
+        with self.feature("projects:workflow-engine-performance-detectors"):
+            settings = get_detection_settings(
+                project_id=project.id,
+                organization=project.organization,
+                project=project,
+            )
+
+        # Should use WFE value for duration_threshold
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
+        # Should use hardcoded value for allowed_span_ops
+        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]
+        # Should use Detector.enabled for detection_enabled
+        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
+
+    def test_feature_flag_disabled_uses_legacy_config(self):
+        """When feature flag is disabled, should use legacy config even if WFE Detector exists"""
+        from sentry.workflow_engine.models.detector import Detector
+
+        project = self.create_project()
+
+        # Create a WFE Detector
+        Detector.objects.create(
+            project=project,
+            type="performance_slow_db_query",
+            name="Test SlowDB Detector",
+            enabled=True,
+            config={"duration_threshold": 5000},
+        )
+
+        # Feature flag is OFF - should not use WFE config
+        settings = get_detection_settings(
+            project_id=project.id,
+            organization=project.organization,
+            project=project,
+        )
+
+        # Should use legacy settings (system default)
+        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
+        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -10,6 +10,7 @@ from sentry.issue_detection.detectors.n_plus_one_db_span_detector import NPlusOn
 from sentry.issue_detection.detectors.utils import total_span_time
 from sentry.issue_detection.performance_detection import (
     EventPerformanceProblem,
+    SettingsMode,
     _detect_performance_problems,
     detect_performance_problems,
     get_detection_settings,
@@ -26,6 +27,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.issue_detection.event_generators import get_event
 from sentry.testutils.issue_detection.experiments import exclude_experimental_detectors
+from sentry.workflow_engine.models.detector import Detector
 
 BASE_DETECTOR_OPTIONS = {
     "performance.issues.n_plus_one_db.problem-creation": 1.0,
@@ -708,42 +710,26 @@ def test_total_span_time(spans: list[Span], duration: float) -> None:
 
 @pytest.mark.django_db
 class WFEDetectorConfigTest(TestCase):
-    """Tests for WFE Detector config resolution in get_detection_settings"""
-
-    def test_wfe_detector_enabled_uses_wfe_config(self):
-        """When WFE Detector exists and is enabled, should use WFE config"""
-        from sentry.workflow_engine.models.detector import Detector
-
+    def test_wfe_detector_enabled_uses_wfe_config(self) -> None:
         project = self.create_project()
 
-        # Create a WFE Detector for SlowDB with custom config
         Detector.objects.create(
             project=project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=True,
-            config={"duration_threshold": 5000},  # Custom threshold (5s)
+            config={"duration_threshold": 5000},
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(
-                project_id=project.id,
-                organization=project.organization,
-                project=project,
-            )
+            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
 
-        # Should use WFE config values
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
-        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
-    def test_wfe_detector_disabled_still_uses_wfe_config(self):
-        """When WFE Detector exists but is disabled, should still use WFE config (not legacy)"""
-        from sentry.workflow_engine.models.detector import Detector
-
+    def test_wfe_detector_disabled_still_uses_wfe_config(self) -> None:
         project = self.create_project()
 
-        # Create a disabled WFE Detector with custom threshold
         Detector.objects.create(
             project=project,
             type="performance_slow_db_query",
@@ -752,7 +738,6 @@ class WFEDetectorConfigTest(TestCase):
             config={"duration_threshold": 5000},
         )
 
-        # Set legacy config - this should be ignored since WFE Detector exists
         projectoptions.set(
             project,
             "sentry:performance_issue_settings",
@@ -763,22 +748,14 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(
-                project_id=project.id,
-                organization=project.organization,
-                project=project,
-            )
+            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
 
-        # Should use WFE config values, NOT legacy config
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
-        # detection_enabled comes from Detector.enabled (False)
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is False
 
-    def test_no_wfe_detector_uses_legacy_config(self):
-        """When no WFE Detector exists, should use legacy config"""
+    def test_no_wfe_detector_uses_legacy_config(self) -> None:
         project = self.create_project()
 
-        # Set legacy config
         projectoptions.set(
             project,
             "sentry:performance_issue_settings",
@@ -789,57 +766,37 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(
-                project_id=project.id,
-                organization=project.organization,
-                project=project,
-            )
+            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
 
-        # Should use legacy settings
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 2000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
-    def test_wfe_detector_missing_field_uses_system_default_not_project_option(self):
-        """When WFE Detector exists but is missing a field, use system default (not ProjectOption)"""
-        from sentry.workflow_engine.models.detector import Detector
-
+    def test_wfe_detector_missing_field_uses_system_default(self) -> None:
         project = self.create_project()
 
-        # Set a ProjectOption value that should be IGNORED when WFE Detector exists
         projectoptions.set(
             project,
             "sentry:performance_issue_settings",
-            {"slow_db_query_duration_threshold": 2000},  # Custom ProjectOption value
+            {"slow_db_query_duration_threshold": 2000},
         )
 
-        # Create a WFE Detector with empty config (missing duration_threshold)
         Detector.objects.create(
             project=project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=True,
-            config={},  # No duration_threshold specified
+            config={},
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(
-                project_id=project.id,
-                organization=project.organization,
-                project=project,
-            )
+            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
 
-        # Should use system default (1000), NOT ProjectOption value (2000)
-        # because WFE Detector exists and owns this detector's config
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
-    def test_wfe_detector_partial_config_uses_wfe_values_and_system_defaults(self):
-        """WFE Detector with partial config uses its values + system defaults"""
-        from sentry.workflow_engine.models.detector import Detector
-
+    def test_feature_flag_disabled_uses_legacy_config(self) -> None:
         project = self.create_project()
 
-        # Create a WFE Detector with duration_threshold specified
         Detector.objects.create(
             project=project,
             type="performance_slow_db_query",
@@ -848,42 +805,6 @@ class WFEDetectorConfigTest(TestCase):
             config={"duration_threshold": 5000},
         )
 
-        with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(
-                project_id=project.id,
-                organization=project.organization,
-                project=project,
-            )
+        settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
 
-        # Should use WFE value for duration_threshold
-        assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
-        # Should use hardcoded value for allowed_span_ops
-        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]
-        # Should use Detector.enabled for detection_enabled
-        assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
-
-    def test_feature_flag_disabled_uses_legacy_config(self):
-        """When feature flag is disabled, should use legacy config even if WFE Detector exists"""
-        from sentry.workflow_engine.models.detector import Detector
-
-        project = self.create_project()
-
-        # Create a WFE Detector
-        Detector.objects.create(
-            project=project,
-            type="performance_slow_db_query",
-            name="Test SlowDB Detector",
-            enabled=True,
-            config={"duration_threshold": 5000},
-        )
-
-        # Feature flag is OFF - should not use WFE config
-        settings = get_detection_settings(
-            project_id=project.id,
-            organization=project.organization,
-            project=project,
-        )
-
-        # Should use legacy settings (system default)
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
-        assert settings[DetectorType.SLOW_DB_QUERY]["allowed_span_ops"] == ["db"]

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -27,7 +27,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.issue_detection.event_generators import get_event
 from sentry.testutils.issue_detection.experiments import exclude_experimental_detectors
-from sentry.workflow_engine.models.detector import Detector
 
 BASE_DETECTOR_OPTIONS = {
     "performance.issues.n_plus_one_db.problem-creation": 1.0,
@@ -710,11 +709,13 @@ def test_total_span_time(spans: list[Span], duration: float) -> None:
 
 @pytest.mark.django_db
 class WFEDetectorConfigTest(TestCase):
-    def test_wfe_detector_enabled_uses_wfe_config(self) -> None:
-        project = self.create_project()
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
 
-        Detector.objects.create(
-            project=project,
+    def test_wfe_detector_enabled_uses_wfe_config(self) -> None:
+        self.create_detector(
+            project=self.project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=True,
@@ -722,16 +723,14 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
+            settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
     def test_wfe_detector_disabled_still_uses_wfe_config(self) -> None:
-        project = self.create_project()
-
-        Detector.objects.create(
-            project=project,
+        self.create_detector(
+            project=self.project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=False,
@@ -739,7 +738,7 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         projectoptions.set(
-            project,
+            self.project,
             "sentry:performance_issue_settings",
             {
                 "slow_db_queries_detection_enabled": True,
@@ -748,16 +747,14 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
+            settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 5000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is False
 
     def test_no_wfe_detector_uses_legacy_config(self) -> None:
-        project = self.create_project()
-
         projectoptions.set(
-            project,
+            self.project,
             "sentry:performance_issue_settings",
             {
                 "slow_db_queries_detection_enabled": True,
@@ -766,22 +763,20 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
+            settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 2000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
     def test_wfe_detector_missing_field_uses_system_default(self) -> None:
-        project = self.create_project()
-
         projectoptions.set(
-            project,
+            self.project,
             "sentry:performance_issue_settings",
             {"slow_db_query_duration_threshold": 2000},
         )
 
-        Detector.objects.create(
-            project=project,
+        self.create_detector(
+            project=self.project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=True,
@@ -789,22 +784,20 @@ class WFEDetectorConfigTest(TestCase):
         )
 
         with self.feature("projects:workflow-engine-performance-detectors"):
-            settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
+            settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
         assert settings[DetectorType.SLOW_DB_QUERY]["detection_enabled"] is True
 
     def test_feature_flag_disabled_uses_legacy_config(self) -> None:
-        project = self.create_project()
-
-        Detector.objects.create(
-            project=project,
+        self.create_detector(
+            project=self.project,
             type="performance_slow_db_query",
             name="Test SlowDB Detector",
             enabled=True,
             config={"duration_threshold": 5000},
         )
 
-        settings = get_detection_settings(project, settings_mode=SettingsMode.WFE)
+        settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -9,6 +9,7 @@ from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.n_plus_one_db_span_detector import NPlusOneDBSpanDetector
 from sentry.issue_detection.detectors.utils import total_span_time
 from sentry.issue_detection.performance_detection import (
+    PERFORMANCE_DETECTOR_CONFIG_MAPPINGS,
     EventPerformanceProblem,
     SettingsMode,
     _detect_performance_problems,
@@ -21,6 +22,7 @@ from sentry.issues.grouptype import (
     PerformanceConsecutiveHTTPQueriesGroupType,
     PerformanceNPlusOneGroupType,
     PerformanceSlowDBQueryGroupType,
+    registry,
 )
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
@@ -801,3 +803,10 @@ class WFEDetectorConfigTest(TestCase):
         settings = get_detection_settings(self.project, settings_mode=SettingsMode.WFE)
 
         assert settings[DetectorType.SLOW_DB_QUERY]["duration_threshold"] == 1000
+
+    def test_all_wfe_detector_types_are_registered_group_types(self) -> None:
+        for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+            group_type = registry.get_by_slug(mapping.wfe_detector_type)
+            assert (
+                group_type is not None
+            ), f"wfe_detector_type '{mapping.wfe_detector_type}' is not a registered GroupType slug"

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -353,7 +353,7 @@ class PerformanceDetectionTest(TestCase):
         sdk_span_mock = Mock()
 
         self.project_option_mock.return_value = projectoptions.get_well_known_default(
-            "sentry:performance_issue_settings", project=1
+            "sentry:performance_issue_settings", project=self.project
         )
         with override_options(
             {
@@ -718,7 +718,7 @@ class WFEDetectorConfigTest(TestCase):
     def test_wfe_detector_enabled_uses_wfe_config(self) -> None:
         self.create_detector(
             project=self.project,
-            type="performance_slow_db_query",
+            type=PerformanceSlowDBQueryGroupType.slug,
             name="Test SlowDB Detector",
             enabled=True,
             config={"duration_threshold": 5000},
@@ -733,7 +733,7 @@ class WFEDetectorConfigTest(TestCase):
     def test_wfe_detector_disabled_still_uses_wfe_config(self) -> None:
         self.create_detector(
             project=self.project,
-            type="performance_slow_db_query",
+            type=PerformanceSlowDBQueryGroupType.slug,
             name="Test SlowDB Detector",
             enabled=False,
             config={"duration_threshold": 5000},
@@ -779,7 +779,7 @@ class WFEDetectorConfigTest(TestCase):
 
         self.create_detector(
             project=self.project,
-            type="performance_slow_db_query",
+            type=PerformanceSlowDBQueryGroupType.slug,
             name="Test SlowDB Detector",
             enabled=True,
             config={},
@@ -794,7 +794,7 @@ class WFEDetectorConfigTest(TestCase):
     def test_feature_flag_disabled_uses_legacy_config(self) -> None:
         self.create_detector(
             project=self.project,
-            type="performance_slow_db_query",
+            type=PerformanceSlowDBQueryGroupType.slug,
             name="Test SlowDB Detector",
             enabled=True,
             config={"duration_threshold": 5000},
@@ -807,6 +807,6 @@ class WFEDetectorConfigTest(TestCase):
     def test_all_wfe_detector_types_are_registered_group_types(self) -> None:
         for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
             group_type = registry.get_by_slug(mapping.wfe_detector_type)
-            assert (
-                group_type is not None
-            ), f"wfe_detector_type '{mapping.wfe_detector_type}' is not a registered GroupType slug"
+            assert group_type is not None, (
+                f"wfe_detector_type '{mapping.wfe_detector_type}' is not a registered GroupType slug"
+            )

--- a/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
+++ b/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
@@ -95,7 +95,7 @@ class RenderBlockingAssetDetectorTest(TestCase):
         event = _valid_render_blocking_asset_event("https://example.com/a.js")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = RenderBlockingAssetSpanDetector(
             settings[RenderBlockingAssetSpanDetector.settings_key], event
         )
@@ -108,7 +108,7 @@ class RenderBlockingAssetDetectorTest(TestCase):
             value={"large_render_blocking_asset_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = RenderBlockingAssetSpanDetector(
             settings[RenderBlockingAssetSpanDetector.settings_key], event
         )

--- a/tests/sentry/issue_detection/test_slow_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_slow_db_span_detector.py
@@ -140,7 +140,7 @@ class SlowDBQueryDetectorTest(TestCase):
         )
         slow_span_event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
         assert detector.is_creation_allowed_for_project(project)
@@ -151,7 +151,7 @@ class SlowDBQueryDetectorTest(TestCase):
             value={"slow_db_queries_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
+++ b/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
@@ -425,7 +425,7 @@ class UncompressedAssetsDetectorTest(TestCase):
         event = get_event("uncompressed-assets/uncompressed-script-asset")
         event["project_id"] = project.id
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = UncompressedAssetSpanDetector(
             settings[UncompressedAssetSpanDetector.settings_key], event
         )
@@ -438,7 +438,7 @@ class UncompressedAssetsDetectorTest(TestCase):
             value={"uncompressed_assets_detection_enabled": False},
         )
 
-        settings = get_detection_settings(project.id)
+        settings = get_detection_settings(project)
         detector = UncompressedAssetSpanDetector(
             settings[UncompressedAssetSpanDetector.settings_key], event
         )


### PR DESCRIPTION
Extend get_merged_settings with a mode parameter that allows us to maintain current operation ("LEGACY", the default, negligible performance cost), read configs from Detector rows and compare them to legacy config ("COMPARE", not yet suitable for prod use at scale), or actually use configs from Detector rows and not ProjectOption configs ("WFE" mode).

We don't currently have Detector rows for performance issues and the flags aren't enabled, so in practice this isn't yet code that will run, but we'll soon be dual-writing and opting in some test projects.

Resolves ISWF-1922. 