### PR TITLE
:sparkles: feat(gitlab): add issue sync outbound support

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -467,7 +467,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/issues.html#list-project-issues
         """
-        path = GitLabApiClientPath.project_issues.format(project=project_id)
+        path = GitLabApiClientPath.project_issues.format(project=quote(str(project_id), safe=""))
 
         return self.get(path, params={"scope": "all", "search": query, "iids": iids})
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -6,6 +6,10 @@ from typing import Any
 from urllib.parse import urlparse
 
 from django.http.request import HttpRequest
+from django.http.response import HttpResponseBase
+from django.urls import reverse
+from django.http.response import HttpResponseBase
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import BooleanField, CharField, URLField
 
@@ -21,10 +25,12 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_WEBHOOK_VERSION_KEY
-from sentry.integrations.gitlab.tasks import update_all_project_webhooks
+from sentry.integrations.gitlab.types import GitLabIssueStatus
+from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.referrer_ids import GITLAB_PR_BOT_REFERRER
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.repository import repository_service
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import (
     CommitContextIntegration,
@@ -47,6 +53,7 @@ from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     ApiUnauthorized,
     IntegrationConfigurationError,
+    IntegrationError,
     IntegrationProviderError,
 )
 from sentry.snuba.referrer import Referrer
@@ -291,6 +298,54 @@ class GitlabIntegration(
 
         has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
 
+        # Add outbound status sync configuration if feature flag is enabled
+        if self.check_feature_flag():
+            # Get currently configured external projects to display their labels
+            current_project_items = []
+            if self.org_integration:
+                external_projects = IntegrationExternalProject.objects.filter(
+                    organization_integration_id=self.org_integration.id
+                )
+
+                if external_projects.exists():
+                    current_project_items = [
+                        {"value": project.external_id, "label": project.name}
+                        for project in external_projects
+                    ]
+
+            config.insert(
+                0,
+                {
+                    "name": self.outbound_status_key,
+                    "type": "choice_mapper",
+                    "label": _("Sync Sentry Status to GitLab"),
+                    "help": _(
+                        "When a Sentry issue changes status, change the status of the linked ticket in GitLab."
+                    ),
+                    "addButtonText": _("Add GitLab Project"),
+                    "addDropdown": {
+                        "emptyMessage": _("All projects configured"),
+                        "noResultsMessage": _("Could not find GitLab project"),
+                        "items": current_project_items,
+                        "url": reverse(
+                            "sentry-extensions-gitlab-search",
+                            args=[organization.slug, self.model.id],
+                        ),
+                        "searchField": "project",
+                    },
+                    "mappedSelectors": {
+                        "on_resolve": {"choices": GitLabIssueStatus.get_choices()},
+                        "on_unresolve": {"choices": GitLabIssueStatus.get_choices()},
+                    },
+                    "columnLabels": {
+                        "on_resolve": _("When resolved"),
+                        "on_unresolve": _("When unresolved"),
+                    },
+                    "mappedColumnLabel": _("GitLab Project"),
+                    "formatMessageValue": False,
+                },
+            )
+
         if not has_issue_sync:
             for field in config:
                 field["disabled"] = True
@@ -306,6 +361,43 @@ class GitlabIntegration(
 
         config = self.org_integration.config
 
+        # Handle status sync configuration
+        if "sync_status_forward" in data:
+            project_mappings = data.pop("sync_status_forward")
+
+            # Validate that all mappings have both statuses
+            if any(
+                not mapping.get("on_unresolve") or not mapping.get("on_resolve")
+                for mapping in project_mappings.values()
+            ):
+                raise IntegrationError("Resolve and unresolve status are required.")
+
+            data["sync_status_forward"] = bool(project_mappings)
+
+            IntegrationExternalProject.objects.filter(
+                organization_integration_id=self.org_integration.id
+            ).delete()
+
+            for project_path, statuses in project_mappings.items():
+                # Validate status values
+                valid_statuses = {GitLabIssueStatus.OPENED.value, GitLabIssueStatus.CLOSED.value}
+                if statuses["on_resolve"] not in valid_statuses:
+                    raise IntegrationError(
+                        f"Invalid resolve status: {statuses['on_resolve']}. Must be 'opened' or 'closed'."
+                    )
+                if statuses["on_unresolve"] not in valid_statuses:
+                    raise IntegrationError(
+                        f"Invalid unresolve status: {statuses['on_unresolve']}. Must be 'opened' or 'closed'."
+                    )
+
+                IntegrationExternalProject.objects.create(
+                    organization_integration_id=self.org_integration.id,
+                    external_id=project_path,
+                    name=project_path,
+                    resolved_status=statuses["on_resolve"],
+                    unresolved_status=statuses["on_unresolve"],
+                )
+
         # Check webhook version BEFORE updating config to determine if migration is needed
         current_webhook_version = config.get(GITLAB_WEBHOOK_VERSION_KEY, 0)
 
@@ -318,11 +410,9 @@ class GitlabIntegration(
         if org_integration is not None:
             self.org_integration = org_integration
 
-        # Only update webhooks if:
-        # 1. A sync setting was enabled, AND
-        # 2. The webhook version is outdated
+        # Only update webhooks if the webhook version is outdated
         if current_webhook_version < GITLAB_WEBHOOK_VERSION:
-            update_all_project_webhooks.delay(
+            repository_service.schedule_update_gitlab_project_webhooks(
                 integration_id=self.model.id,
                 organization_id=self.organization_id,
             )

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -6,9 +6,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseBase
-from django.urls import reverse
-from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import BooleanField, CharField, URLField

--- a/src/sentry/integrations/gitlab/issue_sync.py
+++ b/src/sentry/integrations/gitlab/issue_sync.py
@@ -6,11 +6,12 @@ from typing import Any
 from urllib.parse import quote
 
 from sentry import features
-from sentry.integrations.gitlab.types import GitLabIssueAction
+from sentry.integrations.gitlab.types import GitLabIssueAction, GitLabIssueStatus
 from sentry.integrations.mixins.issues import IssueSyncIntegration, ResolveSyncAction
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE, ExternalProviderEnum
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.services.user.model import RpcUser
@@ -24,6 +25,7 @@ class GitlabIssueSyncSpec(IssueSyncIntegration):
     outbound_assignee_key = "sync_forward_assignment"
     inbound_assignee_key = "sync_reverse_assignment"
     inbound_status_key = "sync_status_reverse"
+    outbound_status_key = "sync_status_forward"
     resolution_strategy_key = "resolution_strategy"
 
     def check_feature_flag(self) -> bool:
@@ -165,7 +167,93 @@ class GitlabIssueSyncSpec(IssueSyncIntegration):
         Propagate a sentry issue's status to a linked GitLab issue's status.
         For GitLab, we only support opened/closed states.
         """
