### PR TITLE
chore(api): deprecate last plugin webhook endpoints

### DIFF
--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -11,6 +11,8 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from rest_framework.request import Request
 
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -94,6 +96,7 @@ class BitbucketPluginWebhookEndpoint(View):
 
         return super().dispatch(request, *args, **kwargs)
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-plugins-bitbucket-webhook"])
     def post(self, request: Request, organization_id: int):
         org_exists = organization_service.check_organization_by_id(
             id=organization_id, only_visible=True

--- a/src/sentry_plugins/github/webhooks/non_integration.py
+++ b/src/sentry_plugins/github/webhooks/non_integration.py
@@ -5,6 +5,8 @@ import logging
 from django.http import HttpResponse
 from rest_framework.request import Request
 
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.web.frontend.base import region_silo_view
@@ -24,6 +26,7 @@ class GithubPluginWebhookEndpoint(GithubWebhookBase):
             organization=organization, key="github:webhook_secret"
         )
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-plugins-github-webhook"])
     def post(self, request: Request, organization_id):
         try:
             organization = Organization.objects.get_from_cache(id=organization_id)


### PR DESCRIPTION
Deprecate `sentry-plugins-github-webhook` and `sentry-plugins-bitbucket-webhook`. Similar to https://github.com/getsentry/sentry/pull/106601.

Refs https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23?source=copy_link