### PR TITLE
feat(tempest): Handle invalid_scope error from Sony auth endpoint

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -96,6 +96,15 @@ def fetch_latest_item_id(credentials_id: int, **kwargs) -> None:
                 credentials.save(update_fields=["message", "message_type"])
                 return
 
+            elif result["error"]["type"] == "invalid_scope":
+                credentials.message = (
+                    "Invalid OAuth scope. Please verify you are using the correct credentials "
+                    "from your PlayStation Developer Portal."
+                )
+                credentials.message_type = MessageType.ERROR
+                credentials.save(update_fields=["message", "message_type"])
+                return
+
         # Default in case things go wrong
         logger.error(
             "Fetching the latest item id failed.",

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -97,10 +97,7 @@ def fetch_latest_item_id(credentials_id: int, **kwargs) -> None:
                 return
 
             elif result["error"]["type"] == "invalid_scope":
-                credentials.message = (
-                    "Invalid OAuth scope. Please verify you are using the correct credentials "
-                    "from your PlayStation Developer Portal."
-                )
+                credentials.message = "Seems like the provided credentials have the wrong scope."
                 credentials.message_type = MessageType.ERROR
                 credentials.save(update_fields=["message", "message_type"])
                 return

--- a/tests/sentry/tempest/test_tempest.py
+++ b/tests/sentry/tempest/test_tempest.py
@@ -73,6 +73,26 @@ class TempestTasksTest(TestCase):
         assert self.credentials.latest_fetched_item_id is None
 
     @patch("sentry.tempest.tasks.fetch_latest_id_from_tempest")
+    def test_fetch_latest_item_id_invalid_scope(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.return_value = Mock()
+        mock_fetch.return_value.json.return_value = {
+            "error": {
+                "type": "invalid_scope",
+                "message": "...",
+            }
+        }
+
+        fetch_latest_item_id(self.credentials.id)
+
+        self.credentials.refresh_from_db()
+        assert self.credentials.message == (
+            "Invalid OAuth scope. Please verify you are using the correct credentials "
+            "from your PlayStation Developer Portal."
+        )
+        assert self.credentials.message_type == MessageType.ERROR
+        assert self.credentials.latest_fetched_item_id is None
+
+    @patch("sentry.tempest.tasks.fetch_latest_id_from_tempest")
     def test_fetch_latest_item_id_unexpected_response(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = Mock()
         mock_fetch.return_value.json.return_value = {

--- a/tests/sentry/tempest/test_tempest.py
+++ b/tests/sentry/tempest/test_tempest.py
@@ -86,8 +86,7 @@ class TempestTasksTest(TestCase):
 
         self.credentials.refresh_from_db()
         assert self.credentials.message == (
-            "Invalid OAuth scope. Please verify you are using the correct credentials "
-            "from your PlayStation Developer Portal."
+            "Seems like the provided credentials have the wrong scope."
         )
         assert self.credentials.message_type == MessageType.ERROR
         assert self.credentials.latest_fetched_item_id is None


### PR DESCRIPTION
Parse Sony's invalid_scope OAuth error and display user-actionable message in Sentry UI directing users to verify their PlayStation Developer Portal credentials.

Related to the changes we made in tempest https://github.com/getsentry/tempest/pull/170