-        raise NotImplementedError
+
+        client = self.get_client()
+        project_path, issue_iid = self.split_external_issue_key(external_issue.key)
+
+        if not project_path or not issue_iid:
+            logger.warning(
+                "status-outbound.invalid-key",
+                extra={
+                    "external_issue_key": external_issue.key,
+                    "provider": self.model.provider,
+                },
+            )
+            return
+
+        # Get the project mapping to determine what status to use
+        external_project = integration_service.get_integration_external_project(
+            organization_id=external_issue.organization_id,
+            integration_id=external_issue.integration_id,
+            external_id=project_path,
+        )
+
+        log_context = {
+            "provider": self.model.provider,
+            "integration_id": external_issue.integration_id,
+            "is_resolved": is_resolved,
+            "issue_key": external_issue.key,
+            "project_path": project_path,
+        }
+
+        if not external_project:
+            logger.info("external-project-not-found", extra=log_context)
+            return
+
+        desired_state = (
+            external_project.resolved_status if is_resolved else external_project.unresolved_status
+        )
+
+        # Fetch current GitLab issue state
+        try:
+            # URL-encode project_path since it's a path_with_namespace
+            encoded_project_path = quote(project_path, safe="")
+            issue_data = client.get_issue(encoded_project_path, issue_iid)
+        except ApiError as e:
+            self.raise_error(e)
+
+        current_state = issue_data.get("state")
+
+        # Don't update if it's already in the desired state
+        if current_state == desired_state:
+            logger.info(
+                "sync_status_outbound.unchanged",
+                extra={
+                    **log_context,
+                    "current_state": current_state,
+                    "desired_state": desired_state,
+                },
+            )
+            return
+
+        # Determine state_event parameter for GitLab API
+        # GitLab uses "close" to transition to closed, "reopen" to transition to opened
+        if desired_state == GitLabIssueStatus.CLOSED.value:
+            state_event = GitLabIssueAction.CLOSE.value
+        elif desired_state == GitLabIssueStatus.OPENED.value:
+            state_event = GitLabIssueAction.REOPEN.value
+        else:
+            logger.warning(
+                "sync_status_outbound.invalid-desired-state",
+                extra={**log_context, "desired_state": desired_state},
+            )
+            return
+
+        # Update the issue state
+        try:
+            encoded_project_path = quote(project_path, safe="")
+            client.update_issue_status(encoded_project_path, issue_iid, state_event)
+            logger.info(
+                "sync_status_outbound.success",
+                extra={
+                    **log_context,
+                    "old_state": current_state,
+                    "new_state": desired_state,
+                    "state_event": state_event,
+                },
+            )
+        except ApiError as e:
+            self.raise_error(e)
 
     def get_resolve_sync_action(self, data: Mapping[str, Any]) -> ResolveSyncAction:
         """

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -77,7 +77,10 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
                 return Response({"detail": str(e)}, status=400)
             return Response(
                 [
-                    {"label": project["name_with_namespace"], "value": str(project["id"])}
+                    {
+                        "label": project["name_with_namespace"],
+                        "value": project["path_with_namespace"],
+                    }
                     for project in response
                 ]
             )

--- a/src/sentry/integrations/gitlab/types.py
+++ b/src/sentry/integrations/gitlab/types.py
@@ -10,3 +10,13 @@ class GitLabIssueAction(StrEnum):
     @classmethod
     def values(cls):
         return [action.value for action in cls]
+
+
+class GitLabIssueStatus(StrEnum):
+    OPENED = "opened"
+    CLOSED = "closed"
+
+    @classmethod
+    def get_choices(cls):
+        """Return choices formatted for dropdown selectors"""
+        return [(status.value, status.value.capitalize()) for status in cls]

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError, router, transaction
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import enforce_constraints
+from sentry.integrations.gitlab.tasks import update_all_project_webhooks
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.repository import RepositoryService, RpcRepository
 from sentry.integrations.services.repository.model import RpcCreateRepository
@@ -256,7 +257,6 @@ class DatabaseBackedRepositoryService(RepositoryService):
             RepositoryProjectPathConfig.objects.filter(
                 organization_integration_id=organization_integration_id
             ).delete()
-
             # Delete Seer project preference handoffs associated with this integration
             transaction.on_commit(
                 lambda: cleanup_seer_automation_handoffs_for_integration.apply_async(
@@ -267,3 +267,14 @@ class DatabaseBackedRepositoryService(RepositoryService):
                 ),
                 using=router.db_for_write(Repository),
             )
+
+    def schedule_update_gitlab_project_webhooks(
+        self,
+        *,
+        organization_id: int,
+        integration_id: int,
+    ) -> None:
+        update_all_project_webhooks.delay(
+            integration_id=integration_id,
+            organization_id=organization_id,
+        )

--- a/src/sentry/integrations/services/repository/service.py
+++ b/src/sentry/integrations/services/repository/service.py
@@ -114,5 +114,18 @@ class RepositoryService(RpcService):
         This will also delete code owners, and code mapping associated with matching repositories.
         """
 
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def schedule_update_gitlab_project_webhooks(
+        self,
+        *,
+        organization_id: int,
+        integration_id: int,
+    ) -> None:
+        """
+        Schedules a task to update all GitLab project webhooks for an integration.
+        This is used when sync settings change and webhooks need to be updated.
+        """
+
 
 repository_service = RepositoryService.create_delegation()

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -60,7 +60,9 @@ class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest)
 
     def test_update_config(self) -> None:
         config = {"setting": "new_value", "setting2": "baz"}
