### PR TITLE
feat(scim): Revoke superuser/staff privileges when removed from default org

### DIFF
--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -166,6 +166,8 @@ class UserUpdateArgs(TypedDict, total=False):
     avatar_type: int
     actor_id: int  # TODO(hybrid-cloud): Remove this after the actor migration is complete
     is_active: bool
+    is_superuser: bool
+    is_staff: bool
 
 
 class UserIdEmailArgs(TypedDict):

--- a/tests/sentry/users/services/test_user_impl.py
+++ b/tests/sentry/users/services/test_user_impl.py
@@ -96,3 +96,45 @@ class DatabaseBackedUserService(TestCase):
         # Tests that only verified emails are returned
         assert verified_emails[user1.id].exists
         assert not verified_emails[user2.id].exists
+
+    def test_update_user_with_superuser_and_staff_fields(self) -> None:
+        """Test that update_user correctly handles is_superuser and is_staff fields."""
+        user = self.create_user(is_superuser=False, is_staff=False)
+
+        # Update user to have superuser and staff privileges
+        result = user_service.update_user(
+            user_id=user.id,
+            attrs={
+                "is_superuser": True,
+                "is_staff": True,
+            },
+        )
+
+        assert result is not None
+        user.refresh_from_db()
+        assert user.is_superuser is True
+        assert user.is_staff is True
+
+        result = user_service.update_user(
+            user_id=user.id,
+            attrs={
+                "is_superuser": False,
+                "is_staff": False,
+            },
+        )
+
+        assert result is not None
+        user.refresh_from_db()
+        assert user.is_staff is False
+        assert user.is_superuser is False  # type: ignore[unreachable]
+
+    def test_update_user_with_nonexistent_user(self) -> None:
+        """Test that update_user returns None for nonexistent users."""
+        result = user_service.update_user(
+            user_id=999999,
+            attrs={
+                "is_superuser": True,
+                "is_staff": True,
+            },
+        )
+        assert result is None


### PR DESCRIPTION
When a superuser or staff member is removed via SCIM from the default
organization (organization 1) in SaaS mode, revoke their elevated privileges. 
This ensures privileged users who leave the default Sentry organization lose their elevated access.

Implementation:
- Check SENTRY_MODE == SAAS and organization.id == SENTRY_DEFAULT_ORGANIZATION_ID
- Call user_service.update_user() to set is_superuser=False and is_staff=False
- Create MEMBER_EDIT audit log entry

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
