### PR TITLE
fix(searchQueryBuilder): Revert memo merge refs

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -585,26 +585,17 @@ export function SearchQueryBuilderCombobox<
 
   const autosizeInput = useAutosizeInput({value: inputValue});
 
-  // Memoize the merged ref to avoid calling callback refs on every render.
-  // mergeRefs creates a new function each call, which causes React to call
-  // old ref with null and new ref with element on every render.
-  const mergedInputRef = useMemo(
-    () =>
-      mergeRefs(
-        ref,
-        inputRef,
-        autosizeInput,
-        triggerProps.ref as React.Ref<HTMLInputElement>
-      ),
-    [ref, autosizeInput, triggerProps.ref]
-  );
-
   return (
     <Flex align="stretch" width="100%" height="100%" position="relative">
       <UnstyledInput
         {...inputProps}
         size="md"
-        ref={mergedInputRef}
+        ref={mergeRefs(
+          ref,
+          inputRef,
+          autosizeInput,
+          triggerProps.ref as React.Ref<HTMLInputElement>
+        )}
         type="text"
         placeholder={placeholder}
         onClick={handleInputClick}


### PR DESCRIPTION
Turns out we need those rerenders sometimes. Clicking "add to filter" on some pages modifies the query without keystrokes leading to large leftover spaces.

We still get the performance gain from not adding/removing the div over and over.

<img width="649" height="148" alt="image" src="https://github.com/user-attachments/assets/66eaedf0-c914-4024-9ea4-6893bd261020" />

the large gap disappears once you type in that area. It would need to notified in some way or force updated after the query is modified.

refs #107082