### PR TITLE
ref(dashboards): remove getTableRequest and getSeriesRequest

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1277,7 +1277,7 @@ describe('Modals -> WidgetViewerModal', () => {
         tableData: [],
         seriesData: [],
       });
-      expect(metricsMock).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(metricsMock).toHaveBeenCalledTimes(1));
       await userEvent.click(await screen.findByText(`sum(session)`), {delay: null});
       await waitFor(() => expect(metricsMock).toHaveBeenCalledTimes(2));
       expect(router.location.query).toEqual(

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -1,6 +1,6 @@
 import trimStart from 'lodash/trimStart';
 
-import type {Client, ResponseMeta} from 'sentry/api';
+import type {Client} from 'sentry/api';
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
@@ -239,22 +239,6 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     queries?: WidgetQuery[]
   ) => Record<string, SelectValue<FieldValue>>;
   /**
-   * Generate the request promises for fetching
-   * series data.
-   * @deprecated use useSeriesQuery instead
-   */
-  getSeriesRequest?: (
-    api: Client,
-    widget: Widget,
-    queryIndex: number,
-    organization: Organization,
-    pageFilters: PageFilters,
-    onDemandControlContext?: OnDemandControlContext,
-    referrer?: string,
-    mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
-  ) => Promise<[SeriesResponse, string | undefined, ResponseMeta | undefined]>;
-  /**
    * Get the result type of the series. ie duration, size, percentage, etc
    */
   getSeriesResultType?: (
@@ -268,24 +252,6 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     data: SeriesResponse,
     widgetQuery: WidgetQuery
   ) => Record<string, DataUnit>;
-  /**
-   * Generate the request promises for fetching
-   * tabular data.
-   * @deprecated use useTableQuery instead
-   */
-  getTableRequest?: (
-    api: Client,
-    widget: Widget,
-    query: WidgetQuery,
-    organization: Organization,
-    pageFilters: PageFilters,
-    onDemandControlContext?: OnDemandControlContext,
-    limit?: number,
-    cursor?: string,
-    referrer?: string,
-    mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
-  ) => Promise<[TableResponse, string | undefined, ResponseMeta | undefined]>;
   /**
    * Generate the list of sort options for table
    * displays on the 'Sort by' step of the Widget Builder.
@@ -329,15 +295,13 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
   useSearchBarDataProvider?: (props: SearchBarDataProviderProps) => SearchBarData;
 
   /**
-   * Hook-based approach for fetching series data
+   * Hook-based approach for fetching series data.
    * Returns transformed data, raw responses for callbacks, and refetch function.
-   * This replaces getSeriesRequest when available.
    */
   useSeriesQuery?: (params: WidgetQueryParams) => HookWidgetQueryResult;
   /**
-   * Hook-based approach for fetching table data
+   * Hook-based approach for fetching table data.
    * Returns transformed data, raw responses for callbacks, and refetch function.
-   * This replaces getTableRequest when available.
    */
   useTableQuery?: (params: WidgetQueryParams) => HookWidgetQueryResult;
 }

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -1,11 +1,7 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useEffect, useRef} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 
 import type {ResponseMeta} from 'sentry/api';
