### PR TITLE
feat(seer): support multiple slack threads per alert for autofix updates

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -897,6 +897,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.seer.autofix.issue_summary",
     "sentry.seer.code_review.webhooks.task",
     "sentry.seer.entrypoints.operator",
+    "sentry.seer.entrypoints.integrations.slack",
     "sentry.snuba.tasks",
     "sentry.tasks.activity",
     "sentry.tasks.assemble",

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -576,7 +576,10 @@ class SlackActionEndpoint(Endpoint):
             group=group,
             organization_id=group.project.organization_id,
         )
-        lock = entrypoint.get_autofix_lock()
+        lock = SlackEntrypoint.get_autofix_lock(
+            group_id=group.id,
+            stopping_point=entrypoint.autofix_stopping_point,
+        )
         try:
             with lock.acquire():
                 SeerOperator(entrypoint=entrypoint).trigger_autofix(

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -570,7 +570,6 @@ class SlackActionEndpoint(Endpoint):
         group: Group,
         user: RpcUser,
     ) -> None:
-
         entrypoint = SlackEntrypoint(
             slack_request=slack_request,
             action=action,

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -275,7 +275,8 @@ def send_thread_update(
     logging_ctx = {
         "entrypoint_key": SeerEntrypointKey.SLACK,
         "integration_id": install.model.id,
-        "thread": thread,
+        "thread_ts": thread["thread_ts"],
+        "channel_id": thread["channel_id"],
         "data_source": data.source,
         "ephemeral_user_id": ephemeral_user_id,
     }
@@ -363,8 +364,8 @@ def schedule_all_thread_updates(
     """Schedules a task for each thread update to allow retries."""
     try:
         orjson.dumps(data)
-    except orjson.JSONDecodeError:
-        raise ValueError("Invalid data object used for thread update. Must be JSON serializable.")
+    except orjson.JSONEncodeError:
+        raise TypeError("Invalid data object used for thread update. Must be JSON serializable.")
 
     for thread in threads:
         process_thread_update.apply_async(

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -446,7 +446,7 @@ def handle_prepare_autofix_update(
     """
     threads: list[SlackThreadDetails] = []
     incoming_thread = SlackThreadDetails(thread_ts=thread_ts, channel_id=channel_id)
-    existing_cache = SeerOperatorAutofixCache.get_pre_autofix_cache(
+    existing_cache = SeerOperatorAutofixCache[SlackEntrypointCachePayload].get(
         entrypoint_key=str(SlackEntrypoint.key),
         group_id=group.id,
     )

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -417,9 +417,10 @@ def handle_prepare_autofix_update(
         entrypoint_key=str(SlackEntrypoint.key),
         group_id=group.id,
     )
-    if existing_cache and existing_cache["payload"]:
+    if existing_cache:
         threads = existing_cache["payload"].get("threads", [])
-    threads.append(incoming_thread)
+    if incoming_thread not in threads:
+        threads.append(incoming_thread)
 
     cache_payload = SlackEntrypointCachePayload(
         threads=threads,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -15,7 +15,7 @@ from sentry.seer.autofix.types import (
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
-from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey
+from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -15,7 +15,7 @@ from sentry.seer.autofix.types import (
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
-from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
+from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.tasks.base import instrumented_task

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -231,15 +231,15 @@ class SlackEntrypointTest(TestCase):
         mock_send_threaded_ephemeral_message.assert_called_once()
         mock_update_message.assert_called_once()
 
-    def test_get_autofix_lock(self):
-        lock = SlackEntrypoint.get_autofix_lock(
+    def test_get_autofix_lock_key(self):
+        lock_key = SlackEntrypoint.get_autofix_lock_key(
             group_id=self.group.id,
             stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
-        assert lock is not None
-        assert "autofix:entrypoint:slack" in lock.key
-        assert str(self.group.id) in lock.key
-        assert AutofixStoppingPoint.ROOT_CAUSE.value in lock.key
+        assert lock_key is not None
+        assert "autofix:entrypoint:slack" in lock_key
+        assert str(self.group.id) in lock_key
+        assert AutofixStoppingPoint.ROOT_CAUSE.value in lock_key
 
     @patch("sentry.seer.entrypoints.integrations.slack.process_thread_update")
     def test_schedule_all_thread_updates(self, mock_process_thread_update):


### PR DESCRIPTION
Does a few things along with adding support for updates to be received in multiple threads (when triggered by automations)

- Splits `_send_thread_update` into three smaller functions:
  - `send_thread_update`:  most of the same business logic, used to make the update synchronously (for example, confirming a run has started) -- operates on one thread
  - `process_thread_update`: a task which takes serializable params to make a call to `send_thread_update`. -- operates on one thread
  - `schedule_all_thread_updates`: A helper function which accepts a list of threads, and schedules a `process_thread_update` task for each, with retries and what not. Done this way so that a failed message on thread 2 doesn't retry a successful message on thread 2.
- Adding locks to trigger autofix call, further reducing the chance of repeated calls from the same thread.

Resolves ISWF-1944, ISWF-1175 and ISWF-1155