### PR TITLE
Add sampled analytics tracking for event processing errors

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -15,6 +15,7 @@ from .comment_webhooks import *  # noqa: F401,F403
 from .cron_monitor_broken_status_recovery import *  # noqa: F401,F403
 from .cron_monitor_created import *  # noqa: F401,F403
 from .data_consent_org_creation import *  # noqa: F401,F403
+from .event_processing_error_recorded import *  # noqa: F401,F403
 from .eventuser_endpoint_request import *  # noqa: F401,F403
 from .eventuser_equality_check import *  # noqa: F401,F403
 from .eventuser_snuba_for_projects import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/event_processing_error_recorded.py
+++ b/src/sentry/analytics/events/event_processing_error_recorded.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+@analytics.eventclass("event_processing_error.recorded")
+class EventProcessingErrorRecorded(analytics.Event):
+    organization_id: int
+    project_id: int
+    event_id: str
+    group_id: int | None
+    error_type: str
+    platform: str | None
+
+
+analytics.register(EventProcessingErrorRecorded)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import random
 import uuid
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from urllib3.exceptions import MaxRetryError, TimeoutError
 from usageaccountant import UsageUnit
 
 from sentry import (
+    analytics,
     audit_log,
     eventstore,
     eventstream,
@@ -32,6 +34,7 @@ from sentry import (
     reprocessing2,
     tsdb,
 )
+from sentry.analytics.events.event_processing_error_recorded import EventProcessingErrorRecorded
 from sentry.attachments import CachedAttachment, MissingAttachmentChunks
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
@@ -1116,6 +1119,31 @@ def _eventstream_insert_many(jobs: Sequence[Job]) -> None:
                 "internal.captured.eventstream_insert",
                 tags={"event_type": job["event"].data.get("type") or "null"},
             )
