### PR TITLE
fix(sentry-apps): default flush to false for sentry app models

### DIFF
--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -88,6 +88,8 @@ class SentryAppManager(ParanoidManager["SentryApp"]):
 
 @control_silo_model
 class SentryApp(ParanoidModel, HasApiScopes, Model):
+    default_flush = False
+
     __relocation_scope__ = RelocationScope.Global
 
     application = models.OneToOneField(
@@ -241,7 +243,7 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
     def delete(self, *args, **kwargs):
         from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 
-        with outbox_context(transaction.atomic(using=router.db_for_write(SentryApp))):
+        with outbox_context(transaction.atomic(using=router.db_for_write(SentryApp)), flush=False):
             for outbox in self.outboxes_for_update():
                 outbox.save()
 

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -66,6 +66,8 @@ class SentryAppInstallationForProviderManager(ParanoidManager["SentryAppInstalla
 
 @control_silo_model
 class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
+    default_flush = False
+
     __relocation_scope__ = RelocationScope.Global
     category = OutboxCategory.SENTRY_APP_INSTALLATION_UPDATE
 
@@ -126,7 +128,9 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         return super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        with outbox_context(transaction.atomic(using=router.db_for_write(SentryAppInstallation))):
+        with outbox_context(
+            transaction.atomic(using=router.db_for_write(SentryAppInstallation)), flush=False
+        ):
             for outbox in self.outboxes_for_delete():
                 outbox.save()
 

--- a/tests/sentry/deletions/test_sentry_app.py
+++ b/tests/sentry/deletions/test_sentry_app.py
@@ -9,6 +9,7 @@ from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.users.models.user import User
 from sentry.workflow_engine.models import Action
@@ -98,7 +99,8 @@ class TestSentryAppDeletionTask(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
-        deletions.exec_sync(self.sentry_app)
+        with outbox_runner():
+            deletions.exec_sync(self.sentry_app)
 
         action.refresh_from_db()
         assert action.status == ObjectStatus.DISABLED

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -136,9 +136,8 @@ class TestSentryAppInstallationDeletionTask(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
-        deletions.exec_sync(self.install)
         with outbox_runner():
-            pass
+            deletions.exec_sync(self.install)
 
         action.refresh_from_db()
         assert action.status == ObjectStatus.DISABLED

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -915,7 +915,7 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
             self.internal_integration.slug,
             status_code=204,
         )
-        with self.tasks():
+        with self.tasks(), outbox_runner():
             run_scheduled_deletions_control()
 
         action.refresh_from_db()


### PR DESCRIPTION
Sentry app and install outboxes for deletion are currently flushed synchronously, they should be async to prevent db contention when the deletion outboxes are processed.