### PR TITLE
chore(github): allow installing orphaned integrations on FE

### DIFF
--- a/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
@@ -122,4 +122,35 @@ describe('GithubInstallationSelect', () => {
       })
     ).toBeInTheDocument();
   });
+  it('does not render upsell if installation has 0 installs', async () => {
+    const installation_info_with_0_installs = installation_info.map(i => ({
+      ...i,
+      count: 0,
+    }));
+    render(
+      <GithubInstallationSelect
+        installation_info={installation_info_with_0_installs}
+        organization={OrganizationFixture()}
+      />
+    );
+
+    expect(
+      screen.getByText('Install on an Existing GitHub Organization')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Install'})).toBeEnabled();
+
+    // Click the select dropdown
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Integrate with a new GitHub organization',
+      })
+    );
+    // Select an installation
+    await userEvent.click(screen.getByText('bufo-bot'));
+
+    // Install button should be enabled
+    expect(screen.getByRole('button', {name: 'Install'})).toBeEnabled();
+  });
 });

--- a/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
@@ -123,13 +123,13 @@ describe('GithubInstallationSelect', () => {
     ).toBeInTheDocument();
   });
   it('does not render upsell if installation has 0 installs', async () => {
-    const installation_info_with_0_installs = installation_info.map(i => ({
+    const installationInfoWithNoInstalls = installation_info.map(i => ({
       ...i,
       count: 0,
     }));
     render(
       <GithubInstallationSelect
-        installation_info={installation_info_with_0_installs}
+        installation_info={installationInfoWithNoInstalls}
         organization={OrganizationFixture()}
       />
     );

--- a/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.spec.tsx
@@ -122,35 +122,4 @@ describe('GithubInstallationSelect', () => {
       })
     ).toBeInTheDocument();
   });
-  it('does not render upsell if installation has 0 installs', async () => {
-    const installation_info_with_0_installs = installation_info.map(i => ({
-      ...i,
-      count: 0,
-    }));
-    render(
-      <GithubInstallationSelect
-        installation_info={installation_info_with_0_installs}
-        organization={OrganizationFixture()}
-      />
-    );
-
-    expect(
-      screen.getByText('Install on an Existing GitHub Organization')
-    ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: 'Install'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Install'})).toBeEnabled();
-
-    // Click the select dropdown
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Integrate with a new GitHub organization',
-      })
-    );
-    // Select an installation
-    await userEvent.click(screen.getByText('bufo-bot'));
-
-    // Install button should be enabled
-    expect(screen.getByRole('button', {name: 'Install'})).toBeEnabled();
-  });
 });

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -6,7 +6,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
-import {BaseAvatar} from 'sentry/components/core/avatar/baseAvatar';
+import {BaseAvatar} from 'sentry/components/core/avatar';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -6,7 +6,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
-import {BaseAvatar} from 'sentry/components/core/avatar';
+import {BaseAvatar} from 'sentry/components/core/avatar/baseAvatar';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';
@@ -23,6 +23,7 @@ import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 type Installation = {
   avatar_url: string;
+  count: number;
   github_account: string;
   installation_id: string;
 };
