### PR TITLE
chore(ui): Disable sentry jest locally

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -341,9 +341,10 @@ const config: Config.InitialOptions = {
     sentryConfig: {
       init: {
         // jest project under Sentry organization (dev productivity team)
-        dsn: CI
-          ? 'https://3fe1dce93e3a4267979ebad67f3de327@o1.ingest.us.sentry.io/4857230'
-          : false,
+        dsn:
+          CI && Boolean(GITHUB_PR_REF)
+            ? 'https://3fe1dce93e3a4267979ebad67f3de327@o1.ingest.us.sentry.io/4857230'
+            : false,
         // Use production env to reduce sampling of commits on master
         environment: CI ? (IS_MASTER_BRANCH ? 'ci:master' : 'ci:pull_request') : 'local',
         tracesSampleRate: CI ? 0.75 : 0,


### PR DESCRIPTION
more people are using CI=true locally which we don't really care about when those tests error or their performance. Check the GITHUB_PR_REF which is set in github actions
