### PR TITLE
feat(tracemetrics): Enable multi-select on aggregate dropdown

### DIFF
--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -1,4 +1,4 @@
-import type {SelectOption} from 'sentry/components/core/compactSelect';
+import type {SelectOption, SelectSection} from 'sentry/components/core/compactSelect';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import {
@@ -187,6 +187,137 @@ export const OPTIONS_BY_TYPE: Record<string, Array<SelectOption<string>>> = {
     {
       label: 'per_minute',
       value: 'per_minute',
+    },
+  ],
+};
+
+export const GROUPED_OPTIONS_BY_TYPE: Record<string, Array<SelectSection<string>>> = {
+  counter: [
+    {
+      key: 'rate',
+      label: t('Rate'),
+      options: [
+        {
+          label: 'per_second',
+          value: 'per_second',
+        },
+        {
+          label: 'per_minute',
+          value: 'per_minute',
+        },
+      ],
+    },
+    {
+      key: 'math',
+      label: t('Math'),
+      options: [
+        {
+          label: 'sum',
+          value: 'sum',
+        },
+      ],
+    },
+  ],
+  gauge: [
+    {
+      key: 'rate',
+      label: t('Rate'),
+      options: [
+        {
+          label: 'per_second',
+          value: 'per_second',
+        },
+        {
+          label: 'per_minute',
+          value: 'per_minute',
+        },
+      ],
+    },
+    {
+      key: 'stats',
+      label: t('Stats'),
+      options: [
+        {
+          label: 'min',
+          value: 'min',
+        },
+        {
+          label: 'max',
+          value: 'max',
+        },
+        {
+          label: 'avg',
+          value: 'avg',
+        },
+      ],
+    },
+  ],
+  distribution: [
+    {
+      key: 'percentiles',
+      label: t('Percentiles'),
+      options: [
+        {
+          label: 'p50',
+          value: 'p50',
+        },
+        {
+          label: 'p75',
+          value: 'p75',
+        },
+        {
+          label: 'p90',
+          value: 'p90',
+        },
+        {
+          label: 'p95',
+          value: 'p95',
+        },
+        {
+          label: 'p99',
+          value: 'p99',
+        },
+        {
+          label: 'avg',
+          value: 'avg',
+        },
+        {
+          label: 'min',
+          value: 'min',
+        },
+        {
+          label: 'max',
+          value: 'max',
+        },
+      ],
+    },
+    {
+      key: 'math',
+      label: t('Math'),
+      options: [
+        {
+          label: 'sum',
+          value: 'sum',
+        },
+        {
+          label: 'count',
+          value: 'count',
+        },
+      ],
+    },
+    {
+      key: 'rate',
+      label: t('Rate'),
+      options: [
+        {
+          label: 'per_second',
+          value: 'per_second',
+        },
+        {
+          label: 'per_minute',
+          value: 'per_minute',
+        },
+      ],
     },
   ],
 };

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -1,3 +1,5 @@
+import {Text} from '@sentry/scraps/text';
+
 import type {SelectOption, SelectSection} from 'sentry/components/core/compactSelect';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
@@ -200,6 +202,7 @@ export const GROUPED_OPTIONS_BY_TYPE: Record<string, Array<SelectSection<string>
         {
           label: 'per_second',
           value: 'per_second',
+          trailingItems: <Text size="xs">{t('Default')}</Text>,
         },
         {
           label: 'per_minute',
@@ -248,6 +251,7 @@ export const GROUPED_OPTIONS_BY_TYPE: Record<string, Array<SelectSection<string>
         {
           label: 'avg',
           value: 'avg',
+          trailingItems: <Text size="xs">{t('Default')}</Text>,
         },
       ],
     },
