### PR TITLE
fix(ai-conversations): use correct query params in converstaion details page

### DIFF
--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -170,9 +171,7 @@ export function useConversation(
   const queryParams = {
     project: selection.projects,
     environment: selection.environments,
-    statsPeriod: selection.datetime.period,
-    start: selection.datetime.start,
-    end: selection.datetime.end,
+    ...normalizeDateTimeParams(selection.datetime),
   };
 
   const conversationQuery = useApiQuery<ConversationApiSpan[]>(


### PR DESCRIPTION
We weren't handling attributes correctly, which resulted in sometimes sending empty `statsPeriod` which triggered 400 from server. There is already existing util which we should use that takes care of this

Closes [TET-1773: Failed to load conversations](https://linear.app/getsentry/issue/TET-1773/failed-to-load-conversations)