### PR TITLE
feat(spans-buffer): add stuck detector for span flusher subprocess

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3094,6 +3094,12 @@ register(
     default=60,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Enable stuck detector to log stack traces when subprocess initialization hangs
+register(
+    "spans.buffer.flusher.use-stuck-detector",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Compression level for spans buffer segments. Default -1 disables compression, 0-22 for zstd levels
 register(

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -193,6 +193,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
             self._create_process_for_shards(process_index, shards)
 
     def _create_process_for_shards(self, process_index: int, shards: list[int]):
+        use_stuck_detector = options.get("spans.buffer.flusher.use-stuck-detector")
         self.process_healthy_since[process_index].value = 0
 
         logger.info("Creating flusher process %s for shards %s", process_index, shards)
@@ -209,6 +210,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                 # synchronization primitives like multiprocessing.Value can
                 # only be done by the Process
                 shard_buffer,
+                use_stuck_detector=use_stuck_detector,
             )
             make_process = self.mp_context.Process
         else:

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -222,9 +222,10 @@ def _import_and_run(
 
     logger = logging.getLogger("sentry.utils.arroyo.subprocess")
 
-    init_done = threading.Event()
+    init_done: threading.Event | None = None
 
     if use_stuck_detector:
+        init_done = threading.Event()
 
         def stuck_detector() -> None:
             start = time.time()
@@ -259,7 +260,8 @@ def _import_and_run(
         logger.info("_import_and_run: unpickling args")
         args = pickle.loads(args_pickle)
     finally:
-        init_done.set()
+        if init_done:
+            init_done.set()
 
     logger.info("_import_and_run: calling main_fn")
     main_fn(*args, *additional_args)

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pickle
+import threading
+import time
 from collections.abc import Callable, Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -21,6 +23,7 @@ from django.conf import settings
 if TYPE_CHECKING:
     from sentry.metrics.base import MetricsBackend
 
+STUCK_DETECTOR_TIMEOUT_SECONDS = 30
 
 Tags = Mapping[str, str]
 
@@ -212,32 +215,69 @@ def _import_and_run(
     initializer: Callable[[], None],
     main_fn_pickle: bytes,
     args_pickle: bytes,
+    use_stuck_detector: bool,
     *additional_args: Any,
 ) -> None:
     import logging
 
     logger = logging.getLogger("sentry.utils.arroyo.subprocess")
 
-    logger.info("_import_and_run: calling initializer")
-    initializer()
+    init_done = threading.Event()
 
-    # explicitly use pickle so that we can be sure arguments get unpickled
-    # after sentry gets initialized
-    logger.info("_import_and_run: unpickling main_fn")
-    main_fn = pickle.loads(main_fn_pickle)
+    if use_stuck_detector:
 
-    logger.info("_import_and_run: unpickling args")
-    args = pickle.loads(args_pickle)
+        def stuck_detector() -> None:
+            start = time.time()
+            while not init_done.is_set():
+                elapsed = time.time() - start
+                if elapsed > STUCK_DETECTOR_TIMEOUT_SECONDS:
+                    from arroyo.processing.processor import get_all_thread_stacks
+
+                    stack_traces = get_all_thread_stacks()
+                    logger.warning(
+                        "subprocess initialization stuck for %s seconds, stacks: %s",
+                        STUCK_DETECTOR_TIMEOUT_SECONDS,
+                        stack_traces,
+                    )
+                    return
+                time.sleep(1)
+
+        detector_thread = threading.Thread(
+            target=stuck_detector, daemon=True, name="stuck-detector"
+        )
+        detector_thread.start()
+
+    try:
+        logger.info("_import_and_run: calling initializer")
+        initializer()
+
+        # explicitly use pickle so that we can be sure arguments get unpickled
+        # after sentry gets initialized
+        logger.info("_import_and_run: unpickling main_fn")
+        main_fn = pickle.loads(main_fn_pickle)
+
+        logger.info("_import_and_run: unpickling args")
+        args = pickle.loads(args_pickle)
+    finally:
+        init_done.set()
 
     logger.info("_import_and_run: calling main_fn")
     main_fn(*args, *additional_args)
 
 
-def run_with_initialized_sentry(main_fn: Callable[..., None], *args: Any) -> Callable[..., None]:
+def run_with_initialized_sentry(
+    main_fn: Callable[..., None],
+    *args: Any,
+    use_stuck_detector: bool = False,
+) -> Callable[..., None]:
     main_fn_pickle = pickle.dumps(main_fn)
     args_pickle = pickle.dumps(args)
     return partial(
-        _import_and_run, _get_arroyo_subprocess_initializer(None), main_fn_pickle, args_pickle
+        _import_and_run,
+        _get_arroyo_subprocess_initializer(None),
+        main_fn_pickle,
+        args_pickle,
+        use_stuck_detector,
     )
 
 

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -179,7 +179,10 @@ def test_flusher_waits_for_processes_to_start() -> None:
     with (
         mock.patch.object(SpanFlusher, "main", never_healthy_main),
         override_options(
-            {"spans.buffer.flusher.max-unhealthy-seconds": 0.5}
+            {
+                "spans.buffer.flusher.max-unhealthy-seconds": 0.5,
+                "spans.buffer.flusher.use-stuck-detector": False,
+            }
         ),  # Should raise RuntimeError because the process never reports as healthy
         pytest.raises(RuntimeError, match="process 0 \\(shards \\[0\\]\\) didn't start up"),
     ):

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -21,6 +21,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.max-memory-percentage": 1.0,
     "spans.buffer.flusher.backpressure-seconds": 10,
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
+    "spans.buffer.flusher.use-stuck-detector": False,
     "spans.buffer.compression.level": 0,
     "spans.buffer.pipeline-batch-size": 0,
     "spans.buffer.max-spans-per-evalsha": 0,

--- a/tests/sentry/utils/test_arroyo.py
+++ b/tests/sentry/utils/test_arroyo.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pickle
+from unittest.mock import MagicMock, patch
+
+from sentry.utils.arroyo import _import_and_run
+
+
+def _test_main_fn() -> None:
+    pass
+
+
+def _test_initializer() -> None:
+    pass
+
+
+def test_stuck_detector_thread_started_when_enabled() -> None:
+    """Test that stuck detector thread is started when enabled."""
+    main_fn_pickle = pickle.dumps(_test_main_fn)
+    args_pickle = pickle.dumps(())
+
+    with patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class:
+        mock_thread = MagicMock()
+        mock_thread_class.return_value = mock_thread
+
+        _import_and_run(
+            _test_initializer,
+            main_fn_pickle,
+            args_pickle,
+            use_stuck_detector=True,
+        )
+
+        mock_thread_class.assert_called_once()
+        assert mock_thread_class.call_args.kwargs["daemon"] is True
+        assert mock_thread_class.call_args.kwargs["name"] == "stuck-detector"
+        mock_thread.start.assert_called_once()
+
+
+def test_stuck_detector_thread_not_started_when_disabled() -> None:
+    """Test that stuck detector thread is NOT started when disabled."""
+    main_fn_pickle = pickle.dumps(_test_main_fn)
+    args_pickle = pickle.dumps(())
+
+    with patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class:
+        _import_and_run(
+            _test_initializer,
+            main_fn_pickle,
+            args_pickle,
+            use_stuck_detector=False,
+        )
+
+        mock_thread_class.assert_not_called()
+
+
+def test_init_done_set_after_initialization() -> None:
+    """Test that init_done event is set after initialization completes."""
+    events_set: list[str] = []
+    main_fn_pickle = pickle.dumps(_test_main_fn)
+    args_pickle = pickle.dumps(())
+
+    with (
+        patch("sentry.utils.arroyo.threading.Event") as mock_event_class,
+        patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class,
+    ):
+        mock_event = MagicMock()
+        mock_event.is_set.return_value = True
+        mock_event.set.side_effect = lambda: events_set.append("init_done")
+        mock_event_class.return_value = mock_event
+
+        mock_thread = MagicMock()
+        mock_thread_class.return_value = mock_thread
+
+        assert len(events_set) == 0
+
+        _import_and_run(
+            _test_initializer,
+            main_fn_pickle,
+            args_pickle,
+            use_stuck_detector=True,
+        )
+
+        assert len(events_set) == 1
+
+
+def test_stuck_detector_logs_warning_when_timeout_exceeded() -> None:
+    """Test that stuck detector logs a warning with stack traces when timeout is exceeded."""
+    import logging
+
+    main_fn_pickle = pickle.dumps(_test_main_fn)
+    args_pickle = pickle.dumps(())
+
+    captured_target = None
+
+    def capture_thread_target(*args, **kwargs):
+        nonlocal captured_target
+        captured_target = kwargs.get("target")
+        mock_thread = MagicMock()
+        return mock_thread
+
+    time_values = [0, 0, 35]  # start, first check, second check (past 30s timeout)
+    time_index = [0]
+
+    def mock_time():
+        val = time_values[min(time_index[0], len(time_values) - 1)]
+        time_index[0] += 1
+        return val
+
+    mock_event = MagicMock()
+    mock_event.is_set.return_value = False
+
+    mock_logger = MagicMock()
+
+    with (
+        patch("sentry.utils.arroyo.threading.Thread", side_effect=capture_thread_target),
+        patch("sentry.utils.arroyo.threading.Event", return_value=mock_event),
+        patch("sentry.utils.arroyo.time.time", side_effect=mock_time),
+        patch("sentry.utils.arroyo.time.sleep"),
+        patch("arroyo.processing.processor.get_all_thread_stacks", return_value={"main": "stack"}),
+        patch.object(logging, "getLogger", return_value=mock_logger),
+    ):
+        _import_and_run(
+            _test_initializer,
+            main_fn_pickle,
+            args_pickle,
+            use_stuck_detector=True,
+        )
+
+        assert captured_target is not None
+        captured_target()
+
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION
Refs STREAM-567

Add stuck detector daemon thread to SpanFlusher main subprocess to debug where exactly the subprocess is hanging during startup. This thread logs all stacktraces from all threads if the subprocess takes longer than 30 seconds.