### PR TITLE
chore(explorer): add repo name to 3rd party coding agent names

### DIFF
--- a/src/sentry/integrations/cursor/client.py
+++ b/src/sentry/integrations/cursor/client.py
@@ -94,7 +94,7 @@ class CursorAgentClient(CodingAgentClient):
             id=launch_response.id,
             status=CodingAgentStatus.RUNNING,  # Cursor agent doesn't send when it actually starts so we just assume it's running
             provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
-            name=launch_response.name or f"Cursor Agent {launch_response.id}",
+            name=f"{request.repository.owner}/{request.repository.name}: {launch_response.name or f'Cursor Agent {launch_response.id}'}",
             started_at=launch_response.createdAt,
             agent_url=launch_response.target.url,
         )

--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -87,7 +87,7 @@ class GithubCopilotAgentClient(CodingAgentClient):
             id=agent_id,
             status=CodingAgentStatus.RUNNING,
             provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
-            name="GitHub Copilot",
+            name=f"{owner}/{repo}: GitHub Copilot",
             started_at=task_response.task.created_at,
             agent_url=None,
         )

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -287,7 +287,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert result.id == "test_session_123"
         assert result.status == CodingAgentStatus.RUNNING
         assert result.provider == CodingAgentProviderType.CURSOR_BACKGROUND_AGENT
-        assert result.name == "Test Session"
+        assert result.name == "testorg/testrepo: Test Session"
 
         mock_post.assert_called_once()
         call_args = mock_post.call_args


### PR DESCRIPTION
Since we can spawn multiple 3rd party agents for one run (one per repo), it would help users distinguish runs if we label the repo each agent is working on. So this PR adds the repo name as a prefix to the agent name that we display on the UI.