### PR TITLE
fix(grouping): Prevent DiagnosticCoroutineContextException from determining issue title

### DIFF
--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -110,7 +110,7 @@ def _get_exception(exceptions: MutableMapping[str, Any], main_exception_id: str)
             for exception in exceptions
             if get_path(exception, "mechanism", "exception_id") == main_exception_id
         )
-        if main_exception_id
+        if main_exception_id is not None
         else None
     )
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -1000,12 +1000,20 @@ def kotlin_coroutine_framework_exceptions(exceptions: list[SingleException]) -> 
     if len(exceptions) < 2:
         return None
 
+    # Build a set of valid exception IDs for validation
+    valid_exception_ids = {
+        exc.mechanism.exception_id
+        for exc in exceptions
+        if exc.mechanism and exc.mechanism.exception_id is not None
+    }
+
     for exception in exceptions:
         if (
             exception.module == "kotlinx.coroutines.internal"
             and exception.type in KOTLIN_COROUTINE_FRAMEWORK_EXCEPTION_TYPES
             and exception.mechanism
             and exception.mechanism.parent_id is not None
+            and exception.mechanism.parent_id in valid_exception_ids
         ):
             # Return the parent as the main exception
             return exception.mechanism.parent_id
@@ -1027,5 +1035,5 @@ def _maybe_override_main_exception_id(event: Event, exceptions: list[SingleExcep
         if main_exception_id is not None:
             break
 
-    if main_exception_id:
+    if main_exception_id is not None:
         event.data["main_exception_id"] = main_exception_id

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -349,6 +349,99 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert event.group is not None
         assert event.group.title == "CompositeException: Can't call onError."
 
+    def test_kotlin_coroutine_diagnostic_exception_correct_title(self) -> None:
+        """DiagnosticCoroutineContextException should not determine the title."""
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "RuntimeException",
+                            "value": "main exception",
+                            "module": "java.lang",
+                            "mechanism": {
+                                "type": "UncaughtExceptionHandler",
+                                "handled": False,
+                                "exception_id": 0,
+                            },
+                        },
+                        {
+                            "type": "DiagnosticCoroutineContextException",
+                            "module": "kotlinx.coroutines.internal",
+                            "mechanism": {
+                                "type": "suppressed",
+                                "exception_id": 1,
+                                "parent_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["type"] == "RuntimeException"
+        assert event.data["metadata"]["value"] == "main exception"
+        assert event.group is not None
+        assert event.group.title == "RuntimeException: main exception"
+
+    def test_kotlin_coroutine_diagnostic_exception_chained_mechanism_correct_title(self) -> None:
+        """DiagnosticCoroutineContextException with chained mechanism should not determine the title."""
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "IllegalStateException",
+                            "value": "coroutine error",
+                            "module": "java.lang",
+                            "mechanism": {
+                                "type": "UncaughtExceptionHandler",
+                                "handled": False,
+                                "exception_id": 0,
+                            },
+                        },
+                        {
+                            "type": "DiagnosticCoroutineContextException",
+                            "module": "kotlinx.coroutines.internal",
+                            "mechanism": {
+                                "type": "chained",
+                                "exception_id": 1,
+                                "parent_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["type"] == "IllegalStateException"
+        assert event.data["metadata"]["value"] == "coroutine error"
+        assert event.group is not None
+        assert event.group.title == "IllegalStateException: coroutine error"
+
+    def test_kotlin_coroutine_diagnostic_exception_no_parent_keeps_default_behavior(self) -> None:
+        """DiagnosticCoroutineContextException without parent_id should not change behavior."""
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "DiagnosticCoroutineContextException",
+                            "module": "kotlinx.coroutines.internal",
+                            "mechanism": {
+                                "type": "generic",
+                                "exception_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["type"] == "DiagnosticCoroutineContextException"
+        assert event.group is not None
+        assert "DiagnosticCoroutineContextException" in event.group.title
+
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     def test_unresolve_auto_resolved_group(self, send_robust: mock.MagicMock) -> None:
         ts = before_now(minutes=5).isoformat()


### PR DESCRIPTION
`DiagnosticCoroutineContextException` is a Kotlin Coroutines debugging wrapper
that has no stacktrace and no meaningful message. When present in an exception
chain, it should not be used for the issue title. Instead, use the parent
exception which contains the actual error information. 

See the linked issue for more examples and context.

Fixes https://github.com/getsentry/sentry-java/issues/4410