### PR TITLE
feat(workflow-engine): Track tainted workflow evaluations

### DIFF
--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -63,6 +63,18 @@ class TriggerResult:
         return TriggerResult(triggered=self.triggered, error=error)
 
     @staticmethod
+    def choose_tainted(a: "TriggerResult", b: "TriggerResult") -> "TriggerResult":
+        """
+        Returns the first tainted TriggerResult, or `a` if neither is tainted.
+        Useful for tracking whether any evaluation in a series was tainted.
+        """
+        if a.is_tainted():
+            return a
+        if b.is_tainted():
+            return b
+        return a
+
+    @staticmethod
     def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
         """
         Like `any()`, but for TriggerResult. If any inputs had errors that could

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Collection, Sequence
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from enum import StrEnum
 
@@ -21,6 +21,7 @@ from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContextData,
 )
 from sentry.workflow_engine.processors.data_condition_group import (
+    TriggerResult,
     get_data_conditions_for_group,
     process_data_condition_group,
 )
@@ -97,13 +98,19 @@ def _get_data_conditions_for_group_by_dcg(dcg_ids: Sequence[int]) -> dict[int, l
     )
 
 
+@dataclass(frozen=True)
+class TriggeredWorkflow:
+    workflow: Workflow
+    result: TriggerResult
+
+
 @sentry_sdk.trace
 @scopedstats.timer()
 def evaluate_workflow_triggers(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
     event_start_time: datetime,
-) -> tuple[set[Workflow], dict[Workflow, DelayedWorkflowItem]]:
+) -> tuple[set[TriggeredWorkflow], dict[Workflow, DelayedWorkflowItem]]:
     """
     Returns a tuple of (triggered_workflows, queue_items_by_workflow)
     - triggered_workflows: set of workflows that were triggered