-import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
-import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
@@ -13,17 +9,12 @@ import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
-import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {DatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
-import {
-  dashboardFiltersToString,
-  isChartDisplayType,
-} from 'sentry/views/dashboards/utils';
-import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 export function getReferrer(displayType: DisplayType) {
@@ -125,10 +116,8 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     afterFetchSeriesData,
     afterFetchTableData,
     cursor,
-    customDidUpdateComparator,
     dashboardFilters,
     disabled,
-    forceOnDemand,
     limit,
     loading: propsLoading,
     mepSetting,
@@ -140,23 +129,12 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     skipDashboardFilterParens,
   } = props;
 
-  const api = useApi();
   const organization = useOrganization();
   const hookPageFilters = usePageFilters();
-  const {queue} = useWidgetQueryQueue();
 
   // Use override selection if provided (for modal zoom), otherwise use hook
   const selection = propsSelection ?? hookPageFilters.selection;
 
-  // Store config in ref to avoid it being a dependency that changes on every render
-  const configRef = useRef(config);
-  configRef.current = config;
-
-  // Store customDidUpdateComparator in ref to avoid dependency issues if not memoized
-  const customDidUpdateComparatorRef = useRef(customDidUpdateComparator);
-  customDidUpdateComparatorRef.current = customDidUpdateComparator;
-
-  // Check if new hook-based approach is available
   const isChartDisplay = isChartDisplayType(widget.displayType);
 
   const hookSeriesResults = config.useSeriesQuery?.({
@@ -189,9 +167,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
 
   // Use the appropriate results based on display type
   const hookResults = isChartDisplay ? hookSeriesResults : hookTableResults;
-  const hasHookApproach = isChartDisplay
-    ? !!config.useSeriesQuery
-    : !!config.useTableQuery;
 
   // Track previous raw data to detect when new data arrives
   const prevRawDataRef = useRef<any[] | undefined>(undefined);
@@ -200,10 +175,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
 
   // Call onDataFetchStart when loading begins
   useEffect(() => {
-    if (!hasHookApproach) {
-      return;
-    }
-
     const isLoadingNow = hookResults?.loading ?? false;
 
     // Detect transition from not loading to loading (fetch start)
@@ -212,11 +183,11 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     }
 
     prevLoadingRef.current = isLoadingNow;
-  }, [hasHookApproach, hookResults?.loading, onDataFetchStart]);
+  }, [hookResults?.loading, onDataFetchStart]);
 
   // Watch for when hook data changes and call callbacks
   useEffect(() => {
-    if (!hasHookApproach || !hookResults?.rawData) {
+    if (!hookResults?.rawData) {
       return;
     }
 
@@ -257,7 +228,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
       });
     }
   }, [
-    hasHookApproach,
     hookResults,
     isChartDisplay,
     afterFetchSeriesData,
@@ -265,496 +235,13 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     onDataFetched,
   ]);
 