-        with patch("sentry.integrations.gitlab.integration.update_all_project_webhooks"):
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
             self.get_success_response(self.organization.slug, self.integration.id, **config)
 
         org_integration = OrganizationIntegration.objects.get(

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -20,8 +20,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
-from sentry.models.repository import Repository
-from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     IntegrationConfigurationError,
@@ -570,13 +568,13 @@ class GitlabIssueSyncTest(GitLabTestCase):
 
         with patch(
             "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
-        ) as mock_task:
+        ) as mock_schedule_webhooks:
             # Update configuration
             data = {"sync_reverse_assignment": True}
             installation.update_organization_config(data)
 
             # Verify task was called with correct arguments
-            mock_task.assert_called_once_with(
+            mock_schedule_webhooks.assert_called_once_with(
                 organization_id=self.organization.id,
                 integration_id=integration.id,
             )
@@ -616,13 +614,13 @@ class GitlabIssueSyncTest(GitLabTestCase):
 
         with patch(
             "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
-        ) as mock_task:
+        ) as mock_schedule_webhooks:
             # Update configuration
             data = {"sync_reverse_assignment": True}
             installation.update_organization_config(data)
 
             # Verify task was NOT called
-            mock_task.assert_not_called()
+            mock_schedule_webhooks.assert_not_called()
 
         # Verify config was still updated
         org_integration = integration_service.get_organization_integration(
@@ -660,13 +658,13 @@ class GitlabIssueSyncTest(GitLabTestCase):
 
         with patch(
             "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
-        ) as mock_task:
+        ) as mock_schedule_webhooks:
             # Update configuration
             data = {"sync_comments": True}
             installation.update_organization_config(data)
 
             # Verify task was called
