### PR TITLE
feat(preprod): Update pydantic models to include new flagged_insights field (EME-372)

### DIFF
--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -81,6 +81,7 @@ class TreemapElement(BaseModel):
     """ Some files (like zip files) are not directories but have children. """
     children: list[TreemapElement]
     misc: TreemapElementMisc | None = None
+    flagged_insights: list[str] = []
 
 
 class TreemapResults(BaseModel):

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -37,7 +37,15 @@ class CompareSizeAnalysisTest(TestCase):
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
 
-    def _create_treemap_element(self, name, size, path=None, children=None, element_type="files"):
+    def _create_treemap_element(
+        self,
+        name,
+        size,
+        path=None,
+        children=None,
+        element_type="files",
+        flagged_insights: list[str] | None = None,
+    ):
         return TreemapElement(
             name=name,
             size=size,
@@ -45,6 +53,7 @@ class CompareSizeAnalysisTest(TestCase):
             is_dir=children is not None,
             type=element_type,
             children=children or [],
+            flagged_insights=flagged_insights or [],
         )
 
     def _create_file_info(self, path: str, hash_value: str, children=None) -> FileInfo:


### PR DESCRIPTION
# Add `flagged_insights` field to TreemapElement model

Added a new `flagged_insights` list field to the `TreemapElement` model to store insights that have been flagged for a particular element. Also updated the test helper method `_create_treemap_element()` to accept this new field as an optional parameter.

Requires the merging of https://github.com/getsentry/launchpad/pull/546