### PR TITLE
feat(preprod): Unhide filters

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -18,12 +18,12 @@ import {useFeatureFilter} from './useFeatureFilter';
 
 const EXAMPLE_BUILDS_COUNT = 5;
 const FEATURE_FILTER_ALLOWED_KEYS = [
-  'app_id',
-  'app_name',
+  // 'app_id',
+  // 'app_name',
   'build_configuration_name',
-  'platform_name',
-  'build_number',
-  'build_version',
+  // 'platform_name',
+  // 'build_number',
+  // 'build_version',
   'git_head_ref',
   'git_base_ref',
   'git_head_sha',

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -40,34 +40,32 @@ export default function PreprodSettings() {
         </TextBlock>
         <Stack gap="lg">
           <StatusCheckRules />
-          <Feature features="organizations:preprod-issues">
+          <FeatureFilter
+            settingsWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
+            settingsReadKey={SIZE_ENABLED_QUERY_READ_KEY}
+            title={t('Size Analysis')}
+            successMessage={t('Size filter updated')}
+          >
+            <Text>
+              {t(
+                "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
+              )}
+            </Text>
+          </FeatureFilter>
+          <Feature features="organizations:preprod-build-distribution">
             <FeatureFilter
-              settingsWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
-              settingsReadKey={SIZE_ENABLED_QUERY_READ_KEY}
-              title={t('Size Analysis')}
-              successMessage={t('Size filter updated')}
+              settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+              settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+              title={t('Build Distribution')}
+              successMessage={t('Distribution filter updated')}
+              display={PreprodBuildsDisplay.DISTRIBUTION}
             >
               <Text>
                 {t(
-                  "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
+                  'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
                 )}
               </Text>
             </FeatureFilter>
-            <Feature features="organizations:preprod-build-distribution">
-              <FeatureFilter
-                settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-                settingsReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-                title={t('Build Distribution')}
-                successMessage={t('Distribution filter updated')}
-                display={PreprodBuildsDisplay.DISTRIBUTION}
-              >
-                <Text>
-                  {t(
-                    'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
-                  )}
-                </Text>
-              </FeatureFilter>
-            </Feature>
           </Feature>
         </Stack>
       </Feature>


### PR DESCRIPTION
For now restrict attributes to those that a know to available at checking time:
- build_configuration_name
- git_head_ref
- git_base_ref
- git_head_sha
- git_base_sha
- git_head_repo_name
- git_pr_number