### PR TITLE
chore(preprod): Optimize the status check task

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -377,7 +377,7 @@ def show_rule_evaluation(artifact_id: int) -> None:
 
     logger.info("\n📋 Rule Evaluation Results:")
 
-    base_metrics_map = _fetch_base_size_metrics(all_artifacts)
+    base_artifact_map, base_metrics_by_artifact = _fetch_base_size_metrics(all_artifacts)
 
     overall_triggered = False
 
@@ -389,7 +389,19 @@ def show_rule_evaluation(artifact_id: int) -> None:
         if not size_metrics:
             continue
 
-        base_metric = base_metrics_map.get(art.id)
+        # Look up base metric using the new structure
+        base_metric = None
+        base_artifact = base_artifact_map.get(art.id)
+        if base_artifact:
+            base_metric = next(
+                (
+                    m
+                    for m in base_metrics_by_artifact.get(base_artifact.id, [])
+                    if m.metrics_artifact_type
+                    == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+                ),
+                None,
+            )
         context = _get_artifact_filter_context(art)
 
         logger.info("\n  📱 %s (%s):", art.app_id, context.get("build.platform", "unknown"))

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from sentry.api.event_search import SearchFilter, parse_search_query
 from sentry.integrations.source_code_management.status_check import StatusCheckStatus
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.models import (
@@ -15,22 +14,10 @@ from sentry.preprod.vcs.status_checks.size.tasks import (
     _get_artifact_filter_context,
     _get_status_check_rules,
     _rule_matches_artifact,
-    preprod_artifact_search_config,
 )
-from sentry.preprod.vcs.status_checks.size.types import BaseSizeMetricsKey, StatusCheckRule
+from sentry.preprod.vcs.status_checks.size.types import StatusCheckRule
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
-
-
-def _parse_filters(filter_query: str) -> list[SearchFilter]:
-    """Helper to parse a filter query string into SearchFilters for testing."""
-    if not filter_query or not filter_query.strip():
-        return []
-    return [
-        f
-        for f in parse_search_query(filter_query, config=preprod_artifact_search_config)
-        if isinstance(f, SearchFilter)
-    ]
 
 
 @region_silo_test
@@ -125,8 +112,8 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="build_configuration_name:Release",
         )
 
-        assert _rule_matches_artifact(context, _parse_filters(rule_debug.filter_query)) is True
-        assert _rule_matches_artifact(context, _parse_filters(rule_release.filter_query)) is False
+        assert _rule_matches_artifact(rule_debug, context) is True
+        assert _rule_matches_artifact(rule_release, context) is False
 
     def test_rule_matches_build_configuration_multiple_values(self):
         artifact = PreprodArtifact.objects.create(
@@ -148,7 +135,7 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="build_configuration_name:[Debug,Release]",
         )
 
-        assert _rule_matches_artifact(context, _parse_filters(rule.filter_query)) is True
+        assert _rule_matches_artifact(rule, context) is True
 
     def test_rule_matches_build_configuration_negated(self):
         artifact = PreprodArtifact.objects.create(
@@ -178,10 +165,8 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="!build_configuration_name:Debug",
         )
 
-        assert (
-            _rule_matches_artifact(context, _parse_filters(rule_not_release.filter_query)) is True
-        )
-        assert _rule_matches_artifact(context, _parse_filters(rule_not_debug.filter_query)) is False
+        assert _rule_matches_artifact(rule_not_release, context) is True
+        assert _rule_matches_artifact(rule_not_debug, context) is False
 
     def test_rule_matches_combined_filters(self):
         artifact = PreprodArtifact.objects.create(
@@ -219,14 +204,9 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="platform_name:apple build_configuration_name:Debug",
         )
 
-        assert (
-            _rule_matches_artifact(context, _parse_filters(rule_apple_release.filter_query)) is True
-        )
-        assert (
-            _rule_matches_artifact(context, _parse_filters(rule_android_release.filter_query))
-            is False
-        )
-        assert _rule_matches_artifact(context, _parse_filters(rule_ios_debug.filter_query)) is False
+        assert _rule_matches_artifact(rule_apple_release, context) is True
+        assert _rule_matches_artifact(rule_android_release, context) is False
+        assert _rule_matches_artifact(rule_ios_debug, context) is False
 
     def test_status_check_fails_when_rule_matches_and_exceeds_threshold(self):
         artifact = PreprodArtifact.objects.create(
@@ -633,13 +613,15 @@ class StatusCheckFiltersTest(TestCase):
             build_configuration=self.build_config_release,
         )
 
