### PR TITLE
feat(onboarding): Add feature flag for new welcome UI

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -250,6 +250,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Only enabled in sentry.io to enable onboarding flows.
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Enable new onboarding welcome and SDK setup UI
+    manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit


### PR DESCRIPTION
## Summary

Registers `organizations:onboarding-new-welcome-ui` feature flag to gate new onboarding welcome page and SDK setup UI improvements.

This flag uses the FLAGPOLE strategy and is exposed to the frontend (`api_expose=True`).

## Related

- sentry-options-automator PR to enable for internal orgs: https://github.com/getsentry/sentry-options-automator/pull/6276

## Test Plan

- [ ] Flag is registered and defaults to `false`
- [ ] Frontend can check `organization.features.includes('onboarding-new-welcome-ui')`