### PR TITLE
perf(ui): Memoize more autosizeinput refs

### DIFF
--- a/static/app/components/arithmeticBuilder/token/literal.tsx
+++ b/static/app/components/arithmeticBuilder/token/literal.tsx
@@ -1,5 +1,5 @@
 import type {ChangeEvent, FocusEvent} from 'react';
-import {Fragment, useCallback, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import type {ListState} from '@react-stately/list';
 import type {KeyboardEvent, Node} from '@react-types/shared';
@@ -240,22 +240,20 @@ function InternalInput({item, state, token}: InternalInputProps) {
   );
 
   return (
-    <Fragment>
-      <InputBox
-        ref={inputRef}
-        inputLabel={t('Add a literal')}
-        inputValue={inputValue}
-        tabIndex={-1}
-        onClick={onClick}
-        onInputBlur={onInputBlur}
-        onInputChange={onInputChange}
-        onInputCommit={onInputCommit}
-        onInputEscape={onInputEscape}
-        onInputFocus={onInputFocus}
-        onKeyDown={onKeyDown}
-        onKeyDownCapture={onKeyDownCapture}
-      />
-    </Fragment>
+    <InputBox
+      ref={inputRef}
+      inputLabel={t('Add a literal')}
+      inputValue={inputValue}
+      tabIndex={-1}
+      onClick={onClick}
+      onInputBlur={onInputBlur}
+      onInputChange={onInputChange}
+      onInputCommit={onInputCommit}
+      onInputEscape={onInputEscape}
+      onInputFocus={onInputFocus}
+      onKeyDown={onKeyDown}
+      onKeyDownCapture={onKeyDownCapture}
+    />
   );
 }
 

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -311,17 +311,21 @@ export function ComboBox({
 
   const autosizeInputRef = useAutosizeInput({value: inputValue});
 
+  const memoizedInputRef = useMemo(() => {
+    return mergeRefs(
+      ref,
+      inputRef,
+      autosizeInputRef,
+      triggerProps.ref as React.Ref<HTMLInputElement>
+    );
+  }, [ref, inputRef, autosizeInputRef, triggerProps.ref]);
+
   return (
     <Flex align="stretch" width="100%" height="100%" position="relative">
       <UnstyledInput
         {...inputProps}
         size="md"
-        ref={mergeRefs(
-          ref,
-          inputRef,
-          autosizeInputRef,
-          triggerProps.ref as React.Ref<HTMLInputElement>
-        )}
+        ref={memoizedInputRef}
         type="text"
         placeholder={placeholder}
         onClick={handleInputClick}

--- a/static/app/components/tokenizedInput/token/inputBox.tsx
+++ b/static/app/components/tokenizedInput/token/inputBox.tsx
@@ -6,7 +6,7 @@ import type {
   MouseEventHandler,
   Ref,
 } from 'react';
-import {useCallback, useRef} from 'react';
+import {useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useTextField} from '@react-aria/textfield';
 import {mergeRefs} from '@react-aria/utils';
@@ -111,12 +111,16 @@ export function InputBox({
 
   const autosizeInputRef = useAutosizeInput({value: inputValue});
 
+  const memoizedInputRef = useMemo(() => {
+    return mergeRefs(ref, inputRef, autosizeInputRef);
+  }, [ref, inputRef, autosizeInputRef]);
+
   return (
     <Flex align="stretch" width="100%" height="100%" position="relative">
       <UnstyledInput
         {...inputProps}
         size="md"
-        ref={mergeRefs(ref, inputRef, autosizeInputRef)}
+        ref={memoizedInputRef}
         type="text"
         placeholder={placeholder}
         onBlur={handleInputBlur}

--- a/static/app/views/issueList/editableIssueViewHeader.tsx
+++ b/static/app/views/issueList/editableIssueViewHeader.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
@@ -116,10 +116,14 @@ function EditingViewTitle({
     value: title,
   });
 
+  const memoizedInputRef = useMemo(() => {
+    return mergeRefs(inputRef, autosizeInputRef);
+  }, [inputRef, autosizeInputRef]);
+
   return (
     <StyledGrowingInput
       value={title}
-      ref={mergeRefs(inputRef, autosizeInputRef)}
+      ref={memoizedInputRef}
       onChange={handleOnChange}
       onKeyDown={handleOnKeyDown}
       onBlur={() => stopEditing()}


### PR DESCRIPTION
Most of the perf gain on autosize input was in pr #107082 this cleans up a few more uses

measured clicking around on this component on explore. Most of the slowness is useNavigate which is expensive.

<img width="341" height="111" alt="image" src="https://github.com/user-attachments/assets/b4b86163-6d0c-4852-9938-2ad778a550f3" />


before you can see little areas of red in the render tree which are recalculating styles
<img width="546" height="599" alt="image" src="https://github.com/user-attachments/assets/eb33536b-af88-43ae-b546-91a7ade8b78c" />


after
<img width="430" height="424" alt="image" src="https://github.com/user-attachments/assets/35ab3f11-72bd-4dd3-9283-0e14110ae078" />



