### PR TITLE
chore(llm-detection): Update LLM detection route

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -41,7 +41,7 @@ MAX_LLM_FIELD_LENGTH = 2000
 
 
 seer_issue_detection_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL,
+    settings.SEER_AUTOFIX_URL,
     timeout=SEER_TIMEOUT_S,
     retries=0,
     maxsize=10,


### PR DESCRIPTION
re-route this url, fits better with Autofix. This change was suggested to match the queue name on Seer side. This change is purely cosmetic.