-        base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics([head_artifact])
+        base_artifact_map, base_metrics_by_artifact = _fetch_base_size_metrics([head_artifact])
 
-        key = BaseSizeMetricsKey(
-            head_artifact.id, PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT, None
-        )
-        assert key in base_size_metrics_map
-        assert base_size_metrics_map[key].id == base_metrics.id
+        assert head_artifact.id in base_artifact_map
+        fetched_base_artifact = base_artifact_map[head_artifact.id]
+        assert fetched_base_artifact.id == base_artifact.id
+        assert fetched_base_artifact.id in base_metrics_by_artifact
+        metrics_list = base_metrics_by_artifact[fetched_base_artifact.id]
+        assert len(metrics_list) == 1
+        assert metrics_list[0].id == base_metrics.id
 
     def test_fetch_base_size_metrics_with_different_build_config(self):
         base_commit_comparison = CommitComparison.objects.create(
@@ -746,7 +728,7 @@ class StatusCheckFiltersTest(TestCase):
             )
         }
 
-        _, base_size_metrics_map = _fetch_base_size_metrics([head_artifact])
+        base_artifact_map, base_metrics_by_artifact = _fetch_base_size_metrics([head_artifact])
 
         rule = StatusCheckRule(
             id="rule1",
@@ -760,7 +742,8 @@ class StatusCheckFiltersTest(TestCase):
             [head_artifact],
             size_metrics_map,
             rules=[rule],
-            base_size_metrics_map=base_size_metrics_map,
+            base_artifact_map=base_artifact_map,
+            base_metrics_by_artifact=base_metrics_by_artifact,
         )
         assert status == StatusCheckStatus.FAILURE
         assert len(triggered_rules) == 1
@@ -841,11 +824,9 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="!build_configuration_name:[Debug,Release]",
         )
 
-        assert _rule_matches_artifact(context, _parse_filters(positive_rule.filter_query)) is False
-        assert _rule_matches_artifact(context, _parse_filters(negated_rule.filter_query)) is False
-        assert (
-            _rule_matches_artifact(context, _parse_filters(negated_in_rule.filter_query)) is False
-        )
+        assert _rule_matches_artifact(positive_rule, context) is False
+        assert _rule_matches_artifact(negated_rule, context) is False
+        assert _rule_matches_artifact(negated_in_rule, context) is False
 
     def test_negated_filters_still_work_when_field_present(self):
         artifact = PreprodArtifact.objects.create(
@@ -874,10 +855,8 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="!build_configuration_name:Debug",
         )
 
-        assert (
-            _rule_matches_artifact(context, _parse_filters(rule_not_release.filter_query)) is True
-        )
-        assert _rule_matches_artifact(context, _parse_filters(rule_not_debug.filter_query)) is False
+        assert _rule_matches_artifact(rule_not_release, context) is True
+        assert _rule_matches_artifact(rule_not_debug, context) is False
 
     def test_combined_filters_fail_when_any_field_missing(self):
         artifact = PreprodArtifact.objects.create(
@@ -900,4 +879,4 @@ class StatusCheckFiltersTest(TestCase):
             filter_query="platform_name:apple !build_configuration_name:Debug",
         )
 
-        assert _rule_matches_artifact(context, _parse_filters(rule.filter_query)) is False
+        assert _rule_matches_artifact(rule, context) is False

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -47,7 +47,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 )
 
                 title, subtitle, summary = format_status_check_messages(
-                    [artifact], {}, StatusCheckStatus.IN_PROGRESS, self.project
+                    [artifact], {}, StatusCheckStatus.IN_PROGRESS, self.project, {}, {}
                 )
 
                 assert title == "Size Analysis"
