### PR TITLE
fix(tracemetrics): Group by selector should allow clearing

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -95,6 +95,7 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
     <CompactSelect
       multiple
       searchable
+      clearable
       trigger={triggerProps => (
         <OverlayTrigger.Button
           {...triggerProps}


### PR DESCRIPTION
One liner to add the ability to clear the group by dropdown. I just feel like with multi-select we should allow clearing if the default state is none