### PR TITLE
fix(preprod): Convert release_version to structured query for builds endpoint

### DIFF
--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -74,15 +74,29 @@ export default function PreprodBuilds() {
 
   const queryParams: Record<string, any> = {
     per_page: 25,
-    release_version: params.release,
   };
 
   if (cursor) {
     queryParams.cursor = cursor;
   }
 
-  if (urlSearchQuery?.trim()) {
-    queryParams.query = urlSearchQuery.trim();
+  // Parse release version (format: "app_id@version+build_number" or "app_id@version")
+  // and convert to structured query.
+  let releaseQuery = '';
+  if (params.release) {
+    const releaseMatch = params.release.match(/^([^@]+)@([^+]+)(?:\+.*)?$/);
+    if (releaseMatch && releaseMatch[1] && releaseMatch[2]) {
+      const appId = releaseMatch[1];
+      const buildVersion = releaseMatch[2];
+      releaseQuery = `app_id:${appId} build_version:${buildVersion}`;
+    }
+  }
+
+  // Combine release filter with user search query
+  const combinedQuery = [releaseQuery, urlSearchQuery?.trim()].filter(Boolean).join(' ');
+
+  if (combinedQuery) {
+    queryParams.query = combinedQuery;
   }
 
   if (projectId) {

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -84,10 +84,9 @@ export default function PreprodBuilds() {
   // and convert to structured query.
   let releaseQuery = '';
   if (params.release) {
-    const releaseMatch = params.release.match(/^([^@]+)@([^+]+)(?:\+.*)?$/);
-    if (releaseMatch?.[1] && releaseMatch[2]) {
-      const appId = releaseMatch[1];
-      const buildVersion = releaseMatch[2];
+    const [appId, versionPart] = params.release.split('@');
+    const buildVersion = versionPart?.split('+')[0];
+    if (appId && buildVersion) {
       releaseQuery = `app_id:${appId} build_version:${buildVersion}`;
     }
   }

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -85,7 +85,7 @@ export default function PreprodBuilds() {
   let releaseQuery = '';
   if (params.release) {
     const releaseMatch = params.release.match(/^([^@]+)@([^+]+)(?:\+.*)?$/);
-    if (releaseMatch && releaseMatch[1] && releaseMatch[2]) {
+    if (releaseMatch?.[1] && releaseMatch[2]) {
       const appId = releaseMatch[1];
       const buildVersion = releaseMatch[2];
       releaseQuery = `app_id:${appId} build_version:${buildVersion}`;


### PR DESCRIPTION
## Summary

Fixes a bug introduced in 626913aa1dd where the Mobile Builds tab on the release details page showed incorrect builds.

The issue occurred because:
1. The frontend was still passing `release_version: params.release`
2. The new `/builds/` endpoint only handles the `query` parameter for search filtering
3. The `release_version` parameter was silently ignored, causing no builds to be shown

## Changes

- Parse the release parameter (format: `"app_id@version+build_number"` or `"app_id@version"`)
- Convert it to a structured query: `app_id:{app_id} build_version:{version}`
- Combine with any user-provided search query