### PR TITLE
fix(auth): Fix CSRF token refresh for multi-tab auth scenarios

### DIFF
--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -5,6 +5,7 @@
 
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load sentry_assets %}
 
 {% block wrapperclass %}narrow auth org-login{% endblock %}
 
@@ -34,4 +35,40 @@
 {% endblock %}
 
 {% block footer %}
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+{% script %}
+<script>
+  // Refresh CSRF tokens for multi-tab scenarios
+  // When user logs in on one tab, CSRF rotates, other tabs need updated tokens
+  (function() {
+    function getCookie(name) {
+      if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+          var cookie = cookies[i].trim();
+          if (cookie.substring(0, name.length + 1) === name + '=') {
+            return decodeURIComponent(cookie.substring(name.length + 1));
+          }
+        }
+      }
+      return null;
+    }
+
+    setInterval(function() {
+      var csrfCookieVal = getCookie(window.csrfCookieName || 'sc');
+      // combine strings for csrf name as some tests grep on the token name :(
+      var csrfName = 'csrf' + 'middleware' + 'token';
+      var csrfEls = document.getElementsByName(csrfName);
+      if (csrfEls.length > 0 && csrfCookieVal) {
+        for (var i = 0; i < csrfEls.length; i++) {
+          csrfEls[i].value = csrfCookieVal;
+        }
+      }
+    }, 200);
+  })();
+</script>
+{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -41,8 +41,10 @@
 {{ block.super }}
 {% script %}
 <script>
-  // Refresh CSRF tokens for multi-tab scenarios
-  // When user logs in on one tab, CSRF rotates, other tabs need updated tokens
+  // HACK(jferge+claude): inline getCookie function from our utils,
+  // update the csrf token value in a rudimentary way (timer based)
+  // on auth forms to help out when users have multiple sentry tabs
+  // and are logged out
   (function() {
     function getCookie(name) {
       if (document.cookie && document.cookie !== '') {

--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -15,32 +15,6 @@
     input: '#id_registration_password',
     element: '.password-strength',
   });
-  // HACK(jferge): inline getCookie function from our utils,
-  // update the csrf token value in a rudimentary way (timer based)
-  // on the SSO login form
-  // to help out when users have multiple sentry tabs and are logged out
-  function getCookie(name) {
-    if (document.cookie && document.cookie !== '') {
-      var cookies = document.cookie.split(';');
-      for (let i = 0; i < cookies.length; i++) {
-        var cookie = cookies[i].trim();
-        // Does this cookie string begin with the name we want?
-        if (cookie.substring(0, name.length + 1) === name + '=') {
-          return decodeURIComponent(cookie.substring(name.length + 1));
-        }
-      }
-    }
-    return null;
-  }
-  setInterval(function() {
-    var csrfCookieVal = getCookie(window.csrfCookieName || 'sc');
-    // combine strings for csrf name as some tests grep on the token name :(
-    var csrfName = 'csrf'+'middleware'+'token';
-    var csrfEls = document.getElementsByName(csrfName);
-    if (csrfEls.length == 1 && csrfCookieVal) {
-      csrfEls[0].value = csrfCookieVal;
-    }
-  },200);
 </script>
 {% endscript %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Moves the CSRF token cross-tab synchronization from `organization-login.html` to the base `auth.html` template
- Synchronization logic now uses `csrfEls.length > 0` and loops through ALL CSRF elements instead of only one.

## Problem
Users experience "CSRF token from POST incorrect" errors when:
1. They have multiple tabs open on auth pages
2. One tab completes login (rotating the CSRF token)
3. Other tabs try to submit with stale CSRF tokens

The original cross-tab synchronization was introduced in https://github.com/getsentry/sentry/pull/32592, but it only worked when there was exactly 1 CSRF form (SSO auth orgs). This PR also fixes it to work on orgs without SSO, where there are multiple login forms (login + register) with multiple tokens.

## Solution
Move the cross-tab synchronization to the base `auth.html` template so ALL auth pages benefit:
- `login.html`
- `twofactor.html`
- `twofactor_u2f.html`
- `organization-login.html`
- `oauth-authorize.html`
- `oauth-device.html`
- And other auth templates

## Test plan
1. Open two tabs to `/auth/login/sentry/`
2. In browser console on both tabs, check CSRF values: `document.getElementsByName('csrfmiddlewaretoken')[0].value`
3. Log in on Tab 1
4. Check Tab 2 - the CSRF values should update within 200ms
5. Submitting on Tab 2 should succeed (no CSRF error)

## Known limitation
WebAuthn/passkey auto-submit (`form.submit()`) may still race ahead of the 200ms interval. This is a narrower edge case. If we still observe problems, we can likely lower the interval.


## Monitoring:
we can use this [logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.web.frontend.csrf_failure%22%0AjsonPayload.reason%3D%22CSRF%20token%20from%20POST%20incorrect.%22;summaryFields=:true:32:beginning;cursorTimestamp=2026-01-29T01:08:45.304939119Z;duration=P30D?project=internal-sentry) query to observe if the number of users hitting this error decreases after the change.

Can monitor as we rollout to confirm changes don't degrade auth, during my local testing all looks good.
