### PR TITLE
fix(preprod): Remove redundant "apps analyzed" text when size checks …

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -75,7 +75,7 @@ def format_status_check_messages(
         raise ValueError("No metrics exist for VCS size status check")
 
     parts = []
-    if analyzed_count > 0:
+    if analyzed_count > 0 and not triggered_rules:
         parts.append(
             ngettext("%(count)d app analyzed", "%(count)d apps analyzed", analyzed_count)
             % {"count": analyzed_count}

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -1289,7 +1289,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 """
 
         assert title == "Size Analysis"
-        assert subtitle == "1 app analyzed"
+        assert subtitle == ""
         assert summary == expected
 
     def test_multiple_triggered_rules_url_formatting(self):
@@ -1386,7 +1386,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 """
 
         assert title == "Size Analysis"
-        assert subtitle == "1 app analyzed"
+        assert subtitle == ""
         assert summary == expected
 
     def test_multiple_apps_with_triggered_rules(self):
@@ -1499,7 +1499,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 """
 
         assert title == "Size Analysis"
-        assert subtitle == "2 apps analyzed"
+        assert subtitle == ""
         assert summary == expected
 
     def test_mixed_pass_fail_with_triggered_rules(self):
@@ -1602,5 +1602,5 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 """
 
         assert title == "Size Analysis"
-        assert subtitle == "2 apps analyzed"
+        assert subtitle == ""
         assert summary == expected


### PR DESCRIPTION

<img width="2232" height="628" alt="CleanShot 2026-01-29 at 15 46 16@2x" src="https://github.com/user-attachments/assets/bd4e9dc0-0096-4bdc-a620-54ffa257f555" />

When size checks fail, the subtitle showed "X apps analyzed" which was redundant since the summary body already displays "❌ X Failed Size Checks". Now the "apps analyzed" count only appears when all checks pass, serving as a success indicator.

Fixes EME-793
