### PR TITLE
feat(seer): Only remind people to setup Seer if the org has GitHub integration

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -31,7 +31,13 @@ import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
 // See also: `IntegrationProviderSlug` in sentry/integrations/types.py
 // `vsts` is ignored for now, not on the early roadmap in January 2026.
-const SCM_PROVIDER_KEYS = ['github', 'gitlab', 'bitbucket', 'bitbucket_server'];
+const SCM_PROVIDER_KEYS = [
+  'github',
+  'github_enterprise',
+  'gitlab',
+  'bitbucket',
+  'bitbucket_server',
+];
 
 /**
  * Fetches all SCM integrations for an organization, filtering for Seer related SCM providers.

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -9,7 +9,10 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Integration} from 'sentry/types/integrations';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useNavContext} from 'sentry/views/nav/context';
 import {
@@ -26,10 +29,58 @@ import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCa
 import {useSeerOnboardingStep} from 'getsentry/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep';
 import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
+// See also: `IntegrationProviderSlug` in sentry/integrations/types.py
+// `vsts` is ignored for now, not on the early roadmap in January 2026.
+const SCM_PROVIDER_KEYS = ['github', 'gitlab', 'bitbucket', 'bitbucket_server'];
+
+/**
+ * Fetches all SCM integrations for an organization, filtering for Seer related SCM providers.
+ */
+function useScmIntegrations() {
+  const organization = useOrganization();
+  const {data, isPending} = useApiQuery<Integration[]>(
+    [
+      getApiUrl(`/organizations/$organizationIdOrSlug/integrations/`, {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+      {query: {includeConfig: 0}},
+    ],
+    {
+      staleTime: 120000, // Cache for 2 minutes
+    }
+  );
+
+  // Filter to only SCM integrations
+  const scmIntegrations = data?.filter(integration =>
+    SCM_PROVIDER_KEYS.includes(integration.provider.key)
+  );
+
+  const hasGithub = scmIntegrations?.some(integration =>
+    ['github', 'github_enterprise'].includes(integration.provider.key)
+  );
+
+  const hasOnlyNonGithubScm =
+    scmIntegrations &&
+    scmIntegrations.length > 0 &&
+    !hasGithub &&
+    scmIntegrations.every(integration =>
+      ['gitlab', 'bitbucket', 'bitbucket_server'].includes(integration.provider.key)
+    );
+
+  return {
+    scmIntegrations,
+    hasGithub,
+    hasOnlyNonGithubScm,
+    isPending,
+  };
+}
+
 export default function PrimaryNavSeerConfigReminder() {
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
   const {isPending, initialStep} = useSeerOnboardingStep();
+
+  const {hasOnlyNonGithubScm, isPending: isScmPending} = useScmIntegrations();
 
   const {
     isOpen,
@@ -52,7 +103,14 @@ export default function PrimaryNavSeerConfigReminder() {
     return null;
   }
 
-  if (isPending || initialStep === Steps.WRAP_UP) {
+  if (isPending || isScmPending || initialStep === Steps.WRAP_UP) {
+    return null;
+  }
+
+  // If org has zero SCM integrations  => show icon
+  // If org has 1 or more GitHub SCM connections => show icon
+  // If org has only BitBucket and/or GitLab SCM's => no icon
+  if (hasOnlyNonGithubScm) {
     return null;
   }
 


### PR DESCRIPTION
For other integrations, like BitBucket and GitLab, we dont want to send a reminder because these things should be as setup as possible already. The extra steps are github only right now (but coming soon to more SCMs!)

Followup of: https://github.com/getsentry/sentry/pull/106931
Fixes CW-720