### PR TITLE
fix(ai-conversations): support gen_ai.input.messages

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -1,0 +1,264 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {SpanFields} from 'sentry/views/insights/types';
+
+import {MessagesPanel} from './messagesPanel';
+
+function createMockNode(overrides: {
+  id: string;
+  attributes?: Record<string, string | number>;
+  startTimestamp?: number;
+}) {
+  const {id, attributes = {}, startTimestamp = 1000} = overrides;
+  return {
+    id,
+    type: 'span' as const,
+    op: 'gen_ai.generate',
+    startTimestamp,
+    value: {
+      start_timestamp: startTimestamp,
+    },
+    attributes: {
+      // Must be 'ai_client' for getIsAiGenerationSpan to return true
+      [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
+      ...attributes,
+    },
+  };
+}
+
+describe('MessagesPanel', () => {
+  const mockOnSelectNode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty message when no nodes provided', () => {
+    render(
+      <MessagesPanel nodes={[]} selectedNodeId={null} onSelectNode={mockOnSelectNode} />
+    );
+
+    expect(screen.getByText('No messages found')).toBeInTheDocument();
+  });
+
+  it('renders user and assistant messages from gen_ai.request.messages', () => {
+    const requestMessages = JSON.stringify([
+      {role: 'user', content: 'Hello from request messages'},
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Assistant response text',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello from request messages')).toBeInTheDocument();
+    expect(screen.getByText('Assistant response text')).toBeInTheDocument();
+  });
+
+  it('prefers gen_ai.input.messages over gen_ai.request.messages', () => {
+    const inputMessages = JSON.stringify([
+      {role: 'user', content: 'Hello from INPUT messages'},
+    ]);
+    const requestMessages = JSON.stringify([
+      {role: 'user', content: 'Hello from REQUEST messages'},
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello from INPUT messages')).toBeInTheDocument();
+    expect(screen.queryByText('Hello from REQUEST messages')).not.toBeInTheDocument();
+  });
+
+  it('falls back to gen_ai.request.messages when gen_ai.input.messages is empty string', () => {
+    const requestMessages = JSON.stringify([
+      {role: 'user', content: 'Hello from REQUEST messages fallback'},
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: '',
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello from REQUEST messages fallback')).toBeInTheDocument();
+  });
+
+  it('handles messages with parts format', () => {
+    const inputMessages = JSON.stringify([
+      {
+        role: 'user',
+        parts: [{type: 'text', content: 'Message from parts format'}],
+      },
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Message from parts format')).toBeInTheDocument();
+  });
+
+  it('handles messages with array content format', () => {
+    const inputMessages = JSON.stringify([
+      {
+        role: 'user',
+        content: [{text: 'Message from array content'}],
+      },
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Message from array content')).toBeInTheDocument();
+  });
+
+  it('calls onSelectNode when assistant message is clicked', async () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Click me assistant',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    const assistantMessage = screen.getByText('Click me assistant').closest('div');
+    // Find the clickable message bubble (parent with onClick)
+    const messageBubble = assistantMessage?.closest('[class*="MessageBubble"]');
+
+    if (messageBubble) {
+      await userEvent.click(messageBubble);
+      expect(mockOnSelectNode).toHaveBeenCalledWith(node);
+    }
+  });
+
+  it('displays user email when available', () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response',
+        [SpanFields.USER_EMAIL]: 'test@example.com',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('deduplicates identical user messages', () => {
+    const sameMessage = JSON.stringify([{role: 'user', content: 'Duplicate message'}]);
+
+    const node1 = createMockNode({
+      id: 'span-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: sameMessage,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response 1',
+      },
+    });
+
+    const node2 = createMockNode({
+      id: 'span-2',
+      startTimestamp: 2000,
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: sameMessage,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Response 2',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node1, node2] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Should only show one instance of the duplicate user message
+    expect(screen.getAllByText('Duplicate message')).toHaveLength(1);
+    // But both assistant responses should be shown
+    expect(screen.getByText('Response 1')).toBeInTheDocument();
+    expect(screen.getByText('Response 2')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -193,14 +193,13 @@ describe('MessagesPanel', () => {
       />
     );
 
-    const assistantMessage = screen.getByText('Click me assistant').closest('div');
-    // Find the clickable message bubble (parent with onClick)
-    const messageBubble = assistantMessage?.closest('[class*="MessageBubble"]');
+    // Find the assistant text and click its parent container
+    const assistantText = screen.getByText('Click me assistant');
+    // The clickable area is the MessageBubble which contains the text
+    // We can click on the text itself - the event will bubble up
+    await userEvent.click(assistantText);
 
-    if (messageBubble) {
-      await userEvent.click(messageBubble);
-      expect(mockOnSelectNode).toHaveBeenCalledWith(node);
-    }
+    expect(mockOnSelectNode).toHaveBeenCalledWith(node);
   });
 
   it('displays user email when available', () => {

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -66,6 +66,33 @@ describe('MessagesPanel', () => {
     expect(screen.getByText('Assistant response text')).toBeInTheDocument();
   });
 
+  it('prefers gen_ai.output.messages over gen_ai.response.text for assistant', () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+    const outputMessages = JSON.stringify([
+      {role: 'assistant', content: 'Hello from OUTPUT messages'},
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Fallback response text',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Hello from OUTPUT messages')).toBeInTheDocument();
+    expect(screen.queryByText('Fallback response text')).not.toBeInTheDocument();
+  });
+
   it('prefers gen_ai.input.messages over gen_ai.request.messages', () => {
     const inputMessages = JSON.stringify([
       {role: 'user', content: 'Hello from INPUT messages'},

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -113,7 +113,7 @@ function parseUserContent(node: AITraceSpanNode): string | null {
     | undefined;
 
   const requestMessages =
-    inputMessages ??
+    inputMessages ||
     (node.attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES] as string | undefined);
 
   if (!requestMessages) {

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -112,6 +112,7 @@ function parseUserContent(node: AITraceSpanNode): string | null {
     | string
     | undefined;
 
+  // Use || instead of ?? so empty strings also fall back to request messages
   const requestMessages =
     inputMessages ||
     (node.attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES] as string | undefined);

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -112,7 +112,6 @@ function parseUserContent(node: AITraceSpanNode): string | null {
     | string
     | undefined;
 
-  // Use || instead of ?? so empty strings also fall back to request messages
   const requestMessages =
     inputMessages ||
     (node.attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES] as string | undefined);

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -1,0 +1,201 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SpanFields} from 'sentry/views/insights/types';
+
+import {useConversation} from './useConversation';
+
+describe('useConversation', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('returns empty nodes when conversationId is empty', () => {
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: ''}),
+      {organization}
+    );
+
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('maps gen_ai.input.messages to node attributes', async () => {
+    const inputMessages = JSON.stringify([{role: 'user', content: 'Hello from input'}]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-123',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1000.5,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'AI generation',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-1',
+          trace: 'trace-1',
+          'gen_ai.operation.type': 'ai_client',
+          'gen_ai.input.messages': inputMessages,
+          'gen_ai.request.messages': JSON.stringify([
+            {role: 'user', content: 'Fallback message'},
+          ]),
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    const node = result.current.nodes[0];
+    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(
+      inputMessages
+    );
+  });
+
+  it('maps gen_ai.request.messages to node attributes', async () => {
+    const requestMessages = JSON.stringify([
+      {role: 'user', content: 'Hello from request'},
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-456/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-456',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1000.5,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'AI generation',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-2',
+          trace: 'trace-2',
+          'gen_ai.operation.type': 'ai_client',
+          'gen_ai.request.messages': requestMessages,
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-456'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    const node = result.current.nodes[0];
+    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(
+      requestMessages
+    );
+  });
+
+  it('uses empty string for missing optional fields', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-789/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-789',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1000.5,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'AI generation',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-3',
+          trace: 'trace-3',
+          'gen_ai.operation.type': 'ai_client',
+          // No input or request messages provided
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-789'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    const node = result.current.nodes[0];
+    // Should default to empty string for missing fields
+    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(
+      ''
+    );
+    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(
+      ''
+    );
+  });
+
+  it('filters to only gen_ai spans', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-filter',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1000.5,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'AI generation',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-ai',
+          trace: 'trace-1',
+          'gen_ai.operation.type': 'ai_client',
+        },
+        {
+          'gen_ai.conversation.id': 'conv-filter',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1001.5,
+          'precise.start_ts': 1001.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'HTTP request',
+          'span.op': 'http.client',
+          'span.status': 'ok',
+          span_id: 'span-http',
+          trace: 'trace-1',
+          // No gen_ai.operation.type - should be filtered out
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-filter'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Only the gen_ai span should be included
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0]?.id).toBe('span-ai');
+  });
+});

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -61,9 +61,9 @@ describe('useConversation', () => {
 
     expect(result.current.nodes).toHaveLength(1);
     const node = result.current.nodes[0];
-    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(
-      inputMessages
-    );
+    const attrs = (node?.value as {additional_attributes?: Record<string, unknown>})
+      .additional_attributes;
+    expect(attrs?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(inputMessages);
   });
 
   it('maps gen_ai.request.messages to node attributes', async () => {
@@ -103,9 +103,9 @@ describe('useConversation', () => {
 
     expect(result.current.nodes).toHaveLength(1);
     const node = result.current.nodes[0];
-    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(
-      requestMessages
-    );
+    const attrs = (node?.value as {additional_attributes?: Record<string, unknown>})
+      .additional_attributes;
+    expect(attrs?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(requestMessages);
   });
 
   it('uses empty string for missing optional fields', async () => {
@@ -141,13 +141,11 @@ describe('useConversation', () => {
 
     expect(result.current.nodes).toHaveLength(1);
     const node = result.current.nodes[0];
+    const attrs = (node?.value as {additional_attributes?: Record<string, unknown>})
+      .additional_attributes;
     // Should default to empty string for missing fields
-    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe(
-      ''
-    );
-    expect(node?.value.additional_attributes?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe(
-      ''
-    );
+    expect(attrs?.[SpanFields.GEN_AI_INPUT_MESSAGES]).toBe('');
+    expect(attrs?.[SpanFields.GEN_AI_REQUEST_MESSAGES]).toBe('');
   });
 
   it('filters to only gen_ai spans', async () => {

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -32,6 +32,7 @@ interface ConversationApiSpan {
   'span.status': string;
   span_id: string;
   trace: string;
+  'gen_ai.input.messages'?: string;
   'gen_ai.operation.type'?: string;
   'gen_ai.request.messages'?: string;
   'gen_ai.response.object'?: string;
@@ -93,6 +94,7 @@ function createNodeFromApiSpan(
     occurrences: [],
     additional_attributes: {
       [SpanFields.GEN_AI_CONVERSATION_ID]: apiSpan['gen_ai.conversation.id'],
+      [SpanFields.GEN_AI_INPUT_MESSAGES]: apiSpan['gen_ai.input.messages'] ?? '',
       [SpanFields.GEN_AI_OPERATION_TYPE]: operationType ?? '',
       [SpanFields.GEN_AI_REQUEST_MESSAGES]: apiSpan['gen_ai.request.messages'] ?? '',
       [SpanFields.GEN_AI_RESPONSE_OBJECT]: apiSpan['gen_ai.response.object'] ?? '',

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -34,6 +34,7 @@ interface ConversationApiSpan {
   trace: string;
   'gen_ai.input.messages'?: string;
   'gen_ai.operation.type'?: string;
+  'gen_ai.output.messages'?: string;
   'gen_ai.request.messages'?: string;
   'gen_ai.response.object'?: string;
   'gen_ai.response.text'?: string;
@@ -96,6 +97,7 @@ function createNodeFromApiSpan(
       [SpanFields.GEN_AI_CONVERSATION_ID]: apiSpan['gen_ai.conversation.id'],
       [SpanFields.GEN_AI_INPUT_MESSAGES]: apiSpan['gen_ai.input.messages'] ?? '',
       [SpanFields.GEN_AI_OPERATION_TYPE]: operationType ?? '',
+      [SpanFields.GEN_AI_OUTPUT_MESSAGES]: apiSpan['gen_ai.output.messages'] ?? '',
       [SpanFields.GEN_AI_REQUEST_MESSAGES]: apiSpan['gen_ai.request.messages'] ?? '',
       [SpanFields.GEN_AI_RESPONSE_OBJECT]: apiSpan['gen_ai.response.object'] ?? '',
       [SpanFields.GEN_AI_RESPONSE_TEXT]: apiSpan['gen_ai.response.text'] ?? '',


### PR DESCRIPTION
- supports `gen_ai.input.messages` in conversation drawer. Falls back to `gen_ai.request.messages`