### PR TITLE
chore(dashboards): Explain when we use base 10 vs. base 2 formatting for size data

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -187,6 +187,13 @@ export enum SizeUnit {
   EXABYTE = 'exabyte',
 }
 
+// NOTE: These units are treated as base 10 (SI) vs. base 2 (IEC). That
+// intuitively makes sense for units like "kilobyte" (vs. kibibyte) where the
+// unit itself indicates its base. If this list contains "byte" (the default
+// unit for size data in Sentry), "byte" becomes a base 10 unit everywhere. That
+// will force effectively all tables and chart to format size data multipliers
+// using base 10. This is not a problem, it's just an important implication to
+// be aware of.
 export const ABYTE_UNITS = [
   'byte',
   'kilobyte',


### PR DESCRIPTION
Add a little code comment to explain the consequences of editing `ABYTE_UNITS`, since I don't think the impact there is clear. Maybe it's worth to update the code to make this even more explicit?
