### PR TITLE
Add GitHub Copilot integration CTA to Seer project details

### DIFF
--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -8,6 +8,7 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import {GithubCopilotIntegrationCta} from 'sentry/components/events/autofix/githubCopilotIntegrationCta';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
@@ -114,6 +115,7 @@ function SeerProjectDetails() {
             preference={preference ?? DEFAULT_PREFERENCE}
             project={project}
           />
+          <GithubCopilotIntegrationCta />
         </Stack>
       )}
     </Fragment>

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -8,6 +8,7 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
 import {GithubCopilotIntegrationCta} from 'sentry/components/events/autofix/githubCopilotIntegrationCta';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
@@ -115,6 +116,7 @@ function SeerProjectDetails() {
             preference={preference ?? DEFAULT_PREFERENCE}
             project={project}
           />
+          <CursorIntegrationCta project={project} />
           <GithubCopilotIntegrationCta />
         </Stack>
       )}


### PR DESCRIPTION
## Description

This PR adds the `GithubCopilotIntegrationCta` component to the Seer project details page. This call-to-action component will prompt users to integrate GitHub Copilot with their Sentry projects.

## Changes

- Import `GithubCopilotIntegrationCta` component from `sentry/components/events/autofix/githubCopilotIntegrationCta`
- Render the component within the project details view, below the existing Seer preferences section

## Motivation

This change enhances the user experience by making GitHub Copilot integration more discoverable and accessible directly from the project details page, allowing users to easily enable AI-powered autofix capabilities.

---

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

https://claude.ai/code/session_01Wcx5ovWfoDE8aimgN3ago8