### PR TITLE
feat(debug): Allow debug to be a string

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -178,7 +178,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 organization=organization,
                 query_string=query,
                 sampling_mode=sampling_mode,
-                debug=request.user.is_superuser and "debug" in request.GET,
+                debug=request.user.is_superuser and request.GET.get("debug", False),
                 case_insensitive=request.GET.get("caseInsensitive", "0") == "1",
             )
             return params

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -240,7 +240,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
 
         use_aggregate_conditions = request.GET.get("allowAggregateConditions", "1") == "1"
-        debug = request.user.is_superuser and "debug" in request.GET
+        debug = request.user.is_superuser and request.GET.get("debug", False)
 
         def _data_fn(
             dataset_query: DatasetQuery,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -240,7 +240,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
 
         use_aggregate_conditions = request.GET.get("allowAggregateConditions", "1") == "1"
-        debug = request.user.is_superuser and request.GET.get("debug", False)
 
         def _data_fn(
             dataset_query: DatasetQuery,
@@ -280,7 +279,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 on_demand_metrics_type=on_demand_metrics_type,
                 fallback_to_transactions=True,
                 query_source=query_source,
-                debug=debug,
             )
 
         @sentry_sdk.tracing.trace

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -289,6 +289,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
         include_other = request.GET.get("excludeOther") != "1"
         referrer = request.GET.get("referrer")
+        debug = request.user.is_superuser and request.GET.get("debug", False)
         # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
         if request.auth:
             referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
@@ -338,6 +339,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                     sampling_mode=snuba_params.sampling_mode,
                     equations=self.get_equation_list(organization, request, param_name="groupBy"),
                     additional_queries=additional_queries,
+                    debug=debug,
                 )
             return dataset.top_events_timeseries(
                 timeseries_columns=query_columns,
@@ -368,6 +370,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,
                 additional_queries=additional_queries,
+                debug=debug,
             )
 
         return dataset.timeseries_query(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -289,7 +289,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
         include_other = request.GET.get("excludeOther") != "1"
         referrer = request.GET.get("referrer")
-        debug = request.user.is_superuser and request.GET.get("debug", False)
         # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
         if request.auth:
             referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
@@ -339,7 +338,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                     sampling_mode=snuba_params.sampling_mode,
                     equations=self.get_equation_list(organization, request, param_name="groupBy"),
                     additional_queries=additional_queries,
-                    debug=debug,
                 )
             return dataset.top_events_timeseries(
                 timeseries_columns=query_columns,
@@ -370,7 +368,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,
                 additional_queries=additional_queries,
-                debug=debug,
             )
 
         return dataset.timeseries_query(

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -102,7 +102,7 @@ class SnubaParams:
     teams: Iterable[Team] = field(default_factory=list)
     organization: Organization | None = None
     sampling_mode: SAMPLING_MODES | None = None
-    debug: bool = False
+    debug: str | bool = False
     case_insensitive: bool = False
 
     def __post_init__(self) -> None:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -186,7 +186,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -186,7 +186,6 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -261,7 +260,7 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -58,7 +58,7 @@ def query(
     dataset: Dataset = Dataset.Events,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -58,7 +58,6 @@ def query(
     dataset: Dataset = Dataset.Events,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -92,7 +91,7 @@ def query(
         builder.add_conditions(conditions)
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
     result["meta"]["tips"] = transform_tips(builder.tips)
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     return result
 

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -42,7 +42,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> Any:
@@ -72,7 +71,7 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -42,7 +42,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> Any:

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -39,7 +39,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -102,7 +101,7 @@ def query(
     if conditions is not None:
         builder.add_conditions(conditions)
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -39,7 +39,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -48,7 +48,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -78,7 +77,6 @@ def query(
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
                 query_source=query_source,
-                debug=debug,
             )
             result["meta"]["datasetReason"] = dataset_reason
 
@@ -117,7 +115,6 @@ def query(
             transform_alias_to_input_format=transform_alias_to_input_format,
             has_metrics=has_metrics,
             query_source=query_source,
-            debug=debug,
         )
         results["meta"]["isMetricsData"] = False
         results["meta"]["isMetricsExtractedData"] = False

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -48,7 +48,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -54,7 +54,7 @@ def query(
     granularity: int | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -54,7 +54,6 @@ def query(
     granularity: int | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -92,7 +91,7 @@ def query(
         results = metrics_query.process_results(results)
         results["meta"]["isMetricsData"] = True
         results["meta"]["isMetricsExtractedData"] = metrics_query.use_on_demand
-        if debug:
+        if snuba_params.debug:
             results["meta"]["debug_info"] = {"query": str(metrics_query.get_snql_query().query)}
         sentry_sdk.set_tag("performance.dataset", "metrics")
         sentry_sdk.set_tag("on_demand.is_extracted", metrics_query.use_on_demand)

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -39,7 +39,6 @@ class OurLogs(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
@@ -80,5 +79,5 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 page_token=page_token,
                 additional_queries=additional_queries,
             ),
-            debug=debug,
+            debug=params.debug,
         )

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -39,7 +39,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64

--- a/src/sentry/snuba/preprod_size.py
+++ b/src/sentry/snuba/preprod_size.py
@@ -40,7 +40,6 @@ class PreprodSize(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
@@ -57,5 +56,5 @@ class PreprodSize(rpc_dataset_common.RPCBase):
                 page_token=page_token,
                 additional_queries=additional_queries,
             ),
-            debug=debug,
+            debug=params.debug,
         )

--- a/src/sentry/snuba/preprod_size.py
+++ b/src/sentry/snuba/preprod_size.py
@@ -40,7 +40,7 @@ class PreprodSize(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(

--- a/src/sentry/snuba/profile_functions.py
+++ b/src/sentry/snuba/profile_functions.py
@@ -33,7 +33,7 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(

--- a/src/sentry/snuba/profile_functions.py
+++ b/src/sentry/snuba/profile_functions.py
@@ -33,7 +33,6 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
@@ -53,5 +52,5 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
                 page_token=page_token,
                 additional_queries=additional_queries,
             ),
-            debug=debug,
+            debug=params.debug,
         )

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -35,7 +35,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -58,7 +57,7 @@ def query(
         ),
     )
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -35,7 +35,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -560,7 +560,7 @@ class RPCBase:
         cls, debug: str | bool, rpc_request: TimeSeriesRequest
     ) -> TimeSeriesResponse:
         try:
-            return snuba_rpc.timeseries_rpc([rpc_request])[0]
+            return snuba_rpc.timeseries_rpc([rpc_request], debug=debug)[0]
         except Exception as e:
             # add the rpc to the error so we can include it in the response
             if debug:
@@ -872,7 +872,8 @@ class RPCBase:
                 resolver=table_search_resolver,
                 equations=equations,
                 additional_queries=additional_queries,
-            )
+            ),
+            debug=params.debug,
         )
         # There aren't any top events, just return an empty dict and save a query
         if len(top_events["data"]) == 0:
@@ -916,7 +917,7 @@ class RPCBase:
 
         """Run the query"""
         try:
-            timeseries_rpc_response = snuba_rpc.timeseries_rpc(requests)
+            timeseries_rpc_response = snuba_rpc.timeseries_rpc(requests, debug=params.debug)
             rpc_response = timeseries_rpc_response[0]
             if len(timeseries_rpc_response) > 1:
                 other_response = timeseries_rpc_response[1]

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -342,7 +342,7 @@ class RPCBase:
     def _run_table_query(
         cls,
         query: TableQuery,
-        debug: bool = False,
+        debug: str | bool = False,
     ) -> EAPResponse:
         """Run the query"""
         table_request = cls.get_table_rpc_request(query)
@@ -406,7 +406,7 @@ class RPCBase:
         cls,
         rpc_response: TraceItemTableResponse,
         table_request: TableRequest,
-        debug: bool = False,
+        debug: str | bool = False,
     ) -> EAPResponse:
         """Process the results"""
         final_data: SnubaData = []
@@ -420,7 +420,10 @@ class RPCBase:
             if attribute not in columns_by_name:
                 logger.warning(
                     "A column was returned by the rpc but not a known column",
-                    extra={"attribute": attribute},
+                    extra={
+                        "attribute": attribute,
+                        "debug": debug,
+                    },
                 )
                 continue
             resolved_column = columns_by_name[attribute]
@@ -553,7 +556,9 @@ class RPCBase:
             raise InvalidSearchQuery("start, end and interval are required")
 
     @classmethod
-    def _run_timeseries_rpc(cls, debug: bool, rpc_request: TimeSeriesRequest) -> TimeSeriesResponse:
+    def _run_timeseries_rpc(
+        cls, debug: str | bool, rpc_request: TimeSeriesRequest
+    ) -> TimeSeriesResponse:
         try:
             return snuba_rpc.timeseries_rpc([rpc_request])[0]
         except Exception as e:

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -45,7 +45,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ):

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -45,7 +45,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ):
@@ -75,7 +74,7 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     return result
 

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -43,7 +43,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ):

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -43,7 +43,6 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ):
@@ -74,7 +73,7 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
-    if debug:
+    if snuba_params.debug:
         result["meta"]["debug_info"] = {"query": str(builder.get_snql_query().query)}
     return result
 

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -40,7 +40,7 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -40,7 +40,6 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
@@ -70,5 +69,5 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
                 page_token=page_token,
                 additional_queries=additional_queries,
             ),
