### PR TITLE
Issue assignment permissions

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -1089,9 +1089,7 @@ def validate_bulk_reassignment(
     # Collect team IDs for groups that are currently assigned to teams
     # (excludes unassigned groups and groups assigned to users)
     current_team_ids = {
-        assignee.team_id
-        for assignee in current_assignees.values()
-        if assignee.team_id is not None
+        assignee.team_id for assignee in current_assignees.values() if assignee.team_id is not None
     }
 
     # If there are no team assignments, allow the assignment

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1403,7 +1403,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_assign_unassigned_issue_to_team_not_member_of(self) -> None:
         """
         Test that a user CAN assign an UNASSIGNED issue to a team they are not a member of.
-        
+
         This ensures that unassigned issues can be freely assigned to any team, while still
         preventing unauthorized reassignment from one team to another (which is tested in
         test_cannot_reassign_from_other_team).
@@ -1508,7 +1508,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         """
         Test that a member CAN assign an UNASSIGNED issue to any team that has
         access to the project, even if they're not a member of that team.
-        
+
         This is a regression test for the bug where members couldn't assign
         unassigned issues after the IDOR fix was introduced.
         """
@@ -1547,7 +1547,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         """
         Test that a member CAN reassign an issue that is assigned to a user
         to any team that has access to the project.
-        
+
         User assignments don't have the same restrictions as team assignments.
         """
         self.organization.flags.allow_joinleave = False


### PR DESCRIPTION
Fixes a regression where members were unable to assign unassigned or user-assigned issues to teams.

The `validate_bulk_reassignment` function, introduced in a recent commit, was overly restrictive. It incorrectly prevented members from assigning issues that were either unassigned or assigned to a user to any team, even if the member had project access.

This PR modifies the validation to:
*   Allow members to assign unassigned issues to any team.
*   Allow members to reassign user-assigned issues to any team.
*   Maintain the security restriction for reassigning issues that are currently assigned to a team the user is not a member of.

New tests have been added, and an existing test updated, to reflect the corrected behavior.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1306](https://linear.app/getsentry/issue/ID-1306/members-unable-to-assign-issues-to-teams)

<a href="https://cursor.com/background-agent?bcId=bc-5d3a2dc7-f2f3-4758-b740-06bc32956376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d3a2dc7-f2f3-4758-b740-06bc32956376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