@@ -67,7 +67,9 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         with pytest.raises(ValueError, match="No metrics exist for VCS size status check"):
-            format_status_check_messages([artifact], {}, StatusCheckStatus.SUCCESS, self.project)
+            format_status_check_messages(
+                [artifact], {}, StatusCheckStatus.SUCCESS, self.project, {}, {}
+            )
 
     def test_processed_state_with_metrics_no_previous(self):
         """Test formatting for processed state with metrics but no previous build."""
@@ -92,7 +94,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [size_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -122,7 +124,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 )
 
                 title, subtitle, summary = format_status_check_messages(
-                    [artifact], {}, StatusCheckStatus.IN_PROGRESS, self.project
+                    [artifact], {}, StatusCheckStatus.IN_PROGRESS, self.project, {}, {}
                 )
 
                 assert expected in summary
@@ -147,7 +149,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
             )
 
         title, subtitle, summary = format_status_check_messages(
-            artifacts, {}, StatusCheckStatus.IN_PROGRESS, self.project
+            artifacts, {}, StatusCheckStatus.IN_PROGRESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -191,7 +193,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [main_metrics, watch_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.IN_PROGRESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.IN_PROGRESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -225,7 +227,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [pending_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.IN_PROGRESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.IN_PROGRESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -259,7 +261,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
         )
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], {}, StatusCheckStatus.FAILURE, self.project
+            [artifact], {}, StatusCheckStatus.FAILURE, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -287,7 +289,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
                 )
 
                 title, subtitle, summary = format_status_check_messages(
-                    [artifact], {}, StatusCheckStatus.FAILURE, self.project
+                    [artifact], {}, StatusCheckStatus.FAILURE, self.project, {}, {}
                 )
 
                 assert expected_error in summary
