### PR TITLE
chore(codeowners): add `design-eng` to `static/eslint/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -705,6 +705,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/.cursor/BUGBOT.md                             @getsentry/design-engineering
 /static/CLAUDE.md                                     @getsentry/design-engineering
 /static/AGENTS.md                                     @getsentry/design-engineering
+/static/eslint/                                       @getsentry/design-engineering
 /scripts/analyze-styled.ts                            @getsentry/design-engineering
 ## End of Frontend Platform
 


### PR DESCRIPTION
Adds @getsentry/design-engineering as codeowner for the `/static/eslint/` directory