-            mock_task.assert_called_once_with(
+            mock_schedule_webhooks.assert_called_once_with(
                 organization_id=self.organization.id,
                 integration_id=integration.id,
             )
@@ -705,13 +703,13 @@ class GitlabIssueSyncTest(GitLabTestCase):
 
         with patch(
             "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
-        ) as mock_task:
+        ) as mock_schedule_webhooks:
             # Update configuration
             data = {"sync_reverse_assignment": False, "sync_comments": False}
             installation.update_organization_config(data)
 
             # Task should be called since version is missing (defaults to 0)
-            mock_task.assert_called_once_with(
+            mock_schedule_webhooks.assert_called_once_with(
                 organization_id=self.organization.id,
                 integration_id=integration.id,
             )

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -15,11 +15,18 @@ from sentry.integrations.gitlab.client import GitLabApiClient, GitLabSetupApiCli
 from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_WEBHOOK_VERSION_KEY
 from sentry.integrations.gitlab.integration import GitlabIntegration, GitlabIntegrationProvider
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
-from sentry.shared_integrations.exceptions import ApiForbiddenError, IntegrationConfigurationError
+from sentry.models.repository import Repository
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import (
+    ApiForbiddenError,
+    IntegrationConfigurationError,
+    IntegrationError,
+)
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
@@ -224,6 +231,7 @@ class GitlabIssueSyncTest(GitLabTestCase):
         fields = installation.get_organization_config()
 
         assert [field["name"] for field in fields] == [
+            "sync_status_forward",
             "sync_reverse_assignment",
             "sync_forward_assignment",
             "sync_comments",
@@ -246,7 +254,9 @@ class GitlabIssueSyncTest(GitLabTestCase):
         # Initial config should be empty
         assert org_integration.config == {}
 
-        with patch("sentry.integrations.gitlab.integration.update_all_project_webhooks"):
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
             # Update configuration
             data = {"sync_reverse_assignment": True, "other_option": "test_value"}
             installation.update_organization_config(data)
@@ -276,7 +286,9 @@ class GitlabIssueSyncTest(GitLabTestCase):
         }
         org_integration.save()
 
-        with patch("sentry.integrations.gitlab.integration.update_all_project_webhooks"):
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
             # Update configuration with new data
             data = {"sync_reverse_assignment": True, "new_key": "new_value"}
             installation.update_organization_config(data)
@@ -557,16 +569,16 @@ class GitlabIssueSyncTest(GitLabTestCase):
         )
 
         with patch(
-            "sentry.integrations.gitlab.integration.update_all_project_webhooks"
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
         ) as mock_task:
             # Update configuration
             data = {"sync_reverse_assignment": True}
             installation.update_organization_config(data)
 
             # Verify task was called with correct arguments
