### PR TITLE
chore(cells): Convert relay endpoints to internal

### DIFF
--- a/src/sentry/api/endpoints/relay/details.py
+++ b/src/sentry/api/endpoints/relay/details.py
@@ -3,13 +3,13 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SuperuserPermission
 from sentry.models.relay import Relay
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayDetailsEndpoint(Endpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/relay/health_check.py
+++ b/src/sentry/api/endpoints/relay/health_check.py
@@ -3,10 +3,10 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayHealthCheck(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -9,7 +9,7 @@ from sentry_sdk import set_tag, start_span
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RelayAuthentication
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
@@ -28,7 +28,7 @@ PROJECT_CONFIG_SIZE_THRESHOLD = 10000
 ProjectConfig = MutableMapping[str, Any]
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayProjectConfigsEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -4,12 +4,12 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RelayAuthentication
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.relay import Relay
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayPublicKeysEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -9,7 +9,7 @@ from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import is_internal_relay, is_static_relay, relay_from_id
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
@@ -21,7 +21,7 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
     public_key = serializers.CharField(max_length=64, required=True)
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayRegisterChallengeEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -10,7 +10,7 @@ from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import is_internal_relay, relay_from_id
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.models.relay import Relay, RelayUsage
@@ -23,7 +23,7 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
     token = serializers.CharField(required=True)
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class RelayRegisterResponseEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,


### PR DESCRIPTION
Convert 6 relay endpoints from `region_silo_endpoint` to `internal_region_silo_endpoint`:
- register_challenge.py
- register_response.py
- project_configs.py
- public_keys.py
- health_check.py
- details.py

Similar to https://github.com/getsentry/sentry/pull/104397

Not converting the `RelayIndex` endpoint since it's being removed here: https://github.com/getsentry/sentry/pull/106998