### PR TITLE
fix(agents): correct pagination spacing

### DIFF
--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -247,7 +247,7 @@ export function TracesTable() {
   );
 
   return (
-    <div>
+    <Container>
       <GridEditableContainer>
         <GridEditable
           isLoading={tracesRequest.isPending}
@@ -265,7 +265,7 @@ export function TracesTable() {
         {tracesRequest.isPlaceholderData && <LoadingOverlay />}
       </GridEditableContainer>
       <StyledPagination pageLinks={pageLinks} onCursor={setCursor} />
-    </div>
+    </Container>
   );
 }
 

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsString, useQueryState} from 'nuqs';
 
@@ -247,7 +247,7 @@ export function TracesTable() {
   );
 
   return (
-    <Fragment>
+    <div>
       <GridEditableContainer>
         <GridEditable
           isLoading={tracesRequest.isPending}
@@ -264,8 +264,8 @@ export function TracesTable() {
         />
         {tracesRequest.isPlaceholderData && <LoadingOverlay />}
       </GridEditableContainer>
-      <Pagination pageLinks={pageLinks} onCursor={setCursor} />
-    </Fragment>
+      <StyledPagination pageLinks={pageLinks} onCursor={setCursor} />
+    </div>
   );
 }
 
@@ -443,7 +443,6 @@ function AgentTags({agents}: {agents: string[]}) {
 
 const GridEditableContainer = styled('div')`
   position: relative;
-  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const LoadingOverlay = styled('div')`
@@ -476,4 +475,8 @@ const HeadCell = styled('div')<{align: 'left' | 'right'}>`
 const TraceIdButton = styled(Button)`
   font-weight: normal;
   padding: 0;
+`;
+
+const StyledPagination = styled(Pagination)`
+  margin-top: 0;
 `;


### PR DESCRIPTION
Before:
<img width="586" height="515" alt="Screenshot 2026-01-29 at 15 31 48" src="https://github.com/user-attachments/assets/80e2de75-7e3c-46ea-9d39-8a38dccad0d9" />

After:
<img width="546" height="452" alt="Screenshot 2026-01-29 at 15 31 34" src="https://github.com/user-attachments/assets/1cad40e4-ac45-4079-9a12-99c9b0310dbd" />

Issues page as comparison:
<img width="664" height="458" alt="Screenshot 2026-01-29 at 15 31 26" src="https://github.com/user-attachments/assets/08a25ce8-8498-47b0-bb4c-dc2d14d1ea3d" />
