### PR TITLE
ref(preprod): improve visual hierarchy for group insight instances

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
@@ -77,11 +77,11 @@ describe('GroupInsightItemDiffTable', () => {
     expect(screen.getByText('icon.png')).toBeInTheDocument();
     expect(screen.getByText('LICENSE.txt')).toBeInTheDocument();
 
-    // Check nested child items
-    expect(screen.getByText('/assets/icon1.png')).toBeInTheDocument();
-    expect(screen.getByText('/assets/icon2.png')).toBeInTheDocument();
-    expect(screen.getByText('/META-INF/LICENSE1.txt')).toBeInTheDocument();
-    expect(screen.getByText('/META-INF/LICENSE2.txt')).toBeInTheDocument();
+    // Check nested child items (rendered with └ prefix)
+    expect(screen.getByText('└ /assets/icon1.png')).toBeInTheDocument();
+    expect(screen.getByText('└ /assets/icon2.png')).toBeInTheDocument();
+    expect(screen.getByText('└ /META-INF/LICENSE1.txt')).toBeInTheDocument();
+    expect(screen.getByText('└ /META-INF/LICENSE2.txt')).toBeInTheDocument();
   });
 
   it('displays correct status tags and sizes', () => {
@@ -95,10 +95,8 @@ describe('GroupInsightItemDiffTable', () => {
     const removedTags = screen.getAllByText('Removed');
     expect(removedTags).toHaveLength(3); // 1 group + 2 children
 
-    // Check sizes
+    // Check sizes (only group totals are shown, not individual child sizes)
     expect(screen.getByText('+1.5 KB')).toBeInTheDocument(); // Group total
-    expect(screen.getByText('+500 B')).toBeInTheDocument(); // Child 1
-    expect(screen.getByText('+1 KB')).toBeInTheDocument(); // Child 2
   });
 
   it('supports sorting by different fields', async () => {

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -252,7 +252,7 @@ export function GroupInsightItemDiffTable({
                     <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
                       <Text variant="muted">└ {diffItem.path ?? ''}</Text>
                     </SimpleTable.RowCell>
-                    <SimpleTable.RowCell />
+                    <SimpleTable.RowCell>{null}</SimpleTable.RowCell>
                   </SimpleTable.Row>
                 );
               })}

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -250,11 +250,9 @@ export function GroupInsightItemDiffTable({
                       </Tag>
                     </SimpleTable.RowCell>
                     <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
-                      <Text variant="muted">{diffItem.path ?? ''}</Text>
+                      <Text variant="muted">└ {diffItem.path ?? ''}</Text>
                     </SimpleTable.RowCell>
-                    <DiffTableChangeAmountCell changeType={diffItem.type}>
-                      {formattedSizeDiff(diffItem.size_diff)}
-                    </DiffTableChangeAmountCell>
+                    <SimpleTable.RowCell />
                   </SimpleTable.Row>
                 );
               })}


### PR DESCRIPTION
Remove size diff from instance rows and add tree connector prefix to visually distinguish instances from their parent group.

Prod
insight diff shows lots of duplicate Potential Savings, sum doesn't add up to overall
<img width="2738" height="1052" alt="CleanShot 2026-01-28 at 13 45 21@2x" src="https://github.com/user-attachments/assets/c9d87557-b975-45c0-87cb-4ab9e344a59d" />


PR
remove potential savings on child rows + add tree marker
<img width="2752" height="962" alt="CleanShot 2026-01-28 at 13 45 57@2x" src="https://github.com/user-attachments/assets/8a496b0a-f41d-4382-9537-f0f853e83575" />


EME-790
