### PR TITLE
✨ feat(gitlab): add inbound status sync support

### DIFF
--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -426,6 +426,156 @@ ISSUE_UNASSIGNED_EVENT = b"""{
 }
 """
 
+ISSUE_CLOSED_EVENT = b"""{
+  "object_kind": "issue",
+  "event_type": "issue",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 15,
+    "name": "Sentry",
+    "description": "",
+    "web_url": "http://example.com/cool-group/sentry",
+    "avatar_url": null,
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
+    "visibility_level": 0,
+    "path_with_namespace": "cool-group/sentry",
+    "default_branch": "master",
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
+  },
+  "object_attributes": {
+    "id": 301,
+    "title": "Test issue",
+    "assignee_ids": [],
+    "assignee_id": null,
+    "author_id": 1,
+    "project_id": 15,
+    "created_at": "2023-01-01 00:00:00 UTC",
+    "updated_at": "2023-01-01 00:00:00 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "Test issue description",
+    "milestone_id": null,
+    "state": "closed",
+    "iid": 23,
+    "url": "http://example.com/cool-group/sentry/issues/23",
+    "action": "close"
+  },
+  "assignees": [],
+  "labels": []
+}
+"""
+
+ISSUE_REOPENED_EVENT = b"""{
+  "object_kind": "issue",
+  "event_type": "issue",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 15,
+    "name": "Sentry",
+    "description": "",
+    "web_url": "http://example.com/cool-group/sentry",
+    "avatar_url": null,
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
+    "visibility_level": 0,
+    "path_with_namespace": "cool-group/sentry",
+    "default_branch": "master",
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
+  },
+  "object_attributes": {
+    "id": 301,
+    "title": "Test issue",
+    "assignee_ids": [],
+    "assignee_id": null,
+    "author_id": 1,
+    "project_id": 15,
+    "created_at": "2023-01-01 00:00:00 UTC",
+    "updated_at": "2023-01-01 00:00:00 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "Test issue description",
+    "milestone_id": null,
+    "state": "opened",
+    "iid": 23,
+    "url": "http://example.com/cool-group/sentry/issues/23",
+    "action": "reopen"
+  },
+  "assignees": [],
+  "labels": []
+}
+"""
+
+ISSUE_OPENED_EVENT = b"""{
+  "object_kind": "issue",
+  "event_type": "issue",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 15,
+    "name": "Sentry",
+    "description": "",
+    "web_url": "http://example.com/cool-group/sentry",
+    "avatar_url": null,
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
+    "visibility_level": 0,
+    "path_with_namespace": "cool-group/sentry",
+    "default_branch": "master",
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
+  },
+  "object_attributes": {
+    "id": 301,
+    "title": "Test issue",
+    "assignee_ids": [],
+    "assignee_id": null,
+    "author_id": 1,
+    "project_id": 15,
+    "created_at": "2023-01-01 00:00:00 UTC",
+    "updated_at": "2023-01-01 00:00:00 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "Test issue description",
+    "milestone_id": null,
+    "state": "opened",
+    "iid": 23,
+    "url": "http://example.com/cool-group/sentry/issues/23",
+    "action": "open"
+  },
+  "assignees": [],
+  "labels": []
+}
+"""
+
 COMPARE_RESPONSE = r"""
 {
   "commit": {

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -226,6 +226,30 @@ class GitlabIntegration(
                         "label": _("Sync Sentry Comments to GitLab"),
                         "help": _("Post comments from Sentry issues to linked GitLab issues"),
                     },
+                    {
+                        "name": self.inbound_status_key,
+                        "type": "boolean",
+                        "label": _("Sync GitLab Status to Sentry"),
+                        "help": _(
+                            "When a GitLab issue is marked closed, resolve its linked issue in Sentry. "
+                            "When a GitLab issue is reopened, unresolve its linked Sentry issue."
+                        ),
+                        "default": False,
+                    },
+                    {
+                        "name": self.resolution_strategy_key,
+                        "label": "Resolve",
+                        "type": "select",
+                        "placeholder": "Resolve",
+                        "choices": [
+                            ("resolve", "Resolve"),
+                            ("resolve_current_release", "Resolve in Current Release"),
+                            ("resolve_next_release", "Resolve in Next Release"),
+                        ],
+                        "help": _(
+                            "Select what action to take on Sentry Issue when GitLab ticket is marked Closed."
+                        ),
+                    },
                 ]
             )
 

--- a/src/sentry/integrations/gitlab/issue_sync.py
+++ b/src/sentry/integrations/gitlab/issue_sync.py
@@ -22,6 +22,8 @@ class GitlabIssueSyncSpec(IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_assignee_key = "sync_forward_assignment"
     inbound_assignee_key = "sync_reverse_assignment"
+    inbound_status_key = "sync_status_reverse"
+    resolution_strategy_key = "resolution_strategy"
 
     def check_feature_flag(self) -> bool:
         """
