### PR TITLE
chore(cells): deprecate non-org-scoped related-issues endpoint

### DIFF
--- a/src/sentry/issues/endpoints/related_issues.py
+++ b/src/sentry/issues/endpoints/related_issues.py
@@ -5,6 +5,8 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.related.same_root_cause import same_root_cause_analysis
 from sentry.issues.related.trace_connected import trace_connected_analysis
@@ -35,6 +37,7 @@ class RelatedIssuesEndpoint(GroupEndpoint):
     )
 
     # We get a Group object since the endpoint is /issues/{issue_id}/related-issues
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-related-issues"])
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve related issues for a Group


### PR DESCRIPTION
Deprecate the non-org scoped `related-issues` endpoint. The frontend (`groupRelatedIssues`) already uses the org-scoped version: `sentry-api-0-organization-group-related-issue`.