### PR TITLE
feat(devservices): Use Shared postgres

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -35,7 +35,11 @@ x-sentry-service-config:
         repo_link: https://github.com/getsentry/relay.git
         mode: containerized
     postgres:
-      description: Database used to store Sentry data
+      description: Shared instance of postgres used by sentry services
+      remote:
+        repo_name: sentry-shared-postgres
+        branch: main
+        repo_link: https://github.com/getsentry/sentry-shared-postgres.git
     redis:
       description: Shared instance of redis used by sentry services
       remote:
@@ -389,37 +393,6 @@ x-programs:
     command: sentry run consumer generic-metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
 
 services:
-  postgres:
-    image: ghcr.io/getsentry/image-mirror-library-postgres:14-alpine
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_DB: sentry
-    command:
-      [
-        postgres,
-        -c,
-        wal_level=logical,
-        -c,
-        max_replication_slots=1,
-        -c,
-        max_wal_senders=1,
-      ]
-    healthcheck:
-      test: pg_isready -U postgres
-      interval: 5s
-      timeout: 5s
-      retries: 3
-    networks:
-      - devservices
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    ports:
-      - 127.0.0.1:5432:5432
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    labels:
-      - orchestrator=devservices
-    restart: unless-stopped
   bigtable:
     image: 'ghcr.io/getsentry/cbtemulator:d28ad6b63e461e8c05084b8c83f1c06627068c04'
     ports:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -448,6 +448,3 @@ networks:
   devservices:
     name: devservices
     external: true
-
-volumes:
-  postgres-data:


### PR DESCRIPTION
Taskbroker was using a separate postgres instance that was resulting in port collisions. This switches sentry devservices to use a shared postgres config.

commit that introduced the change in taskbroker: https://github.com/getsentry/taskbroker/commit/3cb96af0348b91046a7dde07600a12a013b9d589#diff-d24cc055de40646e1a6388589278bb43c25155e40098919903652f5c7e0410b1