@@ -169,6 +171,16 @@ class GitlabIssueSyncSpec(IssueSyncIntegration):
         Given webhook data, check whether the GitLab issue status changed.
         GitLab issues have opened/closed state.
         """
+        if not self.check_feature_flag():
+            return ResolveSyncAction.NOOP
+
+        action = data.get("action")
+
+        if action == "close":
+            return ResolveSyncAction.RESOLVE
+        elif action == "reopen":
+            return ResolveSyncAction.UNRESOLVE
+
         return ResolveSyncAction.NOOP
 
     def get_config_data(self):

--- a/src/sentry/integrations/gitlab/issue_sync.py
+++ b/src/sentry/integrations/gitlab/issue_sync.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import quote
 
 from sentry import features
+from sentry.integrations.gitlab.types import GitLabIssueAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration, ResolveSyncAction
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -176,9 +177,9 @@ class GitlabIssueSyncSpec(IssueSyncIntegration):
 
         action = data.get("action")
 
-        if action == "close":
+        if action == GitLabIssueAction.CLOSE:
             return ResolveSyncAction.RESOLVE
-        elif action == "reopen":
+        elif action == GitLabIssueAction.REOPEN:
             return ResolveSyncAction.UNRESOLVE
 
         return ResolveSyncAction.NOOP

--- a/src/sentry/integrations/gitlab/types.py
+++ b/src/sentry/integrations/gitlab/types.py
@@ -1,20 +1,11 @@
 from enum import StrEnum
 
 
-class GitLabIssueStatus(StrEnum):
-    OPENED = "opened"
-    CLOSED = "closed"
-
-    @classmethod
-    def get_choices(cls):
-        """Return choices formatted for dropdown selectors"""
-        return [(status.value, status.value.capitalize()) for status in cls]
-
-
 class GitLabIssueAction(StrEnum):
     UPDATE = "update"
     OPEN = "open"
     REOPEN = "reopen"
+    CLOSE = "close"
 
     @classmethod
     def values(cls):

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -19,6 +19,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.gitlab.types import GitLabIssueAction
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.webhook import SCMWebhook
@@ -148,6 +149,10 @@ class IssuesEventWebhook(GitlabWebhook):
         if action in GitLabIssueAction.values():
             self._handle_assignment(integration, event, external_issue_key)
 
+        # Handle status changes (CLOSE and REOPEN)
+        if action in [GitLabIssueAction.CLOSE, GitLabIssueAction.REOPEN]:
+            self._handle_status_change(integration, external_issue_key, action)
+
     def _handle_assignment(
         self,
         integration: RpcIntegration,
@@ -215,6 +220,36 @@ class IssuesEventWebhook(GitlabWebhook):
                 "total_assignees": len(assignees),
             },
         )
+
+    def _handle_status_change(
+        self,
+        integration: RpcIntegration,
+        external_issue_key: str,
+        action: str,
+    ) -> None:
+        """
+        Handle issue status changes (close/reopen).
+
+        Triggers the sync_status_inbound task to update linked Sentry issues.
+        """
+        org_integrations = integration_service.get_organization_integrations(
+            integration_id=integration.id
+        )
+        for org_integration in org_integrations:
+            installation = integration.get_installation(org_integration.organization_id)
+            if isinstance(installation, IssueSyncIntegration):
+                installation.sync_status_inbound(
+                    external_issue_key,
+                    {"action": action},
+                )
+                logger.info(
+                    "gitlab.webhook.status.synced",
+                    extra={
+                        "integration_id": integration.id,
+                        "external_issue_key": external_issue_key,
+                        "action": action,
+                    },
+                )
 
     def _extract_issue_key(
         self, event: Mapping[str, Any], integration: RpcIntegration

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -17,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.gitlab.types import GitLabIssueAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
@@ -130,6 +131,7 @@ class IssuesEventWebhook(GitlabWebhook):
     def __call__(self, event: Mapping[str, Any], **kwargs):
         if not (integration := kwargs.get("integration")):
             raise ValueError("Integration must be provided")
+        organization: RpcOrganization | None = kwargs.get("organization")
 
         external_issue_key = self._extract_issue_key(event, integration)
         if not external_issue_key:
@@ -145,13 +147,13 @@ class IssuesEventWebhook(GitlabWebhook):
         object_attributes = event.get("object_attributes", {})
         action = object_attributes.get("action")
 
-        # Handle assignment changes
-        if action in GitLabIssueAction.values():
+        # Handle assignment changes — CLOSE does not affect assignment
+        if action in GitLabIssueAction.values() and action != GitLabIssueAction.CLOSE:
             self._handle_assignment(integration, event, external_issue_key)
 
         # Handle status changes (CLOSE and REOPEN)
-        if action in [GitLabIssueAction.CLOSE, GitLabIssueAction.REOPEN]:
-            self._handle_status_change(integration, external_issue_key, action)
+        if action in [GitLabIssueAction.CLOSE, GitLabIssueAction.REOPEN] and organization:
+            self._handle_status_change(integration, external_issue_key, action, organization.id)
 
     def _handle_assignment(
         self,
@@ -226,6 +228,7 @@ class IssuesEventWebhook(GitlabWebhook):
         integration: RpcIntegration,
         external_issue_key: str,
         action: str,
+        organization_id: int,
     ) -> None:
         """
         Handle issue status changes (close/reopen).
