### PR TITLE
feat(preprod): Add docs link and simplify build filter description

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -1,7 +1,8 @@
 import {useCallback, useState} from 'react';
 
-import {Stack} from 'sentry/components/core/layout';
+import {Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -37,7 +38,6 @@ interface FeatureFilterProps {
   settingsWriteKey: string;
   successMessage: string;
   title: string;
-  children?: React.ReactNode;
   display?: PreprodBuildsDisplay;
 }
 
@@ -47,7 +47,6 @@ export function FeatureFilter({
   settingsReadKey,
   settingsWriteKey,
   display,
-  children,
 }: FeatureFilterProps) {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
@@ -95,13 +94,21 @@ export function FeatureFilter({
 
   return (
     <Panel>
-      <PanelHeader>{title}</PanelHeader>
+      <PanelHeader>
+        <Flex align="center" gap="xs">
+          {t('%s - Configuration', title)}
+          <PageHeadingQuestionTooltip
+            docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
+            title={t('Learn more about configuring build filters.')}
+          />
+        </Flex>
+      </PanelHeader>
       <PanelBody>
         <Stack gap="lg" style={{padding: '16px'}}>
-          {children}
-          <Text size="sm" variant="muted">
+          <Text>
             {t(
-              'Configure a filter to match specific builds. This feature will only apply to new builds that match the filter.'
+              'Builds matching this filter will process for %s. By default, all builds will process.',
+              title
             )}
           </Text>
 

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import Feature from 'sentry/components/acl/feature';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Stack} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -47,13 +46,7 @@ export default function PreprodSettings() {
             settingsReadKey={SIZE_ENABLED_QUERY_READ_KEY}
             title={t('Size Analysis')}
             successMessage={t('Size filter updated')}
-          >
-            <Text>
-              {t(
-                "Size Analysis helps monitor your mobile app's size in pre-production to prevent unexpected size increases (regressions) from reaching users."
-              )}
-            </Text>
-          </FeatureFilter>
+          />
           <Feature features="organizations:preprod-build-distribution">
             <FeatureFilter
               settingsWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
@@ -61,13 +54,7 @@ export default function PreprodSettings() {
               title={t('Build Distribution')}
               successMessage={t('Distribution filter updated')}
               display={PreprodBuildsDisplay.DISTRIBUTION}
-            >
-              <Text>
-                {t(
-                  'Build Distribution helps you securely distribute iOS builds to your internal teams and beta testers. Streamline your distribution workflow with automated uploads from CI.'
-                )}
-              </Text>
-            </FeatureFilter>
+            />
           </Feature>
         </Stack>
       </Feature>


### PR DESCRIPTION
_note: _ right now build distro technically links to size analysis config, imo fine for now

Add a docs link icon to the feature filter panel header that links to the size analysis configuration docs. Simplify the description to clearly explain what the filter does.

<img width="1404" height="274" alt="CleanShot 2026-01-29 at 11 14 02@2x" src="https://github.com/user-attachments/assets/0bbd517d-1cdb-41f6-8d56-710259f90b88" />