### PR TITLE
fix(eap): Include trace_filters in top events timeseries queries

### DIFF
--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -900,6 +900,7 @@ class RPCBase:
             referrer=f"{referrer}.topn",
             sampling_mode=sampling_mode,
             extra_conditions=top_conditions,
+            additional_queries=additional_queries,
         )
         requests = [rpc_request]
         if include_other:
@@ -912,6 +913,7 @@ class RPCBase:
                 referrer=f"{referrer}.query-other",
                 sampling_mode=sampling_mode,
                 extra_conditions=other_conditions,
+                additional_queries=additional_queries,
             )
             requests.append(other_request)
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
@@ -61,16 +61,14 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
         )
 
         assert response.status_code == 200, response.content
-        assert len(response.data["timeSeries"]) == 2
+        # With trace_filters applied correctly, only the span in trace_id (matching logQuery) is included
+        assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
         values = timeseries["values"]
         assert not timeseries["meta"]["isOther"]
         assert len(values) == 2
         assert values[0]["value"] == 0
         assert values[1]["value"] == 1
-
-        other_timeseries = response.data["timeSeries"][1]
-        assert other_timeseries["meta"]["isOther"]
 
     def test_cross_trace_query_with_spans(self) -> None:
         trace_id = uuid.uuid4().hex
@@ -325,3 +323,86 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
         assert len(values) == 2
         assert values[0]["value"] == 0
         assert values[1]["value"] == 1
+
+    def test_top_events_with_log_query_includes_trace_filters(self) -> None:
+        """Test that topEvents queries with logQuery include trace_filters in RPC payload"""
+        from unittest.mock import patch
+
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar", "trace_id": excluded_trace_id},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "six"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        # Patch the RPC call to capture the request payload
+        with patch("sentry.snuba.spans_rpc.snuba_rpc.timeseries_rpc") as mock_timeseries_rpc:
+            # Return a minimal valid response
+            mock_timeseries_rpc.return_value = [
+                type(
+                    "MockResponse",
+                    (),
+                    {
+                        "result_type": 0,
+                        "timeseries": [],
+                        "meta": type("Meta", (), {"request_id": "test", "has_more": False})(),
+                    },
+                )()
+            ]
+
+            self.do_request(
+                {
+                    "field": ["tags[foo]", "count()"],
+                    "query": "description:baz",
+                    "orderby": "count()",
+                    "project": self.project.id,
+                    "dataset": "spans",
+                    "interval": "1d",
+                    "statsPeriod": "1d",
+                    "topEvents": 5,
+                    "groupBy": ["tags[foo]"],
+                    "logQuery": ["message:foo"],
+                }
+            )
+
+            # Verify the RPC was called with trace_filters
+            assert mock_timeseries_rpc.called
+            # Get the requests argument (first positional argument)
+            rpc_requests = mock_timeseries_rpc.call_args[0][0]
+            # Should have at least one request
+            assert len(rpc_requests) > 0
+            # The first request should have trace_filters
+            first_request = rpc_requests[0]
+            assert hasattr(first_request, "trace_filters")
+            # trace_filters should not be empty when logQuery is provided
+            assert len(first_request.trace_filters) > 0

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
@@ -266,7 +266,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
         assert values[0]["value"] == 0
         assert values[1]["value"] == 1
 
-    def test_cross_trace_qurey_with_multiple_logs(self) -> None:
+    def test_cross_trace_query_with_multiple_logs(self) -> None:
         trace_id = uuid.uuid4().hex
         excluded_trace_id = uuid.uuid4().hex
         logs = [
@@ -384,7 +384,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                 )
             ]
 
-            self.do_request(
+            response = self.do_request(
                 {
                     "field": ["tags[foo]", "count()"],
                     "query": "description:baz",
@@ -394,11 +394,14 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                     "interval": "1d",
                     "statsPeriod": "1d",
                     "topEvents": 5,
+                    "excludeOther": 1,
                     "groupBy": ["tags[foo]"],
                     "logQuery": ["message:foo"],
                 }
             )
 
+            # Verify the response was successful
+            assert response.status_code == 200, response.content
             # Verify the RPC was called with trace_filters
             assert mock_timeseries_rpc.called
             # Get the requests argument (first positional argument)


### PR DESCRIPTION
## Bug Fix

When querying top events with cross-trace filtering parameters (`logQuery`, `spanQuery`, or `metricQuery`), the `trace_filters` were not being included in the Snuba RPC payload, causing cross-trace filtering to be ignored.

Here's a screenshot of this in the product:

<img width="959" height="659" alt="image" src="https://github.com/user-attachments/assets/fa8a2a92-f854-4483-8e56-71d43febf256" />

you can see that the Aggregates are displaying wildly different numbers from the timeseries. When I looked at the payload on the snuba side, I saw that `trace_filters` were not being passed in on the timeseries requests. 

### Root Cause

In `rpc_dataset_common.py:894-915`, the `run_top_events_timeseries_query()` method:
- Correctly received the `additional_queries` parameter (line 842)
- Passed it to the initial table query to find top N events (line 874)
- **But omitted it** when calling `get_timeseries_query()` for both:
  - Main timeseries request (line 894-903)
  - "Other" timeseries request (line 906-915)

Without `additional_queries`, the `get_cross_trace_queries()` call received `None` and returned an empty list, resulting in no `trace_filters` in the RPC payload.

### Changes

- **src/sentry/snuba/rpc_dataset_common.py**: Added `additional_queries` parameter to both `get_timeseries_query()` calls
- **tests/.../test_organization_events_timeseries_cross_trace.py**: 
  - Added test verifying `trace_filters` inclusion in RPC payload
  - Updated existing test expectation to reflect correct filtering behavior

### Impact

Top events timeseries queries now correctly filter spans by correlated log/metric data across traces, consistent with regular timeseries queries.