@@ -337,7 +339,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
         artifacts.append(failed_artifact)
 
         title, subtitle, summary = format_status_check_messages(
-            artifacts, size_metrics_map, StatusCheckStatus.FAILURE, self.project
+            artifacts, size_metrics_map, StatusCheckStatus.FAILURE, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -380,7 +382,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             size_metrics_map[artifact.id] = [size_metrics]
 
         title, subtitle, summary = format_status_check_messages(
-            artifacts, size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            artifacts, size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -423,7 +425,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [main_metrics, watch_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -481,7 +483,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [main_metrics, feature_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -519,7 +521,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             build_number=41,
         )
 
-        self.create_preprod_artifact_size_metrics(
+        base_size_metrics = self.create_preprod_artifact_size_metrics(
             base_artifact,
             metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -550,8 +552,16 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
 
         size_metrics_map = {head_artifact.id: [head_size_metrics]}
 
+        base_artifact_map = {head_artifact.id: base_artifact}
+        base_metrics_by_artifact = {base_artifact.id: [base_size_metrics]}
+
         title, subtitle, summary = format_status_check_messages(
-            [head_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [head_artifact],
+            size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+            base_metrics_by_artifact,
         )
 
         assert title == "Size Analysis"
@@ -588,7 +598,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         size_metrics_map = {artifact.id: [size_metrics]}
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         assert title == "Size Analysis"
@@ -601,7 +611,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "N/A" in data_line  # Change columns show N/A
 
     def test_size_changes_with_different_artifact_types(self):
-        """Test that size changes only compare the same artifact types."""
+        """Test that size changes only compare the same artifact types (Watch-to-Watch, Main-to-Main)."""
 
         head_commit_comparison = CommitComparison.objects.create(
             head_repo_name="test/repo",
@@ -618,7 +628,6 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             organization_id=self.organization.id,
         )
 
-        # Create base artifact with only MAIN_ARTIFACT metrics
         base_artifact = self.create_preprod_artifact(
             project=self.project,
             commit_comparison=base_commit_comparison,
@@ -628,7 +637,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             build_number=10,
         )
 
-        self.create_preprod_artifact_size_metrics(
+        base_main_metrics = self.create_preprod_artifact_size_metrics(
             base_artifact,
             metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -670,8 +679,16 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
 
         size_metrics_map = {head_artifact.id: [head_main_metrics, head_watch_metrics]}
 
+        base_artifact_map = {head_artifact.id: base_artifact}
+        base_metrics_by_artifact = {base_artifact.id: [base_main_metrics]}
+
         _, _, summary = format_status_check_messages(
-            [head_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [head_artifact],
+            size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+            base_metrics_by_artifact,
         )
 
         # Main artifact should show changes (has matching base)
@@ -684,6 +701,104 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         # Count N/A occurrences in the watch line - should be 2 (change columns)
         na_count = watch_line.count("N/A")
         assert na_count == 2  # 2 N/A for the change columns
+
+    def test_size_changes_with_watch_base_metrics(self):
+        """Test that Watch-to-Watch comparison works when base Watch metrics exist."""
+
+        head_commit_comparison = CommitComparison.objects.create(
+            head_repo_name="test/repo",
+            head_sha="head_sha_watch_test",
+            base_sha="base_sha_watch_test",
+            provider="github",
+            organization_id=self.organization.id,
+        )
+
+        base_commit_comparison = CommitComparison.objects.create(
+            head_repo_name="test/repo",
+            head_sha="base_sha_watch_test",
+            provider="github",
+            organization_id=self.organization.id,
+        )
+
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=base_commit_comparison,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.ios",
+            build_version="1.0.1",
+            build_number=10,
+        )
+
+        base_main_metrics = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=int(2.8 * 1024 * 1024),
+            max_download_size=int(2.8 * 1024 * 1024),
+            min_install_size=int(6.5 * 1024 * 1024),
+            max_install_size=int(6.5 * 1024 * 1024),
+        )
+
+        base_watch_metrics = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=400 * 1024,
+            max_download_size=400 * 1024,
+            min_install_size=800 * 1024,
+            max_install_size=800 * 1024,
+        )
+
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=head_commit_comparison,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.ios",
+            build_version="1.0.2",
+            build_number=11,
+        )
+
+        head_main_metrics = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=3 * 1024 * 1024,
+            max_download_size=3 * 1024 * 1024,
+            min_install_size=int(6.8 * 1024 * 1024),
+            max_install_size=int(6.8 * 1024 * 1024),
+        )
+
+        head_watch_metrics = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=512 * 1024,
+            max_download_size=512 * 1024,
+            min_install_size=1024 * 1024,
+            max_install_size=1024 * 1024,
+        )
+
+        size_metrics_map = {head_artifact.id: [head_main_metrics, head_watch_metrics]}
+
+        base_artifact_map = {head_artifact.id: base_artifact}
+        base_metrics_by_artifact = {base_artifact.id: [base_main_metrics, base_watch_metrics]}
+
+        _, _, summary = format_status_check_messages(
+            [head_artifact],
+            size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+            base_metrics_by_artifact,
+        )
+
+        assert "+209.7 KB" in summary
+        assert "+314.6 KB" in summary
+
+        lines = summary.split("\n")
+        watch_line = next(line for line in lines if ", Watch)" in line)
+        assert "+114.7 KB" in watch_line
+        assert "+229.4 KB" in watch_line
 
     def test_android_app_shows_uncompressed_label(self):
         """Test that Android apps show 'Uncompressed' instead of 'Install' in column header."""
@@ -710,7 +825,12 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         android_size_metrics_map = {android_artifact.id: [android_size_metrics]}
 
         title, subtitle, android_summary = format_status_check_messages(
-            [android_artifact], android_size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [android_artifact],
+            android_size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+            {},
         )
 
         # Android app should show "Uncompressed" instead of "Install"
@@ -740,7 +860,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         ios_size_metrics_map = {ios_artifact.id: [ios_size_metrics]}
 
         title, subtitle, ios_summary = format_status_check_messages(
-            [ios_artifact], ios_size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [ios_artifact], ios_size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         # iOS app should show "Install" not "Uncompressed"
@@ -795,6 +915,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             size_metrics_map,
             StatusCheckStatus.SUCCESS,
             self.project,
+            {},
+            {},
         )
 
         android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}?project={self.project.slug}"
@@ -907,8 +1029,19 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
 
         size_metrics_map = {head_debug_artifact.id: [head_debug_metrics]}
 
+        from sentry.preprod.vcs.status_checks.size.tasks import _fetch_base_size_metrics
+
+        base_artifact_map, base_metrics_by_artifact = _fetch_base_size_metrics(
+            [head_debug_artifact]
+        )
+
         _, _, summary = format_status_check_messages(
-            [head_debug_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [head_debug_artifact],
+            size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+            base_metrics_by_artifact,
         )
 
         # Verify current sizes are shown
@@ -988,11 +1121,18 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
 
         size_metrics_map = {head_artifact.id: [head_metrics]}
 
-        _, _, summary = format_status_check_messages(
-            [head_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
-        )
+        from sentry.preprod.vcs.status_checks.size.tasks import _fetch_base_size_metrics
 
-        # Verify that comparison works properly for same configuration
+        base_artifact_map, base_metrics_by_artifact = _fetch_base_size_metrics([head_artifact])
+
+        _, _, summary = format_status_check_messages(
+            [head_artifact],
+            size_metrics_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+            base_metrics_by_artifact,
+        )
         assert "3.3 MB" in summary  # Current download size
         assert "6.5 MB" in summary  # Current install size
         assert "+104.9 KB" in summary  # 3.3MB - 3.1MB = 104.9KB
@@ -1062,7 +1202,7 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
         size_metrics_map = {head_artifact.id: [head_metrics]}
 
         _, _, summary = format_status_check_messages(
-            [head_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project
+            [head_artifact], size_metrics_map, StatusCheckStatus.SUCCESS, self.project, {}, {}
         )
 
         # Verify current sizes are shown
@@ -1121,6 +1261,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             size_metrics_map,
             StatusCheckStatus.FAILURE,
             self.project,
+            {},
+            {},
             triggered_rules=[triggered_rule],
         )
 
@@ -1140,7 +1282,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 <summary>1 Failed Check</summary>
 
 `com.example.app` (Android)
-- **Download Size - Total Size** ≥ **52.4 MB**
+- **Download Size (Total Size)** > **52.4 MB**
 </details>
 
 [Configure test_project status check rules]({settings_url})\
@@ -1214,6 +1356,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             size_metrics_map,
             StatusCheckStatus.FAILURE,
             self.project,
+            {},
+            {},
             triggered_rules=triggered_rules,
         )
 
@@ -1233,9 +1377,9 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 <summary>3 Failed Checks</summary>
 
 `com.example.app` (Android)
-- **Download Size - Total Size** ≥ **52.4 MB**
-- **Install Size - Absolute Diff** ≥ **10.5 MB**
-- **Download Size - Relative Diff** ≥ **5.0%**
+- **Download Size (Total Size)** > **52.4 MB**
+- **Install Size (Absolute Diff)** > **10.5 MB**
+- **Download Size (Relative Diff)** > **5.0%**
 </details>
 
 [Configure test_project status check rules]({settings_url})\
@@ -1318,6 +1462,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             size_metrics_map,
             StatusCheckStatus.FAILURE,
             self.project,
+            {},
+            {},
             triggered_rules=triggered_rules,
         )
 
@@ -1344,9 +1490,9 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 <summary>2 Failed Checks</summary>
 
 `com.example.app1` (iOS)
-- **Download Size - Total Size** ≥ **52.4 MB**
+- **Download Size (Total Size)** > **52.4 MB**
 `com.example.app2` (Android)
-- **Install Size - Total Size** ≥ **104.9 MB**
+- **Install Size (Total Size)** > **104.9 MB**
 </details>
 
 [Configure test_project status check rules]({settings_url})\
@@ -1419,6 +1565,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             size_metrics_map,
             StatusCheckStatus.FAILURE,
             self.project,
+            {},
+            {},
             triggered_rules=triggered_rules,
         )
 
@@ -1439,7 +1587,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 <summary>1 Failed Check</summary>
 
 `com.example.failed` (Android)
-- **Download Size - Total Size** ≥ **52.4 MB**
+- **Download Size (Total Size)** > **52.4 MB**
 </details>
 
 ## 1 Analyzed


### PR DESCRIPTION
Performance Optimizations
- Added `select_related` for `commit_comparison`, `mobile_app_info` on initial artifact fetch
- Added `select_related` for `preprod_artifact` on size metrics fetch
- Eliminated N+1 queries in template formatting by pre-fetching and passing base artifact/metrics data
- Single-pass dict grouping for base metrics by artifact ID

Result: ~N+1 queries → ~7 constant queries (artifact, size metrics, rules, approvals, base commit comparison, base artifacts, base size metrics)