### PR TITLE
feat(aci): Make DataSource.type an enum

### DIFF
--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, TypedDict
 
+from sentry.workflow_engine.types import DataSourceType
+
 
 class QuerySubscriptionUpdate(TypedDict):
     entity: str
@@ -41,7 +43,5 @@ class AlertRuleActivationConditionType(Enum):
     RELEASE_CREATION = 0
     DEPLOY_CREATION = 1
 
-
-from sentry.workflow_engine.types import DataSourceType
 
 DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION = DataSourceType.SNUBA_QUERY_SUBSCRIPTION

--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -42,4 +42,6 @@ class AlertRuleActivationConditionType(Enum):
     DEPLOY_CREATION = 1
 
 
-DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION = "snuba_query_subscription"
+from sentry.workflow_engine.types import DataSourceType
+
+DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION = DataSourceType.SNUBA_QUERY_SUBSCRIPTION

--- a/src/sentry/monitors/types.py
+++ b/src/sentry/monitors/types.py
@@ -9,8 +9,9 @@ from django.utils.text import slugify
 from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import CheckIn
 
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
+from sentry.workflow_engine.types import DataSourceType
 
-DATA_SOURCE_CRON_MONITOR = "cron_monitor"
+DATA_SOURCE_CRON_MONITOR = DataSourceType.CRON_MONITOR
 
 
 class CheckinTrace(TypedDict):

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -7,7 +7,9 @@ from typing import Any, Literal, Required, TypedDict
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckStatus, CheckStatusReasonType
 
-DATA_SOURCE_UPTIME_SUBSCRIPTION = "uptime_subscription"
+from sentry.workflow_engine.types import DataSourceType
+
+DATA_SOURCE_UPTIME_SUBSCRIPTION = DataSourceType.UPTIME_SUBSCRIPTION
 """
 The workflow engine DataSource type used for registering handlers and fetching
 the uptime sbuscription data source.

--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -14,7 +14,7 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_source_detector import DataSourceDetector
 from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import DataSourceTypeHandler
+from sentry.workflow_engine.types import DataSourceType, DataSourceTypeHandler
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,7 @@ class DataSource(DefaultFieldsModel):
     # source_id is used in a composite index with type to dynamically lookup the data source
     source_id = models.TextField()
 
-    # This is a dynamic field, depending on the type in the data_source_type_registry
-    type = models.TextField()
+    type = models.TextField(choices=DataSourceType.choices)
 
     detectors = models.ManyToManyField("workflow_engine.Detector", through=DataSourceDetector)
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -7,6 +7,7 @@ from enum import IntEnum, StrEnum
 from logging import Logger
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
+from django.db import models
 from django.db.models import Q
 from sentry_sdk import logger as sentry_logger
 
@@ -35,6 +36,16 @@ if TYPE_CHECKING:
     from sentry.workflow_engine.models.workflow import WorkflowSnapshot
 
 T = TypeVar("T")
+
+
+class DataSourceType(models.TextChoices):
+    # source_id is a QuerySubscription.id
+    SNUBA_QUERY_SUBSCRIPTION = "snuba_query_subscription"
+    # source_id is a Monitor.id
+    CRON_MONITOR = "cron_monitor"
+    # source_id is an UptimeSubscription.id
+    UPTIME_SUBSCRIPTION = "uptime_subscription"
+
 
 ERROR_DETECTOR_NAME = "Error Monitor"
 ISSUE_STREAM_DETECTOR_NAME = "Issue Stream"

--- a/tests/sentry/workflow_engine/models/test_data_source.py
+++ b/tests/sentry/workflow_engine/models/test_data_source.py
@@ -7,10 +7,16 @@ from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.workflow_engine.registry import data_source_type_registry
+from sentry.workflow_engine.types import DataSourceType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 class DataSourceTest(BaseWorkflowTest):
+    def test_all_data_source_types_have_registered_handlers(self) -> None:
+        for ds_type in DataSourceType:
+            handler = data_source_type_registry.get(ds_type.value)
+            assert handler is not None, f"No handler registered for DataSourceType.{ds_type.name}"
+
     def test_invalid_data_source_type(self) -> None:
         with pytest.raises(ValueError):
             self.create_data_source(type="invalid_type")


### PR DESCRIPTION
The set of possible values is limited, and using an enum allows us to more clearly define the data and use stronger typing in DataSource-related code while still allowing handlers to be registered wherever.
