### PR TITLE
feat(uptime-assertion-failure-data): Using the new AssertionFailureTree component

### DIFF
--- a/static/app/components/events/interfaces/uptime/uptimeAssertionsSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeAssertionsSection.tsx
@@ -1,0 +1,36 @@
+import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import {AssertionFailureTree} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+
+export function UptimeAssertionsSection({event}: {event: Event}) {
+  const evidenceData = event.occurrence?.evidenceData;
+
+  if (!evidenceData?.assertionFailureData) {
+    return null;
+  }
+
+  return (
+    <InterimSection
+      type={SectionKey.ASSERTIONS}
+      title={t('Assertions')}
+      disableCollapsePersistence
+    >
+      <KeyValueList
+        data={[
+          {
+            subject: t('Failure'),
+            key: 'assertion_failure_data',
+            value: (
+              <pre className="val-string">
+                <AssertionFailureTree assertion={evidenceData.assertionFailureData} />
+              </pre>
+            ),
+          },
+        ]}
+      />
+    </InterimSection>
+  );
+}

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
@@ -1,5 +1,13 @@
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {Text} from 'sentry/components/core/text/text';
 
 export function AndOpRow() {
-  return <Text ellipsis>Assert All</Text>;
+  const label = 'Assert All';
+
+  return (
+    <Tooltip title={label} showOnlyOnOverflow>
+      <Text ellipsis>{label}</Text>
+    </Tooltip>
+  );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
@@ -1,9 +1,10 @@
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Text} from 'sentry/components/core/text/text';
+import {t} from 'sentry/locale';
 
 export function AndOpRow() {
-  const label = 'Assert All';
+  const label = t('Assert All');
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/headerCheckOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/headerCheckOpRow.tsx
@@ -33,8 +33,8 @@ export function HeaderCheckOpRow({node}: {node: HeaderCheckOpTreeNode}) {
   const keyValueText = keyOperandValue || t('[Empty Header Key]');
   const valueValueText = valueOperandValue || t('[Empty Header Value]');
 
-  return (
-    <Text variant="muted" ellipsis>
+  const content = (
+    <Fragment>
       <Text variant="danger">[Failed] </Text>
       Header Check | Rule:{' '}
       <Text variant="primary">
@@ -53,6 +53,14 @@ export function HeaderCheckOpRow({node}: {node: HeaderCheckOpTreeNode}) {
           </Fragment>
         )}
       </Text>
-    </Text>
+    </Fragment>
+  );
+
+  return (
+    <Tooltip title={<Text variant="muted">{content}</Text>} showOnlyOnOverflow>
+      <Text variant="muted" ellipsis>
+        {content}
+      </Text>
+    </Tooltip>
   );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/jsonPathOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/jsonPathOpRow.tsx
@@ -1,11 +1,23 @@
+import {Fragment} from 'react';
+
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {Text} from 'sentry/components/core/text/text';
 import type {JsonPathOpTreeNode} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode';
 
 export function JsonPathOpRow({node}: {node: JsonPathOpTreeNode}) {
-  return (
-    <Text variant="muted" ellipsis>
+  const content = (
+    <Fragment>
       <Text variant="danger">[Failed] </Text>
       JSON Path | Rule: <Text variant="primary">{node.value.value}</Text>
-    </Text>
+    </Fragment>
+  );
+
+  return (
+    <Tooltip title={<Text variant="muted">{content}</Text>} showOnlyOnOverflow>
+      <Text variant="muted" ellipsis>
+        {content}
+      </Text>
+    </Tooltip>
   );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/notOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/notOpRow.tsx
@@ -1,5 +1,13 @@
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {Text} from 'sentry/components/core/text/text';
 
 export function NotOpRow() {
-  return <Text ellipsis>Assert NOT</Text>;
+  const label = 'Assert NOT';
+
+  return (
+    <Tooltip title={label} showOnlyOnOverflow>
+      <Text ellipsis>{label}</Text>
+    </Tooltip>
+  );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/notOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/notOpRow.tsx
@@ -1,9 +1,10 @@
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Text} from 'sentry/components/core/text/text';
+import {t} from 'sentry/locale';
 
 export function NotOpRow() {
-  const label = 'Assert NOT';
+  const label = t('Assert NOT');
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
@@ -1,4 +1,4 @@
-import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Text} from 'sentry/components/core/text/text';
 import {t} from 'sentry/locale';

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
@@ -1,9 +1,10 @@
 import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
 
 import {Text} from 'sentry/components/core/text/text';
+import {t} from 'sentry/locale';
 
 export function OrOpRow() {
-  const label = 'Assert Any';
+  const label = t('Assert Any');
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
@@ -1,5 +1,13 @@
+import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
+
 import {Text} from 'sentry/components/core/text/text';
 
 export function OrOpRow() {
-  return <Text ellipsis>Assert Any</Text>;
+  const label = 'Assert Any';
+
+  return (
+    <Tooltip title={label} showOnlyOnOverflow>
+      <Text ellipsis>{label}</Text>
+    </Tooltip>
+  );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/statusCodeOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/statusCodeOpRow.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Text} from 'sentry/components/core/text/text';
@@ -15,8 +17,8 @@ export function StatusCodeOpRow({node}: {node: StatusCodeOpTreeNode}) {
 
   const {symbol, label} = comparisonOption;
 
-  return (
-    <Text variant="muted" ellipsis>
+  const content = (
+    <Fragment>
       <Text variant="danger">[Failed] </Text>
       Status Code | Rule:{' '}
       <Text variant="primary">
@@ -26,6 +28,14 @@ export function StatusCodeOpRow({node}: {node: StatusCodeOpTreeNode}) {
         </Tooltip>{' '}
         {node.value.value}
       </Text>
-    </Text>
+    </Fragment>
+  );
+
+  return (
+    <Tooltip title={<Text variant="muted">{content}</Text>} showOnlyOnOverflow>
+      <Text variant="muted" ellipsis>
+        {content}
+      </Text>
+    </Tooltip>
   );
 }

--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -201,7 +201,7 @@ export default function UptimeAlertDetails() {
           <SectionHeading>{t('Checks List')}</SectionHeading>
           <UptimeChecksTable
             detectorId={detector.id}
-            projectSlug={project.slug}
+            project={project}
             traceSampling={uptimeSub.traceSampling}
           />
         </Layout.Main>

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -33,6 +33,7 @@ export interface UptimeRule {
 }
 
 export interface UptimeCheck {
+  assertionFailureData: Assertion | null;
   checkStatus: CheckStatus;
   checkStatusReason: CheckStatusReason | null;
   durationMs: number;
@@ -44,6 +45,7 @@ export interface UptimeCheck {
   scheduledCheckTime: string;
   timestamp: string;
   traceId: string;
+  traceItemId: string;
   uptimeCheckId: string;
 }
 

--- a/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
@@ -2,12 +2,11 @@ import {useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {Text} from 'sentry/components/core/text';
 import BaseSearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -37,7 +36,7 @@ export function UptimeCheckAttributes({
   const theme = useTheme();
 
   const filteredAndSortedAttributes = useMemo(() => {
-    const sortedAttributes = [...attributes].sort((a, b) => {
+    const sortedAttributes = attributes.toSorted((a, b) => {
       return a.name.localeCompare(b.name);
     });
 
@@ -94,19 +93,19 @@ export function UptimeCheckAttributes({
             />
           </div>
         ) : (
-          <NoAttributesMessage>
+          <StyledFlex
+            justify="center"
+            align="center"
+            color={theme.tokens.content.secondary}
+          >
             <p>{t('No matching attributes found')}</p>
-          </NoAttributesMessage>
+          </StyledFlex>
         )}
       </Stack>
     </FoldSection>
   );
 }
 
-const NoAttributesMessage = styled('div')`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: ${space(4)};
-  color: ${p => p.theme.tokens.content.secondary};
+const StyledFlex = styled(Flex)`
+  margin: ${p => p.theme.space['3xl']};
 `;

--- a/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 
 import {Text} from 'sentry/components/core/text';
 import BaseSearchBar from 'sentry/components/searchBar';
@@ -14,8 +14,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
-import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
-import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 
 import {AssertionFailureTree} from './assertions/assertionFailure/assertionFailureTree';
 
@@ -67,12 +65,11 @@ export function UptimeCheckAttributes({
   };
 
   return (
-    <FoldSection
-      sectionKey={SectionKey.SPAN_ATTRIBUTES}
-      title={t('Attributes')}
-      disableCollapsePersistence
-    >
-      <Stack gap="lg" maxWidth="100%">
+    <Flex direction="column" gap="xl">
+      <Text size="lg" bold>
+        {t('Attributes')}
+      </Text>
+      <Flex direction="column" gap="lg">
         <BaseSearchBar
           placeholder={t('Search')}
           onChange={query => setSearchQuery(query)}
@@ -101,8 +98,8 @@ export function UptimeCheckAttributes({
             <p>{t('No matching attributes found')}</p>
           </StyledFlex>
         )}
-      </Stack>
-    </FoldSection>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckAttributes.tsx
@@ -1,0 +1,112 @@
+import {useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Stack} from '@sentry/scraps/layout';
+
+import {Text} from 'sentry/components/core/text';
+import BaseSearchBar from 'sentry/components/searchBar';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+
+import {AssertionFailureTree} from './assertions/assertionFailure/assertionFailureTree';
+
+type CustomRenderersProps = AttributesFieldRendererProps<RenderFunctionBaggage>;
+
+const DEBOUNCE_DELAY = 200;
+
+export function UptimeCheckAttributes({
+  attributes,
+}: {
+  attributes: TraceItemResponseAttribute[];
+}) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, DEBOUNCE_DELAY);
+
+  const organization = useOrganization();
+  const location = useLocation();
+  const theme = useTheme();
+
+  const filteredAndSortedAttributes = useMemo(() => {
+    const sortedAttributes = [...attributes].sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+
+    if (!debouncedSearchQuery.trim()) {
+      return sortedAttributes;
+    }
+
+    const normalizedSearchQuery = debouncedSearchQuery.toLowerCase().trim();
+
+    const matchingAttributes = sortedAttributes.filter(attribute => {
+      return attribute.name.toLowerCase().trim().includes(normalizedSearchQuery);
+    });
+
+    return matchingAttributes;
+  }, [attributes, debouncedSearchQuery]);
+
+  const customRenderers: Record<
+    string,
+    (props: CustomRenderersProps) => React.ReactNode
+  > = {
+    assertion_failure_data: (props: CustomRenderersProps) => {
+      if (props.item.value === null) {
+        return <Text variant="muted">null</Text>;
+      }
+
+      return <AssertionFailureTree assertion={props.item.value.toString()} />;
+    },
+  };
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.SPAN_ATTRIBUTES}
+      title={t('Attributes')}
+      disableCollapsePersistence
+    >
+      <Stack gap="lg" maxWidth="100%">
+        <BaseSearchBar
+          placeholder={t('Search')}
+          onChange={query => setSearchQuery(query)}
+          query={searchQuery}
+          size="sm"
+        />
+        {filteredAndSortedAttributes.length > 0 ? (
+          <div>
+            <AttributesTree
+              columnCount={1}
+              attributes={filteredAndSortedAttributes}
+              renderers={customRenderers}
+              rendererExtra={{
+                theme,
+                location,
+                organization,
+              }}
+            />
+          </div>
+        ) : (
+          <NoAttributesMessage>
+            <p>{t('No matching attributes found')}</p>
+          </NoAttributesMessage>
+        )}
+      </Stack>
+    </FoldSection>
+  );
+}
+
+const NoAttributesMessage = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: ${space(4)};
+  color: ${p => p.theme.tokens.content.secondary};
+`;

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -36,45 +36,47 @@ export function UptimeCheckDetails({check, project}: Props) {
     enabled: true,
   });
 
-  if (isTraceItemPending) {
-    return <LoadingIndicator />;
-  }
-
-  if (isTraceItemError) {
-    return <LoadingError message={t('Failed to fetch trace item details')} />;
-  }
-
-  if (!traceItemData) {
-    return (
-      <NoDetailsAvailable size="xl" variant="muted" align="center">
-        {t('No details available for Check-In')}
-      </NoDetailsAvailable>
-    );
-  }
-
   return (
     <Flex data-overlay="true" direction="column">
       <DrawerHeader hideBar />
-      <StyledFlex direction="row" align="center" justify="between" padding="lg 2xl">
+      <StyledFlex
+        height="60px"
+        direction="row"
+        align="center"
+        justify="between"
+        padding="lg 2xl"
+      >
         <Text size="xl" bold>
           {t('Check-In')}
         </Text>
-        <LinkButton
-          size="xs"
-          to={{
-            pathname: `/organizations/${organization.slug}/performance/trace/${check.traceId}/`,
-            query: {
-              includeUptime: '1',
-              timestamp: new Date(check.timestamp).getTime() / 1000,
-              node: `uptime-check-${check.traceItemId}`,
-            },
-          }}
-        >
-          {t('View in Trace')}
-        </LinkButton>
+        {traceItemData && (
+          <LinkButton
+            size="xs"
+            to={{
+              pathname: `/organizations/${organization.slug}/performance/trace/${check.traceId}/`,
+              query: {
+                includeUptime: '1',
+                timestamp: new Date(check.timestamp).getTime() / 1000,
+                node: `uptime-check-${check.traceItemId}`,
+              },
+            }}
+          >
+            {t('View in Trace')}
+          </LinkButton>
+        )}
       </StyledFlex>
       <DrawerBody>
-        <UptimeCheckAttributes attributes={traceItemData.attributes} />
+        {isTraceItemPending ? (
+          <LoadingIndicator />
+        ) : isTraceItemError ? (
+          <LoadingError message={t('Failed to fetch trace item details')} />
+        ) : traceItemData ? (
+          <UptimeCheckAttributes attributes={traceItemData.attributes} />
+        ) : (
+          <NoDetailsAvailable size="xl" variant="muted" align="center">
+            {t('No details available for Check-In')}
+          </NoDetailsAvailable>
+        )}
       </DrawerBody>
     </Flex>
   );

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+
+import {LinkButton} from '@sentry/scraps/button/linkButton';
 import {Flex} from '@sentry/scraps/layout/flex';
 
 import {Text} from 'sentry/components/core/text';
@@ -6,6 +9,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -18,6 +22,7 @@ type Props = {
 };
 
 export function UptimeCheckDetails({check, project}: Props) {
+  const organization = useOrganization();
   const {
     data: traceItemData,
     isPending: isTraceItemPending,
@@ -40,16 +45,33 @@ export function UptimeCheckDetails({check, project}: Props) {
   }
 
   return (
-    <Flex direction="column" gap="md">
+    <Flex data-overlay="true" direction="column">
       <DrawerHeader hideBar />
+      <StyledFlex direction="row" align="center" justify="between" padding="lg 2xl">
+        <Text size="xl" bold>
+          {t('Check-In')}
+        </Text>
+        <LinkButton
+          size="xs"
+          to={{
+            pathname: `/organizations/${organization.slug}/performance/trace/${check.traceId}/`,
+            query: {
+              includeUptime: '1',
+              timestamp: new Date(check.timestamp).getTime() / 1000,
+              node: `uptime-check-${check.traceItemId}`,
+            },
+          }}
+        >
+          {t('View in Trace')}
+        </LinkButton>
+      </StyledFlex>
       <DrawerBody>
-        <Flex direction="column" gap="md" align="stretch" width="100%">
-          <Text size="xl" bold>
-            {t('Check-In')}
-          </Text>
-          <UptimeCheckAttributes attributes={traceItemData.attributes} />
-        </Flex>
+        <UptimeCheckAttributes attributes={traceItemData.attributes} />
       </DrawerBody>
     </Flex>
   );
 }
+
+const StyledFlex = styled(Flex)`
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -1,0 +1,38 @@
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import type {UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
+import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+type Props = {
+  check: UptimeCheck;
+  project: Project;
+};
+
+export function UptimeCheckDetails({check, project}: Props) {
+  const {
+    data: traceItemData,
+    isPending: isTraceItemPending,
+    isError: isTraceItemError,
+  } = useTraceItemDetails({
+    traceItemId: check.uptimeCheckId,
+    projectId: project.id.toString(),
+    traceId: check.traceId,
+    traceItemType: TraceItemDataset.UPTIME_RESULTS,
+    referrer: 'api.explore.log-item-details', // TODO: change to span details
+    enabled: true,
+  });
+
+  console.log(check);
+  if (isTraceItemPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isTraceItemError) {
+    return <LoadingError message={t('Failed to fetch trace item details')} />;
+  }
+
+  return <div>uptimeCheckDetails</div>;
+}

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -1,3 +1,7 @@
+import {Flex} from '@sentry/scraps/layout/flex';
+
+import {Text} from 'sentry/components/core/text';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -5,6 +9,8 @@ import type {Project} from 'sentry/types/project';
 import type {UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+
+import {UptimeCheckAttributes} from './uptimeCheckAttributes';
 
 type Props = {
   check: UptimeCheck;
@@ -17,7 +23,7 @@ export function UptimeCheckDetails({check, project}: Props) {
     isPending: isTraceItemPending,
     isError: isTraceItemError,
   } = useTraceItemDetails({
-    traceItemId: check.uptimeCheckId,
+    traceItemId: check.traceItemId,
     projectId: project.id.toString(),
     traceId: check.traceId,
     traceItemType: TraceItemDataset.UPTIME_RESULTS,
@@ -25,7 +31,6 @@ export function UptimeCheckDetails({check, project}: Props) {
     enabled: true,
   });
 
-  console.log(check);
   if (isTraceItemPending) {
     return <LoadingIndicator />;
   }
@@ -34,5 +39,17 @@ export function UptimeCheckDetails({check, project}: Props) {
     return <LoadingError message={t('Failed to fetch trace item details')} />;
   }
 
-  return <div>uptimeCheckDetails</div>;
+  return (
+    <Flex direction="column" gap="md">
+      <DrawerHeader hideBar />
+      <DrawerBody>
+        <Flex direction="column" gap="md" align="stretch" width="100%">
+          <Text size="xl" bold>
+            {t('Check-In')}
+          </Text>
+          <UptimeCheckAttributes attributes={traceItemData.attributes} />
+        </Flex>
+      </DrawerBody>
+    </Flex>
+  );
 }

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -27,7 +27,7 @@ export function UptimeCheckDetails({check, project}: Props) {
     projectId: project.id.toString(),
     traceId: check.traceId,
     traceItemType: TraceItemDataset.UPTIME_RESULTS,
-    referrer: 'api.explore.log-item-details', // TODO: change to span details
+    referrer: 'uptime-check-details',
     enabled: true,
   });
 

--- a/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeCheckDetails.tsx
@@ -44,6 +44,14 @@ export function UptimeCheckDetails({check, project}: Props) {
     return <LoadingError message={t('Failed to fetch trace item details')} />;
   }
 
+  if (!traceItemData) {
+    return (
+      <NoDetailsAvailable size="xl" variant="muted" align="center">
+        {t('No details available for Check-In')}
+      </NoDetailsAvailable>
+    );
+  }
+
   return (
     <Flex data-overlay="true" direction="column">
       <DrawerHeader hideBar />
@@ -74,4 +82,8 @@ export function UptimeCheckDetails({check, project}: Props) {
 
 const StyledFlex = styled(Flex)`
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const NoDetailsAvailable = styled(Text)`
+  margin: ${p => p.theme.space['3xl']};
 `;

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -244,7 +244,6 @@ function CheckInBodyCell({
               query: {
                 includeUptime: '1',
                 timestamp: new Date(timestamp).getTime() / 1000,
-                node: `uptime-check-${check.traceItemId}`,
               },
             }}
           >

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -183,15 +183,20 @@ function CheckInBodyCell({
         : null;
       return (
         <StatusCell
+          isMiss={isMiss}
           color={color}
-          onClick={() =>
+          onClick={() => {
+            if (isMiss) {
+              return;
+            }
+
             openDrawer(() => <UptimeCheckDetails check={check} project={project} />, {
               ariaLabel: t('Uptime Check Details'),
               drawerKey: `uptime-check-details-${check.uptimeCheckId}`,
               drawerWidth: DETAILS_DRAWER_WIDTH,
               resizable: true,
-            })
-          }
+            });
+          }}
         >
           {statusToText[checkStatus]}{' '}
           {checkStatusReasonLabel && t('(%s)', checkStatusReasonLabel)}
@@ -279,11 +284,15 @@ const TraceCell = styled(Cell)`
   gap: ${space(1)};
 `;
 
-const StatusCell = styled(Cell)<{color: string}>`
+const StatusCell = styled(Cell)<{color: string; isMiss: boolean}>`
   color: ${p => p.color};
   cursor: pointer;
 
-  &:hover {
-    font-weight: bold;
-  }
+  ${p =>
+    !p.isMiss &&
+    `
+    &:hover {
+      font-weight: bold;
+    }
+  `}
 `;

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -286,11 +286,11 @@ const TraceCell = styled(Cell)`
 
 const StatusCell = styled(Cell)<{color: string; isMiss: boolean}>`
   color: ${p => p.color};
-  cursor: pointer;
 
   ${p =>
     !p.isMiss &&
     `
+    cursor: pointer;
     &:hover {
       font-weight: bold;
     }

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -49,8 +49,6 @@ const EMPTY_TRACE = '00000000000000000000000000000000';
 
 const emptyCell = '\u2014';
 
-const DETAILS_DRAWER_WIDTH = '650px';
-
 /**
  * The number of system uptime spans that are always recorded for each uptime check.
  */
@@ -193,7 +191,6 @@ function CheckInBodyCell({
             openDrawer(() => <UptimeCheckDetails check={check} project={project} />, {
               ariaLabel: t('Uptime Check Details'),
               drawerKey: `uptime-check-details-${check.uptimeCheckId}`,
-              drawerWidth: DETAILS_DRAWER_WIDTH,
               resizable: true,
             });
           }}

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -33,6 +33,14 @@ type Props = {
   uptimeChecks: UptimeCheck[];
 };
 
+type ColumnKey =
+  | 'timestamp'
+  | 'checkStatus'
+  | 'httpStatusCode'
+  | 'durationMs'
+  | 'regionName'
+  | 'traceId';
+
 /**
  * This value is used when a trace was not recorded since the field is required.
  * It will never link to trace, so omit the row to avoid confusion.
@@ -41,7 +49,7 @@ const EMPTY_TRACE = '00000000000000000000000000000000';
 
 const emptyCell = '\u2014';
 
-const DETAILS_DRAWER_WIDTH = '40%';
+const DETAILS_DRAWER_WIDTH = '650px';
 
 /**
  * The number of system uptime spans that are always recorded for each uptime check.
@@ -91,7 +99,7 @@ export function UptimeChecksGrid({project, traceSampling, uptimeChecks}: Props) 
         renderBodyCell: (column, dataRow) => (
           <CheckInBodyCell
             project={project}
-            column={column as GridColumnOrder<keyof UptimeCheck>}
+            column={column as GridColumnOrder<ColumnKey>}
             traceSampling={traceSampling}
             check={dataRow}
             spanCount={traceSpanCounts?.[dataRow.traceId]}
@@ -110,7 +118,7 @@ function CheckInBodyCell({
   traceSampling,
 }: {
   check: UptimeCheck;
-  column: GridColumnOrder<keyof UptimeCheck>;
+  column: GridColumnOrder<ColumnKey>;
   project: Project;
   spanCount: number | undefined;
   traceSampling: boolean;
@@ -236,6 +244,7 @@ function CheckInBodyCell({
               query: {
                 includeUptime: '1',
                 timestamp: new Date(timestamp).getTime() / 1000,
+                node: `uptime-check-${check.traceItemId}`,
               },
             }}
           >

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -4,6 +4,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,13 +14,13 @@ import {UptimeChecksGrid} from './uptimeChecksGrid';
 
 interface UptimeChecksTableProps {
   detectorId: string;
-  projectSlug: string;
+  project: Project;
   traceSampling: boolean;
 }
 
 export function UptimeChecksTable({
   detectorId,
-  projectSlug,
+  project,
   traceSampling,
 }: UptimeChecksTableProps) {
   const location = useLocation();
@@ -40,7 +41,7 @@ export function UptimeChecksTable({
   } = useUptimeChecks(
     {
       orgSlug: organization.slug,
-      projectSlug,
+      projectSlug: project.slug,
       detectorId,
       cursor: decodeScalar(location.query.cursor),
       ...timeRange,
@@ -61,7 +62,11 @@ export function UptimeChecksTable({
       {isPending ? (
         <LoadingIndicator />
       ) : (
-        <UptimeChecksGrid traceSampling={traceSampling} uptimeChecks={uptimeChecks} />
+        <UptimeChecksGrid
+          project={project}
+          traceSampling={traceSampling}
+          uptimeChecks={uptimeChecks}
+        />
       )}
       <Pagination pageLinks={getResponseHeader?.('Link')} />
     </Fragment>

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -71,7 +71,7 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
             <div>
               <UptimeChecksTable
                 detectorId={detector.id}
-                projectSlug={project.slug}
+                project={project}
                 traceSampling={detector.dataSources[0].queryObj.traceSampling}
               />
             </div>

--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -478,9 +478,6 @@ const TreeColumn = styled('div')`
   display: grid;
   grid-template-columns: minmax(min-content, max-content) auto;
   grid-column-gap: ${space(3)};
-  &:first-child {
-    margin-left: -${space(1)};
-  }
   &:not(:first-child) {
     border-left: 1px solid ${p => p.theme.tokens.border.secondary};
     padding-left: ${space(2)};

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -25,11 +25,16 @@ export const reasonToText: Record<
   CheckStatusReason,
   (check: UptimeCheck) => React.ReactNode
 > = {
-  [CheckStatusReason.FAILURE]: check =>
+  [CheckStatusReason.FAILURE]: check => {
+    if (check.assertionFailureData) {
+      return t('Assertion Failed');
+    }
+
     // TODO(epurkhiser): Not all failures include a HTTP status code, we
     // should display the `status_reason_description` somewhere (this is not
     // currently exposed to the frontend)
-    check.httpStatusCode ? t('HTTP %s', check.httpStatusCode) : null,
+    return check.httpStatusCode ? t('HTTP %s', check.httpStatusCode) : null;
+  },
   [CheckStatusReason.TIMEOUT]: _ => t('Timeout'),
   [CheckStatusReason.DNS_ERROR]: _ => t('DNS Error'),
   [CheckStatusReason.TLS_ERROR]: _ => t('TLS Connection Error'),

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -27,7 +27,7 @@ export const reasonToText: Record<
 > = {
   [CheckStatusReason.FAILURE]: check => {
     if (check.assertionFailureData) {
-      return t('Assertion Failed');
+      return t('Assertions Failed');
     }
 
     // TODO(epurkhiser): Not all failures include a HTTP status code, we

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -50,6 +50,7 @@ import {Request} from 'sentry/components/events/interfaces/request';
 import {StackTrace} from 'sentry/components/events/interfaces/stackTrace';
 import {Template} from 'sentry/components/events/interfaces/template';
 import {Threads} from 'sentry/components/events/interfaces/threads';
+import {UptimeAssertionsSection} from 'sentry/components/events/interfaces/uptime/uptimeAssertionsSection';
 import {UptimeDataSection} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
 import {MetricsSection} from 'sentry/components/events/metrics/metricsSection';
 import {OurlogsSection} from 'sentry/components/events/ourlogs/ourlogsSection';
@@ -221,6 +222,9 @@ export function EventDetailsContent({
         />
       )}
       <EventEvidence event={event} group={group} project={project} />
+      {group.issueType === IssueType.UPTIME_DOMAIN_FAILURE && (
+        <UptimeAssertionsSection event={event} />
+      )}
       {hasStreamlinedUI && issueTypeConfig.instrumentationFixSection.enabled && (
         <ErrorBoundary mini>
           <InstrumentationFixSection event={event} group={group} />

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -74,6 +74,7 @@ export default function GroupUptimeChecks() {
       }}
     >
       <UptimeChecksGrid
+        project={group.project}
         traceSampling={uptimeDetector.dataSources[0].queryObj.traceSampling}
         uptimeChecks={uptimeChecks}
       />

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -23,6 +23,7 @@ export const enum SectionKey {
   ACTIVITY = 'activity',
 
   UPTIME = 'uptime', // Only Uptime issues
+  ASSERTIONS = 'assertions', // Only Uptime issues
   DOWNTIME = 'downtime',
   CRON_TIMELINE = 'cron-timeline', // Only Cron issues
   CORRELATED_ISSUES = 'correlated-issues', // Only Metric issues

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -6,6 +6,7 @@ import type {Location, LocationDescriptorObject} from 'history';
 import {Stack} from '@sentry/scraps/layout';
 
 import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import BaseSearchBar from 'sentry/components/searchBar';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
@@ -20,6 +21,7 @@ import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {looksLikeAJSONArray} from 'sentry/utils/string/looksLikeAJSONArray';
 import {looksLikeAJSONObject} from 'sentry/utils/string/looksLikeAJSONObject';
+import {AssertionFailureTree} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree';
 import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -167,6 +169,13 @@ export function Attributes({
     },
     [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: (props: CustomRenderersProps) => {
       return formatDollars(+Number(props.item.value).toFixed(10));
+    },
+    assertion_failure_data: (props: CustomRenderersProps) => {
+      if (props.item.value === null) {
+        return <Text variant="muted">null</Text>;
+      }
+
+      return <AssertionFailureTree assertion={props.item.value.toString()} />;
     },
   };
 

--- a/tests/js/fixtures/uptimeCheck.ts
+++ b/tests/js/fixtures/uptimeCheck.ts
@@ -14,6 +14,8 @@ export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeChe
     timestamp: '2025-01-01T00:00:00Z',
     traceId: '97f0e440317c5bb5b5e0024ca202a61d',
     uptimeCheckId: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
+    assertionFailureData: null,
+    traceItemId: '97f0e440-317c-5bb5-b5e0-024ca202a62d',
     ...params,
   };
 }

--- a/tests/js/fixtures/uptimeCheck.ts
+++ b/tests/js/fixtures/uptimeCheck.ts
@@ -1,3 +1,7 @@
+import {
+  makeAndOp,
+  makeStatusCodeOp,
+} from 'sentry/views/alerts/rules/uptime/assertions/testUtils';
 import {CheckStatus, type UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 
 export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeCheck {
@@ -14,7 +18,12 @@ export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeChe
     timestamp: '2025-01-01T00:00:00Z',
     traceId: '97f0e440317c5bb5b5e0024ca202a61d',
     uptimeCheckId: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
-    assertionFailureData: null,
+    assertionFailureData: {
+      root: makeAndOp({
+        id: 'root',
+        children: [makeStatusCodeOp({id: '1', operator: {cmp: 'equals'}, value: 200})],
+      }),
+    },
     traceItemId: '97f0e440-317c-5bb5-b5e0-024ca202a62d',
     ...params,
   };

--- a/tests/js/fixtures/uptimeCheck.ts
+++ b/tests/js/fixtures/uptimeCheck.ts
@@ -1,7 +1,3 @@
-import {
-  makeAndOp,
-  makeStatusCodeOp,
-} from 'sentry/views/alerts/rules/uptime/assertions/testUtils';
 import {CheckStatus, type UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 
 export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeCheck {
@@ -18,12 +14,7 @@ export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeChe
     timestamp: '2025-01-01T00:00:00Z',
     traceId: '97f0e440317c5bb5b5e0024ca202a61d',
     uptimeCheckId: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
-    assertionFailureData: {
-      root: makeAndOp({
-        id: 'root',
-        children: [makeStatusCodeOp({id: '1', operator: {cmp: 'equals'}, value: 200})],
-      }),
-    },
+    assertionFailureData: null,
     traceItemId: '97f0e440-317c-5bb5-b5e0-024ca202a62d',
     ...params,
   };


### PR DESCRIPTION
- Adds detail panel on uptime status click & in trace view attributes
<img width="404" height="218" alt="Screenshot 2026-01-30 at 12 08 04 PM" src="https://github.com/user-attachments/assets/0e8ee172-5850-46bd-81c0-5b23f73d8f42" />

<img width="875" height="714" alt="Screenshot 2026-01-30 at 12 07 49 PM" src="https://github.com/user-attachments/assets/4e099797-30c5-42d6-811c-7520834c50d5" />


<img width="1430" height="466" alt="Screenshot 2026-01-29 at 4 10 36 PM" src="https://github.com/user-attachments/assets/474323b9-c82c-41fb-a9e9-4ff9474ad818" />