-            debug=debug,
+            debug=params.debug,
         )

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -41,7 +41,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool = False,
+    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -41,7 +41,6 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
-    debug: bool | str = False,
     *,
     referrer: str,
 ) -> EventsResponse:
@@ -72,7 +71,6 @@ def query(
         dataset=Dataset.Transactions,
         fallback_to_transactions=fallback_to_transactions,
         query_source=query_source,
-        debug=debug,
     )
 
 

--- a/src/sentry/snuba/types.py
+++ b/src/sentry/snuba/types.py
@@ -36,7 +36,6 @@ class DatasetQuery(Protocol):
         dataset: Dataset = Dataset.Discover,
         fallback_to_transactions: bool = False,
         query_source: QuerySource | None = None,
-        debug: bool | str = False,
         *,
         referrer: str,
     ) -> EventsResponse: ...

--- a/src/sentry/snuba/types.py
+++ b/src/sentry/snuba/types.py
@@ -36,7 +36,7 @@ class DatasetQuery(Protocol):
         dataset: Dataset = Dataset.Discover,
         fallback_to_transactions: bool = False,
         query_source: QuerySource | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         *,
         referrer: str,
     ) -> EventsResponse: ...

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -35,7 +35,6 @@ class UptimeResults(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
@@ -51,7 +50,7 @@ class UptimeResults(rpc_dataset_common.RPCBase):
                 resolver=search_resolver or cls.get_resolver(params, config),
                 page_token=page_token,
             ),
