### PR TITLE
ref(seer): Ensure correct permission checks for Seer Slack workflows

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -64,6 +64,8 @@ from sentry.notifications.utils.participants import (
     get_suspect_commit_users,
 )
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.seer.entrypoints.operator import SeerOperator
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
@@ -834,7 +836,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     )
                 )
 
-        if features.has("organizations:seer-slack-workflows", self.group.organization):
+        if SeerOperator.has_access(
+            organization=self.group.project.organization, entrypoint_key=SeerEntrypointKey.SLACK
+        ):
             autofix_button: ButtonElement = SeerSlackRenderer.render_autofix_button(
                 data=SeerAutofixTrigger(
                     group_id=self.group.id,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -31,6 +31,7 @@ from sentry.seer.autofix.utils import (
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
+from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
@@ -192,9 +193,7 @@ def _trigger_autofix_task(
             )
             run_id = response.data.get("run_id")
 
-        if run_id and features.has(
-            "organizations:seer-slack-workflows", group.project.organization
-        ):
+        if run_id and SeerOperator.has_access(organization=group.project.organization):
             SeerOperatorAutofixCache.migrate(from_group_id=group_id, to_run_id=run_id)
 
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -75,7 +75,7 @@ from sentry.seer.autofix.autofix_tools import get_error_event_details, get_profi
 from sentry.seer.autofix.coding_agent import launch_coding_agents_for_run
 from sentry.seer.autofix.utils import AutofixTriggerSource
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
-from sentry.seer.entrypoints.operator import process_autofix_updates
+from sentry.seer.entrypoints.operator import SeerOperator, process_autofix_updates
 from sentry.seer.explorer.custom_tool_utils import call_custom_tool
 from sentry.seer.explorer.index_data import (
     rpc_get_issues_for_transaction,
@@ -607,7 +607,7 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
         )
         return {"success": False, "error": "Organization not found or not active"}
 
-    if features.has("organizations:seer-slack-workflows", organization):
+    if SeerOperator.has_access(organization=organization):
         process_autofix_updates.apply_async(
             kwargs={
                 "event_type": sentry_app_event_type,

--- a/src/sentry/seer/entrypoints/cache.py
+++ b/src/sentry/seer/entrypoints/cache.py
@@ -8,7 +8,7 @@ AUTOFIX_CACHE_TIMEOUT_SECONDS = 60 * 60 * 12  # 12 hours
 class SeerOperatorAutofixCache[CachePayloadT]:
 
     @classmethod
-    def get_pre_autofix_cache_key(cls, *, entrypoint_key: str, group_id: int) -> str:
+    def _get_pre_autofix_cache_key(cls, *, entrypoint_key: str, group_id: int) -> str:
         """
         The group cache key is used to store entrypoint-specific cache payloads BEFORE an autofix
         run has been started, thus requires a group_id. When an autofix run does start, Seer emits a
@@ -17,10 +17,18 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         return f"seer:pre_autofix:{entrypoint_key}:{group_id}"
 
     @classmethod
-    def get_pre_autofix_cache(
+    def _get_post_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
+        """
+        The autofix cache key is used to store entrypoint-specific cache payloads AFTER an autofix
+        run has been started, thus requires a run_id.
+        """
+        return f"seer:post_autofix:{entrypoint_key}:{run_id}"
+
+    @classmethod
+    def _get_pre_autofix_cache(
         cls, *, entrypoint_key: str, group_id: int
     ) -> SeerOperatorCacheResult | None:
-        cache_key = cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+        cache_key = cls._get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
         cache_payload = cache.get(cache_key)
         if not cache_payload:
             return None
@@ -31,30 +39,10 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         )
 
     @classmethod
-    def populate_pre_autofix_cache(
-        cls, *, entrypoint_key: str, group_id: int, cache_payload: CachePayloadT
-    ) -> SeerOperatorCacheResult:
-        cache_key = cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
-        cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
-        return SeerOperatorCacheResult[CachePayloadT](
-            payload=cache_payload,
-            source="group_id",
-            key=cache_key,
-        )
-
-    @classmethod
-    def get_post_autofix_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
-        """
-        The autofix cache key is used to store entrypoint-specific cache payloads AFTER an autofix
-        run has been started, thus requires a run_id.
-        """
-        return f"seer:post_autofix:{entrypoint_key}:{run_id}"
-
-    @classmethod
-    def get_post_autofix_cache(
+    def _get_post_autofix_cache(
         cls, *, entrypoint_key: str, run_id: int
     ) -> SeerOperatorCacheResult | None:
-        cache_key = cls.get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
+        cache_key = cls._get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
         cache_payload = cache.get(cache_key)
         if not cache_payload:
             return None
@@ -65,10 +53,22 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         )
 
     @classmethod
+    def populate_pre_autofix_cache(
+        cls, *, entrypoint_key: str, group_id: int, cache_payload: CachePayloadT
+    ) -> SeerOperatorCacheResult:
+        cache_key = cls._get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+        cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
+        return SeerOperatorCacheResult[CachePayloadT](
+            payload=cache_payload,
+            source="group_id",
+            key=cache_key,
+        )
+
+    @classmethod
     def populate_post_autofix_cache(
         cls, *, entrypoint_key: str, run_id: int, cache_payload: CachePayloadT
     ) -> SeerOperatorCacheResult:
-        cache_key = cls.get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
+        cache_key = cls._get_post_autofix_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
         cache.set(cache_key, cache_payload, timeout=AUTOFIX_CACHE_TIMEOUT_SECONDS)
         return SeerOperatorCacheResult[CachePayloadT](
             payload=cache_payload,
@@ -80,18 +80,23 @@ class SeerOperatorAutofixCache[CachePayloadT]:
     def get(
         cls, *, entrypoint_key: str, group_id: int | None = None, run_id: int | None = None
     ) -> SeerOperatorCacheResult | None:
+        """
+        Gets the most specific cache payload for a given entrypoint, group_id and/or run_id.
+        If run_id cache hits, it's returned, and the group_id cache is deleted (if a group_id was provided).
+        If run_id cache misses, the group_id cache result is returned, hit or miss.
+        """
         if not group_id and not run_id:
             raise ValueError("At least one of group_id or run_id must be provided.")
 
         cache_result = None
         if run_id:
-            cache_result = cls.get_post_autofix_cache(entrypoint_key=entrypoint_key, run_id=run_id)
+            cache_result = cls._get_post_autofix_cache(entrypoint_key=entrypoint_key, run_id=run_id)
 
         # We prefer the run cache payload since it's more narrow
         # A group can have multiple runs, and that means many threads to post updates to.
         # A run has a single group, and (usually) a single thread to post updates to.
         if group_id and not cache_result:
-            cache_result = cls.get_pre_autofix_cache(
+            cache_result = cls._get_pre_autofix_cache(
                 entrypoint_key=entrypoint_key, group_id=group_id
             )
 
@@ -102,7 +107,7 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         # updates targeting all matching groups from being sent, limiting updates to just this run.
         if group_id and cache_result["source"] == "run_id":
             cache.delete(
-                cls.get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
+                cls._get_pre_autofix_cache_key(entrypoint_key=entrypoint_key, group_id=group_id)
             )
 
         return cache_result
@@ -120,10 +125,10 @@ class SeerOperatorAutofixCache[CachePayloadT]:
         if one exists. If overwrite is True, any existing post-autofix cache will be overwritten.
         """
         for entrypoint_key in entrypoint_registry.registrations.keys():
-            pre_cache_result = cls.get_pre_autofix_cache(
+            pre_cache_result = cls._get_pre_autofix_cache(
                 entrypoint_key=entrypoint_key, group_id=from_group_id
             )
-            post_cache_result = cls.get_post_autofix_cache(
+            post_cache_result = cls._get_post_autofix_cache(
                 entrypoint_key=entrypoint_key, run_id=to_run_id
             )
             # If we already have a post-autofix cache, and we're not overwriting, skip.
@@ -132,7 +137,7 @@ class SeerOperatorAutofixCache[CachePayloadT]:
             # If we don't have a pre-autofix cache, nothing to migrate, skip.
             if not pre_cache_result:
                 continue
-            post_cache_key = cls.get_post_autofix_cache_key(
+            post_cache_key = cls._get_post_autofix_cache_key(
                 entrypoint_key=entrypoint_key, run_id=to_run_id
             )
             cache.set(

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from slack_sdk.models.blocks.blocks import Block
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.slack.provider import SlackRenderable
@@ -70,6 +72,10 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             action=action, group_id=group.id
         )
         self.autofix_run_id = self.slack_request.callback_data.get("run_id")
+
+    @staticmethod
+    def has_access(organization: Organization) -> bool:
+        return features.has("organizations:seer-slack-workflows", organization)
 
     @staticmethod
     def get_autofix_stopping_point_from_action(

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 from typing import Any, Literal, Protocol, TypedDict
 
+from sentry.models.organization import Organization
 from sentry.sentry_apps.metrics import SentryAppEventType
 
 
@@ -19,6 +20,15 @@ class SeerEntrypoint[CachePayloadT](Protocol):
     """
 
     key: SeerEntrypointKey
+
+    @staticmethod
+    def has_access(organization: Organization) -> bool:
+        """
+        Used by the operator (SeerOperator.has_access) to gate access prevent a workflow unless
+        the organization has access to at least one entrypoint. The operator will check for
+        seer-access prior to this check, so no need to repeat that check on the entrypoint.
+        """
+        ...
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         """

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -978,7 +978,10 @@ class TestSeerRpcMethods(APITestCase):
         """Slack workflows flag should not affect broadcasting the webhooks."""
         from sentry.seer.endpoints.seer_rpc import send_seer_webhook
 
-        with self.feature("organizations:seer-webhooks"):
+        with (
+            self.feature("organizations:seer-webhooks"),
+            patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True),
+        ):
             result = send_seer_webhook(
                 event_name="root_cause_completed",
                 organization_id=self.organization.id,
@@ -1001,6 +1004,7 @@ class TestSeerRpcMethods(APITestCase):
         with (
             self.feature("organizations:seer-webhooks"),
             self.feature("organizations:seer-slack-workflows"),
+            patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True),
         ):
             result = send_seer_webhook(
                 event_name=event_name,

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -44,6 +44,12 @@ class SlackEntrypointTest(TestCase):
             action=self.action,
         )
 
+    def test_has_access(self):
+        with self.feature("organizations:seer-slack-workflows"):
+            assert SlackEntrypoint.has_access(self.organization)
+        with self.feature({"organizations:seer-slack-workflows": False}):
+            assert not SlackEntrypoint.has_access(self.organization)
+
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_autofix_error(self, mock_send_threaded_ephemeral_message):
         ep = self._get_entrypoint()

--- a/tests/sentry/seer/entrypoints/test_cache.py
+++ b/tests/sentry/seer/entrypoints/test_cache.py
@@ -14,10 +14,10 @@ class MockCachePayload(TypedDict):
 class SeerOperatorAutofixCacheTest(TestCase):
     def setUp(self):
         self.entrypoint_key = str(SeerEntrypointKey.SLACK)
-        self.pre_cache_key = SeerOperatorAutofixCache.get_pre_autofix_cache_key(
+        self.pre_cache_key = SeerOperatorAutofixCache._get_pre_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
         )
-        self.post_cache_key = SeerOperatorAutofixCache.get_post_autofix_cache_key(
+        self.post_cache_key = SeerOperatorAutofixCache._get_post_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 
@@ -66,7 +66,7 @@ class SeerOperatorAutofixCacheTest(TestCase):
         pre_cache_payload = MockCachePayload(thread_id="pre_cache_payload")
         mock_cache_get.return_value = pre_cache_payload
 
-        result = SeerOperatorAutofixCache.get_pre_autofix_cache(
+        result = SeerOperatorAutofixCache._get_pre_autofix_cache(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
         )
 
@@ -80,7 +80,7 @@ class SeerOperatorAutofixCacheTest(TestCase):
     def test_get_pre_autofix_cache_miss(self, mock_cache_get):
         mock_cache_get.return_value = None
 
-        result = SeerOperatorAutofixCache.get_pre_autofix_cache(
+        result = SeerOperatorAutofixCache._get_pre_autofix_cache(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
         )
 
@@ -91,7 +91,7 @@ class SeerOperatorAutofixCacheTest(TestCase):
         post_cache_payload = MockCachePayload(thread_id="post_cache_payload")
         mock_cache_get.return_value = post_cache_payload
 
-        result = SeerOperatorAutofixCache.get_post_autofix_cache(
+        result = SeerOperatorAutofixCache._get_post_autofix_cache(
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 
@@ -105,7 +105,7 @@ class SeerOperatorAutofixCacheTest(TestCase):
     def test_get_post_autofix_cache_miss(self, mock_cache_get):
         mock_cache_get.return_value = None
 
-        result = SeerOperatorAutofixCache.get_post_autofix_cache(
+        result = SeerOperatorAutofixCache._get_post_autofix_cache(
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 
@@ -160,10 +160,10 @@ class SeerOperatorAutofixCacheTest(TestCase):
 class SeerOperatorAutofixCacheMigrateTest(TestCase):
     def setUp(self):
         self.entrypoint_key = str(SeerEntrypointKey.SLACK)
-        self.pre_cache_key = SeerOperatorAutofixCache.get_pre_autofix_cache_key(
+        self.pre_cache_key = SeerOperatorAutofixCache._get_pre_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
         )
-        self.post_cache_key = SeerOperatorAutofixCache.get_post_autofix_cache_key(
+        self.post_cache_key = SeerOperatorAutofixCache._get_post_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -86,7 +86,7 @@ class SeerOperatorTest(TestCase):
         for entrypoint_key in entrypoint_registry.registrations.keys():
             assert not SeerOperator.has_access(
                 organization=self.group.project.organization,
-                entrypoint_key=entrypoint_key,
+                entrypoint_key=cast(SeerEntrypointKey, entrypoint_key),
             )
 
     @patch(

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -1,12 +1,14 @@
 import uuid
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 from unittest.mock import ANY, Mock, patch
 
 from rest_framework.response import Response
 
 from fixtures.seer.webhooks import MOCK_RUN_ID
+from sentry.models.organization import Organization
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.operator import SeerOperator, process_autofix_updates
+from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import TestCase
@@ -19,13 +21,17 @@ class MockCachePayload(TypedDict):
 class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
     """Mock entrypoint implementation for testing. Stores function calls similar to a mock."""
 
-    key = SeerEntrypointKey.SLACK
+    key = cast(SeerEntrypointKey, "MOCK")
 
     def __init__(self):
         self.thread_id = str(uuid.uuid4())
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
+
+    @staticmethod
+    def has_access(organization: Organization) -> bool:
+        return True
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         self.autofix_errors.append(error)
@@ -49,6 +55,39 @@ class SeerOperatorTest(TestCase):
     def setUp(self):
         self.entrypoint = MockEntrypoint()
         self.operator = SeerOperator(self.entrypoint)
+
+    @patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True)
+    def test_has_access_with_seer(self, _mock_has_seer_access):
+        MockNoAccessEntrypoint = Mock(spec=SeerEntrypoint)
+        MockNoAccessEntrypoint.key = cast(SeerEntrypointKey, "MOCK_NO_ACCESS")
+        MockNoAccessEntrypoint.has_access.return_value = False
+        with (
+            patch.dict(
+                "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
+                {
+                    MockEntrypoint.key: MockEntrypoint,
+                    MockNoAccessEntrypoint.key: MockNoAccessEntrypoint,
+                },
+                clear=True,
+            ),
+        ):
+            assert SeerOperator.has_access(organization=self.group.project.organization)
+            assert SeerOperator.has_access(
+                organization=self.group.project.organization, entrypoint_key=MockEntrypoint.key
+            )
+            assert not SeerOperator.has_access(
+                organization=self.group.project.organization,
+                entrypoint_key=MockNoAccessEntrypoint.key,
+            )
+
+    @patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=False)
+    def test_has_access_without_seer(self, _mock_has_seer_access):
+        assert not SeerOperator.has_access(organization=self.group.project.organization)
+        for entrypoint_key in entrypoint_registry.registrations.keys():
+            assert not SeerOperator.has_access(
+                organization=self.group.project.organization,
+                entrypoint_key=entrypoint_key,
+            )
 
     @patch(
         "sentry.seer.entrypoints.operator.update_autofix",
@@ -133,6 +172,7 @@ class SeerOperatorTest(TestCase):
     @patch.dict(
         "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
         {MockEntrypoint.key: MockEntrypoint},
+        clear=True,
     )
     @patch("sentry.seer.entrypoints.operator.logger")
     def test_process_autofix_updates_early_exits(self, mock_logger):
@@ -180,6 +220,7 @@ class SeerOperatorTest(TestCase):
         with patch.dict(
             "sentry.seer.entrypoints.operator.entrypoint_registry.registrations",
             {MockEntrypoint.key: mock_entrypoint_cls},
+            clear=True,
         ):
             process_autofix_updates(
                 event_type=event_type,


### PR DESCRIPTION
adding `SeerOperator.has_access()` and entrypoint versions too.

 - the operator version checks for seer access + access to any entrypoint (which checks the entry point version)
 - most app code that invokes the operator uses this check
 - app code that needs to check a single entrypoint still can, but ALSO gets seer checks now 👍 