### PR TITLE
chore(preprod): Add support for SKIPPED and NO_QUOTA cases in size status check

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -389,7 +389,6 @@ def show_rule_evaluation(artifact_id: int) -> None:
         if not size_metrics:
             continue
 
-        # Look up base metric using the new structure
         base_metric = None
         base_artifact = base_artifact_map.get(art.id)
         if base_artifact:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -205,6 +205,7 @@ def create_preprod_status_check_task(
         return
 
     target_url = get_preprod_artifact_url(preprod_artifact)
+    completed_at: datetime | None = None
 
     # Check if any artifact hit quota limits - show neutral status with quota message
     if _has_no_quota_artifact(all_artifacts, size_metrics_map):
@@ -235,7 +236,6 @@ def create_preprod_status_check_task(
             triggered_rules,
         )
 
-        completed_at: datetime | None = None
         if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
             completed_at = preprod_artifact.date_updated
 

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -204,7 +204,12 @@ def create_preprod_status_check_task(
         )
         return
 
-    target_url = get_preprod_artifact_url(preprod_artifact)
+    url_artifact = (
+        preprod_artifact
+        if preprod_artifact.id in {a.id for a in all_artifacts}
+        else all_artifacts[0]
+    )
+    target_url = get_preprod_artifact_url(url_artifact)
     completed_at: datetime | None = None
 
     # Check if any artifact hit quota limits - show neutral status with quota message

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -456,11 +456,11 @@ def _has_no_quota_artifact(
     size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]],
 ) -> bool:
     """Check if any artifact has NO_QUOTA error."""
-    for artifact in artifacts:
-        for m in size_metrics_map.get(artifact.id, []):
-            if m.error_code == PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA:
-                return True
-    return False
+    return any(
+        m.error_code == PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA
+        for artifact in artifacts
+        for m in size_metrics_map.get(artifact.id, [])
+    )
 
 
 def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str]:

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -34,7 +34,10 @@ from sentry.preprod.models import (
     PreprodComparisonApproval,
 )
 from sentry.preprod.url_utils import get_preprod_artifact_url
