### PR TITLE
fix(billing): Fix feature flags for emerge categories on usage stats page

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -502,9 +502,9 @@ describe('OrganizationStats', () => {
     expect(screen.queryByRole('option', {name: 'Issue Scans'})).not.toBeInTheDocument();
   });
 
-  it('shows size analysis when billing feature flag is enabled', async () => {
+  it('shows size analysis when expose category feature flag is enabled', async () => {
     const newOrg = OrganizationFixture({
-      features: ['size-analysis-billing'],
+      features: ['expose-category-size-analysis'],
     });
 
     render(<OrganizationStats />, {
@@ -517,7 +517,7 @@ describe('OrganizationStats', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not show size analysis when billing feature flag is disabled', async () => {
+  it('does not show size analysis when expose category feature flag is disabled', async () => {
     const newOrg = OrganizationFixture({
       features: [],
     });
@@ -532,9 +532,9 @@ describe('OrganizationStats', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows installable build when billing feature flag is enabled', async () => {
+  it('shows installable build when expose category feature flag is enabled', async () => {
     const newOrg = OrganizationFixture({
-      features: ['installable-build-billing'],
+      features: ['expose-category-installable-build'],
     });
 
     render(<OrganizationStats />, {
@@ -545,7 +545,7 @@ describe('OrganizationStats', () => {
     expect(screen.getByRole('option', {name: 'Build Distributions'})).toBeInTheDocument();
   });
 
-  it('does not show installable build when billing feature flag is disabled', async () => {
+  it('does not show installable build when expose category feature flag is disabled', async () => {
     const newOrg = OrganizationFixture({
       features: [],
     });

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -288,10 +288,10 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
         return !hasProfilingStats;
       }
       if (opt.value === DataCategory.SIZE_ANALYSIS) {
-        return organization.features.includes('size-analysis-billing');
+        return organization.features.includes('expose-category-size-analysis');
       }
       if (opt.value === DataCategory.INSTALLABLE_BUILD) {
-        return organization.features.includes('installable-build-billing');
+        return organization.features.includes('expose-category-installable-build');
       }
       return true;
     }).map(opt => {


### PR DESCRIPTION
We tie the visibility of the emerge categories on the usage stats page to `expose-category-size-analysis` and `expose-category-installable-build`.

We plan to use `expose-category-size-analysis` for the GA launch.