### PR TITLE
fix(tracemetrics): Switch to Aggregates mode when a group by is added

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -38,7 +38,7 @@ export default function MetricInfoTabs({
   const setAggregatesMode = useSetQueryParamsMode();
   return (
     <TabStateProvider<Mode>
-      defaultValue={queryParamsMode}
+      value={queryParamsMode}
       onChange={mode => {
         setAggregatesMode(mode);
       }}

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -573,11 +573,13 @@ describe('MetricsTabContent', () => {
     const regionOption = await screen.findByRole('option', {name: 'test.region'});
     await userEvent.click(regionOption);
 
-    // Verify that the mode switched to aggregate in the URL
-    const metricQuery = router.location.query.metric;
+    let metricQuery = router.location.query.metric;
     expect(metricQuery).toBeDefined();
+
+    // Verify that the mode switched to aggregate in the URL
     let parsedQuery: ReturnType<typeof JSON.parse>;
     await waitFor(() => {
+      metricQuery = router.location.query.metric;
       parsedQuery = JSON.parse(metricQuery as string);
       expect(parsedQuery.mode).toBe('aggregate');
     });

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -522,4 +522,65 @@ describe('MetricsTabContent', () => {
 
     expect(trackAnalyticsMock).toHaveBeenCalledTimes(1);
   });
+
+  it('should switch to aggregate mode when a group by is added', async () => {
+    // Mock the trace-items attributes endpoint for string type attributes
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
+        {key: 'test.region', name: 'test.region'},
+        {key: 'test.service', name: 'test.service'},
+      ],
+      match: [MockApiClient.matchQuery({attributeType: 'string'})],
+    });
+
+    // Mock the trace-items attributes endpoint for number type attributes (empty)
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'number'})],
+    });
+
+    const {router} = render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig,
+        organization,
+      }
+    );
+
+    const toolbars = screen.getAllByTestId('metric-toolbar');
+    expect(toolbars).toHaveLength(1);
+
+    // Wait for the toolbar to load
+    await waitFor(() => {
+      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    });
+
+    // Verify initial state is samples mode
+    const initialMetricQuery = JSON.parse(router.location.query.metric as string);
+    expect(initialMetricQuery.mode).toBe('samples');
+
+    // Click on the Group by selector - use text content since prefix renders differently
+    const groupByButton = within(toolbars[0]!).getByText('Group by');
+    await userEvent.click(groupByButton);
+
+    // Select a group by option (test.region)
+    const regionOption = await screen.findByRole('option', {name: 'test.region'});
+    await userEvent.click(regionOption);
+
+    // Verify that the mode switched to aggregate in the URL
+    const metricQuery = router.location.query.metric;
+    expect(metricQuery).toBeDefined();
+    let parsedQuery: ReturnType<typeof JSON.parse>;
+    await waitFor(() => {
+      parsedQuery = JSON.parse(metricQuery as string);
+      expect(parsedQuery.mode).toBe('aggregate');
+    });
+    expect(parsedQuery.aggregateFields).toContainEqual({groupBy: 'test.region'});
+  });
 });


### PR DESCRIPTION
Grouping is most visible on Aggregates mode, so when a new grouping is applied, switch to the aggregates mode so users can view the values of the new grouping.

This behaviour matches spans and logs.