### PR TITLE
fix(seer): Show repo owner/name in the list of seer connected repos

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
@@ -119,7 +119,9 @@ export function AutofixRepositoriesItem({
           size="zero"
           priority="transparent"
         >
-          {repository.name}
+          <Text size="md">
+            {[repository.owner, repository.name].filter(Boolean).join('/')}
+          </Text>
         </RowButton>
       </Flex>
 


### PR DESCRIPTION
Also adjust font size to match content

<img width="1172" height="356" alt="SCR-20260128-jvlg" src="https://github.com/user-attachments/assets/3917877b-e077-46de-a6c5-3fe4049ae6b4" />