-            mock_task.delay.assert_called_once_with(
-                integration_id=integration.id,
+            mock_task.assert_called_once_with(
                 organization_id=self.organization.id,
+                integration_id=integration.id,
             )
 
         # Verify config was updated (but version stays at 0 since task was mocked)
@@ -603,14 +615,14 @@ class GitlabIssueSyncTest(GitLabTestCase):
         )
 
         with patch(
-            "sentry.integrations.gitlab.integration.update_all_project_webhooks"
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
         ) as mock_task:
             # Update configuration
             data = {"sync_reverse_assignment": True}
             installation.update_organization_config(data)
 
             # Verify task was NOT called
-            mock_task.delay.assert_not_called()
+            mock_task.assert_not_called()
 
         # Verify config was still updated
         org_integration = integration_service.get_organization_integration(
@@ -647,16 +659,16 @@ class GitlabIssueSyncTest(GitLabTestCase):
         )
 
         with patch(
-            "sentry.integrations.gitlab.integration.update_all_project_webhooks"
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
         ) as mock_task:
             # Update configuration
             data = {"sync_comments": True}
             installation.update_organization_config(data)
 
             # Verify task was called
-            mock_task.delay.assert_called_once_with(
-                integration_id=integration.id,
+            mock_task.assert_called_once_with(
                 organization_id=self.organization.id,
+                integration_id=integration.id,
             )
 
         # Verify config was updated (but version is not set since task was mocked)
@@ -692,16 +704,16 @@ class GitlabIssueSyncTest(GitLabTestCase):
         )
 
         with patch(
-            "sentry.integrations.gitlab.integration.update_all_project_webhooks"
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
         ) as mock_task:
             # Update configuration
             data = {"sync_reverse_assignment": False, "sync_comments": False}
             installation.update_organization_config(data)
 
             # Task should be called since version is missing (defaults to 0)
-            mock_task.delay.assert_called_once_with(
-                integration_id=integration.id,
+            mock_task.assert_called_once_with(
                 organization_id=self.organization.id,
+                integration_id=integration.id,
             )
 
     @responses.activate
@@ -729,7 +741,9 @@ class GitlabIssueSyncTest(GitLabTestCase):
             },
         )
 
-        with patch("sentry.integrations.gitlab.integration.update_all_project_webhooks"):
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
             # Update configuration
             data = {"sync_comments": True}
             installation.update_organization_config(data)
