### PR TITLE
fix(explore): Copy changes for saving widget, monitor, query

### DIFF
--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -104,8 +104,8 @@ export function useSaveAsItems({
 
     items.push({
       key: 'save-query',
-      label: <span>{t('A New Query')}</span>,
-      textValue: t('A New Query'),
+      label: <span>{t('New Query')}</span>,
+      textValue: t('New Query'),
       onAction: () => {
         trackAnalytics('logs.save_query_modal', {
           action: 'open',
@@ -153,8 +153,8 @@ export function useSaveAsItems({
     });
 
     const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('A Monitor for')
-      : t('An Alert for');
+      ? t('Monitor for')
+      : t('Alert for');
 
     return {
       key: 'create-alert',
@@ -227,12 +227,12 @@ export function useSaveAsItems({
         <Feature
           hookName="feature-disabled:dashboards-edit"
           features="organizations:dashboards-edit"
-          renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
+          renderDisabled={() => <DisabledText>{t('Dashboard widget')}</DisabledText>}
         >
-          {t('A Dashboard widget')}
+          {t('Dashboard widget')}
         </Feature>
       ),
-      textValue: t('A Dashboard widget'),
+      textValue: t('Dashboard widget'),
       children: dashboardsUrls,
       disabled: !dashboardsUrls || dashboardsUrls.length === 0,
       isSubmenu: true,

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -72,8 +72,8 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
 
     items.push({
       key: 'save-query',
-      label: <span>{t('A New Query')}</span>,
-      textValue: t('A New Query'),
+      label: <span>{t('New Query')}</span>,
+      textValue: t('New Query'),
       onAction: () => {
         trackAnalytics('metrics.save_query_modal', {
           action: 'open',
@@ -101,8 +101,8 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
     if (hasTraceMetricsDashboards) {
       items.push({
         key: 'add-to-dashboard',
-        label: t('A Dashboard widget'),
-        textValue: t('A Dashboard widget'),
+        label: t('Dashboard widget'),
+        textValue: t('Dashboard widget'),
         isSubmenu: true,
         children: [
           ...(metricQueries.length > 1

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -1140,7 +1140,7 @@ describe('MultiQueryModeContent', () => {
     });
     expect(await screen.findByLabelText('Save')).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText('Save'));
-    expect(await screen.findByText('A New Query')).toBeInTheDocument();
+    expect(await screen.findByText('New Query')).toBeInTheDocument();
   });
 
   it('highlights save button when query has changes', async () => {

--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -150,7 +150,7 @@ function Content({datePageFilterProps}: ContentProps) {
                 : []),
               {
                 key: 'save-query',
-                label: t('A New Query'),
+                label: t('New Query'),
                 onAction: () => {
                   trackAnalytics('trace_explorer.save_query_modal', {
                     action: 'open',

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -685,7 +685,7 @@ describe('ExploreToolbar', () => {
 
     await userEvent.click(within(section).getByText(/Save as/));
     await userEvent.hover(
-      within(section).getByRole('menuitemradio', {name: 'An Alert for'})
+      within(section).getByRole('menuitemradio', {name: 'Alert for'})
     );
     await userEvent.click(
       await within(section).findByRole('menuitemradio', {name: 'count(spans)'})
@@ -730,7 +730,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-save-as');
 
     await userEvent.click(within(section).getByText(/Save as/));
-    await userEvent.click(within(section).getByText('A Dashboard widget'));
+    await userEvent.click(within(section).getByText('Dashboard widget'));
     await waitFor(() => {
       expect(openAddToDashboardModal).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -134,8 +134,8 @@ export function ToolbarSaveAs() {
   }
   items.push({
     key: 'save-query',
-    label: <span>{t('A New Query')}</span>,
-    textValue: t('A New Query'),
+    label: <span>{t('New Query')}</span>,
+    textValue: t('New Query'),
     onAction: () => {
       trackAnalytics('trace_explorer.save_query_modal', {
         action: 'open',
@@ -153,8 +153,8 @@ export function ToolbarSaveAs() {
   });
 
   const newAlertLabel = organization.features.includes('workflow-engine-ui')
-    ? t('A Monitor for')
-    : t('An Alert for');
+    ? t('Monitor for')
+    : t('Alert for');
 
   items.push({
     key: 'create-alert',
@@ -196,15 +196,15 @@ export function ToolbarSaveAs() {
 
   items.push({
     key: 'add-to-dashboard',
-    textValue: t('A Dashboard widget'),
+    textValue: t('Dashboard widget'),
     isSubmenu: chartOptions.length > 1 ? true : false,
     label: (
       <Feature
         hookName="feature-disabled:dashboards-edit"
         features="organizations:dashboards-edit"
-        renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
+        renderDisabled={() => <DisabledText>{t('Dashboard widget')}</DisabledText>}
       >
-        {t('A Dashboard widget')}
+        {t('Dashboard widget')}
       </Feature>
     ),
     disabled: disableAddToDashboard,


### PR DESCRIPTION
We want to drop the "A ..." format of these labels since on Metrics they get confused with the A query. Removing it across all explore pages to make it consistent.