@@ -264,6 +268,7 @@ export const GROUPED_OPTIONS_BY_TYPE: Record<string, Array<SelectSection<string>
         {
           label: 'p75',
           value: 'p75',
+          trailingItems: <Text size="xs">{t('Default')}</Text>,
         },
         {
           label: 'p90',

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
@@ -1,14 +1,57 @@
+import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
+import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 jest.mock('sentry/utils/usePageFilters');
+
+function MockMetricQueryParamsContextWithMultiVisualize({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const mockQueryParams = new ReadableQueryParams({
+    extrapolate: true,
+    mode: Mode.SAMPLES,
+    query: '',
+    cursor: '',
+    fields: ['id', 'timestamp'],
+    sortBys: [{field: 'timestamp', kind: 'desc'}],
+    aggregateCursor: '',
+    aggregateFields: [
+      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+    ],
+    aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+  });
+
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsQueryParamsProvider
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryParams={mockQueryParams}
+        setQueryParams={() => {}}
+        setTraceMetric={() => {}}
+        removeMetric={() => {}}
+      >
+        {children}
+      </MetricsQueryParamsProvider>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
 
 describe('useMetricTimeseries', () => {
   beforeEach(() => {
@@ -55,16 +98,14 @@ describe('useMetricTimeseries', () => {
       ],
       method: 'GET',
     });
-    renderHookWithProviders(
-      () =>
-        useMetricTimeseries({
-          traceMetric: {name: 'test metric', type: 'counter'},
-          enabled: true,
-        }),
-      {
-        additionalWrapper: MockMetricQueryParamsContext,
-      }
-    );
+
+    renderHookWithProviders(useMetricTimeseries, {
+      initialProps: {
+        traceMetric: {name: 'test metric', type: 'counter'},
+        enabled: true,
+      },
+      additionalWrapper: MockMetricQueryParamsContext,
+    });
 
     expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);
     expect(mockNormalRequestUrl).toHaveBeenCalledWith(
@@ -87,5 +128,168 @@ describe('useMetricTimeseries', () => {
         }),
       })
     );
+  });
+
+  describe('with tracemetrics-overlay-charts-ui feature', () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-overlay-charts-ui'],
+    });
+
+    beforeEach(() => {
+      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+      jest.clearAllMocks();
+    });
+
+    it('requests multiple yAxis values from the API', async () => {
+      const mockTimeSeries1 = TimeSeriesFixture();
+      const mockTimeSeries2 = TimeSeriesFixture();
+      const mockTimeSeries3 = TimeSeriesFixture();
+
+      const mockRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-timeseries/',
+        body: {
+          timeSeries: [
+            {
+              ...mockTimeSeries1,
+              yAxis: 'p50(value,test_metric,distribution,-)',
+            },
+            {
+              ...mockTimeSeries2,
+              yAxis: 'p75(value,test_metric,distribution,-)',
+            },
+            {
+              ...mockTimeSeries3,
+              yAxis: 'p99(value,test_metric,distribution,-)',
+            },
+          ],
+        },
+        method: 'GET',
+      });
+
+      renderHookWithProviders(useMetricTimeseries, {
+        initialProps: {
+          traceMetric: {name: 'test_metric', type: 'distribution'},
+          enabled: true,
+        },
+        additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
+        organization,
+      });
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-timeseries/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: [
+              'p50(value,test_metric,distribution,-)',
+              'p75(value,test_metric,distribution,-)',
+              'p99(value,test_metric,distribution,-)',
+            ],
+          }),
+        })
+      );
+    });
+
+    it('triggers high accuracy for all visualizes', async () => {
+      const mockTimeSeries = TimeSeriesFixture();
+
+      const mockNormalRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-timeseries/',
+        body: {
+          timeSeries: [
+            {
+              ...mockTimeSeries,
+              yAxis: 'p50(value,test_metric,distribution,-)',
+              values: [
+                {
+                  ...mockTimeSeries.values[0]!,
+                  value: 0,
+                },
+              ],
+              meta: {
+                ...mockTimeSeries.meta,
+                dataScanned: 'partial',
+              },
+            },
+            {
+              ...mockTimeSeries,
+              yAxis: 'p75(value,test_metric,distribution,-)',
+              values: [
+                {
+                  ...mockTimeSeries.values[0]!,
+                  value: 0,
+                },
+              ],
+              meta: {
+                ...mockTimeSeries.meta,
+                dataScanned: 'partial',
+              },
+            },
+            {
+              ...mockTimeSeries,
+              yAxis: 'p99(value,test_metric,distribution,-)',
+              values: [
+                {
+                  ...mockTimeSeries.values[0]!,
+                  value: 0,
+                },
+              ],
+              meta: {
+                ...mockTimeSeries.meta,
+                dataScanned: 'partial',
+              },
+            },
+          ],
+        },
+        method: 'GET',
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.sampling === SAMPLING_MODE.NORMAL;
+          },
+        ],
+      });
+
+      const mockHighAccuracyRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-timeseries/',
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.sampling === SAMPLING_MODE.HIGH_ACCURACY;
+          },
+        ],
+        method: 'GET',
+      });
+
+      renderHookWithProviders(useMetricTimeseries, {
+        initialProps: {
+          traceMetric: {name: 'test_metric', type: 'distribution'},
+          enabled: true,
+        },
+        additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
+        organization,
+      });
+
+      expect(mockNormalRequest).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-timeseries/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            sampling: SAMPLING_MODE.HIGH_ACCURACY,
+            yAxis: [
+              'p50(value,test_metric,distribution,-)',
+              'p75(value,test_metric,distribution,-)',
+              'p99(value,test_metric,distribution,-)',
+            ],
+          }),
+        })
+      );
+    });
   });
 });

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
@@ -1,6 +1,7 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import useOrganization from 'sentry/utils/useOrganization';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {shouldTriggerHighAccuracy} from 'sentry/views/explore/hooks/useExploreTimeseries';
@@ -10,7 +11,10 @@ import {
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {
+  useMetricVisualize,
+  useMetricVisualizes,
+} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {
   useQueryParamsAggregateSortBys,
   useQueryParamsGroupBys,
@@ -24,13 +28,23 @@ interface UseMetricTimeseriesOptions {
 }
 
 export function useMetricTimeseries({traceMetric, enabled}: UseMetricTimeseriesOptions) {
+  const hasMultiVisualize = useOrganization().features.includes(
+    'tracemetrics-overlay-charts-ui'
+  );
+
   const visualize = useMetricVisualize();
+  const visualizes = useMetricVisualizes();
+
   const topEvents = useTopEvents();
   const canTriggerHighAccuracy = useCallback(
     (result: ReturnType<typeof useMetricTimeseriesImpl>['result']) => {
+      if (hasMultiVisualize) {
+        return shouldTriggerHighAccuracy(result.data, visualizes, !!topEvents);
+      }
+
       return shouldTriggerHighAccuracy(result.data, [visualize], !!topEvents);
     },
-    [visualize, topEvents]
+    [hasMultiVisualize, topEvents, visualize, visualizes]
   );
   return useProgressiveQuery<typeof useMetricTimeseriesImpl>({
     queryHookImplementation: useMetricTimeseriesImpl,
@@ -51,16 +65,28 @@ function useMetricTimeseriesImpl({
   enabled,
 }: UseMetricTimeseriesImplOptions) {
   const visualize = useMetricVisualize();
+  const visualizes = useMetricVisualizes();
   const groupBys = useQueryParamsGroupBys();
   const [interval] = useChartInterval();
   const topEvents = useTopEvents();
   const search = useQueryParamsSearch();
   const sortBys = useQueryParamsAggregateSortBys();
 
+  const hasMultiVisualize = useOrganization().features.includes(
+    'tracemetrics-overlay-charts-ui'
+  );
+
+  const yAxis = useMemo(() => {
+    if (hasMultiVisualize) {
+      return visualizes.map(v => v.yAxis);
+    }
+    return [visualize.yAxis];
+  }, [hasMultiVisualize, visualize.yAxis, visualizes]);
+
   const timeseriesResult = useSortedTimeSeries(
     {
       search,
-      yAxis: [visualize.yAxis],
+      yAxis,
       interval,
       fields: [...groupBys, visualize.yAxis],
       enabled: enabled && Boolean(traceMetric.name),

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
@@ -88,7 +88,7 @@ function useMetricTimeseriesImpl({
       search,
       yAxis,
       interval,
-      fields: [...groupBys, visualize.yAxis],
+      fields: [...groupBys, ...yAxis],
       enabled: enabled && Boolean(traceMetric.name),
       topEvents,
       orderby: sortBys.map(formatSort),

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -1,0 +1,137 @@
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {
+  decodeMetricsQueryParams,
+  encodeMetricQueryParams,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+describe('decodeMetricsQueryParams', () => {
+  it('parses only first visualize when multiVisualize=false', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {yAxes: ['p50(value,test_metric,distribution,-)']},
+        {yAxes: ['p75(value,test_metric,distribution,-)']},
+        {yAxes: ['p99(value,test_metric,distribution,-)']},
+      ],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json, false);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+    ]);
+  });
+
+  it('parses all visualizes when multiVisualize=true', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {yAxes: ['p50(value,test_metric,distribution,-)']},
+        {yAxes: ['p75(value,test_metric,distribution,-)']},
+        {yAxes: ['p99(value,test_metric,distribution,-)']},
+      ],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json, true);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+    ]);
+  });
+
+  it('returns null for invalid JSON', () => {
+    const result = decodeMetricsQueryParams('invalid json', false);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when metric is missing', () => {
+    const json = JSON.stringify({
+      query: '',
+      aggregateFields: [{yAxes: ['p50(value)']}],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json, false);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no visualizes are found', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json, false);
+    expect(result).toBeNull();
+  });
+
+  it('handles groupBys correctly with multiVisualize', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {yAxes: ['p50(value,test_metric,distribution,-)']},
+        {yAxes: ['p75(value,test_metric,distribution,-)']},
+        {groupBy: 'environment'},
+      ],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json, true);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+      {groupBy: 'environment'},
+    ]);
+  });
+
+  it('round-trips encode/decode with multiVisualize', () => {
+    const original = {
+      metric: {name: 'test_metric', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.SAMPLES,
+        query: 'has:environment',
+        cursor: '',
+        fields: ['id', 'timestamp'],
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateCursor: '',
+        aggregateFields: [
+          new VisualizeFunction('per_second(value,test_metric,counter,-)'),
+          new VisualizeFunction('sum(value,test_metric,counter,-)'),
+        ],
+        aggregateSortBys: [
+          {field: 'per_second(value,test_metric,counter,-)', kind: 'desc'},
+        ],
+      }),
+    };
+
+    const encoded = encodeMetricQueryParams(original);
+    const decoded = decodeMetricsQueryParams(encoded, true);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded?.metric).toEqual(original.metric);
+    expect(decoded?.queryParams.aggregateFields).toEqual(
+      original.queryParams.aggregateFields
+    );
+  });
+});

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -43,7 +43,10 @@ export interface MetricQuery extends BaseMetricQuery {
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
-export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null {
+export function decodeMetricsQueryParams(
+  value: string,
+  multiVisualize = false
+): BaseMetricQuery | null {
   let json: any;
   try {
     json = JSON.parse(value);
@@ -57,7 +60,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
 
   const metric = json.metric;
   const query = parseQuery(json.query);
-  const visualizes = parseVisualizes(json.aggregateFields);
+  const visualizes = parseVisualizes(json.aggregateFields, multiVisualize);
 
   if (!visualizes.length) {
     return null;
@@ -186,9 +189,13 @@ function parseQuery(value: unknown): string {
   return typeof value === 'string' ? value : defaultQuery();
 }
 
-function parseVisualizes(value: unknown): Visualize[] {
+function parseVisualizes(value: unknown, multiVisualize = false): Visualize[] {
   if (!Array.isArray(value)) {
     return [];
+  }
+
+  if (multiVisualize) {
+    return value.filter(isBaseVisualize).flatMap(Visualize.fromJSON);
   }
 
   const baseVisualize = value.find(isBaseVisualize);

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -1,0 +1,240 @@
+import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {AggregateDropdown} from 'sentry/views/explore/metrics/metricToolbar/aggregateDropdown';
+import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+function Wrapper({
+  children,
+  queryParams,
+}: {
+  children: ReactNode;
+  queryParams?: ReadableQueryParams;
+}) {
+  const defaultQueryParams =
+    queryParams ??
+    new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        new VisualizeFunction('per_second(value,test_metric,distribution,-)'),
+      ],
+      aggregateSortBys: [
+        {field: 'per_second(value,test_metric,distribution,-)', kind: 'desc'},
+      ],
+    });
+
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsQueryParamsProvider
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryParams={defaultQueryParams}
+        setQueryParams={() => {}}
+        setTraceMetric={() => {}}
+        removeMetric={() => {}}
+      >
+        {children}
+      </MetricsQueryParamsProvider>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
+
+describe('AggregateDropdown', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders single-select dropdown without feature flag', async () => {
+    const organization = OrganizationFixture({
+      features: [],
+    });
+
+    render(
+      <Wrapper>
+        <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />
+      </Wrapper>,
+      {organization}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    expect(trigger).toBeInTheDocument();
+
+    await userEvent.click(trigger);
+
+    expect(await screen.findByRole('option', {name: 'p50'})).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'p75'})).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'p99'})).toBeInTheDocument();
+  });
+
+  it('renders multi-select dropdown with grouped options when feature enabled', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-overlay-charts-ui'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+      ],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <Wrapper queryParams={queryParams}>
+        <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />
+      </Wrapper>,
+      {organization}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    expect(trigger).toBeInTheDocument();
+
+    await userEvent.click(trigger);
+
+    expect(await screen.findByText('Percentiles')).toBeInTheDocument();
+    expect(await screen.findByText('Math')).toBeInTheDocument();
+    expect(await screen.findByText('Rate')).toBeInTheDocument();
+
+    expect(screen.getByRole('option', {name: 'p50'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'p75'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('updates multiple visualizes on selection change', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-overlay-charts-ui'],
+    });
+
+    const setQueryParams = jest.fn();
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    function WrapperWithMock({children}: {children: ReactNode}) {
+      return (
+        <MultiMetricsQueryParamsProvider>
+          <MetricsQueryParamsProvider
+            traceMetric={{name: 'test_metric', type: 'distribution'}}
+            queryParams={queryParams}
+            setQueryParams={setQueryParams}
+            setTraceMetric={() => {}}
+            removeMetric={() => {}}
+          >
+            {children}
+          </MetricsQueryParamsProvider>
+        </MultiMetricsQueryParamsProvider>
+      );
+    }
+
+    render(
+      <WrapperWithMock>
+        <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />
+      </WrapperWithMock>,
+      {organization}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', {name: 'p75'})).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('option', {name: 'p75'}));
+
+    await waitFor(() => {
+      expect(setQueryParams).toHaveBeenCalled();
+    });
+
+    const callArgs = setQueryParams.mock.calls[0]![0];
+    expect(callArgs.aggregateFields).toHaveLength(2);
+    expect(callArgs.aggregateFields[0]).toBeInstanceOf(VisualizeFunction);
+    expect(callArgs.aggregateFields[1]).toBeInstanceOf(VisualizeFunction);
+  });
+
+  it('shows correct options for counter metric type', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-overlay-charts-ui'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('per_second(value,test_metric,counter,-)')],
+      aggregateSortBys: [
+        {field: 'per_second(value,test_metric,counter,-)', kind: 'desc'},
+      ],
+    });
+
+    function WrapperForCounter({children}: {children: ReactNode}) {
+      return (
+        <MultiMetricsQueryParamsProvider>
+          <MetricsQueryParamsProvider
+            traceMetric={{name: 'test_metric', type: 'counter'}}
+            queryParams={queryParams}
+            setQueryParams={() => {}}
+            setTraceMetric={() => {}}
+            removeMetric={() => {}}
+          >
+            {children}
+          </MetricsQueryParamsProvider>
+        </MultiMetricsQueryParamsProvider>
+      );
+    }
+
+    render(
+      <WrapperForCounter>
+        <AggregateDropdown traceMetric={{name: 'test_metric', type: 'counter'}} />
+      </WrapperForCounter>,
+      {organization}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    await userEvent.click(trigger);
+
+    expect(await screen.findByText('Rate')).toBeInTheDocument();
+    expect(await screen.findByText('Math')).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'per_second'})).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'sum'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -4,6 +4,7 @@ import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSe
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
+  DEFAULT_YAXIS_BY_TYPE,
   GROUPED_OPTIONS_BY_TYPE,
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
@@ -40,9 +41,19 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
         options={GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? []}
         value={visualizes.map(v => v.parsedFunction?.name ?? '')}
         onChange={(option: Array<SelectOption<string>>) => {
-          setMetricVisualizes(
-            option.map(o => updateVisualizeYAxis(visualize, o.value, traceMetric))
-          );
+          if (option.length === 0) {
+            setMetricVisualizes([
+              updateVisualizeYAxis(
+                visualize,
+                DEFAULT_YAXIS_BY_TYPE[traceMetric.type]!,
+                traceMetric
+              ),
+            ]);
+          } else {
+            setMetricVisualizes(
+              option.map(o => updateVisualizeYAxis(visualize, o.value, traceMetric))
+            );
+          }
         }}
         style={{width: '100%'}}
       />

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,18 +1,53 @@
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
-import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
-import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  GROUPED_OPTIONS_BY_TYPE,
+  OPTIONS_BY_TYPE,
+} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricVisualize,
+  useMetricVisualizes,
   useSetMetricVisualize,
