### PR TITLE
ref(api): remove deprecated crossdomain.xml endpoint

### DIFF
--- a/src/sentry/templates/sentry/crossdomain.xml
+++ b/src/sentry/templates/sentry/crossdomain.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<!DOCTYPE cross-domain-policy SYSTEM
-    "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
-<cross-domain-policy>
-    {% for origin in origin_list %}
-        <allow-access-from domain="{{ origin }}" secure="false" />
-    {% endfor %}
-    <allow-http-request-headers-from domain="*" headers="*" secure="false" />
-</cross-domain-policy>

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -5,12 +5,9 @@ from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 
 from sentry.conf.types.sentry_config import SentryMode
-from sentry.models.project import Project
 from sentry.utils import json
-from sentry.utils.http import get_origins
 from sentry.web.client_config import get_client_config
-from sentry.web.frontend.base import all_silo_view, region_silo_view
-from sentry.web.helpers import render_to_response
+from sentry.web.frontend.base import all_silo_view
 
 # Paths to pages should not be added here, otherwise crawlers will
 # not be able to access the metadata with the 'none' directive
@@ -98,21 +95,6 @@ def mcp_json(request):
         return HttpResponse(status=404)
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
-
-
-@region_silo_view
-@cache_control(max_age=60)
-def crossdomain_xml(request, project_id):
-    try:
-        project = Project.objects.get_from_cache(id=project_id)
-    except Project.DoesNotExist:
-        return HttpResponse(status=404)
-
-    origin_list = get_origins(project)
-    response = render_to_response("sentry/crossdomain.xml", {"origin_list": origin_list})
-    response["Content-Type"] = "application/xml"
-
-    return response
 
 
 @all_silo_view

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -131,11 +131,6 @@ urlpatterns += [
         WarmupEndpoint.as_view(),
         name="sentry-warmup",
     ),
-    re_path(
-        r"^api/(?P<project_id>[^/]+)/crossdomain\.xml$",
-        api.crossdomain_xml,
-        name="sentry-api-crossdomain-xml",
-    ),
     # Frontend client config
     re_path(
         r"^api/client-config/?$",
@@ -1276,12 +1271,6 @@ urlpatterns += [
         r"^favicon\.ico$",
         api.not_found,
         name="sentry-favicon-404",
-    ),
-    # crossdomain.xml
-    re_path(
-        r"^crossdomain\.xml$",
-        api.not_found,
-        name="sentry-crossdomain-404",
     ),
     # plugins
     # XXX(dcramer): preferably we'd be able to use 'integrations' as the URL

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -20,53 +20,6 @@ from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, re
 from sentry.utils import json
 
 
-class CrossDomainXmlTest(TestCase):
-    @cached_property
-    def path(self) -> str:
-        return reverse("sentry-api-crossdomain-xml", kwargs={"project_id": self.project.id})
-
-    @mock.patch("sentry.web.api.get_origins")
-    def test_output_with_global(self, get_origins: mock.MagicMock) -> None:
-        get_origins.return_value = "*"
-        resp = self.client.get(self.path)
-        get_origins.assert_called_once_with(self.project)
-        assert resp.status_code == 200, resp.content
-        self.assertEqual(resp["Content-Type"], "application/xml")
-        self.assertTemplateUsed(resp, "sentry/crossdomain.xml")
-        assert b'<allow-access-from domain="*" secure="false" />' in resp.content
-
-    @mock.patch("sentry.web.api.get_origins")
-    def test_output_with_allowed_origins(self, get_origins: mock.MagicMock) -> None:
-        get_origins.return_value = ["disqus.com", "www.disqus.com"]
-        resp = self.client.get(self.path)
-        get_origins.assert_called_once_with(self.project)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp["Content-Type"], "application/xml")
-        self.assertTemplateUsed(resp, "sentry/crossdomain.xml")
-        assert b'<allow-access-from domain="disqus.com" secure="false" />' in resp.content
-        assert b'<allow-access-from domain="www.disqus.com" secure="false" />' in resp.content
-
-    @mock.patch("sentry.web.api.get_origins")
-    def test_output_with_no_origins(self, get_origins: mock.MagicMock) -> None:
-        get_origins.return_value = []
-        resp = self.client.get(self.path)
-        get_origins.assert_called_once_with(self.project)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp["Content-Type"], "application/xml")
-        self.assertTemplateUsed(resp, "sentry/crossdomain.xml")
-        assert b"<allow-access-from" not in resp.content
-
-    def test_output_allows_x_sentry_auth(self) -> None:
-        resp = self.client.get(self.path)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp["Content-Type"], "application/xml")
-        self.assertTemplateUsed(resp, "sentry/crossdomain.xml")
-        assert (
-            b'<allow-http-request-headers-from domain="*" headers="*" secure="false" />'
-            in resp.content
-        )
-
-
 class RobotsTxtTest(TestCase):
     @cached_property
     def path(self) -> str:


### PR DESCRIPTION
Remove the Flash-era crossdomain.xml endpoint that served Adobe Flash cross-domain policy files. [Every request in the last 30 days has 404ed](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.web.api.crossdomain_xml%22;summaryFields=jsonPayload%252Fresponse,jsonPayload%252Fgroup,jsonPayload%252Fremaining,jsonPayload%252Flimit:true:32:beginning;cursorTimestamp=2026-01-29T20:44:43.374770021Z;duration=P30D?project=internal-sentry&inv=1&invt=Ab4cdA&rapt=AEjHL4NVcpenKwNoNumUiCOR7tKbL2AQCVs5fjJ7hYW7nTYAk4UPTdiljvaadG8nxFeNStsb5-hnlZL0xD2FlIeyg4luRYyig0qdsWyQu4ns7ZlPvPin2E4). Motivation is that this endpoint is not compatible with cells

Refs https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23?source=copy_link