### PR TITLE
feat: add metrics onboarding for Apple platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -384,6 +384,9 @@ export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir']);
 // List of platforms that have metrics onboarding checklist content
 export const withMetricsOnboarding: Set<PlatformKey> = new Set([
   'android',
+  'apple',
+  'apple-ios',
+  'apple-macos',
   'go',
   'go-echo',
   'go-fasthttp',

--- a/static/app/gettingStartedDocs/apple-ios/index.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/index.tsx
@@ -1,9 +1,9 @@
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logs} from 'sentry/gettingStartedDocs/apple-ios/logs';
+import {metrics} from 'sentry/gettingStartedDocs/apple-ios/metrics';
 import {onboarding} from 'sentry/gettingStartedDocs/apple-ios/onboarding';
 import {sessionReplay} from 'sentry/gettingStartedDocs/apple-ios/sessionReplay';
 import {crashReport} from 'sentry/gettingStartedDocs/apple-macos/crashReport';
-import {metrics} from 'sentry/gettingStartedDocs/apple-macos/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/apple-macos/profiling';
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/apple-ios/index.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/index.tsx
@@ -3,6 +3,7 @@ import {logs} from 'sentry/gettingStartedDocs/apple-ios/logs';
 import {onboarding} from 'sentry/gettingStartedDocs/apple-ios/onboarding';
 import {sessionReplay} from 'sentry/gettingStartedDocs/apple-ios/sessionReplay';
 import {crashReport} from 'sentry/gettingStartedDocs/apple-macos/crashReport';
+import {metrics} from 'sentry/gettingStartedDocs/apple-macos/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/apple-macos/profiling';
 
 const docs: Docs = {
@@ -12,6 +13,7 @@ const docs: Docs = {
   replayOnboarding: sessionReplay,
   profilingOnboarding: profiling,
   logsOnboarding: logs,
+  metricsOnboarding: metrics,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple-ios/metrics.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/metrics.tsx
@@ -16,7 +16,7 @@ export const metrics: OnboardingConfig = {
             {
               code: <code />,
               link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/macos/migration/" />
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/migration/" />
               ),
             }
           ),
@@ -112,7 +112,7 @@ SentrySDK.metrics.count(
             'For more detailed information, see the [link:metrics documentation].',
             {
               link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/macos/metrics/" />
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/metrics/" />
               ),
             }
           ),

--- a/static/app/gettingStartedDocs/apple-ios/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/onboarding.spec.tsx
@@ -24,4 +24,11 @@ describe('apple-ios onboarding docs', () => {
       screen.getByRole('heading', {name: /manual configuration/i})
     ).toBeInTheDocument();
   });
+
+  it('has metrics onboarding configuration', () => {
+    expect(docs.metricsOnboarding).toBeDefined();
+    expect(docs.metricsOnboarding?.install).toBeDefined();
+    expect(docs.metricsOnboarding?.configure).toBeDefined();
+    expect(docs.metricsOnboarding?.verify).toBeDefined();
+  });
 });

--- a/static/app/gettingStartedDocs/apple-macos/index.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/index.tsx
@@ -1,6 +1,7 @@
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReport} from 'sentry/gettingStartedDocs/apple-macos/crashReport';
 import {logs} from 'sentry/gettingStartedDocs/apple-macos/logs';
+import {metrics} from 'sentry/gettingStartedDocs/apple-macos/metrics';
 import {onboarding} from 'sentry/gettingStartedDocs/apple-macos/onboarding';
 import {profiling} from 'sentry/gettingStartedDocs/apple-macos/profiling';
 
@@ -10,6 +11,7 @@ const docs: Docs = {
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
   logsOnboarding: logs,
+  metricsOnboarding: metrics,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple-macos/metrics.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/metrics.tsx
@@ -1,0 +1,123 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+export const metrics: OnboardingConfig = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Metrics for Apple platforms are supported in Sentry Cocoa SDK version [code:9.2.0] and above. If you are using an older version of the SDK, follow our [link:migration guide] to upgrade.',
+            {
+              code: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/macos/migration/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'SPM',
+              language: 'swift',
+              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '9.2.0'
+              )}"),`,
+            },
+            {
+              label: 'CocoaPods',
+              language: 'ruby',
+              code: `pod update`,
+            },
+            {
+              label: 'Carthage',
+              language: 'swift',
+              code: `github "getsentry/sentry-cocoa" "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '9.2.0'
+              )}"`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Metrics are enabled by default once the SDK is initialized. No additional configuration is required.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'swift',
+          code: `import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "${params.dsn.public}"
+}`,
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Send test metrics from your app to verify metrics are arriving in Sentry.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'swift',
+          code: `import Sentry
+
+// Counter metric
+SentrySDK.metrics.count(key: "button_click", value: 1)
+
+// Gauge metric
+SentrySDK.metrics.gauge(key: "queue_depth", value: 42.0)
+
+// Distribution metric with unit
+SentrySDK.metrics.distribution(key: "response_time", value: 187.5, unit: .millisecond)
+
+// Counter with unit and attributes
+SentrySDK.metrics.count(
+    key: "network.request.count",
+    value: 1,
+    unit: .generic("request"),
+    attributes: ["endpoint": "/api/users", "method": "POST"]
+)`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'For more detailed information, see the [link:metrics documentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/metrics/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/apple-macos/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/onboarding.spec.tsx
@@ -91,4 +91,11 @@ describe('apple-macos onboarding docs', () => {
     expect(stopMatches.length).toBeGreaterThan(0);
     stopMatches.forEach(match => expect(match).toBeInTheDocument());
   });
+
+  it('has metrics onboarding configuration', () => {
+    expect(docs.metricsOnboarding).toBeDefined();
+    expect(docs.metricsOnboarding?.install).toBeDefined();
+    expect(docs.metricsOnboarding?.configure).toBeDefined();
+    expect(docs.metricsOnboarding?.verify).toBeDefined();
+  });
 });


### PR DESCRIPTION
Add metrics onboarding documentation for apple, apple-ios, and apple-macos platforms. This enables the metrics tab onboarding UI at /explore/metrics to show Swift code examples for the Sentry Cocoa SDK metrics API.

Closes https://github.com/getsentry/sentry-cocoa/issues/7274