+  useSetMetricVisualizes,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {updateVisualizeYAxis} from 'sentry/views/explore/metrics/utils';
 
 export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
+
+  const visualizes = useMetricVisualizes();
+  const setMetricVisualizes = useSetMetricVisualizes();
+  const hasMultiSelect = useOrganization().features.includes(
+    'tracemetrics-overlay-charts-ui'
+  );
+
+  if (hasMultiSelect) {
+    return (
+      <CompactSelect
+        multiple
+        trigger={triggerProps => (
+          <OverlayTrigger.Button
+            {...triggerProps}
+            prefix={t('Agg')}
+            style={{width: '100%'}}
+          />
+        )}
+        options={GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? []}
+        value={visualizes.map(v => v.parsedFunction?.name ?? '')}
+        onChange={(option: Array<SelectOption<string>>) => {
+          setMetricVisualizes(
+            option.map(o => updateVisualizeYAxis(visualize, o.value, traceMetric))
+          );
+        }}
+        style={{width: '100%'}}
+      />
+    );
+  }
 
   return (
     <CompactSelect

--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -1,6 +1,7 @@
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useSaveAsMetricItems} from 'sentry/views/explore/metrics/useSaveAsMetricItems';
 
@@ -8,7 +9,11 @@ export function MetricSaveAs() {
   const [interval] = useChartInterval();
   const items = useSaveAsMetricItems({interval});
 
-  if (items.length === 0) {
+  const hasMultiVisualize = useOrganization().features.includes(
+    'tracemetrics-overlay-charts-ui'
+  );
+
+  if (items.length === 0 || hasMultiVisualize) {
     return null;
   }
 

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -119,10 +119,18 @@ function getUpdatedValue<T>(
 
 export function useMetricVisualize(): VisualizeFunction {
   const visualizes = useQueryParamsVisualizes();
-  if (visualizes.length === 1 && isVisualizeFunction(visualizes[0]!)) {
+  if (visualizes.length > 0 && isVisualizeFunction(visualizes[0]!)) {
     return visualizes[0];
   }
-  throw new Error('Only 1 visualize per metric allowed');
+  throw new Error('No visualize found');
+}
+
+export function useMetricVisualizes(): readonly VisualizeFunction[] {
+  const visualizes = useQueryParamsVisualizes();
+  if (visualizes.length > 0 && visualizes.every(isVisualizeFunction)) {
+    return visualizes;
+  }
+  throw new Error('Only visualize functions are allowed');
 }
 
 export function useMetricLabel(): string {
@@ -155,6 +163,17 @@ export function useSetMetricVisualize() {
     [setVisualizes]
   );
   return setVisualize;
+}
+
+export function useSetMetricVisualizes() {
+  const setVisualizes = useSetQueryParamsVisualizes();
+  const setMetricVisualizes = useCallback(
+    (newVisualizes: VisualizeFunction[]) => {
+      setVisualizes(newVisualizes.map(v => v.serialize()));
+    },
+    [setVisualizes]
+  );
+  return setMetricVisualizes;
 }
 
 function updateQueryParams(


### PR DESCRIPTION
This PR adds in a new aggregate dropdown that enables users to multi-select different aggregates. It also includes all the work passing all of the selections through to the API. There will be a follow up PR that contains the work needed to display the extra data in the chart.

Tickets: LOGS-548, LOGS-552

Example:
<img width="182" height="580" alt="Screenshot 2026-01-28 at 12 38 55" src="https://github.com/user-attachments/assets/de11503f-9b17-4798-a94a-ca2ec4f9d009" />