### PR TITLE
fix(preprod): register snapshot models with Django to resolve migration drift

### DIFF
--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -798,3 +798,8 @@ class PreprodComparisonApproval(DefaultFieldsModel):
     class Meta:
         app_label = "preprod"
         db_table = "sentry_preprodcomparisonapproval"
+
+
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+
+__all__ = ["PreprodSnapshotComparison", "PreprodSnapshotMetrics"]


### PR DESCRIPTION
The `PreprodSnapshotMetrics` and `PreprodSnapshotComparison` models were defined in `src/sentry/preprod/snapshots/models.py` but never imported anywhere that Django could discover them. This caused migration drift: the tables existed in the database (created by migration 0026), but Django's model registry didn't know about them, so the migration comparison tool reported drift.

This adds an import at the bottom of `src/sentry/preprod/models.py` to register these models with Django.