@@ -233,7 +236,10 @@ class IssuesEventWebhook(GitlabWebhook):
         Triggers the sync_status_inbound task to update linked Sentry issues.
         """
         org_integrations = integration_service.get_organization_integrations(
-            integration_id=integration.id
+            integration_id=integration.id,
+            organization_id=organization_id,
+            providers=[integration.provider],
+            status=ObjectStatus.ACTIVE,
         )
         for org_integration in org_integrations:
             installation = integration.get_installation(org_integration.organization_id)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -839,6 +839,8 @@ class GitlabIssueSyncTest(GitLabTestCase):
             "sync_reverse_assignment",
             "sync_forward_assignment",
             "sync_comments",
+            "sync_status_reverse",
+            "resolution_strategy",
         ]
 
     @responses.activate

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -5,6 +5,9 @@ import orjson
 from fixtures.gitlab import (
     EXTERNAL_ID,
     ISSUE_ASSIGNED_EVENT,
+    ISSUE_CLOSED_EVENT,
+    ISSUE_OPENED_EVENT,
+    ISSUE_REOPENED_EVENT,
     ISSUE_UNASSIGNED_EVENT,
     MERGE_REQUEST_OPENED_EVENT,
     PUSH_EVENT,
@@ -490,3 +493,68 @@ class WebhookTest(GitLabTestCase):
             call_args[1]["external_issue_key"] == "example.gitlab.com/group-x:cool-group/sentry#23"
         )
         assert call_args[1]["assign"] is False
+
+
+class TestIssuesEventWebhookStatusSync(GitLabTestCase):
+    url = "/extensions/gitlab/webhook/"
+
+    @patch("sentry.integrations.gitlab.integration.GitlabIntegration.sync_status_inbound")
+    def test_close_event_triggers_sync(self, mock_sync_status: MagicMock) -> None:
+        response = self.client.post(
+            self.url,
+            data=ISSUE_CLOSED_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Issue Hook",
+        )
+        assert response.status_code == 204
+
+        assert mock_sync_status.called
+        call_args = mock_sync_status.call_args
+        assert call_args[0][0] == "example.gitlab.com/group-x:cool-group/sentry#23"
+        assert call_args[0][1] == {"action": "close"}
+
+    @patch("sentry.integrations.gitlab.integration.GitlabIntegration.sync_status_inbound")
+    def test_reopen_event_triggers_sync(self, mock_sync_status: MagicMock) -> None:
+        response = self.client.post(
+            self.url,
+            data=ISSUE_REOPENED_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Issue Hook",
+        )
+        assert response.status_code == 204
+
+        assert mock_sync_status.called
+        call_args = mock_sync_status.call_args
+        assert call_args[0][0] == "example.gitlab.com/group-x:cool-group/sentry#23"
+        assert call_args[0][1] == {"action": "reopen"}
+
+    @patch("sentry.integrations.gitlab.integration.GitlabIntegration.sync_status_inbound")
+    def test_open_event_does_not_trigger_sync(self, mock_sync_status: MagicMock) -> None:
+        response = self.client.post(
+            self.url,
+            data=ISSUE_OPENED_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Issue Hook",
+        )
+        assert response.status_code == 204
+
+        assert not mock_sync_status.called
+
+    @patch("sentry.integrations.gitlab.integration.GitlabIntegration.sync_status_inbound")
+    def test_sync_called_with_correct_params(self, mock_sync_status: MagicMock) -> None:
+        response = self.client.post(
+            self.url,
+            data=ISSUE_CLOSED_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Issue Hook",
+        )
+        assert response.status_code == 204
+
+        assert mock_sync_status.called
+        call_args = mock_sync_status.call_args
+        assert call_args[0][0] == "example.gitlab.com/group-x:cool-group/sentry#23"
+        assert call_args[0][1]["action"] == "close"


### PR DESCRIPTION
Adding Issue Sync Inbound Support for Gitlab. Very similar implementation to Github


https://github.com/user-attachments/assets/f29ccb1a-1591-4690-9bf3-b56b08125bfe



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
