### PR TITLE
button: deprecate button borderless prop

### DIFF
--- a/static/app/components/core/button/types.tsx
+++ b/static/app/components/core/button/types.tsx
@@ -22,6 +22,7 @@ export interface DO_NOT_USE_CommonButtonProps {
   analyticsParams?: Record<string, any>;
   /**
    * Removes borders from the button.
+   * @deprecated Use `priority="transparent"` instead.
    */
   borderless?: boolean;
   /**


### PR DESCRIPTION
Deprecate borderless prop in favor of transparent variant. 

https://github.com/user-attachments/assets/6914c6ed-0a89-4c0d-aa6b-4e7fc3374d8e

Looking at the button prop matrix, the combo of warning, primary, danger + borderless breaks the color of the button. The correct substitute here would be to swap borderless for transparent priority where possible and that is what I will attempt via codemod next - we know this is a viable option because borderless applies the exact same styles as transparent.

There will still be instances where this will not be possible due to the restyling `<Button variant=primary borderless />`. In this case, we should be able to swap the button variant for transparent. 

From a design system POV, there is an interesting case here where these buttons are on a colored background. We are seeing those be styled with `color: white` or similar light color such that they do not look wonky on something like a red background