@@ -75,7 +76,12 @@ export function GithubInstallationSelect({
   const source = 'github.multi_org';
 
   const doesntRequireUpgrade = (id: SelectKey): boolean => {
-    return hasSCMMultiOrg || isSelfHosted || id === '-1';
+    return (
+      hasSCMMultiOrg ||
+      isSelfHosted ||
+      id === '-1' ||
+      installation_info.find(i => i.installation_id === id)?.count === 0
+    );
   };
 
   const handleSubmit = (e: React.MouseEvent, id?: SelectKey) => {
@@ -190,7 +196,11 @@ export function GithubInstallationSelect({
         <Stack alignSelf="flex-end" paddingTop="xl">
           {organization.features.includes('github-multi-org-upsell-modal') ? (
             <InstallButtonHook
-              hasSCMMultiOrg={hasSCMMultiOrg}
+              hasSCMMultiOrg={
+                hasSCMMultiOrg ||
+                installation_info.find(i => i.installation_id === installationID)
+                  ?.count === 0
+              }
               installationID={installationID}
               isSaving={isSaving}
               handleSubmit={handleSubmit}

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -23,6 +23,7 @@ import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 type Installation = {
   avatar_url: string;
+  count: number;
   github_account: string;
   installation_id: string;
 };
@@ -188,9 +189,13 @@ export function GithubInstallationSelect({
           )}
         />
         <Stack alignSelf="flex-end" paddingTop="xl">
+          {/* All GitHub app installs will show up here. If the corresponding Integration has 0 installs we should also allow install */}
           {organization.features.includes('github-multi-org-upsell-modal') ? (
             <InstallButtonHook
-              hasSCMMultiOrg={hasSCMMultiOrg}
+              hasSCMMultiOrg={
+                hasSCMMultiOrg ||
+                installation_info.some(installation => installation.count === 0)
+              }
               installationID={installationID}
               isSaving={isSaving}
               handleSubmit={handleSubmit}

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -194,7 +194,8 @@ export function GithubInstallationSelect({
             <InstallButtonHook
               hasSCMMultiOrg={
                 hasSCMMultiOrg ||
-                installation_info.some(installation => installation.count === 0)
+                installation_info.find(i => i.installation_id === installationID)
+                  ?.count === 0
               }
               installationID={installationID}
               isSaving={isSaving}

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -23,7 +23,6 @@ import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 type Installation = {
   avatar_url: string;
-  count: number;
   github_account: string;
   installation_id: string;
 };
@@ -76,12 +75,7 @@ export function GithubInstallationSelect({
   const source = 'github.multi_org';
 
   const doesntRequireUpgrade = (id: SelectKey): boolean => {
-    return (
-      hasSCMMultiOrg ||
-      isSelfHosted ||
-      id === '-1' ||
-      installation_info.find(i => i.installation_id === id)?.count === 0
-    );
+    return hasSCMMultiOrg || isSelfHosted || id === '-1';
   };
 
   const handleSubmit = (e: React.MouseEvent, id?: SelectKey) => {
@@ -196,11 +190,7 @@ export function GithubInstallationSelect({
         <Stack alignSelf="flex-end" paddingTop="xl">
           {organization.features.includes('github-multi-org-upsell-modal') ? (
             <InstallButtonHook
-              hasSCMMultiOrg={
-                hasSCMMultiOrg ||
-                installation_info.find(i => i.installation_id === installationID)
-                  ?.count === 0
-              }
+              hasSCMMultiOrg={hasSCMMultiOrg}
               installationID={installationID}
               isSaving={isSaving}
               handleSubmit={handleSubmit}

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -76,7 +76,12 @@ export function GithubInstallationSelect({
   const source = 'github.multi_org';
 
   const doesntRequireUpgrade = (id: SelectKey): boolean => {
-    return hasSCMMultiOrg || isSelfHosted || id === '-1';
+    return (
+      hasSCMMultiOrg ||
+      isSelfHosted ||
+      id === '-1' ||
+      installation_info.find(i => i.installation_id === id)?.count === 0
+    );
   };
 
   const handleSubmit = (e: React.MouseEvent, id?: SelectKey) => {
@@ -189,7 +194,6 @@ export function GithubInstallationSelect({
           )}
         />
         <Stack alignSelf="flex-end" paddingTop="xl">
-          {/* All GitHub app installs will show up here. If the corresponding Integration has 0 installs we should also allow install */}
           {organization.features.includes('github-multi-org-upsell-modal') ? (
             <InstallButtonHook
               hasSCMMultiOrg={

--- a/tests/js/fixtures/githubInstallationSelect.ts
+++ b/tests/js/fixtures/githubInstallationSelect.ts
@@ -4,17 +4,20 @@ export const installation_info = [
     installation_id: '1',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-matrix.gif',
+    count: 1,
   },
   {
     github_account: 'bufo-bot',
     installation_id: '2',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/awesomebufo.png',
+    count: 1,
   },
   {
     github_account: 'Integrate with a new GitHub organization',
     installation_id: '-1',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-pog-surprise.png',
+    count: 0,
   },
 ];

--- a/tests/js/fixtures/githubInstallationSelect.ts
+++ b/tests/js/fixtures/githubInstallationSelect.ts
@@ -4,20 +4,17 @@ export const installation_info = [
     installation_id: '1',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-matrix.gif',
-    count: 1,
   },
   {
     github_account: 'bufo-bot',
     installation_id: '2',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/awesomebufo.png',
-    count: 1,
   },
   {
     github_account: 'Integrate with a new GitHub organization',
     installation_id: '-1',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-pog-surprise.png',
-    count: 0,
   },
 ];


### PR DESCRIPTION
FE follow up to https://github.com/getsentry/sentry/pull/107130

We show the upsell icon for GH orgs that have at least 1 install and the org does not have biz plan.