### PR TITLE
chore(infra): Remove explicit paths from backend-selective workflow

### DIFF
--- a/.github/workflows/backend-selective.yml
+++ b/.github/workflows/backend-selective.yml
@@ -2,11 +2,6 @@ name: '[NOT REQUIRED] backend (selective)'
 
 on:
   pull_request:
-    paths:
-      - 'src/sentry/issues/**'
-      - 'src/sentry/preprod/**'
-      - 'src/sentry/releases/**'
-      - 'src/sentry/workflow_engine/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
In prep to rollout selective testing (not required) to all PRs, this removes the explicit path opt-in for approved modules. All backend changes will now get the new selective testing shadow job.