+
+        # Record processing errors to analytics at 1% sample rate
+        processing_errors = job["data"].get("errors", [])
+        event = job["event"]
+        if (
+            processing_errors
+            and features.has("organizations:processing-error-analytics", event.project.organization)
+            and random.random() < 0.01
+        ):
+            group_id = job["groups"][0].group.id if job["groups"] else None
+            for error in processing_errors:
+                error_type = error.get("type", "unknown")
+                try:
+                    analytics.record(
+                        EventProcessingErrorRecorded(
+                            organization_id=event.project.organization_id,
+                            project_id=event.project_id,
+                            event_id=event.event_id,
+                            group_id=group_id,
+                            error_type=error_type,
+                            platform=job["data"].get("platform"),
+                        )
+                    )
+                except Exception:
+                    logger.warning("Failed to save EventProcessingErrorRecorded", exc_info=True)
 
         # XXX: Temporary hack so that we keep this group info working for error issues. We'll need
         # to change the format of eventstream to be able to handle data for multiple groups

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -371,6 +371,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:prevent-ai", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent team Replay Assertions (Flows) POC
     manager.add("organizations:prevent-flows-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables recording processing errors to analytics for product validation
+    manager.add("organizations:processing-error-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -19,7 +19,8 @@ from django.core.cache import cache
 from django.db.models import F
 from django.utils import timezone
 
-from sentry import nodestore, tsdb
+from sentry import analytics, nodestore, tsdb
+from sentry.analytics.events.event_processing_error_recorded import EventProcessingErrorRecorded
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.constants import MAX_VERSION_LENGTH, DataCategory, InsightModules
@@ -4213,3 +4214,124 @@ def test_cogs_event_manager(
     # We cannot assert for exact length because manager save method adds some extra fields. So we
     # assert that the length is at least greater than the expected length.
     assert formatted["amount"] >= expected_len
+
+
+class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
+    """
+    Unit tests for processing error analytics recording.
+
+    These tests use store_event() which goes through the full EventManager flow.
+    Errors can come from:
+    1. Normalization (validation errors like invalid_data, future_timestamp)
+    2. Symbolication (js_*, native_*, proguard_* errors)
+    """
+
+    @mock.patch("sentry.event_manager.random.random")
+    def test_validation_errors_recorded_to_analytics(self, mock_random: mock.MagicMock) -> None:
+        """Test that validation errors from normalization are also recorded."""
+        mock_random.return_value = 0.001
+        with (
+            self.feature("organizations:processing-error-analytics"),
+            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
+        ):
+            # Create an event with a future timestamp, which produces a validation error
+            future = timezone.now() + timedelta(minutes=10)
+            event = self.store_event(
+                data=make_event(
+                    platform="python",
+                    timestamp=future.isoformat(),
+                ),
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            recorded_events = [
+                call[0][0]
+                for call in spy_analytics_record.call_args_list
+                if isinstance(call[0][0], EventProcessingErrorRecorded)
+            ]
+            expected_events = [
+                EventProcessingErrorRecorded(
+                    organization_id=self.project.organization_id,
+                    project_id=self.project.id,
+                    event_id=event.event_id,
+                    group_id=event.group_id,
+                    error_type="future_timestamp",
+                    platform="python",
+                ),
+            ]
+            assert recorded_events == expected_events
+
+    @mock.patch("sentry.event_manager.random.random")
+    def test_processing_errors_not_recorded_when_not_sampled(
+        self, mock_random: mock.MagicMock
+    ) -> None:
+        """Test that processing errors are not recorded when outside the 1% sample."""
+        mock_random.return_value = 0.5
+        with (
+            self.feature("organizations:processing-error-analytics"),
+            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
+        ):
+            # Create an event with a future timestamp, which produces a validation error
+            future = timezone.now() + timedelta(minutes=10)
+            self.store_event(
+                data=make_event(
+                    platform="python",
+                    timestamp=future.isoformat(),
+                ),
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            processing_error_calls = [
+                call
+                for call in spy_analytics_record.call_args_list
+                if isinstance(call[0][0], EventProcessingErrorRecorded)
+            ]
+            assert len(processing_error_calls) == 0
+
+    @mock.patch("sentry.event_manager.random.random")
+    def test_processing_errors_not_recorded_when_no_errors(
+        self, mock_random: mock.MagicMock
+    ) -> None:
+        """Test that analytics is not recorded when there are no processing errors."""
+        mock_random.return_value = 0.001
+        with (
+            self.feature("organizations:processing-error-analytics"),
+            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
+        ):
+            self.store_event(
+                data=make_event(platform="python"),
+                project_id=self.project.id,
+            )
+            processing_error_calls = [
+                call
+                for call in spy_analytics_record.call_args_list
+                if isinstance(call[0][0], EventProcessingErrorRecorded)
+            ]
+            assert len(processing_error_calls) == 0
+
+    @mock.patch("sentry.event_manager.random.random")
+    def test_processing_errors_not_recorded_when_feature_disabled(
+        self, mock_random: mock.MagicMock
+    ) -> None:
+        """Test that analytics is not recorded when feature flag is disabled."""
+        mock_random.return_value = 0.001
+        with (
+            self.feature({"organizations:processing-error-analytics": False}),
+            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
+        ):
+            # Create an event with a future timestamp, which produces a validation error
+            future = timezone.now() + timedelta(minutes=10)
+            self.store_event(
+                data=make_event(
+                    platform="python",
+                    timestamp=future.isoformat(),
+                ),
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            processing_error_calls = [
+                call
+                for call in spy_analytics_record.call_args_list
+                if isinstance(call[0][0], EventProcessingErrorRecorded)
+            ]
+            assert len(processing_error_calls) == 0


### PR DESCRIPTION
Record error event processing errors (symbolication failures, validation errors, etc.) to BigQuery via analytics events at 1% sample rate for product validation. Gated behind the organizations:processing-error-analytics flagpole flag, enabled by default.

<!-- Describe your PR here. -->