-from sentry.preprod.vcs.status_checks.size.templates import format_status_check_messages
+from sentry.preprod.vcs.status_checks.size.templates import (
+    format_no_quota_messages,
+    format_status_check_messages,
+)
 from sentry.preprod.vcs.status_checks.size.types import StatusCheckRule, TriggeredRule
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -190,39 +193,57 @@ def create_preprod_status_check_task(
         for approval in approval_qs:
             approvals_map[approval.preprod_artifact_id] = approval
 
-    rules = _get_status_check_rules(preprod_artifact.project)
-    base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
-
-    status, triggered_rules = _compute_overall_status(
-        all_artifacts,
-        size_metrics_map,
-        rules=rules,
-        base_artifact_map=base_artifact_map,
-        base_metrics_by_artifact=base_size_metrics_map,
-        approvals_map=approvals_map,
-    )
-
-    title, subtitle, summary = format_status_check_messages(
-        all_artifacts,
-        size_metrics_map,
-        status,
-        preprod_artifact.project,
-        base_artifact_map,
-        base_size_metrics_map,
-        triggered_rules,
-    )
+    # Filter out SKIPPED artifacts (user didn't request size analysis)
+    all_artifacts = [
+        a for a in all_artifacts if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
+    ]
+    if not all_artifacts:
+        logger.info(
+            "preprod.status_checks.create.all_skipped",
+            extra={"artifact_id": preprod_artifact.id},
+        )
+        return
 
     target_url = get_preprod_artifact_url(preprod_artifact)
 
-    completed_at: datetime | None = None
-    if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
-        completed_at = preprod_artifact.date_updated
-
-    # When no rules are configured, always show neutral status.
-    # When rules exist, show actual status (in_progress, failure, success).
-    if not rules:
+    # Check if any artifact hit quota limits - show neutral status with quota message
+    if _has_no_quota_artifact(all_artifacts, size_metrics_map):
+        title, subtitle, summary = format_no_quota_messages()
         status = StatusCheckStatus.NEUTRAL
         completed_at = preprod_artifact.date_updated
+        triggered_rules: list[TriggeredRule] = []
+    else:
+        rules = _get_status_check_rules(preprod_artifact.project)
+        base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
+
+        status, triggered_rules = _compute_overall_status(
+            all_artifacts,
+            size_metrics_map,
+            rules=rules,
+            base_artifact_map=base_artifact_map,
+            base_metrics_by_artifact=base_size_metrics_map,
+            approvals_map=approvals_map,
+        )
+
+        title, subtitle, summary = format_status_check_messages(
+            all_artifacts,
+            size_metrics_map,
+            status,
+            preprod_artifact.project,
+            base_artifact_map,
+            base_size_metrics_map,
+            triggered_rules,
+        )
+
+        completed_at: datetime | None = None
+        if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
+            completed_at = preprod_artifact.date_updated
+
+        # When no rules are configured, always show neutral status.
+        # When rules exist, show actual status (in_progress, failure, success).
+        if not rules:
+            status = StatusCheckStatus.NEUTRAL
+            completed_at = preprod_artifact.date_updated
 
     try:
         check_id = provider.create_status_check(
@@ -416,6 +437,30 @@ def _fetch_base_size_metrics(
         base_metrics_by_artifact.setdefault(metrics.preprod_artifact_id, []).append(metrics)
 
     return base_artifact_map, base_metrics_by_artifact
+
+
+def _is_artifact_size_skipped(
+    size_metrics_list: list[PreprodArtifactSizeMetrics],
+) -> bool:
+    """Check if artifact should be excluded because size analysis was skipped."""
+    if not size_metrics_list:
+        return False
+
+    return all(
+        m.error_code == PreprodArtifactSizeMetrics.ErrorCode.SKIPPED for m in size_metrics_list
+    )
+
+
+def _has_no_quota_artifact(
+    artifacts: list[PreprodArtifact],
+    size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]],
+) -> bool:
+    """Check if any artifact has NO_QUOTA error."""
+    for artifact in artifacts:
+        for m in size_metrics_map.get(artifact.id, []):
+            if m.error_code == PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA:
+                return True
+    return False
 
 
 def _get_artifact_filter_context(artifact: PreprodArtifact) -> dict[str, str]:

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -15,11 +15,9 @@ _SIZE_ANALYZER_TITLE_BASE = _("Size Analysis")
 def format_no_quota_messages() -> tuple[str, str, str]:
     """Format status check messages when quota is exhausted."""
     title = _SIZE_ANALYZER_TITLE_BASE
-    subtitle = str(_("Quota exceeded"))
-    summary = str(
-        _("No quota available for size analysis. Contact support to increase your quota.")
-    )
-    return str(title), subtitle, summary
+    subtitle = _("Quota exceeded")
+    summary = _("No quota available for size analysis. Contact support to increase your quota.")
+    return str(title), str(subtitle), str(summary)
 
 
 def format_status_check_messages(

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -12,6 +12,16 @@ from sentry.preprod.vcs.status_checks.size.types import TriggeredRule
 _SIZE_ANALYZER_TITLE_BASE = _("Size Analysis")
 
 
+def format_no_quota_messages() -> tuple[str, str, str]:
+    """Format status check messages when quota is exhausted."""
+    title = _SIZE_ANALYZER_TITLE_BASE
+    subtitle = str(_("Quota exceeded"))
+    summary = str(
+        _("No quota available for size analysis. Contact support to increase your quota.")
+    )
+    return str(title), subtitle, summary
+
+
 def format_status_check_messages(
     artifacts: list[PreprodArtifact],
     size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]],

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -1296,3 +1296,99 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 mock_provider.create_status_check.assert_called_once()
                 call_kwargs = mock_provider.create_status_check.call_args.kwargs
                 assert call_kwargs["status"] == expected_status
+
+    def test_skipped_artifacts_not_included_in_status_check(self):
+        """SKIPPED artifacts are filtered out from the status check."""
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        valid = Factories.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.valid",
+            commit_comparison=commit_comparison,
+        )
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=valid,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=1024,
+            max_install_size=2048,
+        )
+
+        skipped = Factories.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.skipped",
+            commit_comparison=commit_comparison,
+        )
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=skipped,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+        )
+
+        _, mock_provider, client_patch, provider_patch = self._create_working_status_check_setup(
+            valid
+        )
+
+        with client_patch, provider_patch:
+            with self.tasks():
+                create_preprod_status_check_task(valid.id)
+
+            mock_provider.create_status_check.assert_called_once()
+            kwargs = mock_provider.create_status_check.call_args.kwargs
+            assert "com.valid" in kwargs["summary"]
+            assert "com.skipped" not in kwargs["summary"]
+
+    def test_all_skipped_artifacts_no_status_check(self):
+        """No status check created when all artifacts are SKIPPED."""
+        artifact = self._create_preprod_artifact(state=PreprodArtifact.ArtifactState.PROCESSED)
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+        )
+
+        _, mock_provider, client_patch, provider_patch = self._create_working_status_check_setup(
+            artifact
+        )
+
+        with client_patch, provider_patch:
+            with self.tasks():
+                create_preprod_status_check_task(artifact.id)
+            mock_provider.create_status_check.assert_not_called()
+
+    def test_no_quota_shows_neutral_status(self):
+        """NO_QUOTA artifacts trigger neutral status with quota exceeded message."""
+        artifact = self._create_preprod_artifact(state=PreprodArtifact.ArtifactState.PROCESSED)
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA,
+        )
+
+        _, mock_provider, client_patch, provider_patch = self._create_working_status_check_setup(
+            artifact
+        )
+
+        with client_patch, provider_patch:
+            with self.tasks():
+                create_preprod_status_check_task(artifact.id)
+
+            mock_provider.create_status_check.assert_called_once()
+            kwargs = mock_provider.create_status_check.call_args.kwargs
+            assert kwargs["status"] == StatusCheckStatus.NEUTRAL
+            assert "Quota exceeded" in kwargs["subtitle"]
+            assert "No quota available" in kwargs["summary"]


### PR DESCRIPTION
Closes EME-784
Closes EME-742

- Omits any builds that were skipped
- if ANY of the builds that would be included in the status check had NO_QUOTA, then just show a neutral status check with a simple message that they hit their quota limit

<img width="648" height="666" alt="image" src="https://github.com/user-attachments/assets/ff695802-5409-4508-9681-ce18a66e7814" />