@@ -111,7 +118,7 @@ def evaluate_workflow_triggers(
       in the next step (evaluate action filters) to enqueue workflows with slow conditions
       within that function
     """
-    triggered_workflows: set[Workflow] = set()
+    triggered_workflows: set[TriggeredWorkflow] = set()
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem] = {}
 
     dcg_ids = [
@@ -128,6 +135,7 @@ def evaluate_workflow_triggers(
         project.organization,
     )
 
+    tainted_untriggered, untainted_untriggered = 0, 0
     for workflow in workflows:
         when_data_conditions = None
         if dcg_id := workflow.when_condition_group_id:
@@ -163,7 +171,7 @@ def evaluate_workflow_triggers(
                 )
         else:
             if evaluation.triggered:
-                triggered_workflows.add(workflow)
+                triggered_workflows.add(TriggeredWorkflow(workflow, evaluation))
                 if dual_processing_logs_enabled:
                     try:
                         detector = WorkflowEventContext.get().detector
@@ -180,10 +188,22 @@ def evaluate_workflow_triggers(
                         )
                     except DetectorWorkflow.DoesNotExist:
                         continue
+            else:
+                if evaluation.is_tainted():
+                    tainted_untriggered += 1
+                else:
+                    untainted_untriggered += 1
 
+    metrics_incr("process_workflows.triggered_workflows", len(triggered_workflows))
     metrics_incr(
-        "process_workflows.triggered_workflows",
-        len(triggered_workflows),
+        "process_workflows.workflows_evaluated",
+        tainted_untriggered + untainted_untriggered,
+        tags={"tainted": True},
+    )
+    metrics_incr(
+        "process_workflows.workflows_evaluated",
+        untainted_untriggered,
+        tags={"tainted": False},
     )
 
     # TODO - Remove `environment` access once it's in the shared logger.
@@ -206,7 +226,9 @@ def evaluate_workflow_triggers(
             "event_id": event_id,
             "event_data": asdict(event_data),
             "event_environment_id": environment.id if environment else None,
-            "triggered_workflows": [workflow.id for workflow in triggered_workflows],
+            "triggered_workflows": [
+                triggered_workflow.workflow.id for triggered_workflow in triggered_workflows
+            ],
             "queue_workflows": sorted(wf.id for wf in queue_items_by_workflow.keys()),
         },
     )
@@ -217,7 +239,7 @@ def evaluate_workflow_triggers(
 @sentry_sdk.trace
 @scopedstats.timer()
 def evaluate_workflows_action_filters(
-    workflows: set[Workflow],
+    workflows: set[TriggeredWorkflow],
     event_data: WorkflowEventData,
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem],
     event_start_time: datetime,
@@ -231,8 +253,12 @@ def evaluate_workflows_action_filters(
     # to evaluate all fast conditions
     all_workflows = workflows.union(set(queue_items_by_workflow.keys()))
 
-    action_conditions_to_workflow = {
-        wdcg.condition_group: wdcg.workflow
+    triggered_wf_to_tained = {wf.workflow: wf.result for wf in workflows}
+
+    action_conditions_to_workflow: dict[DataConditionGroup, TriggeredWorkflow] = {
+        wdcg.condition_group: TriggeredWorkflow(
+            wdcg.workflow, triggered_wf_to_tained.get(wdcg.workflow, TriggerResult.FALSE)
+        )
         for wdcg in WorkflowDataConditionGroup.objects.select_related(
             "workflow", "condition_group"
         ).filter(workflow__in=all_workflows)
@@ -256,7 +282,9 @@ def evaluate_workflows_action_filters(
         )
     }
 
-    for action_condition_group, workflow in action_conditions_to_workflow.items():
+    workflow_to_result = {workflow.id: workflow.result for workflow in workflows}
+    for action_condition_group, triggered_workflow in action_conditions_to_workflow.items():
+        workflow = triggered_workflow.workflow
         env = env_by_id.get(workflow.environment_id) if workflow.environment_id else None
         workflow_event_data = replace(event_data, workflow_env=env)
         group_evaluation, slow_conditions = process_data_condition_group(
@@ -303,6 +331,16 @@ def evaluate_workflows_action_filters(
                         delayed_workflow_item.passing_if_group_ids.append(action_condition_group.id)
                 else:
                     filtered_action_groups.add(action_condition_group)
+                    workflow_to_result[workflow.id] &= group_evaluation.logic_result
+
+    tainted, untained = 0, 0
+    for result in workflow_to_result.values():
+        if result.is_tainted():
+            tainted += 1
+        else:
+            untained += 1
+    metrics_incr("process_workflows.workflows_evaluated", tainted, tags={"tainted": True})
+    metrics_incr("process_workflows.workflows_evaluated", untained, tags={"tainted": False})
 
     event_id = (
         event_data.event.event_id

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Collection, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from enum import StrEnum
@@ -41,6 +41,57 @@ logger = log_context.get_logger(__name__)
 class WorkflowDataConditionGroupType(StrEnum):
     ACTION_FILTER = "action_filter"
     WORKFLOW_TRIGGER = "workflow_trigger"
+
+
+@dataclass(frozen=True)
+class EvaluationStats:
+    """
+    Counts of fully-evaluated workflows by result reliability.
+    Tainted results may be incorrect due to errors during evaluation.
+    """
+
+    tainted: int = 0
+    untainted: int = 0
+
+    @classmethod
+    def from_results(cls, results: Iterable[TriggerResult]) -> "EvaluationStats":
+        tainted, untainted = 0, 0
+        for result in results:
+            if result.is_tainted():
+                tainted += 1
+            else:
+                untainted += 1
+        return cls(tainted=tainted, untainted=untainted)
+
+    def report_metrics(self, metric_name: str) -> None:
+        metrics_incr(metric_name, self.tainted, tags={"tainted": True})
+        metrics_incr(metric_name, self.untainted, tags={"tainted": False})
+
+
+def delete_workflow(workflow: Workflow) -> bool:
+    with transaction.atomic(router.db_for_write(Workflow)):
+        action_filters = DataConditionGroup.objects.filter(
+            workflowdataconditiongroup__workflow=workflow
+        )
+
+        actions = Action.objects.filter(
+            dataconditiongroupaction__condition_group__in=action_filters
+        )
+
+        # Delete the actions associated with a workflow, this is not a cascade delete
+        # because we want to create a UI to maintain notification actions separately
+        if actions:
+            actions.delete()
+
+        if action_filters:
+            action_filters.delete()
+
+        if workflow.when_condition_group:
+            workflow.when_condition_group.delete()
+
+        workflow.delete()
+
+    return True
 
 
 @scopedstats.timer()
@@ -98,27 +149,22 @@ def _get_data_conditions_for_group_by_dcg(dcg_ids: Sequence[int]) -> dict[int, l
     )
 
 
-@dataclass(frozen=True)
-class TriggeredWorkflow:
-    workflow: Workflow
-    result: TriggerResult
-
-
 @sentry_sdk.trace
 @scopedstats.timer()
 def evaluate_workflow_triggers(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
     event_start_time: datetime,
-) -> tuple[set[TriggeredWorkflow], dict[Workflow, DelayedWorkflowItem]]:
+) -> tuple[dict[Workflow, TriggerResult], dict[Workflow, DelayedWorkflowItem], EvaluationStats]:
     """
-    Returns a tuple of (triggered_workflows, queue_items_by_workflow)
-    - triggered_workflows: set of workflows that were triggered
+    Returns a tuple of (triggered_workflows, queue_items_by_workflow, stats)
+    - triggered_workflows: mapping of workflows that triggered to their evaluation result
     - queue_items_by_workflow: mapping of workflow to the delayed workflow item, used
       in the next step (evaluate action filters) to enqueue workflows with slow conditions
       within that function
+    - stats: tainted/untainted counts for workflows that didn't trigger (fully evaluated)
     """
-    triggered_workflows: set[TriggeredWorkflow] = set()
+    triggered_workflows: dict[Workflow, TriggerResult] = {}
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem] = {}
 
     dcg_ids = [
@@ -156,11 +202,8 @@ def evaluate_workflow_triggers(
                     timestamp=event_start_time,
                 )
             else:
-                """
-                Tracking when we try to enqueue a slow condition for an activity.
-                Currently, we are assuming those cases are evaluating as True since
-                an activity update is meant to respond to a previous event.
-                """
+                # Activity updates with slow conditions are not enqueued because an activity
+                # update is meant to respond to a previous event.
                 metrics_incr("process_workflows.enqueue_workflow.activity")
                 logger.debug(
                     "workflow_engine.process_workflows.enqueue_workflow.activity",
@@ -171,7 +214,7 @@ def evaluate_workflow_triggers(
                 )
         else:
             if evaluation.triggered:
-                triggered_workflows.add(TriggeredWorkflow(workflow, evaluation))
+                triggered_workflows[workflow] = evaluation
                 if dual_processing_logs_enabled:
                     try:
                         detector = WorkflowEventContext.get().detector
@@ -194,17 +237,8 @@ def evaluate_workflow_triggers(
                 else:
                     untainted_untriggered += 1
 
+    stats = EvaluationStats(tainted=tainted_untriggered, untainted=untainted_untriggered)
     metrics_incr("process_workflows.triggered_workflows", len(triggered_workflows))
-    metrics_incr(
-        "process_workflows.workflows_evaluated",
-        tainted_untriggered + untainted_untriggered,
-        tags={"tainted": True},
-    )
-    metrics_incr(
-        "process_workflows.workflows_evaluated",
-        untainted_untriggered,
-        tags={"tainted": False},
-    )
 
     # TODO - Remove `environment` access once it's in the shared logger.
     environment = WorkflowEventContext.get().environment
@@ -212,7 +246,7 @@ def evaluate_workflow_triggers(
         try:
             environment = get_environment_by_event(event_data)
         except Environment.DoesNotExist:
-            return set(), {}
+            return {}, {}, stats
 
     event_id = (
         event_data.event.event_id
@@ -226,39 +260,37 @@ def evaluate_workflow_triggers(
             "event_id": event_id,
             "event_data": asdict(event_data),
             "event_environment_id": environment.id if environment else None,
-            "triggered_workflows": [
-                triggered_workflow.workflow.id for triggered_workflow in triggered_workflows
-            ],
+            "triggered_workflows": [workflow.id for workflow in triggered_workflows],
             "queue_workflows": sorted(wf.id for wf in queue_items_by_workflow.keys()),
         },
     )
 
-    return triggered_workflows, queue_items_by_workflow
+    return triggered_workflows, queue_items_by_workflow, stats
 
 
 @sentry_sdk.trace
 @scopedstats.timer()
 def evaluate_workflows_action_filters(
-    workflows: set[TriggeredWorkflow],
+    triggered_workflows: dict[Workflow, TriggerResult],
     event_data: WorkflowEventData,
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem],
     event_start_time: datetime,
-) -> tuple[set[DataConditionGroup], dict[Workflow, DelayedWorkflowItem]]:
+) -> tuple[set[DataConditionGroup], dict[Workflow, DelayedWorkflowItem], EvaluationStats]:
     """
     Evaluate the action filters for the given workflows.
-    Returns a set of DataConditionGroups that were evaluated to True.
-    Enqueues workflows with slow conditions to be evaluated in a batched task.
+    Returns a tuple of (filtered_action_groups, queue_items_by_workflow, stats)
+    - filtered_action_groups: set of DataConditionGroups that were evaluated to True
+    - queue_items_by_workflow: updated with workflows that have slow conditions
+    - stats: tainted/untainted counts for fully-evaluated workflows
     """
     # Collect all workflows, including those with pending slow condition results (queue_items_by_workflow)
     # to evaluate all fast conditions
-    all_workflows = workflows.union(set(queue_items_by_workflow.keys()))
+    all_workflows: set[Workflow] = set(triggered_workflows.keys()) | set(
+        queue_items_by_workflow.keys()
+    )
 
-    triggered_wf_to_tained = {wf.workflow: wf.result for wf in workflows}
-
-    action_conditions_to_workflow: dict[DataConditionGroup, TriggeredWorkflow] = {
-        wdcg.condition_group: TriggeredWorkflow(
-            wdcg.workflow, triggered_wf_to_tained.get(wdcg.workflow, TriggerResult.FALSE)
-        )
+    action_conditions_to_workflow: dict[DataConditionGroup, Workflow] = {
+        wdcg.condition_group: wdcg.workflow
         for wdcg in WorkflowDataConditionGroup.objects.select_related(
             "workflow", "condition_group"
         ).filter(workflow__in=all_workflows)
@@ -282,9 +314,10 @@ def evaluate_workflows_action_filters(
         )
     }
 
-    workflow_to_result = {workflow.id: workflow.result for workflow in workflows}
-    for action_condition_group, triggered_workflow in action_conditions_to_workflow.items():
-        workflow = triggered_workflow.workflow
+    workflow_to_result: dict[int, TriggerResult] = {
+        wf.id: result for wf, result in triggered_workflows.items()
+    }
+    for action_condition_group, workflow in action_conditions_to_workflow.items():
         env = env_by_id.get(workflow.environment_id) if workflow.environment_id else None
         workflow_event_data = replace(event_data, workflow_env=env)
         group_evaluation, slow_conditions = process_data_condition_group(
@@ -323,6 +356,12 @@ def evaluate_workflows_action_filters(
                     },
                 )
         else:
+            # Only accumulate taint for triggered workflows (not those with slow WHEN conditions)
+            if workflow.id in workflow_to_result:
+                workflow_to_result[workflow.id] = TriggerResult.choose_tainted(
+                    workflow_to_result[workflow.id], group_evaluation.logic_result
+                )
+
             if group_evaluation.logic_result.triggered:
                 if delayed_workflow_item := queue_items_by_workflow.get(workflow):
                     if delayed_workflow_item.delayed_when_group_id:
@@ -331,16 +370,12 @@ def evaluate_workflows_action_filters(
                         delayed_workflow_item.passing_if_group_ids.append(action_condition_group.id)
                 else:
                     filtered_action_groups.add(action_condition_group)
-                    workflow_to_result[workflow.id] &= group_evaluation.logic_result
 
-    tainted, untained = 0, 0
-    for result in workflow_to_result.values():
-        if result.is_tainted():
-            tainted += 1
-        else:
-            untained += 1
-    metrics_incr("process_workflows.workflows_evaluated", tainted, tags={"tainted": True})
-    metrics_incr("process_workflows.workflows_evaluated", untained, tags={"tainted": False})
+    # Count tainted/untainted only for fully-evaluated workflows (not delayed)
+    fully_evaluated_workflows = triggered_workflows.keys() - queue_items_by_workflow.keys()
+    stats = EvaluationStats.from_results(
+        workflow_to_result[wf.id] for wf in fully_evaluated_workflows
+    )
 
     event_id = (
         event_data.event.event_id
@@ -353,7 +388,7 @@ def evaluate_workflows_action_filters(
         extra={
             "group_id": event_data.group.id,
             "event_id": event_id,
-            "workflow_ids": [workflow.id for workflow in action_conditions_to_workflow.values()],
+            "workflow_ids": [wf.id for wf in action_conditions_to_workflow.values()],
             "action_conditions": [
                 action_condition_group.id
                 for action_condition_group in action_conditions_to_workflow.keys()
@@ -363,7 +398,7 @@ def evaluate_workflows_action_filters(
         },
     )
 
-    return filtered_action_groups, queue_items_by_workflow
+    return filtered_action_groups, queue_items_by_workflow, stats
 
 
 def get_environment_by_event(event_data: WorkflowEventData) -> Environment | None:
@@ -515,11 +550,12 @@ def process_workflows(
             data=workflow_evaluation_data,
         )
 
-    triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+    triggered_workflows, queue_items_by_workflow_id, trigger_stats = evaluate_workflow_triggers(
         workflows, event_data, event_start_time
     )
+    trigger_stats.report_metrics("process_workflows.workflows_evaluated")
 
-    workflow_evaluation_data.triggered_workflows = triggered_workflows
+    workflow_evaluation_data.triggered_workflows = set(triggered_workflows.keys())
 
     if not triggered_workflows and not queue_items_by_workflow_id:
         # TODO - re-think tainted once the actions are removed from process_workflows.
@@ -531,9 +567,12 @@ def process_workflows(
 
     # TODO - we should probably return here and have the rest from here be
     # `process_actions`, this will take a list of "triggered_workflows"
-    actions_to_trigger, queue_items_by_workflow_id = evaluate_workflows_action_filters(
-        triggered_workflows, event_data, queue_items_by_workflow_id, event_start_time
+    actions_to_trigger, queue_items_by_workflow_id, action_stats = (
+        evaluate_workflows_action_filters(
+            triggered_workflows, event_data, queue_items_by_workflow_id, event_start_time
+        )
     )
+    action_stats.report_metrics("process_workflows.workflows_evaluated")
 
     enqueue_workflows(batch_client, queue_items_by_workflow_id)
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -74,32 +74,6 @@ class EvaluationStats:
         metrics_incr(metric_name, self.untainted, tags={"tainted": False})
 
 
-def delete_workflow(workflow: Workflow) -> bool:
-    with transaction.atomic(router.db_for_write(Workflow)):
-        action_filters = DataConditionGroup.objects.filter(
-            workflowdataconditiongroup__workflow=workflow
-        )
-
-        actions = Action.objects.filter(
-            dataconditiongroupaction__condition_group__in=action_filters
-        )
-
-        # Delete the actions associated with a workflow, this is not a cascade delete
-        # because we want to create a UI to maintain notification actions separately
-        if actions:
-            actions.delete()
-
-        if action_filters:
-            action_filters.delete()
-
-        if workflow.when_condition_group:
-            workflow.when_condition_group.delete()
-
-        workflow.delete()
-
-    return True
-
-
 @scopedstats.timer()
 def enqueue_workflows(
     client: DelayedWorkflowClient,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -63,6 +63,12 @@ class EvaluationStats:
                 untainted += 1
         return cls(tainted=tainted, untainted=untainted)
 
+    def __add__(self, other: "EvaluationStats") -> "EvaluationStats":
+        return EvaluationStats(
+            tainted=self.tainted + other.tainted,
+            untainted=self.untainted + other.untainted,
+        )
+
     def report_metrics(self, metric_name: str) -> None:
         metrics_incr(metric_name, self.tainted, tags={"tainted": True})
         metrics_incr(metric_name, self.untainted, tags={"tainted": False})
@@ -553,11 +559,11 @@ def process_workflows(
     triggered_workflows, queue_items_by_workflow_id, trigger_stats = evaluate_workflow_triggers(
         workflows, event_data, event_start_time
     )
-    trigger_stats.report_metrics("process_workflows.workflows_evaluated")
 
     workflow_evaluation_data.triggered_workflows = set(triggered_workflows.keys())
 
     if not triggered_workflows and not queue_items_by_workflow_id:
+        trigger_stats.report_metrics("process_workflows.workflows_evaluated")
         # TODO - re-think tainted once the actions are removed from process_workflows.
         return WorkflowEvaluation(
             tainted=True,
@@ -572,7 +578,7 @@ def process_workflows(
             triggered_workflows, event_data, queue_items_by_workflow_id, event_start_time
         )
     )
-    action_stats.report_metrics("process_workflows.workflows_evaluated")
+    (trigger_stats + action_stats).report_metrics("process_workflows.workflows_evaluated")
 
     enqueue_workflows(batch_client, queue_items_by_workflow_id)
 

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -567,3 +567,9 @@ class TestTriggerResult(unittest.TestCase):
         assert TriggerResult.none(iter([FALSE, FALSE.with_error(ERR), FALSE])) == TRUE.with_error(
             ERR
         )
+
+    def test_choose_tainted(self) -> None:
+        assert TriggerResult.choose_tainted(TRUE.with_error(ERR), FALSE) == TRUE.with_error(ERR)
+        assert TriggerResult.choose_tainted(TRUE, FALSE.with_error(ERR)) == FALSE.with_error(ERR)
+        assert TriggerResult.choose_tainted(TRUE, FALSE) == TRUE
+        assert TriggerResult.choose_tainted(FALSE, TRUE) == FALSE

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -672,6 +672,7 @@ class TestTaintTracking(BaseWorkflowTest):
         assert stats == EvaluationStats(tainted=0, untainted=0)
 
     def test_trigger_stats_untainted_not_triggered(self) -> None:
+        assert self.workflow.when_condition_group
         self.workflow.when_condition_group.conditions.all().delete()
         self.create_data_condition(
             condition_group=self.workflow.when_condition_group,

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -741,6 +741,11 @@ class TestTaintTracking(BaseWorkflowTest):
         assert self.workflow in queue_items
         assert stats == EvaluationStats(tainted=0, untainted=0)
 
+    def test_evaluation_stats_add(self) -> None:
+        a = EvaluationStats(tainted=1, untainted=2)
+        b = EvaluationStats(tainted=3, untainted=4)
+        assert a + b == EvaluationStats(tainted=4, untainted=6)
+
 
 @freeze_time(FROZEN_TIME)
 class TestWorkflowEnqueuing(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -22,19 +22,25 @@ from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
     WorkflowEventContextData,
 )
-from sentry.workflow_engine.processors.data_condition_group import get_data_conditions_for_group
+from sentry.workflow_engine.processors.data_condition_group import (
+    ProcessedDataConditionGroup,
+    TriggerResult,
+    get_data_conditions_for_group,
+)
 from sentry.workflow_engine.processors.workflow import (
+    EvaluationStats,
     enqueue_workflows,
     evaluate_workflow_triggers,
     evaluate_workflows_action_filters,
     process_workflows,
 )
 from sentry.workflow_engine.tasks.workflows import process_workflows_event
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
+ERR = ConditionError(msg="test")
 
 
 class TestProcessWorkflows(BaseWorkflowTest):
@@ -396,7 +402,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_workflow_fire_history_with_action_deduping(
         self, mock_trigger_action: MagicMock
     ) -> None:
-        """Fire a single action, but record that it was fired for multiple workflows"""
         self.action_group, self.action = self.create_workflow_action(workflow=self.error_workflow)
 
         error_workflow_2 = self.create_workflow(
@@ -477,10 +482,10 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.event_start_time = timezone.now()
 
     def test_workflow_trigger(self) -> None:
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
-        assert triggered_workflows == {self.workflow}
+        assert set(triggered_workflows.keys()) == {self.workflow}
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch("sentry.workflow_engine.processors.workflow.logger")
@@ -508,13 +513,13 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         assert self.workflow.when_condition_group
         self.workflow.when_condition_group.conditions.all().delete()
 
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
-        assert triggered_workflows == {self.workflow}
+        assert set(triggered_workflows.keys()) == {self.workflow}
 
     def test_no_workflow_trigger(self) -> None:
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             set(), self.event_data, self.event_start_time
         )
         assert not triggered_workflows
@@ -530,10 +535,10 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=75,
         )
 
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
-        assert triggered_workflows == {self.workflow}
+        assert set(triggered_workflows.keys()) == {self.workflow}
 
     def test_workflow_filtered_out(self) -> None:
         assert self.workflow.when_condition_group
@@ -545,22 +550,21 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert not triggered_workflows
 
     def test_many_workflows(self) -> None:
         workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow, workflow_two}, self.event_data, self.event_start_time
         )
 
-        assert triggered_workflows == {self.workflow, workflow_two}
+        assert set(triggered_workflows.keys()) == {self.workflow, workflow_two}
 
     @patch.object(get_data_conditions_for_group, "batch")
     def test_batched_data_condition_lookup_is_used(self, mock_batch: MagicMock) -> None:
-        """Test that batch lookup is used when evaluating multiple workflows."""
         workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
 
         assert self.workflow.when_condition_group
@@ -601,11 +605,11 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         # no workflows are triggered because the slow conditions need to be evaluated
-        assert triggered_workflows == set()
+        assert triggered_workflows == {}
         # we return the list of items we may enqueue in the filtering function
         assert list(queue_items_by_workflow_id.keys()) == [self.workflow]
 
@@ -634,15 +638,107 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             event=self.event,
             group=self.group,
         )
-        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
 
         # no workflows are triggered because the slow conditions need to be evaluated
-        assert triggered_workflows == set()
+        assert triggered_workflows == {}
         assert (
             not queue_items_by_workflow_id.keys()
         )  # TODO: implement evaluating slow conditions for activity updates
+
+
+@freeze_time(FROZEN_TIME)
+class TestTaintTracking(BaseWorkflowTest):
+    def setUp(self) -> None:
+        self.project = self.create_project(create_default_detectors=True)
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
+        occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=occurrence, group_type_id=MetricIssue.type_id
+        )
+        self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        self.action_group, _ = self.create_workflow_action(self.workflow)
+
+    def test_trigger_stats_excludes_triggered_workflows(self) -> None:
+        _, _, stats = evaluate_workflow_triggers({self.workflow}, self.event_data, FROZEN_TIME)
+        assert stats == EvaluationStats(tainted=0, untainted=0)
+
+    def test_trigger_stats_untainted_not_triggered(self) -> None:
+        self.workflow.when_condition_group.conditions.all().delete()
+        self.create_data_condition(
+            condition_group=self.workflow.when_condition_group,
+            type=Condition.EVENT_CREATED_BY_DETECTOR,
+            comparison=self.detector.id + 1,
+        )
+
+        triggered_workflows, _, stats = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data, FROZEN_TIME
+        )
+        assert triggered_workflows == {}
+        assert stats == EvaluationStats(tainted=0, untainted=1)
+
+    @patch("sentry.workflow_engine.processors.data_condition_group.process_data_condition_group")
+    def test_trigger_stats_tainted_not_triggered(self, mock_process: MagicMock) -> None:
+        mock_process.return_value = (
+            ProcessedDataConditionGroup(
+                logic_result=TriggerResult.FALSE.with_error(ERR),
+                condition_results=[],
+            ),
+            [],
+        )
+
+        triggered_workflows, _, stats = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data, FROZEN_TIME
+        )
+        assert triggered_workflows == {}
+        assert stats == EvaluationStats(tainted=1, untainted=0)
+
+    def test_action_filter_stats_from_trigger_result(self) -> None:
+        _, _, stats = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
+        )
+        assert stats == EvaluationStats(tainted=0, untainted=1)
+
+        _, _, stats = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE.with_error(ERR)}, self.event_data, {}, FROZEN_TIME
+        )
+        assert stats == EvaluationStats(tainted=1, untainted=0)
+
+    @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
+    def test_action_filter_stats_tainted_from_action_filter(self, mock_process: MagicMock) -> None:
+        mock_process.return_value = (
+            ProcessedDataConditionGroup(
+                logic_result=TriggerResult.TRUE.with_error(ERR),
+                condition_results=[],
+            ),
+            [],
+        )
+
+        _, _, stats = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
+        )
+        assert stats == EvaluationStats(tainted=1, untainted=0)
+
+    def test_action_filter_stats_excludes_delayed_workflows(self) -> None:
+        self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 7},
+        )
+
+        _, queue_items, stats = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
+        )
+        assert self.workflow in queue_items
+        assert stats == EvaluationStats(tainted=0, untainted=0)
 
 
 @freeze_time(FROZEN_TIME)
@@ -680,7 +776,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -713,7 +809,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -743,10 +839,10 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
-        assert triggered_workflows == {self.workflow}
+        assert set(triggered_workflows.keys()) == {self.workflow}
         assert not queue_items_by_workflow_id
 
     def test_skips_enqueuing_all(self) -> None:
@@ -770,7 +866,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -891,8 +987,8 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         mock_trigger.assert_called_once()
 
     def test_basic__no_filter(self) -> None:
-        triggered_action_filters, _ = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data, {}, FROZEN_TIME
+        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert set(triggered_action_filters) == {self.action_group}
 
@@ -904,21 +1000,20 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_action_filters, _ = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data, {}, FROZEN_TIME
+        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert set(triggered_action_filters) == {self.action_group}
 
     def test_basic__with_filter__filtered(self) -> None:
-        # Add a filter to the action's group
         self.create_data_condition(
             condition_group=self.action_group,
             type=Condition.EVENT_CREATED_BY_DETECTOR,
             comparison=self.detector.id + 1,
         )
 
-        triggered_action_filters, _ = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data, {}, FROZEN_TIME
+        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert not triggered_action_filters
 
@@ -939,33 +1034,30 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
         self.action_group.save()
 
-        triggered_action_filters, _ = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data, {}, FROZEN_TIME
+        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
 
         assert self.action_group.conditions.count() == 2
 
-        # The first condition passes, but the second is enqueued for later evaluation
         assert not triggered_action_filters
 
     @patch.object(get_data_conditions_for_group, "batch")
     def test_batched_data_condition_lookup_for_action_filters(self, mock_batch: MagicMock) -> None:
-        """Test that batch lookup is used when evaluating action filters."""
-        # Create a second workflow with action filters
         workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
         action_group_two, action_two = self.create_workflow_action(workflow=workflow_two)
 
-        # Mock the batch method to return the expected data
         mock_batch.return_value = [
             list(self.action_group.conditions.all()),
             list(action_group_two.conditions.all()),
         ]
 
-        # Evaluate workflows action filters with batching
-        workflows = {self.workflow, workflow_two}
+        workflows = {
+            self.workflow: TriggerResult.TRUE,
+            workflow_two: TriggerResult.TRUE,
+        }
         evaluate_workflows_action_filters(workflows, self.event_data, {}, FROZEN_TIME)
 
-        # Verify batch was called once with the correct DCG IDs
         mock_batch.assert_called_once()
         call_args = mock_batch.call_args[0][0]
 
@@ -975,7 +1067,6 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         assert actual_dcg_ids == expected_dcg_ids
 
     def test_activity__with_slow_conditions(self) -> None:
-        # Create a condition group with fast and slow conditions
         self.action_group.logic_type = DataConditionGroup.Type.ALL
 
         self.create_data_condition(
@@ -992,7 +1083,6 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
         self.action_group.save()
 
-        # Create an activity update
         self.event = Activity.objects.create(
             project=self.project,
             group=self.group,
@@ -1003,12 +1093,10 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             group=self.group,
         )
 
-        # Evaluate the workflow actions with a slow condition
-        _, queue_items = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data, {}, FROZEN_TIME
+        _, queue_items, _ = evaluate_workflows_action_filters(
+            {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
 
-        # ensure we do not enqueue slow condition evaluation
         assert not queue_items
 
     def test_enqueues_when_slow_conditions(self) -> None:
@@ -1024,8 +1112,8 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             )
         }
 
-        triggered_action_filters, queue_items = evaluate_workflows_action_filters(
-            set(), self.event_data, queue_items_by_workflow_id, FROZEN_TIME
+        triggered_action_filters, queue_items, _ = evaluate_workflows_action_filters(
+            {}, self.event_data, queue_items_by_workflow_id, FROZEN_TIME
         )
         assert not triggered_action_filters
 


### PR DESCRIPTION
 Report metrics for workflow evaluations that may have produced incorrect results due to errors during condition evaluation ("tainted" results).

This helps monitor evaluation reliability by emitting a single metric `process_workflows.workflows_evaluated` with a `tainted` tag, allowing us to track the ratio and number of tainted workflows.
This doesn't yet propagate taintedness to delayed evaluation; that's a planned follow-up.

Updates ISWF-1960.