### PR TITLE
feat(tracemetrics): Pull data into chart

### DIFF
--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -8,7 +8,10 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconClock, IconGraph} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {parseFunction} from 'sentry/utils/discover/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
@@ -17,7 +20,9 @@ import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {
   useMetricLabel,
+  useMetricName,
   useMetricVisualize,
+  useMetricVisualizes,
   useSetMetricVisualize,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {METRICS_CHART_GROUP} from 'sentry/views/explore/metrics/metricsTab';
@@ -58,9 +63,15 @@ export function MetricsGraph({
   infoContentHidden,
   isMetricOptionsEmpty,
 }: MetricsGraphProps) {
+  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
+  const visualizes = useMetricVisualizes();
   const setVisualize = useSetMetricVisualize();
+
+  const hasMultiVisualize = organization.features.includes(
+    'tracemetrics-overlay-charts-ui'
+  );
 
   useSynchronizeCharts(
     metricQueries.length,
@@ -75,6 +86,8 @@ export function MetricsGraph({
   return (
     <Graph
       visualize={visualize}
+      visualizes={visualizes}
+      hasMultiVisualize={hasMultiVisualize}
       timeseriesResult={timeseriesResult}
       onChartTypeChange={handleChartTypeChange}
       orientation={orientation}
@@ -86,8 +99,10 @@ export function MetricsGraph({
 }
 
 interface GraphProps extends MetricsGraphProps {
+  hasMultiVisualize: boolean;
   onChartTypeChange: (chartType: ChartType) => void;
   visualize: ReturnType<typeof useMetricVisualize>;
+  visualizes: ReturnType<typeof useMetricVisualizes>;
 }
 
 function Graph({
@@ -95,6 +110,8 @@ function Graph({
   timeseriesResult,
   orientation,
   visualize,
+  visualizes,
+  hasMultiVisualize,
   infoContentHidden,
   additionalActions,
   isMetricOptionsEmpty,
@@ -102,13 +119,44 @@ function Graph({
   const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const metricLabel = useMetricLabel();
+  const metricName = useMetricName();
   const userQuery = useQueryParamsQuery();
   const [interval, setInterval, intervalOptions] = useChartInterval();
 
   const chartInfo = useMemo(() => {
-    const series = timeseriesResult.data[aggregate] ?? [];
     const isTopEvents = defined(topEventsLimit);
+    const yAxes = hasMultiVisualize ? visualizes.map(v => v.yAxis) : [visualize.yAxis];
+    const rawSeries = yAxes.flatMap(yAxis => timeseriesResult.data[yAxis] ?? []);
+
+    // When displaying multiple aggregates, simplify the legend labels
+    // to just show the function name (e.g., "p50" instead of "p50(metric.name)")
+    // For series with groupBy, show "groupByValue : functionName"
+    let series = rawSeries;
+    if (hasMultiVisualize && visualizes.length > 1) {
+      series = rawSeries.map(s => {
+        const parsed = parseFunction(s.yAxis);
+        if (!parsed) {
+          return s;
+        }
+
+        if (s.groupBy?.length) {
+          // Build a custom label combining groupBy values and the function name,
+          // using the shared formatter to preserve "(no value)" and release formatting.
+          // Clear groupBy so formatTimeSeriesLabel uses yAxis instead
+          const groupByLabel = formatTimeSeriesLabel(s);
+          return {
+            ...s,
+            yAxis: `${groupByLabel} : ${parsed.name}`,
+            groupBy: undefined,
+          };
+        }
+
+        return {...s, yAxis: parsed.name};
+      });
+    }
+
     const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopEvents);
+
     return {
       chartType: visualize.chartType,
       series,
@@ -121,13 +169,24 @@ function Graph({
       samplingMode: undefined,
       topEvents: isTopEvents ? TOP_EVENTS_LIMIT : undefined,
     };
-  }, [visualize.chartType, timeseriesResult, aggregate, topEventsLimit]);
+  }, [
+    visualize.chartType,
+    visualize.yAxis,
+    timeseriesResult,
+    aggregate,
+    topEventsLimit,
+    hasMultiVisualize,
+    visualizes,
+  ]);
 
-  const Title = (
-    <Widget.WidgetTitle
-      title={metricLabel ?? prettifyAggregation(aggregate) ?? aggregate}
-    />
-  );
+  const chartTitle = useMemo(() => {
+    if (hasMultiVisualize && visualizes.length > 1) {
+      return metricName;
+    }
+    return metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
+  }, [aggregate, hasMultiVisualize, metricLabel, metricName, visualizes.length]);
+
+  const Title = <Widget.WidgetTitle title={chartTitle} />;
 
   const chartIcon =
     visualize.chartType === ChartType.LINE

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -133,6 +133,11 @@ export function useMetricVisualizes(): readonly VisualizeFunction[] {
   throw new Error('Only visualize functions are allowed');
 }
 
+export function useMetricName(): string {
+  const {metric} = useTraceMetricContext();
+  return metric.name;
+}
+
 export function useMetricLabel(): string {
   const visualize = useMetricVisualize();
   const {metric} = useTraceMetricContext();


### PR DESCRIPTION
This PR builds on the work for overlaying data on the metrics chart by pulling the data into the chart fully and displaying it to the user.

Ticket: LOGS-547

Example:
<img width="1093" height="481" alt="Screenshot 2026-01-29 at 15 09 58" src="https://github.com/user-attachments/assets/884bde48-d4c2-4656-b9a8-686aa86aaa02" />