### PR TITLE
fix(preprod): Remove ineffective retry logic for size status checks

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -48,7 +48,6 @@ from sentry.shared_integrations.exceptions import (
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
-from sentry.taskworker.retry import Retry
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -87,7 +86,6 @@ preprod_artifact_search_config = SearchConfig.create_from(
     name="sentry.preprod.tasks.create_preprod_status_check",
     namespace=preprod_tasks,
     processing_deadline_duration=30,
-    retry=Retry(times=3, delay=60, on=(ApiRateLimitedError,)),
     silo_mode=SiloMode.REGION,
 )
 def create_preprod_status_check_task(


### PR DESCRIPTION
## Summary
- Remove retry configuration from `create_preprod_status_check_task` that only retried on `ApiRateLimitedError` with 60-second delays
- GitHub rate limits use fixed hourly windows, so retrying at 60s intervals cannot succeed (the limit won't reset until the `x-ratelimit-reset` timestamp, up to 1 hour later)
- This eliminates wasted compute cycles on retries that have no chance of success

## Test plan
- [x] Existing tests pass (`tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py`)
- [x] Rate limit errors still raised correctly (not swallowed)