### PR TITLE
fix(spans-migration): add spm translation and decimal apdex

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -10,7 +10,7 @@ from sentry.search.events import fields
 from sentry.snuba.metrics import parse_mri
 from sentry.utils.snuba import get_measurement_name
 
-APDEX_USER_MISERY_PATTERN = r"(apdex|user_misery)\((\d+)\)"
+APDEX_USER_MISERY_PATTERN = r"(apdex|user_misery)\((\d*\.?\d+)\)"
 
 INDEXED_EQUATIONS_PATTERN = r"^equation\[(\d+)\]$"
 
@@ -160,6 +160,8 @@ def function_switcheroo(term):
     swapped_term = term
     if term == "count()":
         swapped_term = "count(span.duration)"
+    elif term == "spm()":
+        swapped_term = "epm()"
     elif term.startswith("percentile("):
         swapped_term = format_percentile_term(term)
     elif term == "apdex()":
@@ -169,7 +171,9 @@ def function_switcheroo(term):
 
     match = re.match(APDEX_USER_MISERY_PATTERN, term)
     if match:
-        swapped_term = f"{match.group(1)}(span.duration,{match.group(2)})"
+        # making sure numeric parameter is properly formatted with 0 before decimal point and no trailing zeros
+        numeric_parameter = float(match.group(2))
+        swapped_term = f"{match.group(1)}(span.duration,{numeric_parameter:g})"
 
     return swapped_term, swapped_term != term
 

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -150,10 +150,18 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
             [],
         ),
         pytest.param(
-            ["user_misery(300)", "apdex(300)", "count_if(transaction.duration,greater,300)"],
+            [
+                "user_misery(300)",
+                "apdex(300)",
+                "apdex(.5)",
+                "apdex(0.7)",
+                "count_if(transaction.duration,greater,300)",
+            ],
             [
                 "equation|user_misery(span.duration,300)",
                 "equation|apdex(span.duration,300)",
+                "equation|apdex(span.duration,0.5)",
+                "equation|apdex(span.duration,0.7)",
                 "equation|count_if(span.duration,greater,300)",
             ],
             [],


### PR DESCRIPTION
during migration with majority EA orgs we ran into a couple of errors:
- `spm()` is not a valid EAP aggregate
- decimal numbers like .6 weren't matching the regex that we had in place for apdex/user_misery

In this PR i'm adding `spm` to the translation layer and translating it to `epm` and updating the apdex regex to check for decimal numeric values and formatting it properly (this way there's less risk of formatting errors in the future)