### PR TITLE
fix(ACI): Add back outbox category

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -64,6 +64,7 @@ class OutboxCategory(IntEnum):
     SENTRY_APP_DELETE = 41
     SENTRY_APP_INSTALLATION_DELETE = 42
     IDENTITY_UPDATE = 43
+    SENTRY_APP_NORMALIZE_ACTIONS = 44
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, int]]:
@@ -329,6 +330,7 @@ class OutboxScope(IntEnum):
         10, {OutboxCategory.RELOCATION_EXPORT_REQUEST, OutboxCategory.RELOCATION_EXPORT_REPLY}
     )
     API_TOKEN_SCOPE = scope_categories(11, {OutboxCategory.API_TOKEN_UPDATE})
+    ACTION_SCOPE = scope_categories(12, {OutboxCategory.SENTRY_APP_NORMALIZE_ACTIONS})
 
     def __str__(self) -> str:
         return self.name

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -35,6 +35,15 @@ from sentry.types.region import get_local_region
 logger = logging.getLogger(__name__)
 
 
+@receiver(process_region_outbox, sender=OutboxCategory.SENTRY_APP_NORMALIZE_ACTIONS)
+def update_sentry_app_action_data(
+    shard_identifier: int,
+    object_identifier: int,
+    **kwds: Any,
+):
+    pass
+
+
 @receiver(process_region_outbox, sender=OutboxCategory.AUDIT_LOG_EVENT)
 def process_audit_log_event(payload: Any, **kwds: Any):
     if payload is not None:


### PR DESCRIPTION
Reverting https://github.com/getsentry/sentry/pull/107091 caused some messages to get stuck because the outbox category wasn't there anymore. This adds it back and adds a noop receiver to they can be processed.

Fixes https://sentry.sentry.io/issues/7225310852/?project=1