-            debug,
+            params.debug,
         )
 
     @classmethod

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -35,7 +35,7 @@ class UptimeResults(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        debug: bool = False,
+        debug: bool | str = False,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -91,12 +91,16 @@ class SnubaRPCRequest(Protocol):
     ) -> RequestMeta: ...
 
 
-def table_rpc(requests: list[TraceItemTableRequest]) -> list[TraceItemTableResponse]:
-    return _make_rpc_requests(table_requests=requests).table_response
+def table_rpc(
+    requests: list[TraceItemTableRequest], debug: str | bool = False
+) -> list[TraceItemTableResponse]:
+    return _make_rpc_requests(table_requests=requests, debug=debug).table_response
 
 
-def timeseries_rpc(requests: list[TimeSeriesRequest]) -> list[TimeSeriesResponse]:
-    return _make_rpc_requests(timeseries_requests=requests).timeseries_response
+def timeseries_rpc(
+    requests: list[TimeSeriesRequest], debug: str | bool = False
+) -> list[TimeSeriesResponse]:
+    return _make_rpc_requests(timeseries_requests=requests, debug=debug).timeseries_response
 
 
 def get_trace_rpc(request: GetTraceRequest) -> GetTraceResponse:
@@ -110,6 +114,7 @@ def get_trace_rpc(request: GetTraceRequest) -> GetTraceResponse:
 def _make_rpc_requests(
     table_requests: list[TraceItemTableRequest] | None = None,
     timeseries_requests: list[TimeSeriesRequest] | None = None,
+    debug: str | bool = False,
 ) -> MultiRpcResponse:
     """Given lists of requests batch and run them together"""
     # Throw the two lists together, _make_rpc_requests will just run them all
@@ -132,6 +137,7 @@ def _make_rpc_requests(
                 "referrer": request.meta.referrer,
                 "organization_id": request.meta.organization_id,
                 "trace_item_type": request.meta.trace_item_type,
+                "debug": debug,
             },
         )
 
@@ -183,6 +189,7 @@ def _make_rpc_requests(
                     "organization_id": request.meta.organization_id,
                     "page_token": table_response.page_token,
                     "meta": table_response.meta,
+                    "debug": debug,
                 },
             )
             metrics.distribution("snuba_rpc.table_response.length", rpc_rows)
@@ -201,6 +208,7 @@ def _make_rpc_requests(
                     "rpc_rows": rpc_rows,
                     "organization_id": request.meta.organization_id,
                     "meta": timeseries_response.meta,
+                    "debug": debug,
                 },
             )
             metrics.distribution("snuba_rpc.timeseries_response.length", rpc_rows)

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -103,6 +103,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 ],
             )
         self.store_spans(spans)
+        self.user = self.create_user("superuser@example.com", is_superuser=True)
 
         response = self._do_request(
             data={
@@ -112,6 +113,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 "yAxis": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
+                "debug": "wmak",
             },
         )
         assert response.status_code == 200, response.content


### PR DESCRIPTION
- This allows superusers to set debug to a string so that its easier to find the event in logs by searching for that debug string afterwards