-  // OLD APPROACH: Use existing Promise-based logic for non-migrated datasets
-  // These hooks are only used when hasHookApproach is false
-  const [loading, setLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
-  const [timeseriesResults, setTimeseriesResults] = useState<Series[] | undefined>(
-    undefined
+  // Return hook results, with a fallback for the loading state
+  return (
+    hookResults ?? {
+      loading: true,
+      rawData: [],
+    }
   );
-  const [rawResults, setRawResults] = useState<SeriesResponse[] | undefined>(undefined);
-  const [tableResults, setTableResults] = useState<TableDataWithTitle[] | undefined>(
-    undefined
-  );
-  const [pageLinks, setPageLinks] = useState<string | undefined>(undefined);
-  const [timeseriesResultsTypes, setTimeseriesResultsTypes] = useState<
-    Record<string, AggregationOutputType> | undefined
-  >(undefined);
-  const [timeseriesResultsUnits, setTimeseriesResultsUnits] = useState<
-    Record<string, DataUnit> | undefined
-  >(undefined);
-
-  const isMountedRef = useRef(false);
-  const queryFetchIDRef = useRef<symbol | undefined>(undefined);
-  const prevPropsRef = useRef<
-    UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> | undefined
-  >(undefined);
-  const prevSelectionRef = useRef(selection);
-  const rawResultsRef = useRef<SeriesResponse[] | undefined>(undefined);
-  const hasInitialFetchRef = useRef(false);
-  // Ref to store the latest fetchData function for the queue
-  const fetchDataRef = useRef<() => Promise<void>>(() => Promise.resolve());
-
-  // Store latest props for queue execution to avoid stale closures
-  const latestPropsRef = useRef({
-    widget,
-    selection,
-    cursor,
-    limit,
-    disabled,
-    mepSetting,
-    samplingMode,
-    onDemandControlContext,
-    dashboardFilters,
-    forceOnDemand,
-    skipDashboardFilterParens,
-  });
-
-  // Keep refs in sync with latest props
-  useEffect(() => {
-    rawResultsRef.current = rawResults;
-    latestPropsRef.current = {
-      widget,
-      selection,
-      cursor,
-      limit,
-      disabled,
-      mepSetting,
-      samplingMode,
-      onDemandControlContext,
-      dashboardFilters,
-      forceOnDemand,
-      skipDashboardFilterParens,
-    };
-  }, [
-    rawResults,
-    widget,
-    selection,
-    cursor,
-    limit,
-    disabled,
-    mepSetting,
-    samplingMode,
-    onDemandControlContext,
-    dashboardFilters,
-    forceOnDemand,
-    skipDashboardFilterParens,
-  ]);
-
-  const applyDashboardFilters = useCallback((widgetToFilter: Widget): Widget => {
-    // Read from ref to get latest dashboard filters (avoids stale closure when queued)
-    const currentProps = latestPropsRef.current;
-    const dashboardFilterConditions = dashboardFiltersToString(
-      currentProps.dashboardFilters,
-      widgetToFilter.widgetType
-    );
-    widgetToFilter.queries.forEach(query => {
-      if (dashboardFilterConditions) {
-        // If there is no base query, there's no need to add parens
-        if (query.conditions && !currentProps.skipDashboardFilterParens) {
-          query.conditions = `(${query.conditions})`;
-        }
-        query.conditions = query.conditions + ` ${dashboardFilterConditions}`;
-      }
-    });
-    return widgetToFilter;
-  }, []);
-
-  const widgetForRequest = useCallback(
-    (widgetToProcess: Widget): Widget => {
-      const processedWidget = applyDashboardFilters(widgetToProcess);
-      return cleanWidgetForRequest(processedWidget);
-    },
-    [applyDashboardFilters]
-  );
-
-  const fetchTableData = useCallback(
-    async (fetchID: symbol) => {
-      // Read from ref to get latest props (avoids stale closure when queued)
-      const currentProps = latestPropsRef.current;
-
-      if (currentProps.disabled) {
-        return;
-      }
-      const originalWidget = currentProps.widget;
-      const widgetToFetch = widgetForRequest(cloneDeep(originalWidget));
-      const responses = await Promise.all(
-        widgetToFetch.queries.map(query => {
-          const requestLimit: number | undefined =
-            currentProps.limit ?? DEFAULT_TABLE_LIMIT;
-          const requestCreator = config.getTableRequest;
-
-          if (!requestCreator) {
-            throw new Error(
-              t('This display type is not supported by the selected dataset.')
-            );
-          }
-
-          return requestCreator(
-            api,
-            widgetToFetch,
-            query,
-            organization,
-            currentProps.selection,
-            currentProps.onDemandControlContext,
-            requestLimit,
-            currentProps.cursor,
-            getReferrer(widgetToFetch.displayType),
-            currentProps.mepSetting,
-            currentProps.samplingMode
-          );
-        })
-      );
-
-      let transformedTableResults: TableDataWithTitle[] = [];
-      let responsePageLinks: string | undefined;
-      let afterTableFetchData: OnDataFetchedProps | undefined;
-      responses.forEach(([data, _textstatus, resp], i) => {
-        afterTableFetchData = afterFetchTableData?.(data, resp) ?? {};
-        // Cast so we can add the title.
-        const transformedData = config.transformTable(
-          data,
-          widgetToFetch.queries[0]!,
-          organization,
-          currentProps.selection
-        ) as TableDataWithTitle;
-        transformedData.title = widgetToFetch.queries[i]?.name ?? '';
-
-        const meta = transformedData.meta;
-        const fieldMeta = widgetToFetch?.queries?.[i]?.fieldMeta;
-        if (fieldMeta && meta) {
-          fieldMeta.forEach((m, index) => {
-            const field = widgetToFetch.queries?.[i]?.fields?.[index];
-            if (m && field) {
-              meta.units![field] = m.valueUnit ?? '';
-              meta.fields![field] = m.valueType;
-            }
-          });
-        }
-
-        // Overwrite the local var to work around state being stale in tests.
-        transformedTableResults = [...transformedTableResults, transformedData];
-
-        // There is some inconsistency with the capitalization of "link" in response headers
-        responsePageLinks =
-          (resp?.getResponseHeader('Link') || resp?.getResponseHeader('link')) ??
-          undefined;
-      });
-
-      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
-        onDataFetched?.({
-          tableResults: transformedTableResults,
-          pageLinks: responsePageLinks,
-          ...afterTableFetchData,
-        });
-        setTableResults(transformedTableResults);
-        setPageLinks(responsePageLinks);
-      }
-      // Intentionally reading widget, selection, etc. from latestPropsRef instead of closure
-      // to avoid stale data when function is queued and props change before execution
-    },
-    [widgetForRequest, config, api, organization, afterFetchTableData, onDataFetched]
-  );
-
-  const fetchSeriesData = useCallback(
-    async (fetchID: symbol) => {
-      // Read from ref to get latest props (avoids stale closure when queued)
-      const currentProps = latestPropsRef.current;
-
-      if (currentProps.disabled) {
-        return;
-      }
-
-      const originalWidget = currentProps.widget;
-      const widgetToFetch = widgetForRequest(cloneDeep(originalWidget));
-
-      const responses = await Promise.all(
-        widgetToFetch.queries.map((_query, index) => {
-          return config.getSeriesRequest!(
-            api,
-            widgetToFetch,
-            index,
-            organization,
-            currentProps.selection,
-            currentProps.onDemandControlContext,
-            getReferrer(widgetToFetch.displayType),
-            currentProps.mepSetting,
-            currentProps.samplingMode
-          );
-        })
-      );
-      const rawResultsClone = cloneDeep(rawResultsRef.current) ?? [];
-      const transformedTimeseriesResults: Series[] = []; // Watch out, this is a sparse array. `map` and `forEach` will skip the empty slots. Spreading the array with `...` will create an `undefined` for each slot.
-      responses.forEach(([data], requestIndex) => {
-        afterFetchSeriesData?.(data);
-        rawResultsClone[requestIndex] = data;
-        const transformedResult = config.transformSeries!(
-          data,
-          widgetToFetch.queries[requestIndex]!,
-          organization
-        );
-        // When charting timeseriesData on echarts, color association to a timeseries result
-        // is order sensitive, ie series at index i on the timeseries array will use color at
-        // index i on the color array. This means that on multi series results, we need to make
-        // sure that the order of series in our results do not change between fetches to avoid
-        // coloring inconsistencies between renders.
-        transformedResult.forEach((result, resultIndex) => {
-          transformedTimeseriesResults[
-            requestIndex * transformedResult.length + resultIndex
-          ] = result;
-        });
-      });
-
-      // Retrieve the config's series result types and units
-      // Since each query only differs in its query filter, we can use the first widget queries
-      // to derive the types and units since they share the same aggregations and fields
-      const newTimeseriesResultsTypes = responses.reduce(
-        (acc, response) => {
-          let allResultTypes: Record<string, AggregationOutputType> = {};
-          widgetToFetch.queries.forEach(query => {
-            allResultTypes = {
-              ...allResultTypes,
-              ...config.getSeriesResultType?.(response[0], query),
-            };
-          });
-          acc = {...acc, ...allResultTypes};
-          return acc;
-        },
-        {} as Record<string, AggregationOutputType>
-      );
-      const newTimeseriesResultsUnits = responses.reduce(
-        (acc, response) => {
-          let allResultUnits: Record<string, DataUnit> = {};
-          widgetToFetch.queries.forEach(query => {
-            allResultUnits = {
-              ...allResultUnits,
-              ...config.getSeriesResultUnit?.(response[0], query),
-            };
-          });
-          acc = {...acc, ...allResultUnits};
-          return acc;
-        },
-        {} as Record<string, DataUnit>
-      );
-
-      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
-        onDataFetched?.({
-          timeseriesResults: transformedTimeseriesResults,
-          timeseriesResultsTypes: newTimeseriesResultsTypes,
-          timeseriesResultsUnits: newTimeseriesResultsUnits,
-        });
-        setTimeseriesResults(transformedTimeseriesResults);
-        setRawResults(rawResultsClone);
-        setTimeseriesResultsTypes(newTimeseriesResultsTypes);
-        setTimeseriesResultsUnits(newTimeseriesResultsUnits);
-      }
-    },
-    [widgetForRequest, config, api, organization, afterFetchSeriesData, onDataFetched]
-  );
-
-  const fetchData = useCallback(async () => {
-    const fetchID = Symbol('queryFetchID');
-    queryFetchIDRef.current = fetchID;
-    setLoading(true);
-    setTableResults(undefined);
-    setTimeseriesResults(undefined);
-    setErrorMessage(undefined);
-
-    onDataFetchStart?.();
-
-    try {
-      // Read from ref to get latest widget (avoids stale closure when queued)
-      const currentWidget = latestPropsRef.current.widget;
-      if (isChartDisplayType(currentWidget.displayType)) {
-        await fetchSeriesData(fetchID);
-      } else {
-        await fetchTableData(fetchID);
-      }
-    } catch (err: any) {
-      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
-        setErrorMessage(
-          err?.responseJSON?.detail || err?.message || t('An unknown error occurred.')
-        );
-      }
-    } finally {
-      if (isMountedRef.current && queryFetchIDRef.current === fetchID) {
-        setLoading(false);
-      }
-    }
-  }, [onDataFetchStart, fetchSeriesData, fetchTableData]);
-
-  // Keep fetchDataRef in sync with the latest fetchData function
-  useEffect(() => {
-    fetchDataRef.current = fetchData;
-  }, [fetchData]);
-
-  const fetchDataWithQueueIfAvailable = useCallback(() => {
-    if (queue) {
-      queryFetchIDRef.current = undefined;
-      // Pass the ref to the queue instead of the function
-      // When the queue executes, it will call fetchDataRef.current which always points to the latest fetchData
-      // Deduplication is based on fetchDataRef identity (per-component-instance)
-      setLoading(true);
-      setTableResults(undefined);
-      setTimeseriesResults(undefined);
-      setErrorMessage(undefined);
-      queue.addItem({fetchDataRef});
-      return;
-    }
-    fetchData();
-  }, [queue, fetchData]);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (hasHookApproach) {
-      return;
-    }
-
-    if (!propsLoading && isMountedRef.current && !hasInitialFetchRef.current) {
-      hasInitialFetchRef.current = true;
-      prevPropsRef.current = props;
-      fetchDataWithQueueIfAvailable();
-    }
-  }, [propsLoading, fetchDataWithQueueIfAvailable, hasHookApproach, props]);
-
-  // This effect checks if props have changed and triggers refetch for old Promise-based approach
-  // Hook-based queries don't need this - React Query handles prop changes automatically
-  useEffect(() => {
-    // Only run for non-hook approach (legacy Promise-based widgets)
-    if (hasHookApproach) {
-      return;
-    }
-
-    const prevProps = prevPropsRef.current;
-    if (!prevProps) {
-      prevPropsRef.current = props;
-      return;
-    }
-
-    // We do not fetch data whenever the query name changes.
-    // Also don't count empty fields when checking for field changes
-    const previousQueries = prevProps.widget.queries;
-    const [prevWidgetQueryNames, prevWidgetQueries] = previousQueries.reduce(
-      (
-        [names, queries]: [string[], Array<Omit<WidgetQuery, 'name'>>],
-        {name, ...rest}
-      ) => {
-        names.push(name);
-        rest.fields = rest.fields?.filter(field => !!field) ?? [];
-
-        // Ignore aliases because changing alias does not need a query
-        rest = omit(rest, 'fieldAliases');
-        queries.push(rest);
-        return [names, queries];
-      },
-      [[], []]
-    );
-
-    const nextQueries = widget.queries;
-    const [widgetQueryNames, widgetQueries] = nextQueries.reduce(
-      (
-        [names, queries]: [string[], Array<Omit<WidgetQuery, 'name'>>],
-        {name, ...rest}
-      ) => {
-        names.push(name);
-        rest.fields = rest.fields?.filter(field => !!field) ?? [];
-
-        // Ignore aliases because changing alias does not need a query
-        rest = omit(rest, 'fieldAliases');
-        queries.push(rest);
-        return [names, queries];
-      },
-      [[], []]
-    );
-
-    // Read customDidUpdateComparator from ref to avoid dependency issues
-    const currentCustomComparator = customDidUpdateComparatorRef.current;
-    const refetchReasons = {
-      customComparator: currentCustomComparator?.(prevProps, props),
-      limit: widget.limit !== prevProps.widget.limit,
-      widgetType: !isEqual(widget.widgetType, prevProps.widget.widgetType),
-      displayType: !isEqual(widget.displayType, prevProps.widget.displayType),
-      interval: !isEqual(widget.interval, prevProps.widget.interval),
-      queries: !isEqual(new Set(widgetQueries), new Set(prevWidgetQueries)),
-      dashboardFilters: !isEqual(dashboardFilters, prevProps.dashboardFilters),
-      forceOnDemand: !isEqual(forceOnDemand, prevProps.forceOnDemand),
-      disabled: !isEqual(disabled, prevProps.disabled),
-      selection: !isSelectionEqual(selection, prevSelectionRef.current),
-      cursor: cursor !== prevProps.cursor,
-    };
-
-    const shouldRefetch = currentCustomComparator
-      ? refetchReasons.customComparator
-      : Object.values(refetchReasons).some(Boolean);
-
-    if (shouldRefetch) {
-      // For hook-based queries, React Query auto-refetches when query keys change
-      // We only need to manually refetch for old Promise-based approach
-      if (!hasHookApproach) {
-        fetchDataWithQueueIfAvailable();
-      }
-      prevPropsRef.current = props;
-      prevSelectionRef.current = selection;
-      return;
-    }
-
-    if (
-      !loading &&
-      !isEqual(prevWidgetQueryNames, widgetQueryNames) &&
-      rawResults?.length === widget.queries.length
-    ) {
-      // If the query names has changed, then update timeseries labels
-      // Read config from ref to avoid dependency issues
-      const currentConfig = configRef.current;
-      const newTimeseriesResults = widget.queries.reduce(
-        (acc: Series[], query, index) => {
-          return acc.concat(
-            currentConfig.transformSeries!(rawResults[index]!, query, organization)
-          );
-        },
-        []
-      );
-
-      setTimeseriesResults(newTimeseriesResults);
-    }
-
-    prevPropsRef.current = props;
-  }, [
-    hasHookApproach,
-    widget,
-    dashboardFilters,
-    forceOnDemand,
-    disabled,
-    selection,
-    cursor,
-    loading,
-    rawResults,
-    fetchDataWithQueueIfAvailable,
-    organization,
-    props,
-  ]);
-
-  // If using hook-based approach, return hook results
-  // Otherwise, return old approach results
-  if (hasHookApproach && hookResults) {
-    return hookResults;
-  }
-
-  return {
-    loading,
-    tableResults,
-    timeseriesResults,
-    errorMessage,
-    pageLinks,
-    timeseriesResultsTypes,
-    timeseriesResultsUnits,
-  };
 }
 
 export function cleanWidgetForRequest(widget: Widget): Widget {

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -78,13 +78,8 @@ export type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
     response?: ResponseMeta
   ) => void | {totalIssuesCount?: string};
   cursor?: string;
