### PR TITLE
chore(preprod): Convert preprod admin endpoints to internal

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import StaffPermission
 from sentry.preprod.analytics import PreprodArtifactApiAdminBatchDeleteEvent
 from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
@@ -19,7 +19,7 @@ from sentry.preprod.models import PreprodArtifact
 logger = logging.getLogger(__name__)
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class PreprodArtifactAdminBatchDeleteEndpoint(Endpoint):
     owner = ApiOwner.EMERGE_TOOLS
     permission_classes = (StaffPermission,)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import StaffPermission
 from sentry.preprod.analytics import PreprodArtifactApiAdminGetInfoEvent
 from sentry.preprod.models import (
@@ -20,7 +20,7 @@ from sentry.preprod.models import (
 logger = logging.getLogger(__name__)
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class PreprodArtifactAdminInfoEndpoint(Endpoint):
     owner = ApiOwner.EMERGE_TOOLS
     permission_classes = (StaffPermission,)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, internal_region_silo_endpoint, region_silo_endpoint
 from sentry.api.permissions import StaffPermission
 from sentry.models.files.file import File
 from sentry.models.project import Project
@@ -119,7 +119,7 @@ class PreprodArtifactRerunAnalysisEndpoint(PreprodArtifactEndpoint):
         )
 
 
-@region_silo_endpoint
+@internal_region_silo_endpoint
 class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
     owner = ApiOwner.EMERGE_TOOLS
     permission_classes = (StaffPermission,)


### PR DESCRIPTION
Convert emerge-related preprod endpoints from region_silo_endpoint to internal_region_silo_endpoint

Similar to https://github.com/getsentry/sentry/pull/104397

Refs https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23?source=copy_link