### PR TITLE
feat(preprod): Add frontend support for treemap insights (EME-372)

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -285,6 +285,15 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     }
   };
 
+  // Determine if insights highlighting is available:
+  // 1. The treemap must have flagged_insights support (new schema)
+  // 2. There must be at least one insight in the insights object
+  const hasFlaggedInsightsSupport =
+    appSizeData.treemap.root && 'flagged_insights' in appSizeData.treemap.root;
+  const hasAnyInsights =
+    appSizeData.insights && Object.keys(appSizeData.insights).length > 0;
+  const insightsAvailable = hasFlaggedInsightsSupport && hasAnyInsights;
+
   // Filter data based on search query and categories
   const filteredRoot = filterTreemapElement(
     appSizeData.treemap.root,
@@ -317,6 +326,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             onSearchChange={value => setSearchQuery(value || undefined)}
             highlightInsights={highlightInsights}
             onHighlightInsightsChange={setHighlightInsights}
+            insightsAvailable={insightsAvailable}
           />
         ) : (
           <Alert variant="info">No files found matching "{searchQuery}"</Alert>
@@ -339,6 +349,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         onSearchChange={value => setSearchQuery(value || undefined)}
         highlightInsights={highlightInsights}
         onHighlightInsightsChange={setHighlightInsights}
+        insightsAvailable={insightsAvailable}
       />
     ) : (
       <Alert variant="info">No files found matching "{searchQuery}"</Alert>

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -288,10 +288,10 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // Determine if insights highlighting is available:
   // 1. The treemap must have flagged_insights support (new schema)
   // 2. There must be at least one insight in the insights object
-  const hasFlaggedInsightsSupport =
-    appSizeData.treemap.root && 'flagged_insights' in appSizeData.treemap.root;
-  const hasAnyInsights =
-    appSizeData.insights && Object.keys(appSizeData.insights).length > 0;
+  const hasFlaggedInsightsSupport = 'flagged_insights' in appSizeData.treemap.root;
+  const hasAnyInsights = appSizeData.insights
+    ? Object.keys(appSizeData.insights).length > 0
+    : false;
   const insightsAvailable = hasFlaggedInsightsSupport && hasAnyInsights;
 
   // Filter data based on search query and categories

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import styled from '@emotion/styled';
+import {parseAsBoolean, useQueryState} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -88,6 +89,11 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   const [searchQuery, setSearchQuery] = useQueryParamState<string>({
     fieldName: 'search',
   });
+
+  const [highlightInsights, setHighlightInsights] = useQueryState(
+    'highlightInsights',
+    parseAsBoolean.withDefault(true)
+  );
 
   const [selectedCategoriesParam, setSelectedCategoriesParam] =
     useQueryParamState<string>({
@@ -309,6 +315,8 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
                 : undefined
             }
             onSearchChange={value => setSearchQuery(value || undefined)}
+            highlightInsights={highlightInsights}
+            onHighlightInsightsChange={setHighlightInsights}
           />
         ) : (
           <Alert variant="info">No files found matching "{searchQuery}"</Alert>
@@ -329,6 +337,8 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             : undefined
         }
         onSearchChange={value => setSearchQuery(value || undefined)}
+        highlightInsights={highlightInsights}
+        onHighlightInsightsChange={setHighlightInsights}
       />
     ) : (
       <Alert variant="info">No files found matching "{searchQuery}"</Alert>

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -35,6 +35,7 @@ interface AppSizeTreemapProps {
   searchQuery: string;
   alertMessage?: string;
   highlightInsights?: boolean;
+  insightsAvailable?: boolean;
   onAlertClick?: () => void;
   onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
@@ -49,11 +50,13 @@ function FullscreenModalContent({
   onSearchChange,
   initialHighlightInsights,
   onHighlightInsightsChange,
+  insightsAvailable,
 }: {
   initialSearch: string;
   unfilteredRoot: TreemapElement;
   alertMessage?: string;
   initialHighlightInsights?: boolean;
+  insightsAvailable?: boolean;
   onAlertClick?: () => void;
   onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
@@ -106,6 +109,7 @@ function FullscreenModalContent({
           onAlertClick={onAlertClick}
           highlightInsights={localHighlightInsights}
           onHighlightInsightsChange={handleHighlightInsightsChange}
+          insightsAvailable={insightsAvailable}
         />
       </Container>
     </Flex>
@@ -123,6 +127,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     onSearchChange,
     highlightInsights,
     onHighlightInsightsChange,
+    insightsAvailable,
   } = props;
   const appSizeCategoryInfo = getAppSizeCategoryInfo(theme);
   const renderingContext = useContext(ChartRenderingContext);
@@ -380,14 +385,18 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
   };
 
   const treemapControlButtons: TreemapControlButton[] = [
-    {
-      ariaLabel: t('Toggle Insight Highlighting'),
-      title: highlightInsights ? t('Hide Insights') : t('Insights'),
-      icon: <IconLightning />,
-      onClick: () => onHighlightInsightsChange?.(!highlightInsights),
-      disabled: false,
-      active: highlightInsights,
-    },
+    ...(insightsAvailable
+      ? [
+          {
+            ariaLabel: t('Toggle Insight Highlighting'),
+            title: highlightInsights ? t('Hide Insights') : t('Insights'),
+            icon: <IconLightning />,
+            onClick: () => onHighlightInsightsChange?.(!highlightInsights),
+            disabled: false,
+            active: highlightInsights,
+          },
+        ]
+      : []),
     {
       ariaLabel: t('Recenter View'),
       title: t('Recenter'),
@@ -415,6 +424,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
               onSearchChange={onSearchChange}
               initialHighlightInsights={highlightInsights}
               onHighlightInsightsChange={onHighlightInsightsChange}
+              insightsAvailable={insightsAvailable}
             />
           ) : (
             <Container height="100%" width="100%">
@@ -425,6 +435,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
                 onAlertClick={onAlertClick}
                 highlightInsights={highlightInsights}
                 onHighlightInsightsChange={onHighlightInsightsChange}
+                insightsAvailable={insightsAvailable}
               />
             </Container>
           ),

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -47,23 +47,31 @@ function FullscreenModalContent({
   alertMessage,
   onAlertClick,
   onSearchChange,
-  highlightInsights,
+  initialHighlightInsights,
   onHighlightInsightsChange,
 }: {
   initialSearch: string;
   unfilteredRoot: TreemapElement;
   alertMessage?: string;
-  highlightInsights?: boolean;
+  initialHighlightInsights?: boolean;
   onAlertClick?: () => void;
   onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
 }) {
   const [localSearch, setLocalSearch] = useState(initialSearch);
+  const [localHighlightInsights, setLocalHighlightInsights] = useState(
+    initialHighlightInsights ?? false
+  );
   const filteredRoot = filterTreemapElement(unfilteredRoot, localSearch, '');
 
   const handleSearchChange = (value: string) => {
     setLocalSearch(value);
     onSearchChange?.(value);
+  };
+
+  const handleHighlightInsightsChange = (enabled: boolean) => {
+    setLocalHighlightInsights(enabled);
+    onHighlightInsightsChange?.(enabled);
   };
 
   return (
@@ -96,8 +104,8 @@ function FullscreenModalContent({
           searchQuery={localSearch}
           alertMessage={alertMessage}
           onAlertClick={onAlertClick}
-          highlightInsights={highlightInsights}
-          onHighlightInsightsChange={onHighlightInsightsChange}
+          highlightInsights={localHighlightInsights}
+          onHighlightInsightsChange={handleHighlightInsightsChange}
         />
       </Container>
     </Flex>
@@ -405,7 +413,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
               alertMessage={alertMessage}
               onAlertClick={onAlertClick}
               onSearchChange={onSearchChange}
-              highlightInsights={highlightInsights}
+              initialHighlightInsights={highlightInsights}
               onHighlightInsightsChange={onHighlightInsightsChange}
             />
           ) : (

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -63,7 +63,7 @@ function FullscreenModalContent({
 }) {
   const [localSearch, setLocalSearch] = useState(initialSearch);
   const [localHighlightInsights, setLocalHighlightInsights] = useState(
-    initialHighlightInsights ?? false
+    initialHighlightInsights ?? true
   );
   const filteredRoot = filterTreemapElement(unfilteredRoot, localSearch, '');
 

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -11,7 +11,13 @@ import {Heading} from '@sentry/scraps/text';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
-import {IconClose, IconContract, IconExpand, IconSearch} from 'sentry/icons';
+import {
+  IconClose,
+  IconContract,
+  IconExpand,
+  IconLightning,
+  IconSearch,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {ChartRenderingContext} from 'sentry/views/insights/common/components/chart';
@@ -21,13 +27,16 @@ import {
   type TreemapControlButton,
 } from 'sentry/views/preprod/components/visualizations/treemapControlButtons';
 import {TreemapType, type TreemapElement} from 'sentry/views/preprod/types/appSizeTypes';
+import {getInsightConfig} from 'sentry/views/preprod/utils/insightProcessing';
 import {filterTreemapElement} from 'sentry/views/preprod/utils/treemapFiltering';
 
 interface AppSizeTreemapProps {
   root: TreemapElement | null;
   searchQuery: string;
   alertMessage?: string;
+  highlightInsights?: boolean;
   onAlertClick?: () => void;
+  onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
   unfilteredRoot?: TreemapElement;
 }
@@ -38,11 +47,15 @@ function FullscreenModalContent({
   alertMessage,
   onAlertClick,
   onSearchChange,
+  highlightInsights,
+  onHighlightInsightsChange,
 }: {
   initialSearch: string;
   unfilteredRoot: TreemapElement;
   alertMessage?: string;
+  highlightInsights?: boolean;
   onAlertClick?: () => void;
+  onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
 }) {
   const [localSearch, setLocalSearch] = useState(initialSearch);
@@ -83,6 +96,8 @@ function FullscreenModalContent({
           searchQuery={localSearch}
           alertMessage={alertMessage}
           onAlertClick={onAlertClick}
+          highlightInsights={highlightInsights}
+          onHighlightInsightsChange={onHighlightInsightsChange}
         />
       </Container>
     </Flex>
@@ -91,8 +106,16 @@ function FullscreenModalContent({
 
 export function AppSizeTreemap(props: AppSizeTreemapProps) {
   const theme = useTheme();
-  const {root, searchQuery, unfilteredRoot, alertMessage, onAlertClick, onSearchChange} =
-    props;
+  const {
+    root,
+    searchQuery,
+    unfilteredRoot,
+    alertMessage,
+    onAlertClick,
+    onSearchChange,
+    highlightInsights,
+    onHighlightInsightsChange,
+  } = props;
   const appSizeCategoryInfo = getAppSizeCategoryInfo(theme);
   const renderingContext = useContext(ChartRenderingContext);
   const isFullscreen = renderingContext?.isFullscreen ?? false;
@@ -127,8 +150,13 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
 
     // Use headerColor for parent nodes, regular color for leaf nodes
     const hasChildren = element.children && element.children.length > 0;
-    const borderColor =
-      hasChildren && categoryInfo.translucentColor
+    const hasFlaggedInsights =
+      element.flagged_insights && element.flagged_insights.length > 0;
+    const shouldHighlight = highlightInsights && hasFlaggedInsights;
+
+    const borderColor = shouldHighlight
+      ? theme.colors.red400
+      : hasChildren && categoryInfo.translucentColor
         ? categoryInfo.translucentColor
         : categoryInfo.color;
 
@@ -138,6 +166,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       path: element.path,
       category: element.type,
       misc: element.misc,
+      flaggedInsights: element.flagged_insights,
       itemStyle: {
         color: 'transparent',
         borderColor,
@@ -310,10 +339,17 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       const percent = ((value / totalSize) * 100).toFixed(2);
       const pathElement = params.data?.path
         ? `<p style="font-size: 12px; margin-bottom: -4px;">${params.data.path}</p>`
-        : null;
+        : '';
       const scaleElement = params.data?.misc?.scale
         ? `<span style="font-size: 10px; background-color: ${theme.tokens.background.secondary}; color: ${theme.tokens.content.primary}; padding: 4px; border-radius: 3px; font-weight: normal;">@${params.data.misc.scale}x</span>`
         : '';
+      const flaggedInsights: string[] = params.data?.flaggedInsights || [];
+      const insightBadgesHtml =
+        flaggedInsights.length > 0
+          ? `<div style="display: flex; flex-direction: column; gap: 4px; padding-top: 8px;">
+              ${flaggedInsights.map(insightKey => `<span style="display: inline-block; font-size: 11px; background-color: ${theme.colors.red100}; color: ${theme.colors.red400}; padding: 2px 6px; border-radius: 3px;">${getInsightConfig(insightKey).name}</span>`).join('')}
+            </div>`
+          : '';
 
       return `
             <div style="font-family: Rubik;">
@@ -326,15 +362,24 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
                   <span style="font-size: 14px; font-weight: bold;">${params.name}</span>
                   ${scaleElement}
                 </div>
-                ${pathElement || ''}
+                ${pathElement}
                 <p style="font-size: 12px; margin-bottom: -4px;">${formatBytesBase10(value)} (${percent}%)</p>
               </div>
+              ${insightBadgesHtml}
             </div>
           `.trim();
     },
   };
 
   const treemapControlButtons: TreemapControlButton[] = [
+    {
+      ariaLabel: t('Toggle Insight Highlighting'),
+      title: highlightInsights ? t('Hide Insights') : t('Insights'),
+      icon: <IconLightning />,
+      onClick: () => onHighlightInsightsChange?.(!highlightInsights),
+      disabled: false,
+      active: highlightInsights,
+    },
     {
       ariaLabel: t('Recenter View'),
       title: t('Recenter'),
@@ -360,6 +405,8 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
               alertMessage={alertMessage}
               onAlertClick={onAlertClick}
               onSearchChange={onSearchChange}
+              highlightInsights={highlightInsights}
+              onHighlightInsightsChange={onHighlightInsightsChange}
             />
           ) : (
             <Container height="100%" width="100%">
@@ -368,6 +415,8 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
                 searchQuery={searchQuery}
                 alertMessage={alertMessage}
                 onAlertClick={onAlertClick}
+                highlightInsights={highlightInsights}
+                onHighlightInsightsChange={onHighlightInsightsChange}
               />
             </Container>
           ),

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -168,7 +168,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     const shouldHighlight = highlightInsights && hasFlaggedInsights;
 
     const borderColor = shouldHighlight
-      ? theme.colors.red400
+      ? theme.tokens.border.danger.vibrant
       : hasChildren && categoryInfo.translucentColor
         ? categoryInfo.translucentColor
         : categoryInfo.color;

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -31,13 +31,13 @@ import {getInsightConfig} from 'sentry/views/preprod/utils/insightProcessing';
 import {filterTreemapElement} from 'sentry/views/preprod/utils/treemapFiltering';
 
 interface AppSizeTreemapProps {
+  highlightInsights: boolean;
+  insightsAvailable: boolean;
+  onHighlightInsightsChange: (enabled: boolean) => void;
   root: TreemapElement | null;
   searchQuery: string;
   alertMessage?: string;
-  highlightInsights?: boolean;
-  insightsAvailable?: boolean;
   onAlertClick?: () => void;
-  onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
   unfilteredRoot?: TreemapElement;
 }
@@ -52,18 +52,18 @@ function FullscreenModalContent({
   onHighlightInsightsChange,
   insightsAvailable,
 }: {
+  initialHighlightInsights: boolean;
   initialSearch: string;
+  insightsAvailable: boolean;
+  onHighlightInsightsChange: (enabled: boolean) => void;
   unfilteredRoot: TreemapElement;
   alertMessage?: string;
-  initialHighlightInsights?: boolean;
-  insightsAvailable?: boolean;
   onAlertClick?: () => void;
-  onHighlightInsightsChange?: (enabled: boolean) => void;
   onSearchChange?: (query: string) => void;
 }) {
   const [localSearch, setLocalSearch] = useState(initialSearch);
   const [localHighlightInsights, setLocalHighlightInsights] = useState(
-    initialHighlightInsights ?? true
+    initialHighlightInsights
   );
   const filteredRoot = filterTreemapElement(unfilteredRoot, localSearch, '');
 
@@ -74,7 +74,7 @@ function FullscreenModalContent({
 
   const handleHighlightInsightsChange = (enabled: boolean) => {
     setLocalHighlightInsights(enabled);
-    onHighlightInsightsChange?.(enabled);
+    onHighlightInsightsChange(enabled);
   };
 
   return (
@@ -391,7 +391,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
             ariaLabel: t('Toggle Insight Highlighting'),
             title: highlightInsights ? t('Hide Insights') : t('Insights'),
             icon: <IconLightning />,
-            onClick: () => onHighlightInsightsChange?.(!highlightInsights),
+            onClick: () => onHighlightInsightsChange(!highlightInsights),
             disabled: false,
             active: highlightInsights,
           },

--- a/static/app/views/preprod/components/visualizations/treemapControlButtons.tsx
+++ b/static/app/views/preprod/components/visualizations/treemapControlButtons.tsx
@@ -10,6 +10,7 @@ export interface TreemapControlButton {
   icon: React.ReactNode;
   onClick: () => void;
   title: string;
+  active?: boolean;
 }
 
 interface TreemapControlButtonsProps {
@@ -38,13 +39,14 @@ export function TreemapControlButtons({buttons}: TreemapControlButtonsProps) {
           icon={button.icon}
           onClick={button.onClick}
           disabled={button.disabled}
+          $active={button.active}
         />
       ))}
     </Flex>
   );
 }
 
-const TreemapControlButton = styled(Button)`
+const TreemapControlButton = styled(Button)<{$active?: boolean}>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -53,12 +55,12 @@ const TreemapControlButton = styled(Button)`
   min-height: 20px;
   max-height: 20px;
   padding: 0 ${p => p.theme.space.xs};
-  background: rgba(0, 0, 0, 0.8);
+  background: ${p => (p.$active ? p.theme.colors.blue400 : 'rgba(0, 0, 0, 0.8)')};
   border-radius: ${p => p.theme.radius.md};
   box-shadow: ${p => p.theme.dropShadowMedium};
 
   &:hover {
     color: ${p => p.theme.colors.white};
-    background: rgba(0, 0, 0, 0.9);
+    background: ${p => (p.$active ? p.theme.colors.blue500 : 'rgba(0, 0, 0, 0.9)')};
   }
 `;

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -63,11 +63,11 @@ interface TreemapElementMisc {
 
 export interface TreemapElement {
   children: TreemapElement[];
-  flagged_insights: string[];
   is_dir: boolean;
   name: string;
   size: number;
   type: TreemapType;
+  flagged_insights?: string[];
   misc?: TreemapElementMisc;
   path?: string;
 }

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -63,6 +63,7 @@ interface TreemapElementMisc {
 
 export interface TreemapElement {
   children: TreemapElement[];
+  flagged_insights: string[];
   is_dir: boolean;
   name: string;
   size: number;

--- a/static/app/views/preprod/utils/treemapFiltering.spec.tsx
+++ b/static/app/views/preprod/utils/treemapFiltering.spec.tsx
@@ -14,6 +14,7 @@ describe('filterTreemapElement', () => {
     type: TreemapType.FILES,
     children,
     path: name,
+    flagged_insights: [],
   });
 
   it('returns original element when no search query', () => {


### PR DESCRIPTION
# Add Insight Highlighting Feature to App Size Treemap

This PR adds a new feature to highlight files with insights in the App Size Treemap visualization. Key changes include:

- Added a toggle button to enable/disable insight highlighting
- Files with flagged insights are now highlighted with a red border when the feature is enabled
- Added insight badges to the tooltip for files with insights
- Persisted the highlight state in the URL using `nuqs` query state management
- Default highlighting is enabled (true)

### Video

Ignore build in Mobile Builds tab this is a separate bug.

[Screen Recording 2026-01-28 at 14.41.16.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d4f14c66-2ae2-4aa1-ae05-8c91897d1fd9.mov" />](https://app.graphite.com/user-attachments/video/d4f14c66-2ae2-4aa1-ae05-8c91897d1fd9.mov)