-  customDidUpdateComparator?: (
-    prevProps: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>,
-    nextProps: UseGenericWidgetQueriesProps<SeriesResponse, TableResponse>
-  ) => boolean;
   dashboardFilters?: DashboardFilters;
   disabled?: boolean;
-  forceOnDemand?: boolean;
   limit?: number;
   loading?: boolean;
   mepSetting?: MEPState | null;
@@ -165,7 +160,6 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     cursor,
   });
 
-  // Use the appropriate results based on display type
   const hookResults = isChartDisplay ? hookSeriesResults : hookTableResults;
 
   // Track previous raw data to detect when new data arrives

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -1,11 +1,8 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import trimStart from 'lodash/trimStart';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
@@ -35,10 +32,7 @@ import {
   METRICS_EXPRESSION_TO_FIELD,
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 
-import type {
-  GenericWidgetQueriesResult,
-  UseGenericWidgetQueriesProps,
-} from './genericWidgetQueries';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 interface ReleaseWidgetQueriesProps {
@@ -152,63 +146,6 @@ function getLimit(displayType: DisplayType, limit?: number) {
     default:
       return limit ?? 20; // TODO(dam): Can be changed to undefined once [INGEST-1079] is resolved
   }
-}
-
-function customDidUpdateComparator(
-  prevProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>,
-  nextProps: UseGenericWidgetQueriesProps<SessionApiResponse, SessionApiResponse>
-) {
-  const {loading, limit, widget, cursor, dashboardFilters, selection} = nextProps;
-  const ignoredWidgetProps: Array<Partial<keyof Widget>> = [
-    'queries',
-    'title',
-    'id',
-    'layout',
-    'tempId',
-    'widgetType',
-    'tableWidths',
-  ];
-  const ignoredQueryProps: Array<Partial<keyof WidgetQuery>> = [
-    'name',
-    'fields',
-    'aggregates',
-    'columns',
-  ];
-  return (
-    limit !== prevProps.limit ||
-    !isEqual(dashboardFilters, prevProps.dashboardFilters) ||
-    // Compare selection changes - must check even when undefined since this custom comparator
-    // completely replaces the hook's default comparison logic. Use isSelectionEqual to ignore
-    // the utc field which has undefined/null/boolean inconsistency issues
-    (selection !== undefined && prevProps.selection !== undefined
-      ? !isSelectionEqual(selection, prevProps.selection)
-      : selection !== prevProps.selection) ||
-    // If the widget changed (ignore unimportant fields, + queries as they are handled lower)
-    !isEqual(
-      omit(widget, ignoredWidgetProps),
-      omit(prevProps.widget, ignoredWidgetProps)
-    ) ||
-    // If the queries changed (ignore unimportant name, + fields as they are handled lower)
-    !isEqual(
-      widget.queries.map(q => omit(q, ignoredQueryProps)),
-      prevProps.widget.queries.map(q => omit(q, ignoredQueryProps))
-    ) ||
-    // If the fields changed (ignore falsy/empty fields -> they can happen after clicking on Add Series)
-    !isEqual(
-      widget.queries.flatMap(q => q.fields?.filter(field => !!field)),
-      prevProps.widget.queries.flatMap(q => q.fields?.filter(field => !!field))
-    ) ||
-    !isEqual(
-      widget.queries.flatMap(q => q.aggregates.filter(aggregate => !!aggregate)),
-      prevProps.widget.queries.flatMap(q => q.aggregates.filter(aggregate => !!aggregate))
-    ) ||
-    !isEqual(
-      widget.queries.flatMap(q => q.columns.filter(column => !!column)),
-      prevProps.widget.queries.flatMap(q => q.columns.filter(column => !!column))
-    ) ||
-    loading !== prevProps.loading ||
-    cursor !== prevProps.cursor
-  );
 }
 
 function ReleaseWidgetQueries({
@@ -397,7 +334,6 @@ function ReleaseWidgetQueries({
     onDataFetchStart,
     selection,
     loading: requiresCustomReleaseSorting(widget.queries[0]!) ? !releases : undefined,
-    customDidUpdateComparator,
     afterFetchTableData: afterFetchData,
     afterFetchSeriesData: afterFetchData,
   });


### PR DESCRIPTION
We have fully transitioned to `useTableQuery` and `useSeriesQuery`, therefore we can remove the old promise based config and appropriate code. This also means we can remove the customComparator stuff now that we rely on useQueries + query keys