### PR TITLE
feat(billing): Add admin-only product trial support for emerge categories

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -446,50 +446,53 @@ describe('CustomerOverview', () => {
   it('renders admin-only product trials when feature flag is graduated (true)', () => {
     // Mock BILLED_DATA_CATEGORY_INFO to simulate a graduated flag (adminOnlyProductTrialFeature: true)
     const originalBilledDataCategoryInfo = constants.BILLED_DATA_CATEGORY_INFO;
-    const mockedBilledDataCategoryInfo = {
-      ...originalBilledDataCategoryInfo,
-      [DataCategoryExact.SIZE_ANALYSIS]: {
-        ...originalBilledDataCategoryInfo[DataCategoryExact.SIZE_ANALYSIS],
-        adminOnlyProductTrialFeature: true, // Graduated - no feature flag check needed
-      },
-    };
 
-    // Override the module export for this test
-    Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
-      value: mockedBilledDataCategoryInfo,
-      configurable: true,
-    });
+    try {
+      const mockedBilledDataCategoryInfo = {
+        ...originalBilledDataCategoryInfo,
+        [DataCategoryExact.SIZE_ANALYSIS]: {
+          ...originalBilledDataCategoryInfo[DataCategoryExact.SIZE_ANALYSIS],
+          adminOnlyProductTrialFeature: true, // Graduated - no feature flag check needed
+        },
+      };
 
-    // Organization has NO feature flags - but graduated flag should still show
-    const organization = OrganizationFixture({
-      features: [], // No feature flags!
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_f',
-      planTier: PlanTier.AM3,
-    });
+      // Override the module export for this test
+      Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
+        value: mockedBilledDataCategoryInfo,
+        configurable: true,
+      });
 
-    render(
-      <CustomerOverview
-        customer={subscription}
-        onAction={jest.fn()}
-        organization={organization}
-      />
-    );
+      // Organization has NO feature flags - but graduated flag should still show
+      const organization = OrganizationFixture({
+        features: [], // No feature flags!
+      });
+      const subscription = SubscriptionFixture({
+        organization,
+        plan: 'am3_f',
+        planTier: PlanTier.AM3,
+      });
 
-    expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    // SIZE_ANALYSIS should appear because the flag is graduated (true), not requiring feature flag
-    expect(screen.getByText('Size Analysis Builds:')).toBeInTheDocument();
-    // Regular product trials should still appear
-    expect(screen.getByText('Spans:')).toBeInTheDocument();
-    expect(screen.getByText('Replays:')).toBeInTheDocument();
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
 
-    // Restore the original
-    Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
-      value: originalBilledDataCategoryInfo,
-      configurable: true,
-    });
+      expect(screen.getByText('Product Trials')).toBeInTheDocument();
+      // SIZE_ANALYSIS should appear because the flag is graduated (true), not requiring feature flag
+      expect(screen.getByText('Size Analysis Builds:')).toBeInTheDocument();
+      // Regular product trials should still appear
+      expect(screen.getByText('Spans:')).toBeInTheDocument();
+      expect(screen.getByText('Replays:')).toBeInTheDocument();
+    } finally {
+      // Restore the original - always runs even if assertions fail
+      Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
+        value: originalBilledDataCategoryInfo,
+        configurable: true,
+      });
+    }
   });
 
   it('renders product trials based on current subscription state', () => {

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -395,6 +395,53 @@ describe('CustomerOverview', () => {
     expect(screen.queryByText('Transactions:')).not.toBeInTheDocument();
   });
 
+  it('renders admin-only product trials when feature flag is enabled', () => {
+    const organization = OrganizationFixture({
+      features: ['expose-category-size-analysis'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('Product Trials')).toBeInTheDocument();
+    // SIZE_ANALYSIS should appear because org has the feature flag
+    expect(screen.getByText('Size Analysis Builds:')).toBeInTheDocument();
+  });
+
+  it('does not render admin-only product trials when feature flag is disabled', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('Product Trials')).toBeInTheDocument();
+    // SIZE_ANALYSIS should NOT appear because org lacks the feature flag
+    expect(screen.queryByText('Size Analysis Builds:')).not.toBeInTheDocument();
+    // Regular product trials should still appear
+    expect(screen.getByText('Spans:')).toBeInTheDocument();
+    expect(screen.getByText('Replays:')).toBeInTheDocument();
+  });
+
   it('renders product trials based on current subscription state', () => {
     const organization = OrganizationFixture();
     const am3Subscription = SubscriptionFixture({

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -473,9 +473,24 @@ function CustomerOverview({customer, onAction, organization}: Props) {
   const region = regionMap[organization.links.regionUrl] ?? '??';
 
   const productTrialCategories = Object.values(BILLED_DATA_CATEGORY_INFO).filter(
-    categoryInfo =>
-      categoryInfo.canProductTrial &&
-      customer.planDetails?.categories.includes(categoryInfo.plural)
+    categoryInfo => {
+      // Category must be in the plan's categories
+      if (!customer.planDetails?.categories.includes(categoryInfo.plural)) {
+        return false;
+      }
+      // Include if regular product trial is enabled
+      if (categoryInfo.canProductTrial) {
+        return true;
+      }
+      // Include admin-only product trials if the feature flag is enabled
+      if (
+        categoryInfo.adminOnlyProductTrialFeature &&
+        organization.features?.includes(categoryInfo.adminOnlyProductTrialFeature)
+      ) {
+        return true;
+      }
+      return false;
+    }
   );
 
   const productTrialAddOns = Object.values(customer.addOns || {}).filter(

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -516,7 +516,8 @@ function CustomerOverview({customer, onAction, organization}: Props) {
   const getTrialManagementActions = (
     category: DataCategory,
     apiName: string,
-    trialName: string
+    trialName: string,
+    isAdminOnly = false
   ) => {
     const formattedApiName = upperFirst(apiName);
     const formattedTrialName = toTitleCase(trialName, {allowInnerUpperCase: true});
@@ -560,7 +561,9 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                 hasActiveProductTrial
                   ? `A product trial is currently active for ${formattedTrialName}`
                   : hasUsedProductTrial
-                    ? `Allow customer to start a new trial for ${formattedTrialName}`
+                    ? isAdminOnly
+                      ? `Reset trial eligibility for ${formattedTrialName}`
+                      : `Allow customer to start a new trial for ${formattedTrialName}`
                     : `A product trial is already available for ${formattedTrialName}`
               }
             >
@@ -794,7 +797,8 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                 return getTrialManagementActions(
                   categoryInfo.plural,
                   categoryInfo.plural,
-                  categoryName
+                  categoryName,
+                  !!categoryInfo.adminOnlyProductTrialFeature
                 );
               })}
               {productTrialAddOns.map(addOn => {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -482,9 +482,13 @@ function CustomerOverview({customer, onAction, organization}: Props) {
       if (categoryInfo.canProductTrial) {
         return true;
       }
-      // Include admin-only product trials if the feature flag is enabled
+      // Include admin-only product trials if graduated (true) or feature flag is enabled
+      if (categoryInfo.adminOnlyProductTrialFeature === true) {
+        // Graduated flag - always include without feature flag check
+        return true;
+      }
       if (
-        categoryInfo.adminOnlyProductTrialFeature &&
+        typeof categoryInfo.adminOnlyProductTrialFeature === 'string' &&
         organization.features?.includes(categoryInfo.adminOnlyProductTrialFeature)
       ) {
         return true;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -222,11 +222,13 @@ export const BILLED_DATA_CATEGORY_INFO = {
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     shortenedUnitName: t('build'),
+    adminOnlyProductTrialFeature: 'expose-category-size-analysis',
   },
   [DataCategoryExact.INSTALLABLE_BUILD]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.INSTALLABLE_BUILD],
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     shortenedUnitName: t('install'),
+    adminOnlyProductTrialFeature: 'expose-category-installable-build',
   },
 } as const satisfies Record<DataCategoryExact, BilledDataCategoryInfo>;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -61,6 +61,7 @@ Object.entries(DEFAULT_BILLED_DATA_CATEGORY_INFO).forEach(
       checkoutTooltip: null,
       tallyType: 'usage',
       hasPerCategory: false,
+      adminOnlyProductTrialFeature: null,
     };
   }
 );

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<T> {
+    interface DOMAttributes<_T> {
       'data-test-id'?: string;
     }
   }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,6 +37,7 @@ declare global {
   }
 
   namespace React {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- T required for declaration merging with React.DOMAttributes
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }
@@ -1197,6 +1198,12 @@ export interface BilledDataCategoryInfo extends DataCategoryInfo {
    * How usage is tallied for the category
    */
   tallyType: 'usage' | 'seat';
+  /**
+   * Feature flag required for admin-only product trials.
+   * When set, this category can have product trials started by admins
+   * only if the organization has this feature flag enabled.
+   */
+  adminOnlyProductTrialFeature?: string | null;
   /**
    * The shortened form of the singular unit name (ie. 'error', 'hour', 'monitor').
    */

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,6 @@ declare global {
   }
 
   namespace React {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- T required for declaration merging with React.DOMAttributes
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -1199,10 +1199,11 @@ export interface BilledDataCategoryInfo extends DataCategoryInfo {
   tallyType: 'usage' | 'seat';
   /**
    * Feature flag required for admin-only product trials.
-   * When set, this category can have product trials started by admins
-   * only if the organization has this feature flag enabled.
+   * - `string`: Feature flag name - trials only available if org has this flag
+   * - `true`: Graduated - trials always available (no flag check needed)
+   * - `null/undefined`: Not an admin-only trial category
    */
-  adminOnlyProductTrialFeature?: string | null;
+  adminOnlyProductTrialFeature?: string | boolean | null;
   /**
    * The shortened form of the singular unit name (ie. 'error', 'hour', 'monitor').
    */

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,6 @@ declare global {
   }
 
   namespace React {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,8 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<_T> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface DOMAttributes<T> {
       'data-test-id'?: string;
     }
   }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-2021/add-product-trials-for-emerge-categories-in-admin

## Summary
- Add `adminOnlyProductTrialFeature` field to `BilledDataCategoryInfo` type for gating product trials behind feature flags
- Configure SIZE_ANALYSIS and INSTALLABLE_BUILD categories with their respective feature flags (`expose-category-size-analysis`, `expose-category-installable-build`)
- Update admin customer overview to show product trial options for these categories when the organization has the feature flag enabled
- Fix pre-existing eslint issue with unused type parameter in DOMAttributes

Screenshots

<img width="1006" height="136" alt="Screenshot 2026-02-03 at 6 03 05 PM" src="https://github.com/user-attachments/assets/5e5213c6-6aea-4a29-9327-aac9001ee0bd" />



<img width="1012" height="792" alt="Screenshot 2026-02-03 at 6 03 12 PM" src="https://github.com/user-attachments/assets/497a612d-1177-42b5-a089-44d6f0cfc985" />

## Test plan
- [x] Unit tests pass (`pnpm test static/gsAdmin/components/customers/customerOverview.spec.tsx`)
- [x] Manual verification in admin UI at `/_admin/customers/{org}/` - SIZE_ANALYSIS and INSTALLABLE_BUILD trials appear when feature flags are enabled
- [x] Pre-commit hooks pass