### PR TITLE
feat(code-review): Register experiment controllers for code-review

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,6 +74,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-run-per-commit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabled for orgs that participated in the code review beta
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable tracking of noop experiment for code review A/B testing
+    manager.add("organizations:code-review.noop-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Prevent Test Analytics
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,8 +74,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-run-per-commit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabled for orgs that participated in the code review beta
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable tracking of noop experiment for code review A/B testing
-    manager.add("organizations:code-review.noop-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable A/B testing experiments for code review (org eligibility)
+    manager.add("organizations:code-review-experiments-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Prevent Test Analytics
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1113,9 +1113,13 @@ register(
 )
 
 # Code Review A/B Testing Experiments
-# List of (experiment_name, rollout_rate) tuples evaluated in order
-# rollout_rate: 0.0 = disabled, 1.0 = fully released, 0.5 = 50% of PRs
-# Example: [["noop-experiment", 0.5], ["cost-optimized", 0.3]]
+# List of (experiment_name, weight) tuples using proportional weight allocation
+# Weight system works like CSS flex-grow: relative values determine proportions
+# weight: 0 = disabled, positive values determine proportion of traffic
+# Examples:
+#   [["a", 1], ["b", 1]] → 50% A, 50% B (equal weights)
+#   [["a", 10], ["b", 1]] → 90.9% A, 9.1% B (10:1 ratio)
+#   [["a", 3], ["b", 2], ["c", 1]] → 50% A, 33% B, 17% C
 register(
     "code-review.experiments",
     default=[],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1117,7 +1117,7 @@ register(
 # rollout_rate: 0.0 = disabled, 1.0 = fully released, 0.5 = 50% of PRs
 # Example: [["noop-experiment", 0.5], ["cost-optimized", 0.3]]
 register(
-    "bug-prediction.experiments",
+    "code-review.experiments",
     default=[],
     type=Sequence,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1112,6 +1112,17 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Code Review A/B Testing Experiments
+# List of (experiment_name, rollout_rate) tuples evaluated in order
+# rollout_rate: 0.0 = disabled, 1.0 = fully released, 0.5 = 50% of PRs
+# Example: [["noop-experiment", 0.5], ["cost-optimized", 0.3]]
+register(
+    "bug-prediction.experiments",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "seer.similarity.global-rate-limit",
     type=Dict,

--- a/src/sentry/seer/code_review/assignment.py
+++ b/src/sentry/seer/code_review/assignment.py
@@ -37,7 +37,7 @@ def get_code_review_experiment(
     """
     Determine which experiment this PR should be assigned to.
 
-    Evaluates experiments in order from the bug-prediction.experiments option.
+    Evaluates experiments in order from the code-review.experiments option.
     First matching experiment wins. Uses deterministic hashing for per-PR
     variable assignment.
 
@@ -68,7 +68,7 @@ def get_code_review_experiment(
         return "baseline"
 
     # Get experiment configurations from Options
-    experiments: list[tuple[str, float]] = options.get("bug-prediction.experiments")
+    experiments: list[tuple[str, float]] = options.get("code-review.experiments")
 
     # Evaluate experiments in order - first match wins
     for experiment_name, rollout_rate in experiments:

--- a/src/sentry/seer/code_review/assignment.py
+++ b/src/sentry/seer/code_review/assignment.py
@@ -1,0 +1,90 @@
+import hashlib
+
+from sentry import features, options
+from sentry.models.organization import Organization
+from sentry.users.models.user import User
+
+
+def _hash_assignment_key(key: str, rollout_rate: float, granularity: int = 100) -> bool:
+    """
+    Deterministically decide if a key should be included in a rollout.
+
+    Uses SHA1 hashing to create consistent assignment across the same key.
+
+    Args:
+        key: The assignment key (e.g., "org_id:pr_id:experiment_name")
+        rollout_rate: Percentage as float (0.0 to 1.0)
+        granularity: Modulo granularity (default 100 for percentage)
+
+    Returns:
+        True if the key is included in the rollout, False otherwise
+    """
+    # Hash the key to get a consistent number
+    hash_value = int(hashlib.sha1(key.encode("utf-8")).hexdigest(), 16)
+
+    # Use modulo to get a value between 0 and granularity-1
+    bucket = hash_value % granularity
+
+    # Check if this bucket is within the rollout percentage
+    return bucket < (granularity * rollout_rate)
+
+
+def get_code_review_experiment(
+    organization: Organization,
+    pr_id: str,
+    user: User | None = None,
+) -> str:
+    """
+    Determine which experiment this PR should be assigned to.
+
+    Evaluates experiments in order from the bug-prediction.experiments option.
+    First matching experiment wins. Uses deterministic hashing for per-PR
+    variable assignment.
+
+    Args:
+        organization: The organization owning the PR
+        pr_id: The pull request identifier (e.g., GitHub PR number)
+        user: The user who opened the PR (optional)
+
+    Returns:
+        Experiment name (e.g., "noop-experiment", "cost-optimized") or "baseline"
+
+    Examples:
+        >>> # Option: [["noop", 1.0], ["cost", 0.5]]
+        >>> # All PRs get "noop" (100% rollout takes priority)
+        >>>
+        >>> # Option: [["noop", 0.0], ["cost", 0.5]]
+        >>> # noop disabled, 50% of PRs get "cost", 50% get "baseline"
+        >>>
+        >>> # Option: []
+        >>> # No experiments configured → all PRs get "baseline"
+    """
+    # Check if org is eligible for experiments via Flagpole
+    if not features.has(
+        "organizations:code-review-experiments-enabled",
+        organization,
+        actor=user,
+    ):
+        return "baseline"
+
+    # Get experiment configurations from Options
+    experiments: list[tuple[str, float]] = options.get("bug-prediction.experiments")
+
+    # Evaluate experiments in order - first match wins
+    for experiment_name, rollout_rate in experiments:
+        # Skip disabled experiments
+        if rollout_rate <= 0.0:
+            continue
+
+        # Fully released experiment (100%)
+        if rollout_rate >= 1.0:
+            return experiment_name
+
+        # Per-PR variable assignment using hash of org + PR + experiment
+        # Including experiment_name ensures independent rollout per experiment
+        assignment_key = f"{organization.id}:{pr_id}:{experiment_name}"
+        if _hash_assignment_key(assignment_key, rollout_rate):
+            return experiment_name
+
+    # No experiment matched
+    return "baseline"

--- a/tests/sentry/seer/code_review/test_assignment.py
+++ b/tests/sentry/seer/code_review/test_assignment.py
@@ -4,10 +4,10 @@ from sentry.testutils.cases import TestCase
 
 
 class CodeReviewExperimentAssignmentTest(TestCase):
-    def test_fully_released_experiment(self) -> None:
-        """Rollout 1.0 means all PRs get the experiment."""
+    def test_single_experiment_gets_all_traffic(self) -> None:
+        """Single experiment with any positive weight gets 100% of traffic."""
         org = self.create_organization(slug="test-org")
-        options.set("code-review.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Test multiple PRs - all should get the experiment
@@ -16,9 +16,9 @@ class CodeReviewExperimentAssignmentTest(TestCase):
                 assert result == "test-exp"
 
     def test_disabled_experiment(self) -> None:
-        """Rollout 0.0 means no PRs get the experiment."""
+        """Weight 0 means experiment is disabled."""
         org = self.create_organization(slug="test-org")
-        options.set("code-review.experiments", [["test-exp", 0.0]])
+        options.set("code-review.experiments", [["test-exp", 0]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             for pr_id in range(10):
@@ -34,25 +34,34 @@ class CodeReviewExperimentAssignmentTest(TestCase):
             result = get_code_review_experiment(org, pr_id="123")
             assert result == "baseline"
 
-    def test_first_match_wins(self) -> None:
-        """When multiple experiments could match, first one wins."""
+    def test_equal_weights_split_traffic(self) -> None:
+        """Equal weights split traffic proportionally."""
         org = self.create_organization(slug="test-org")
         options.set(
             "code-review.experiments",
             [
-                ["exp-1", 1.0],  # This will always match first
-                ["exp-2", 1.0],
+                ["exp-1", 1],
+                ["exp-2", 1],
             ],
         )
 
         with self.feature("organizations:code-review-experiments-enabled"):
-            result = get_code_review_experiment(org, pr_id="123")
-            assert result == "exp-1"  # First match wins
+            results = {"exp-1": 0, "exp-2": 0, "baseline": 0}
+
+            # Test 100 PRs to see distribution
+            for pr_id in range(100):
+                result = get_code_review_experiment(org, pr_id=str(pr_id))
+                results[result] += 1
+
+            # Should have both experiments represented, no baseline
+            assert results["exp-1"] > 0
+            assert results["exp-2"] > 0
+            assert results["baseline"] == 0
 
     def test_deterministic_per_pr_assignment(self) -> None:
         """Same PR always gets same result (deterministic hashing)."""
         org = self.create_organization(slug="test-org")
-        options.set("code-review.experiments", [["test-exp", 0.5]])
+        options.set("code-review.experiments", [["exp-a", 1], ["exp-b", 1]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Call multiple times with same PR ID
@@ -66,7 +75,7 @@ class CodeReviewExperimentAssignmentTest(TestCase):
     def test_variable_assignment_across_prs(self) -> None:
         """Different PRs from same org can get different assignments."""
         org = self.create_organization(slug="test-org")
-        options.set("code-review.experiments", [["test-exp", 0.5]])
+        options.set("code-review.experiments", [["exp-a", 1], ["exp-b", 1]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             results = set()
@@ -74,48 +83,59 @@ class CodeReviewExperimentAssignmentTest(TestCase):
                 result = get_code_review_experiment(org, pr_id=str(pr_id))
                 results.add(result)
 
-            # With 50% rollout and 100 PRs, should see both outcomes
-            assert "baseline" in results
-            assert "test-exp" in results
+            # With equal weights, should see both experiments
+            assert "exp-a" in results
+            assert "exp-b" in results
 
     def test_org_not_eligible_always_baseline(self) -> None:
         """Orgs without flag enabled always get baseline."""
         org = self.create_organization(slug="not-eligible")
-        options.set("code-review.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1]])
 
         # Feature flag NOT enabled for this org
         result = get_code_review_experiment(org, pr_id="123")
         assert result == "baseline"
 
-    def test_multiple_experiments_cascading(self) -> None:
-        """Multiple experiments evaluated in order until match."""
+    def test_weighted_distribution(self) -> None:
+        """Weights determine proportional distribution of traffic."""
         org = self.create_organization(slug="test-org")
         options.set(
             "code-review.experiments",
             [
-                ["exp-1", 0.0],  # Disabled - skip
-                ["exp-2", 0.3],  # 30% of PRs
-                ["exp-3", 0.5],  # 50% of remaining PRs
+                ["exp-1", 0],  # Disabled - skip
+                ["exp-2", 3],  # 3 parts
+                ["exp-3", 2],  # 2 parts
+                ["exp-4", 1],  # 1 part
             ],
         )
+        # Total weight: 6, so exp-2: 50%, exp-3: 33%, exp-4: 17%
 
         with self.feature("organizations:code-review-experiments-enabled"):
-            results = {"baseline": 0, "exp-2": 0, "exp-3": 0}
+            results = {"baseline": 0, "exp-1": 0, "exp-2": 0, "exp-3": 0, "exp-4": 0}
 
             # Test 1000 PRs to get distribution
             for pr_id in range(1000):
                 result = get_code_review_experiment(org, pr_id=str(pr_id))
                 results[result] += 1
 
-            # Should have all three outcomes
-            assert results["exp-2"] > 0  # Some get exp-2
-            assert results["exp-3"] > 0  # Some get exp-3
-            assert results["baseline"] > 0  # Some get baseline
+            # exp-1 disabled, should get 0
+            assert results["exp-1"] == 0
+
+            # Weights should be proportional: exp-2 > exp-3 > exp-4
+            assert results["exp-2"] > results["exp-3"] > results["exp-4"]
+
+            # All experiments should have some traffic
+            assert results["exp-2"] > 0
+            assert results["exp-3"] > 0
+            assert results["exp-4"] > 0
+
+            # No baseline since all weights add up to 100%
+            assert results["baseline"] == 0
 
     def test_user_parameter_optional(self) -> None:
         """User parameter is optional for assignment."""
         org = self.create_organization(slug="test-org")
-        options.set("code-review.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Should work without user

--- a/tests/sentry/seer/code_review/test_assignment.py
+++ b/tests/sentry/seer/code_review/test_assignment.py
@@ -1,0 +1,123 @@
+from sentry import options
+from sentry.seer.code_review.assignment import get_code_review_experiment
+from sentry.testutils.cases import TestCase
+
+
+class CodeReviewExperimentAssignmentTest(TestCase):
+    def test_fully_released_experiment(self):
+        """Rollout 1.0 means all PRs get the experiment."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            # Test multiple PRs - all should get the experiment
+            for pr_id in range(10):
+                result = get_code_review_experiment(org, pr_id=str(pr_id))
+                assert result == "test-exp"
+
+    def test_disabled_experiment(self):
+        """Rollout 0.0 means no PRs get the experiment."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [["test-exp", 0.0]])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            for pr_id in range(10):
+                result = get_code_review_experiment(org, pr_id=str(pr_id))
+                assert result == "baseline"
+
+    def test_empty_experiments_list(self):
+        """Empty list means all PRs get baseline."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            result = get_code_review_experiment(org, pr_id="123")
+            assert result == "baseline"
+
+    def test_first_match_wins(self):
+        """When multiple experiments could match, first one wins."""
+        org = self.create_organization(slug="test-org")
+        options.set(
+            "bug-prediction.experiments",
+            [
+                ["exp-1", 1.0],  # This will always match first
+                ["exp-2", 1.0],
+            ],
+        )
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            result = get_code_review_experiment(org, pr_id="123")
+            assert result == "exp-1"  # First match wins
+
+    def test_deterministic_per_pr_assignment(self):
+        """Same PR always gets same result (deterministic hashing)."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [["test-exp", 0.5]])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            # Call multiple times with same PR ID
+            result1 = get_code_review_experiment(org, pr_id="123")
+            result2 = get_code_review_experiment(org, pr_id="123")
+            result3 = get_code_review_experiment(org, pr_id="123")
+
+            # All results should be identical
+            assert result1 == result2 == result3
+
+    def test_variable_assignment_across_prs(self):
+        """Different PRs from same org can get different assignments."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [["test-exp", 0.5]])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            results = set()
+            for pr_id in range(100):
+                result = get_code_review_experiment(org, pr_id=str(pr_id))
+                results.add(result)
+
+            # With 50% rollout and 100 PRs, should see both outcomes
+            assert "baseline" in results
+            assert "test-exp" in results
+
+    def test_org_not_eligible_always_baseline(self):
+        """Orgs without flag enabled always get baseline."""
+        org = self.create_organization(slug="not-eligible")
+        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+
+        # Feature flag NOT enabled for this org
+        result = get_code_review_experiment(org, pr_id="123")
+        assert result == "baseline"
+
+    def test_multiple_experiments_cascading(self):
+        """Multiple experiments evaluated in order until match."""
+        org = self.create_organization(slug="test-org")
+        options.set(
+            "bug-prediction.experiments",
+            [
+                ["exp-1", 0.0],  # Disabled - skip
+                ["exp-2", 0.3],  # 30% of PRs
+                ["exp-3", 0.5],  # 50% of remaining PRs
+            ],
+        )
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            results = {"baseline": 0, "exp-2": 0, "exp-3": 0}
+
+            # Test 1000 PRs to get distribution
+            for pr_id in range(1000):
+                result = get_code_review_experiment(org, pr_id=str(pr_id))
+                results[result] += 1
+
+            # Should have all three outcomes
+            assert results["exp-2"] > 0  # Some get exp-2
+            assert results["exp-3"] > 0  # Some get exp-3
+            assert results["baseline"] > 0  # Some get baseline
+
+    def test_user_parameter_optional(self):
+        """User parameter is optional for assignment."""
+        org = self.create_organization(slug="test-org")
+        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+
+        with self.feature("organizations:code-review-experiments-enabled"):
+            # Should work without user
+            result = get_code_review_experiment(org, pr_id="123", user=None)
+            assert result == "test-exp"

--- a/tests/sentry/seer/code_review/test_assignment.py
+++ b/tests/sentry/seer/code_review/test_assignment.py
@@ -4,10 +4,10 @@ from sentry.testutils.cases import TestCase
 
 
 class CodeReviewExperimentAssignmentTest(TestCase):
-    def test_fully_released_experiment(self):
+    def test_fully_released_experiment(self) -> None:
         """Rollout 1.0 means all PRs get the experiment."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1.0]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Test multiple PRs - all should get the experiment
@@ -15,30 +15,30 @@ class CodeReviewExperimentAssignmentTest(TestCase):
                 result = get_code_review_experiment(org, pr_id=str(pr_id))
                 assert result == "test-exp"
 
-    def test_disabled_experiment(self):
+    def test_disabled_experiment(self) -> None:
         """Rollout 0.0 means no PRs get the experiment."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [["test-exp", 0.0]])
+        options.set("code-review.experiments", [["test-exp", 0.0]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             for pr_id in range(10):
                 result = get_code_review_experiment(org, pr_id=str(pr_id))
                 assert result == "baseline"
 
-    def test_empty_experiments_list(self):
+    def test_empty_experiments_list(self) -> None:
         """Empty list means all PRs get baseline."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [])
+        options.set("code-review.experiments", [])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             result = get_code_review_experiment(org, pr_id="123")
             assert result == "baseline"
 
-    def test_first_match_wins(self):
+    def test_first_match_wins(self) -> None:
         """When multiple experiments could match, first one wins."""
         org = self.create_organization(slug="test-org")
         options.set(
-            "bug-prediction.experiments",
+            "code-review.experiments",
             [
                 ["exp-1", 1.0],  # This will always match first
                 ["exp-2", 1.0],
@@ -49,10 +49,10 @@ class CodeReviewExperimentAssignmentTest(TestCase):
             result = get_code_review_experiment(org, pr_id="123")
             assert result == "exp-1"  # First match wins
 
-    def test_deterministic_per_pr_assignment(self):
+    def test_deterministic_per_pr_assignment(self) -> None:
         """Same PR always gets same result (deterministic hashing)."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [["test-exp", 0.5]])
+        options.set("code-review.experiments", [["test-exp", 0.5]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Call multiple times with same PR ID
@@ -63,10 +63,10 @@ class CodeReviewExperimentAssignmentTest(TestCase):
             # All results should be identical
             assert result1 == result2 == result3
 
-    def test_variable_assignment_across_prs(self):
+    def test_variable_assignment_across_prs(self) -> None:
         """Different PRs from same org can get different assignments."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [["test-exp", 0.5]])
+        options.set("code-review.experiments", [["test-exp", 0.5]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             results = set()
@@ -78,20 +78,20 @@ class CodeReviewExperimentAssignmentTest(TestCase):
             assert "baseline" in results
             assert "test-exp" in results
 
-    def test_org_not_eligible_always_baseline(self):
+    def test_org_not_eligible_always_baseline(self) -> None:
         """Orgs without flag enabled always get baseline."""
         org = self.create_organization(slug="not-eligible")
-        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1.0]])
 
         # Feature flag NOT enabled for this org
         result = get_code_review_experiment(org, pr_id="123")
         assert result == "baseline"
 
-    def test_multiple_experiments_cascading(self):
+    def test_multiple_experiments_cascading(self) -> None:
         """Multiple experiments evaluated in order until match."""
         org = self.create_organization(slug="test-org")
         options.set(
-            "bug-prediction.experiments",
+            "code-review.experiments",
             [
                 ["exp-1", 0.0],  # Disabled - skip
                 ["exp-2", 0.3],  # 30% of PRs
@@ -112,10 +112,10 @@ class CodeReviewExperimentAssignmentTest(TestCase):
             assert results["exp-3"] > 0  # Some get exp-3
             assert results["baseline"] > 0  # Some get baseline
 
-    def test_user_parameter_optional(self):
+    def test_user_parameter_optional(self) -> None:
         """User parameter is optional for assignment."""
         org = self.create_organization(slug="test-org")
-        options.set("bug-prediction.experiments", [["test-exp", 1.0]])
+        options.set("code-review.experiments", [["test-exp", 1.0]])
 
         with self.feature("organizations:code-review-experiments-enabled"):
             # Should work without user


### PR DESCRIPTION
## Summary

Register `organizations:code-review-experiments-enabled` feature flag and `code-review.experiments` to enable A/B testing infrastructure for code review experiments.

### Why a feature flag and an option?

We want targeted assignment to orgs - some orgs should get this, others shouldn't, and we want good segmentation. That is why we use the feature flag to evaluate if a given org should be part of any experiment or not.

We also want variable PR assignment. Apparently that is not one of the identify fields for flags. So we'd have to implement a new context transformer that I'm reluctant to do.

The alternative is to have an option that will hold the active experiments and their rollout rate, as explained in the code.

That's why both :)

## Changes                                                                                                                                                                                              
                                                                                                                                                                                                       
  - Add feature flag organizations:code-review-experiments-enabled in src/sentry/features/temporary.py                                                                                                 
    - Uses FLAGPOLE strategy for remote control via identity fields (org_id)                                                                                                                           
    - Not exposed via API (api_expose=False)                                                                                                                                                           
  - Add option code-review.experiments in src/sentry/options/defaults.py                                                                                                                               
    - Holds list of [experiment_name, rollout_rate] tuples                                                                                                                                             
    - Evaluated in order (first match wins)                                                                                                                                                            
    - Modifiable via Options Automator                                                                                                                                                                 
  - Add assignment logic in src/sentry/seer/code_review/assignment.py                                                                                                                                  
    - get_code_review_experiment(): Main function to determine PR experiment assignment                                                                                                                
    - _hash_assignment_key(): Deterministic hashing for per-PR variable rollout                                                                                                                        
    - Uses org_id:pr_id:experiment_name as hash key for consistent assignment                                                                                                                          
  - Add comprehensive test coverage in tests/sentry/seer/code_review/test_assignment.py 

Refs: CW-696

🤖 Generated with [Claude Code](https://claude.com/claude-code)