@@ -743,6 +757,412 @@ class GitlabIssueSyncTest(GitLabTestCase):
         assert org_integration.config["existing_key"] == "existing_value"
         assert org_integration.config["sync_forward_assignment"] is True
         assert org_integration.config["sync_comments"] is True
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_update_organization_config_status_sync(self) -> None:
+        """Test that status sync configuration creates IntegrationExternalProject records"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # No external projects initially
+        assert (
+            IntegrationExternalProject.objects.filter(
+                organization_integration_id=org_integration.id
+            ).count()
+            == 0
+        )
+
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
+            # Configure status sync for two projects
+            data = {
+                "sync_status_forward": {
+                    "my-group/project-1": {"on_resolve": "closed", "on_unresolve": "opened"},
+                    "my-group/project-2": {"on_resolve": "closed", "on_unresolve": "opened"},
+                }
+            }
+            installation.update_organization_config(data)
+
+        # Verify IntegrationExternalProject records were created
+        external_projects = IntegrationExternalProject.objects.filter(
+            organization_integration_id=org_integration.id
+        )
+        assert external_projects.count() == 2
+
+        project1 = external_projects.get(external_id="my-group/project-1")
+        assert project1.name == "my-group/project-1"
+        assert project1.resolved_status == "closed"
+        assert project1.unresolved_status == "opened"
+
+        project2 = external_projects.get(external_id="my-group/project-2")
+        assert project2.name == "my-group/project-2"
+        assert project2.resolved_status == "closed"
+        assert project2.unresolved_status == "opened"
+
+        # Verify the boolean flag is set
+        org_integration.refresh_from_db()
+        assert org_integration.config["sync_status_forward"] is True
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_update_organization_config_invalid_status(self) -> None:
+        """Test that invalid status values raise IntegrationError"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
+            # Try to configure with invalid status
+            data = {
+                "sync_status_forward": {
+                    "my-group/project": {"on_resolve": "invalid_status", "on_unresolve": "opened"}
+                }
+            }
+
+            with pytest.raises(IntegrationError) as exc_info:
+                installation.update_organization_config(data)
+
+            assert "Invalid resolve status" in str(exc_info.value)
+            assert "invalid_status" in str(exc_info.value)
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_update_organization_config_missing_status(self) -> None:
+        """Test that missing on_resolve/on_unresolve raises IntegrationError"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
+            # Try to configure with missing on_unresolve
+            data = {"sync_status_forward": {"my-group/project": {"on_resolve": "closed"}}}
+
+            with pytest.raises(IntegrationError) as exc_info:
+                installation.update_organization_config(data)
+
+            assert "Resolve and unresolve status are required" in str(exc_info.value)
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_get_config_data_returns_status_mappings(self) -> None:
+        """Test that get_config_data returns status mappings correctly"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Create some IntegrationExternalProject records
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="my-group/project-1",
+            name="my-group/project-1",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="my-group/project-2",
+            name="my-group/project-2",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+
+        # Get config data
+        config_data = installation.get_config_data()
+
+        # Verify status mappings are returned
+        assert "sync_status_forward" in config_data
+        mappings = config_data["sync_status_forward"]
+        assert len(mappings) == 2
+        assert mappings["my-group/project-1"] == {"on_resolve": "closed", "on_unresolve": "opened"}
+        assert mappings["my-group/project-2"] == {"on_resolve": "closed", "on_unresolve": "opened"}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_resolve(self) -> None:
+        """Test resolving a Sentry issue closes the GitLab issue"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Create IntegrationExternalProject for status mapping
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="cool-group/sentry",
+            name="cool-group/sentry",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        # Mock get issue endpoint to return current state
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"iid": 45, "state": "opened", "title": "Test Issue"},
+            status=200,
+        )
+
+        # Mock update issue status endpoint
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"iid": 45, "state": "closed", "title": "Test Issue"},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            installation.sync_status_outbound(external_issue, is_resolved=True, project_id=1)
+
+        assert len(responses.calls) == 2
+        # First call gets current state
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == responses.calls[0].request.url
+        )
+        # Second call updates state
+        request = responses.calls[1].request
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == request.url
+        )
+        assert orjson.loads(request.body) == {"state_event": "close"}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_unresolve(self) -> None:
+        """Test unresolving a Sentry issue reopens the GitLab issue"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Create IntegrationExternalProject for status mapping
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="cool-group/sentry",
+            name="cool-group/sentry",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        # Mock get issue endpoint to return current state
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"iid": 45, "state": "closed", "title": "Test Issue"},
+            status=200,
+        )
+
+        # Mock update issue status endpoint
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"iid": 45, "state": "opened", "title": "Test Issue"},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            installation.sync_status_outbound(external_issue, is_resolved=False, project_id=1)
+
+        assert len(responses.calls) == 2
+        # First call gets current state
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == responses.calls[0].request.url
+        )
+        # Second call updates state
+        request = responses.calls[1].request
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == request.url
+        )
+        assert orjson.loads(request.body) == {"state_event": "reopen"}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_no_mapping(self) -> None:
+        """Test that sync returns early if no IntegrationExternalProject exists"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            installation.sync_status_outbound(external_issue, is_resolved=True, project_id=1)
+
+        # Should not make any API calls
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_already_in_state(self) -> None:
+        """Test that sync skips update if GitLab issue is already in desired state"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Create IntegrationExternalProject for status mapping
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="cool-group/sentry",
+            name="cool-group/sentry",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        # Mock get issue endpoint to return state already closed
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"iid": 45, "state": "closed", "title": "Test Issue"},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            installation.sync_status_outbound(external_issue, is_resolved=True, project_id=1)
+
+        # Should only call GET, not PUT since already in correct state
+        assert len(responses.calls) == 1
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == responses.calls[0].request.url
+        )
+        assert responses.calls[0].request.method == "GET"
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_invalid_key(self) -> None:
+        """Test that sync handles malformed external issue keys gracefully"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="invalid-key-format",
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            installation.sync_status_outbound(external_issue, is_resolved=True, project_id=1)
+
+        # Should not make any API calls
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_status_outbound_api_error(self) -> None:
+        """Test that sync handles API errors gracefully"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Create IntegrationExternalProject for status mapping
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="cool-group/sentry",
+            name="cool-group/sentry",
+            resolved_status="closed",
+            unresolved_status="opened",
+        )
+
+        group = self.create_group()
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        # Mock get issue endpoint to return error
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"message": "404 Not Found"},
+            status=404,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            with pytest.raises(IntegrationError):
+                installation.sync_status_outbound(external_issue, is_resolved=True, project_id=1)
 
 
 @control_silo_test

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -95,8 +95,8 @@ class GitlabSearchTest(GitLabTestCase):
 
         assert resp.status_code == 200
         assert resp.data == [
-            {"value": "1", "label": "GetSentry / Sentry"},
-            {"value": "2", "label": "GetSentry2 / Sentry2"},
+            {"value": "getsentry/sentry", "label": "GetSentry / Sentry"},
+            {"value": "getsentry2/sentry2", "label": "GetSentry2 / Sentry2"},
         ]
         assert len(mock_record.mock_calls) == 8
         middleware_calls = mock_record.mock_calls[:3] + mock_record.mock_calls[-1:]
@@ -141,8 +141,8 @@ class GitlabSearchTest(GitLabTestCase):
         resp = self.client.get(self.url, data={"field": "project", "query": "GetSentry"})
 
         assert resp.status_code == 200
-        assert resp.data[0] == {"value": "1", "label": "GetSentry / Sentry"}
-        assert resp.data[1] == {"value": "2", "label": "GetSentry2 / Sentry2"}
+        assert resp.data[0] == {"value": "getsentry/sentry", "label": "GetSentry / Sentry"}
+        assert resp.data[1] == {"value": "getsentry2/sentry2", "label": "GetSentry2 / Sentry2"}
 
         assert len(resp.data) == 220
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Outbound status sync support. It also uses the async repo loading pattern as github.


Configuring a Repo

https://github.com/user-attachments/assets/2aab05ed-96b8-4417-84f5-8c2b8ea77aa6

Outbound Status Sync

https://github.com/user-attachments/assets/e470b9a4-86d5-4443-8e4a-db62ef8aa38c





### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
