### PR TITLE
feat(aci): Add open period timeline to metric issue details

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -43,16 +43,7 @@ describe('MetricDetectorTriggeredSection', () => {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/open-periods/',
-      body: [
-        {
-          id: '101',
-          start: openPeriodStartDate,
-          end: openPeriodEndDate,
-          isOpen: false,
-          eventId: 'event-1',
-          activities: [],
-        },
-      ],
+      body: [],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/open-periods/',
@@ -156,6 +147,7 @@ describe('MetricDetectorTriggeredSection', () => {
     // Check sections exist by aria-label
     expect(await screen.findByRole('region', {name: 'Message'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Triggered Condition'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Timeline'})).toBeInTheDocument();
 
     // Check message content
     expect(screen.getByText('Subtitle')).toBeInTheDocument();
@@ -183,9 +175,6 @@ describe('MetricDetectorTriggeredSection', () => {
       body: [GroupFixture()],
     });
     const event = EventFixture({
-      dateCreated: openPeriodStartDate,
-      eventID: 'event-1',
-      groupID: '123',
       dateCreated: openPeriodStartDate,
       eventID: 'event-1',
       groupID: '123',
@@ -221,7 +210,6 @@ describe('MetricDetectorTriggeredSection', () => {
         query: expect.objectContaining({
           query: 'issue.type:error event.type:error is:unresolved',
           start: startDate,
-          end: openPeriodEndDate,
           end: openPeriodEndDate,
         }),
       })
@@ -281,7 +269,6 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
       '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
     );
   });

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -54,6 +54,19 @@ describe('MetricDetectorTriggeredSection', () => {
         },
       ],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [
+        {
+          id: '101',
+          start: openPeriodStartDate,
+          end: openPeriodEndDate,
+          isOpen: false,
+          eventId: 'event-1',
+          activities: [],
+        },
+      ],
+    });
   });
 
   it('renders nothing when event has no occurrence', () => {
@@ -173,6 +186,9 @@ describe('MetricDetectorTriggeredSection', () => {
       dateCreated: openPeriodStartDate,
       eventID: 'event-1',
       groupID: '123',
+      dateCreated: openPeriodStartDate,
+      eventID: 'event-1',
+      groupID: '123',
       occurrence: {
         id: '1',
         eventId: 'event-1',
@@ -205,6 +221,7 @@ describe('MetricDetectorTriggeredSection', () => {
         query: expect.objectContaining({
           query: 'issue.type:error event.type:error is:unresolved',
           start: startDate,
+          end: openPeriodEndDate,
           end: openPeriodEndDate,
         }),
       })
@@ -264,6 +281,7 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
       'href',
+      '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
       '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
     );
   });

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -258,6 +258,7 @@ function OpenInDestinationButton({
 }
 
 function TriggeredConditionDetails({
+  evidenceData,
   eventDateCreated,
   eventId,
   groupId,

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -12,6 +12,7 @@ import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import GroupList from 'sentry/components/issues/groupList';
 import Placeholder from 'sentry/components/placeholder';
+import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
@@ -35,6 +36,7 @@ import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/de
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {useEventOpenPeriod} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {useEventOpenPeriod} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
@@ -256,7 +258,6 @@ function OpenInDestinationButton({
 }
 
 function TriggeredConditionDetails({
-  evidenceData,
   eventDateCreated,
   eventId,
   groupId,
@@ -298,6 +299,14 @@ function TriggeredConditionDetails({
         title="Triggered Condition"
         type="triggered_condition"
         actions={
+          isOpenPeriodLoading ? null : (
+            <OpenInDestinationButton
+              snubaQuery={snubaQuery}
+              projectId={projectId}
+              start={startDate}
+              end={endDate}
+            />
+          )
           isOpenPeriodLoading ? null : (
             <OpenInDestinationButton
               snubaQuery={snubaQuery}
@@ -364,6 +373,21 @@ function TriggeredConditionDetails({
           ]}
         />
       </InterimSection>
+      {isErrorsDataset &&
+        (isOpenPeriodLoading ? (
+          <InterimSection title={t('Contributing Issues')} type="contributing_issues">
+            <Placeholder height="200px" />
+          </InterimSection>
+        ) : (
+          <ContributingIssues
+            projectId={projectId}
+            query={issueSearchQuery}
+            eventDateCreated={eventDateCreated}
+            aggregate={snubaQuery.aggregate}
+            start={startDate}
+            end={endDate}
+          />
+        ))}
       {isErrorsDataset &&
         (isOpenPeriodLoading ? (
           <InterimSection title={t('Contributing Issues')} type="contributing_issues">

--- a/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
@@ -1,0 +1,72 @@
+import type {ComponentProps} from 'react';
+import {
+  GroupOpenPeriodActivityFixture,
+  GroupOpenPeriodFixture,
+} from 'sentry-fixture/groupOpenPeriod';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {OpenPeriodTimelineSection} from 'sentry/views/issueDetails/streamline/sidebar/openPeriodTimelineSection';
+
+describe('OpenPeriodTimelineSection', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  const defaultProps: ComponentProps<typeof OpenPeriodTimelineSection> = {
+    eventId: 'event-1',
+    groupId: 'group-1',
+    evaluatedValue: '150',
+  };
+
+  it('renders loading error when open period is missing', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+    });
+
+    render(<OpenPeriodTimelineSection {...defaultProps} />);
+
+    expect(
+      await screen.findByText('Error loading open period timeline')
+    ).toBeInTheDocument();
+  });
+
+  it('renders open period activities', async () => {
+    const openPeriod = GroupOpenPeriodFixture({
+      activities: [
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-1',
+          type: 'opened',
+          value: 'high',
+          dateCreated: '2024-01-01T00:00:00Z',
+        }),
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-2',
+          type: 'status_change',
+          value: 'high',
+          dateCreated: '2024-01-01T00:02:00Z',
+        }),
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-3',
+          type: 'closed',
+          value: null,
+          dateCreated: '2024-01-01T00:05:00Z',
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [openPeriod],
+    });
+
+    render(<OpenPeriodTimelineSection {...defaultProps} />);
+
+    expect(await screen.findByText('Opened')).toBeInTheDocument();
+    expect(screen.getByText('Status Changed')).toBeInTheDocument();
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.getAllByText('Priority: high')).toHaveLength(2);
+    expect(screen.getByText('Value: 150')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
@@ -16,7 +16,6 @@ describe('OpenPeriodTimelineSection', () => {
   const defaultProps: ComponentProps<typeof OpenPeriodTimelineSection> = {
     eventId: 'event-1',
     groupId: 'group-1',
-    evaluatedValue: '150',
   };
 
   it('renders loading error when open period is missing', async () => {
@@ -67,6 +66,5 @@ describe('OpenPeriodTimelineSection', () => {
     expect(screen.getByText('Status Changed')).toBeInTheDocument();
     expect(screen.getByText('Resolved')).toBeInTheDocument();
     expect(screen.getAllByText('Priority: high')).toHaveLength(2);
-    expect(screen.getByText('Value: 150')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.tsx
@@ -1,0 +1,114 @@
+import {Fragment, type ReactNode} from 'react';
+
+import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
+import {DateTime} from 'sentry/components/dateTime';
+import LoadingError from 'sentry/components/loadingError';
+import Placeholder from 'sentry/components/placeholder';
+import {Timeline} from 'sentry/components/timeline';
+import {IconCheckmark, IconFire} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {GroupOpenPeriod} from 'sentry/types/group';
+import {unreachable} from 'sentry/utils/unreachable';
+import {useEventOpenPeriod} from 'sentry/views/detectors/hooks/useOpenPeriods';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+
+type OpenPeriodTimelineSectionProps = {
+  eventId: string;
+  groupId: string;
+};
+
+function getOpenPeriodActivityLabel(
+  activity: GroupOpenPeriod['activities'][number]
+): string {
+  switch (activity.type) {
+    case 'opened':
+      return t('Opened');
+    case 'closed':
+      return t('Resolved');
+    case 'status_change':
+      return t('Status Changed');
+    default:
+      unreachable(activity.type);
+      return t('Updated');
+  }
+}
+
+function getOpenPeriodActivitySubtext(
+  activity: GroupOpenPeriod['activities'][number]
+): ReactNode {
+  const priority = activity.value;
+
+  if (!priority) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <Timeline.Text>{t('Priority: %s', priority)}</Timeline.Text>
+    </Fragment>
+  );
+}
+
+function getOpenPeriodActivityIcon(activity: GroupOpenPeriod['activities'][number]) {
+  switch (activity.type) {
+    case 'opened':
+      return <IconFire size="xs" />;
+    case 'closed':
+      return <IconCheckmark size="xs" />;
+    case 'status_change':
+      return <IconCellSignal size="xs" bars={activity.value === 'high' ? 3 : 2} />;
+    default:
+      return null;
+  }
+}
+
+function TimelineSection({children}: {children: ReactNode}) {
+  return (
+    <InterimSection title={t('Timeline')} type="timeline">
+      {children}
+    </InterimSection>
+  );
+}
+
+export function OpenPeriodTimelineSection({
+  groupId,
+  eventId,
+}: OpenPeriodTimelineSectionProps) {
+  const {openPeriod, isPending, isError} = useEventOpenPeriod({
+    groupId,
+    eventId,
+  });
+
+  if (isPending) {
+    return (
+      <TimelineSection>
+        <Placeholder height="110px" />
+      </TimelineSection>
+    );
+  }
+
+  if (isError || !openPeriod?.activities.length) {
+    return (
+      <TimelineSection>
+        <LoadingError message={t('Error loading open period timeline')} />
+      </TimelineSection>
+    );
+  }
+
+  return (
+    <TimelineSection>
+      <Timeline.Container>
+        {openPeriod.activities.map(activity => (
+          <Timeline.Item
+            key={activity.id}
+            title={getOpenPeriodActivityLabel(activity)}
+            timestamp={<DateTime date={activity.dateCreated} />}
+            icon={getOpenPeriodActivityIcon(activity)}
+          >
+            {getOpenPeriodActivitySubtext(activity)}
+          </Timeline.Item>
+        ))}
+      </Timeline.Container>
+    </TimelineSection>
+  );
+}

--- a/tests/js/fixtures/groupOpenPeriod.ts
+++ b/tests/js/fixtures/groupOpenPeriod.ts
@@ -1,0 +1,40 @@
+import type {GroupOpenPeriod} from 'sentry/types/group';
+
+type GroupOpenPeriodActivity = GroupOpenPeriod['activities'][number];
+
+const DEFAULT_ACTIVITY: GroupOpenPeriodActivity = {
+  id: 'activity-1',
+  type: 'opened',
+  value: 'high',
+  dateCreated: '2024-01-01T00:00:00Z',
+};
+
+const DEFAULT_OPEN_PERIOD: GroupOpenPeriod = {
+  id: 'open-period-1',
+  start: '2024-01-01T00:00:00Z',
+  end: '2024-01-01T00:05:00Z',
+  duration: '5m',
+  eventId: 'event-1',
+  isOpen: false,
+  lastChecked: '2024-01-01T00:05:00Z',
+  activities: [DEFAULT_ACTIVITY],
+};
+
+export function GroupOpenPeriodActivityFixture(
+  params: Partial<GroupOpenPeriodActivity> = {}
+): GroupOpenPeriodActivity {
+  return {
+    ...DEFAULT_ACTIVITY,
+    ...params,
+  };
+}
+
+export function GroupOpenPeriodFixture(
+  params: Partial<GroupOpenPeriod> = {}
+): GroupOpenPeriod {
+  return {
+    ...DEFAULT_OPEN_PERIOD,
+    ...params,
+    activities: params.activities ?? DEFAULT_OPEN_PERIOD.activities,
+  };
+}


### PR DESCRIPTION
Closes ISWF-1953

This gives a much better view of what occurred over the course of the open period. Previously it was difficult to tell if an open period was closed or not.

<img width="2108" height="746" alt="CleanShot 2026-01-28 at 16 17 18@2x" src="https://github.com/user-attachments/assets/b677d425-208a-4a7a-8603-97289898480c" />
