### PR TITLE
fix(ai-conversations): use gen_ai.input.messages

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -1,0 +1,324 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {SpanFields} from 'sentry/views/insights/types';
+
+import {MessagesPanel} from './messagesPanel';
+
+function createMockNode(
+  overrides: Partial<{
+    attributes: Record<string, unknown>;
+    id: string;
+    startTimestamp: number;
+  }> = {}
+): AITraceSpanNode {
+  return {
+    id: overrides.id ?? 'test-node-1',
+    type: 'span',
+    value: {
+      start_timestamp: overrides.startTimestamp ?? 1000,
+    },
+    attributes: overrides.attributes ?? {},
+    startTimestamp: overrides.startTimestamp ?? 1000,
+  } as unknown as AITraceSpanNode;
+}
+
+describe('MessagesPanel', () => {
+  const mockOnSelectNode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows empty message when no nodes are provided', () => {
+    render(
+      <MessagesPanel nodes={[]} selectedNodeId={null} onSelectNode={mockOnSelectNode} />
+    );
+
+    expect(screen.getByText('No messages found')).toBeInTheDocument();
+  });
+
+  it('extracts user messages from gen_ai.input.messages attribute', () => {
+    const inputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: [{type: 'text', text: 'Hello, how are you?'}]},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'I am doing well!',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello, how are you?')).toBeInTheDocument();
+    expect(screen.getByText('I am doing well!')).toBeInTheDocument();
+  });
+
+  it('extracts user messages with string content format', () => {
+    const inputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: 'What is the weather today?'},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'The weather is sunny!',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('What is the weather today?')).toBeInTheDocument();
+    expect(screen.getByText('The weather is sunny!')).toBeInTheDocument();
+  });
+
+  it('extracts user messages with parts format', () => {
+    const inputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', parts: [{type: 'text', text: 'Calculate 2+2'}]},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'The answer is 4.',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Calculate 2+2')).toBeInTheDocument();
+    expect(screen.getByText('The answer is 4.')).toBeInTheDocument();
+  });
+
+  it('falls back to gen_ai.request.messages when gen_ai.input.messages is not available', () => {
+    const requestMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: 'Fallback message test'},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response to fallback',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Fallback message test')).toBeInTheDocument();
+    expect(screen.getByText('Response to fallback')).toBeInTheDocument();
+  });
+
+  it('extracts the last user message from conversation history', () => {
+    const inputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: 'First user message'},
+      {role: 'assistant', content: 'First assistant response'},
+      {role: 'user', content: 'Second user message'},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response to second message',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Should show the last user message
+    expect(screen.getByText('Second user message')).toBeInTheDocument();
+    // Should not show the first user message (would be duplicate)
+    expect(screen.queryByText('First user message')).not.toBeInTheDocument();
+  });
+
+  it('displays multiple conversation turns from multiple nodes', () => {
+    const firstInputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: [{type: 'text', text: 'First question'}]},
+    ]);
+
+    const secondInputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: [{type: 'text', text: 'First question'}]},
+      {role: 'assistant', content: [{type: 'text', text: 'First answer'}]},
+      {role: 'user', content: [{type: 'text', text: 'Second question'}]},
+    ]);
+
+    const firstNode = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: firstInputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'First answer',
+      },
+    });
+
+    const secondNode = createMockNode({
+      id: 'node-2',
+      startTimestamp: 2000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: secondInputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Second answer',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[firstNode, secondNode]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(screen.getByText('First answer')).toBeInTheDocument();
+    expect(screen.getByText('Second question')).toBeInTheDocument();
+    expect(screen.getByText('Second answer')).toBeInTheDocument();
+  });
+
+  it('displays user email when available', () => {
+    const inputMessages = JSON.stringify([{role: 'user', content: 'Hello from user'}]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Hello!',
+        [SpanFields.USER_EMAIL]: 'test@example.com',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('only processes ai_client spans for messages', () => {
+    const inputMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+
+    const agentNode = createMockNode({
+      id: 'agent-node',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'agent',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Agent response',
+      },
+    });
+
+    const clientNode = createMockNode({
+      id: 'client-node',
+      startTimestamp: 1001,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Client response',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[agentNode, clientNode]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Should only show message from ai_client span
+    expect(screen.getByText('Client response')).toBeInTheDocument();
+    expect(screen.queryByText('Agent response')).not.toBeInTheDocument();
+  });
+
+  it('extracts assistant messages from gen_ai.output.messages when available', () => {
+    const inputMessages = JSON.stringify([{role: 'user', content: 'Hello'}]);
+
+    const outputMessages = JSON.stringify([
+      {role: 'assistant', content: 'Hi from output messages!'},
+    ]);
+
+    const node = createMockNode({
+      id: 'node-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Fallback response text',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node]}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi from output messages!')).toBeInTheDocument();
+    // Should use output.messages, not response.text
+    expect(screen.queryByText('Fallback response text')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -1,0 +1,248 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {SpanFields} from 'sentry/views/insights/types';
+
+import {useConversation} from './useConversation';
+
+describe('useConversation', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), true);
+  });
+
+  it('maps gen_ai.input.messages from API response to node attributes', async () => {
+    const inputMessages = JSON.stringify([
+      {role: 'system', content: 'You are a helpful assistant.'},
+      {role: 'user', content: [{type: 'text', text: 'Hello'}]},
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/ai-conversations/test-conversation/',
+      body: [
+        {
+          span_id: 'span-1',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1000,
+          'precise.finish_ts': 1001,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Test span',
+          'span.op': 'gen_ai.stream_text',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+          'gen_ai.operation.type': 'ai_client',
+          'gen_ai.input.messages': inputMessages,
+          'gen_ai.response.text': 'Hello back!',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'test-conversation'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0]?.attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(
+      inputMessages
+    );
+  });
+
+  it('maps gen_ai.output.messages from API response to node attributes', async () => {
+    const outputMessages = JSON.stringify([
+      {role: 'assistant', content: 'Response from output messages'},
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/ai-conversations/test-conversation/',
+      body: [
+        {
+          span_id: 'span-1',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1000,
+          'precise.finish_ts': 1001,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Test span',
+          'span.op': 'gen_ai.stream_text',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+          'gen_ai.operation.type': 'ai_client',
+          'gen_ai.output.messages': outputMessages,
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'test-conversation'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0]?.attributes?.[SpanFields.GEN_AI_OUTPUT_MESSAGES]).toBe(
+      outputMessages
+    );
+  });
+
+  it('maps all gen_ai fields correctly', async () => {
+    const inputMessages = JSON.stringify([{role: 'user', content: 'Hello'}]);
+    const outputMessages = JSON.stringify([{role: 'assistant', content: 'Hi'}]);
+    const requestMessages = JSON.stringify([{role: 'user', content: 'Request'}]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/ai-conversations/test-conversation/',
+      body: [
+        {
+          span_id: 'span-1',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1000,
+          'precise.finish_ts': 1001,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Test span',
+          'span.op': 'gen_ai.stream_text',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+          'gen_ai.operation.type': 'ai_client',
+          'gen_ai.input.messages': inputMessages,
+          'gen_ai.output.messages': outputMessages,
+          'gen_ai.request.messages': requestMessages,
+          'gen_ai.response.text': 'Response text',
+          'gen_ai.response.object': '{"key": "value"}',
+          'gen_ai.tool.name': 'test-tool',
+          'user.email': 'test@example.com',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'test-conversation'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const nodeAttributes = result.current.nodes[0]?.attributes;
+    expect(nodeAttributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(inputMessages);
+    expect(nodeAttributes?.[SpanFields.GEN_AI_OUTPUT_MESSAGES]).toBe(outputMessages);
+    expect(nodeAttributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(requestMessages);
+    expect(nodeAttributes?.[SpanFields.GEN_AI_RESPONSE_TEXT]).toBe('Response text');
+    expect(nodeAttributes?.[SpanFields.GEN_AI_RESPONSE_OBJECT]).toBe('{"key": "value"}');
+    expect(nodeAttributes?.[SpanFields.GEN_AI_TOOL_NAME]).toBe('test-tool');
+    expect(nodeAttributes?.[SpanFields.USER_EMAIL]).toBe('test@example.com');
+  });
+
+  it('defaults missing optional fields to empty strings', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/ai-conversations/test-conversation/',
+      body: [
+        {
+          span_id: 'span-1',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1000,
+          'precise.finish_ts': 1001,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Test span',
+          'span.op': 'gen_ai.stream_text',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'test-conversation'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const nodeAttributes = result.current.nodes[0]?.attributes;
+    expect(nodeAttributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe('');
+    expect(nodeAttributes?.[SpanFields.GEN_AI_OUTPUT_MESSAGES]).toBe('');
+    expect(nodeAttributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe('');
+    expect(nodeAttributes?.[SpanFields.GEN_AI_RESPONSE_TEXT]).toBe('');
+  });
+
+  it('returns empty nodes when conversationId is empty', () => {
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: ''}),
+      {organization}
+    );
+
+    expect(result.current.nodes).toHaveLength(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('filters to only gen_ai spans', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/ai-conversations/test-conversation/',
+      body: [
+        {
+          span_id: 'span-1',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1000,
+          'precise.finish_ts': 1001,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'HTTP span',
+          'span.op': 'http.client',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+        },
+        {
+          span_id: 'span-2',
+          trace: 'trace-1',
+          parent_span: 'parent-1',
+          'precise.start_ts': 1002,
+          'precise.finish_ts': 1003,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Gen AI span',
+          'span.op': 'gen_ai.stream_text',
+          'span.status': 'ok',
+          'gen_ai.conversation.id': 'test-conversation',
+          'gen_ai.operation.type': 'ai_client',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'test-conversation'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0]?.id).toBe('span-2');
+  });
+});

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -32,7 +32,9 @@ interface ConversationApiSpan {
   'span.status': string;
   span_id: string;
   trace: string;
+  'gen_ai.input.messages'?: string;
   'gen_ai.operation.type'?: string;
+  'gen_ai.output.messages'?: string;
   'gen_ai.request.messages'?: string;
   'gen_ai.response.object'?: string;
   'gen_ai.response.text'?: string;
@@ -93,7 +95,9 @@ function createNodeFromApiSpan(
     occurrences: [],
     additional_attributes: {
       [SpanFields.GEN_AI_CONVERSATION_ID]: apiSpan['gen_ai.conversation.id'],
+      [SpanFields.GEN_AI_INPUT_MESSAGES]: apiSpan['gen_ai.input.messages'] ?? '',
       [SpanFields.GEN_AI_OPERATION_TYPE]: operationType ?? '',
+      [SpanFields.GEN_AI_OUTPUT_MESSAGES]: apiSpan['gen_ai.output.messages'] ?? '',
       [SpanFields.GEN_AI_REQUEST_MESSAGES]: apiSpan['gen_ai.request.messages'] ?? '',
       [SpanFields.GEN_AI_RESPONSE_OBJECT]: apiSpan['gen_ai.response.object'] ?? '',
       [SpanFields.GEN_AI_RESPONSE_TEXT]: apiSpan['gen_ai.response.text'] ?? '',


### PR DESCRIPTION
- Fixes an issue where some user messages were not shown in the conversations panel because they are sent as `gen_ai.input.messages`.
- Adds tests for messages panel and useConversation hook