### PR TITLE
fix(preprod): handle missing diff_type in treemap tooltip

### DIFF
--- a/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
@@ -199,11 +199,10 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
     },
     formatter: function (params: any) {
       const sizeDiff = params.data?.size_diff || 0;
-      const diffType = params.data?.diff_type || 'unchanged';
-      const diffCategoryInfo = getAppSizeDiffCategoryInfo(theme)[diffType];
-      if (!diffCategoryInfo) {
-        throw new Error(`Diff type ${diffType} not found`);
-      }
+      const diffType = params.data?.diff_type;
+      const diffCategoryInfo = diffType
+        ? getAppSizeDiffCategoryInfo(theme)[diffType]
+        : null;
 
       const diffString = formattedSizeDiff(sizeDiff);
       let tagType: TagType = 'muted';
@@ -219,7 +218,11 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
             <Text bold>{params.name}</Text>
           </Flex>
           {params.data?.path ? <Text size="sm">{params.data.path}</Text> : null}
-          <Tag variant={tagType}>{`${diffString} (${diffCategoryInfo.displayName})`}</Tag>
+          {diffCategoryInfo ? (
+            <Tag
+              variant={tagType}
+            >{`${diffString} (${diffCategoryInfo.displayName})`}</Tag>
+          ) : null}
         </Stack>
       );
     },


### PR DESCRIPTION
## Summary

Fixes [JAVASCRIPT-35Q0](https://sentry.sentry.io/issues/7119214254) - "Diff type unchanged not found" error occurring in the treemap tooltip.

**Root cause**: When `params.data?.diff_type` is undefined, the tooltip formatter defaulted to `'unchanged'`, but `getAppSizeDiffCategoryInfo()` only supports `'added'`, `'increased'`, `'decreased'`, and `'removed'` - not `'unchanged'`.

**Fix**: Conditionally render the diff tag only when `diffCategoryInfo` exists. The tooltip remains useful by still showing name and path, but gracefully handles incomplete data instead of throwing.

