### PR TITLE
feat(issues): Hide package and address for non-native frames in mixed stacktraces

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -121,6 +121,234 @@ describe('Native StackTrace', () => {
     expect(screen.getByText('non-in-app-frame')).toBeInTheDocument();
   });
 
+  describe('Non-native frames in mixed stacktraces', () => {
+    it('hides package and instruction address for Java frames', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'java',
+        package: 'com.example.MyClass',
+        instructionAddr: '0x00007fff5bf3d000',
+        symbolAddr: '0x00007fff5bf3d000',
+        function: 'myJavaMethod',
+        filename: 'MyClass.java',
+        lineNo: 42,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="java-android"
+        />,
+        {organization}
+      );
+
+      // Java frame should show function name but not package or instruction address
+      expect(screen.getByText('myJavaMethod')).toBeInTheDocument();
+      expect(screen.queryByText('com.example.MyClass')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d000')).not.toBeInTheDocument();
+    });
+
+    it('hides package and instruction address for Kotlin frames', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'kotlin',
+        package: 'com.example.MyClass',
+        instructionAddr: '0x00007fff5bf3d000',
+        symbolAddr: '0x00007fff5bf3d000',
+        function: 'myKotlinMethod',
+        filename: 'MyClass.kt',
+        lineNo: 42,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="java-android"
+        />,
+        {organization}
+      );
+
+      // Kotlin frame should show function name but not package or instruction address
+      expect(screen.getByText('myKotlinMethod')).toBeInTheDocument();
+      expect(screen.queryByText('com.example.MyClass')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d000')).not.toBeInTheDocument();
+    });
+
+    it('hides package and instruction address for JavaScript frames', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'javascript',
+        package: 'webpack://myapp',
+        instructionAddr: '0x00007fff5bf3d000',
+        symbolAddr: '0x00007fff5bf3d000',
+        function: 'myJsFunction',
+        filename: 'app.js',
+        lineNo: 42,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="javascript"
+        />,
+        {organization}
+      );
+
+      // JavaScript frame should show function name but not package or instruction address
+      expect(screen.getByText('myJsFunction')).toBeInTheDocument();
+      expect(screen.queryByText('webpack://myapp')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d000')).not.toBeInTheDocument();
+    });
+
+    it('hides package and address even when package is null', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'java',
+        package: null,
+        instructionAddr: '0x00007fff5bf3d000',
+        function: 'javaMethod',
+        filename: 'MyClass.java',
+        lineNo: 10,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="java-android"
+        />,
+        {organization}
+      );
+
+      // Non-native frame should show function name but not address
+      expect(screen.getByText('javaMethod')).toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d000')).not.toBeInTheDocument();
+    });
+
+    it('hides package and address for multiple non-native frames', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'java',
+        package: 'com.example.ClassA',
+        instructionAddr: '0x00007fff5bf3d001',
+        function: 'methodA',
+        filename: 'ClassA.java',
+        lineNo: 10,
+        inApp: true,
+      };
+      dataFrames[1] = {
+        ...dataFrames[1]!,
+        platform: 'kotlin',
+        package: 'com.example.ClassB',
+        instructionAddr: '0x00007fff5bf3d002',
+        function: 'methodB',
+        filename: 'ClassB.kt',
+        lineNo: 20,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="java-android"
+        />,
+        {organization}
+      );
+
+      // Both non-native frames should show function names but not packages or addresses
+      expect(screen.getByText('methodA')).toBeInTheDocument();
+      expect(screen.getByText('methodB')).toBeInTheDocument();
+      expect(screen.queryByText('com.example.ClassA')).not.toBeInTheDocument();
+      expect(screen.queryByText('com.example.ClassB')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d001')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d002')).not.toBeInTheDocument();
+    });
+
+    it('frame.platform overrides event platform', () => {
+      const dataFrames = [...data.frames];
+      dataFrames[0] = {
+        ...dataFrames[0]!,
+        platform: 'java', // Frame is Java
+        package: 'com.example.MyClass',
+        instructionAddr: '0x00007fff5bf3d000',
+        function: 'javaMethod',
+        filename: 'MyClass.java',
+        lineNo: 42,
+        inApp: true,
+      };
+
+      const newData = {
+        ...data,
+        frames: dataFrames,
+      };
+
+      render(
+        <NativeContent
+          data={newData}
+          event={event}
+          newestFirst
+          includeSystemFrames
+          platform="native" // Event platform is native, but frame overrides
+        />,
+        {organization}
+      );
+
+      // Frame platform (Java) should override event platform (native)
+      // So package/address should be hidden
+      expect(screen.getByText('javaMethod')).toBeInTheDocument();
+      expect(screen.queryByText('com.example.MyClass')).not.toBeInTheDocument();
+      expect(screen.queryByText('0x00007fff5bf3d000')).not.toBeInTheDocument();
+    });
+  });
+
   it('does not display a toggle button when there is only one non-inapp frame', () => {
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0]!, inApp: true};

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -321,39 +321,42 @@ function NativeFrame({
               </Tooltip>
             ) : null}
           </SymbolicatorIcon>
-          {showNativeInfo && (
-            <div>
-              {!fullStackTrace && !expanded && leadsToApp && (
-                <Fragment>
-                  <PackageNote>
-                    {getLeadHint({event, hasNextFrame: defined(nextFrame)})}
-                  </PackageNote>
-                </Fragment>
-              )}
-              <Tooltip
-                title={
-                  frame.package ??
-                  (isDartAsyncSuspensionFrame
-                    ? t('Dart async operation')
-                    : t('Go to images loaded'))
-                }
-                containerDisplayMode="inline-flex"
-                delay={tooltipDelay}
-                maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
-                position="auto-start"
-              >
-                <Package>
-                  {frame.package
-                    ? trimPackage(frame.package)
-                    : isDartAsyncSuspensionFrame
-                      ? t('Dart async')
-                      : `<${t('unknown')}>`}
-                </Package>
-              </Tooltip>
-            </div>
-          )}
-          {showNativeInfo && (
-            <Flex>
+
+          <div>
+            {showNativeInfo && (
+              <Fragment>
+                {!fullStackTrace && !expanded && leadsToApp && (
+                  <Fragment>
+                    <PackageNote>
+                      {getLeadHint({event, hasNextFrame: defined(nextFrame)})}
+                    </PackageNote>
+                  </Fragment>
+                )}
+                <Tooltip
+                  title={
+                    frame.package ??
+                    (isDartAsyncSuspensionFrame
+                      ? t('Dart async operation')
+                      : t('Go to images loaded'))
+                  }
+                  containerDisplayMode="inline-flex"
+                  delay={tooltipDelay}
+                  maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
+                  position="auto-start"
+                >
+                  <Package>
+                    {frame.package
+                      ? trimPackage(frame.package)
+                      : isDartAsyncSuspensionFrame
+                        ? t('Dart async')
+                        : `<${t('unknown')}>`}
+                  </Package>
+                </Tooltip>
+              </Fragment>
+            )}
+          </div>
+          <Flex>
+            {showNativeInfo && (
               <AddressCell
                 onClick={packageClickable ? handleGoToImagesLoaded : undefined}
               >
@@ -366,8 +369,9 @@ function NativeFrame({
                   {!relativeAddress || absolute ? frame.instructionAddr : relativeAddress}
                 </Tooltip>
               </AddressCell>
-            </Flex>
-          )}
+            )}
+          </Flex>
+
           <FunctionNameCell>
             {functionName ? (
               <Tooltip title={frame?.rawFunction ?? frame?.symbol} delay={tooltipDelay}>

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -380,11 +380,14 @@ export function getStacktracePlatform(
   event: Event,
   stacktrace?: StacktraceType | null
 ): PlatformKey {
-  const overridePlatform = stacktrace?.frames?.find(frame =>
-    defined(frame.platform)
-  )?.platform;
+  const frames = stacktrace?.frames;
+  const eventPlatform = event.platform ?? 'other';
 
-  return overridePlatform ?? event.platform ?? 'other';
+  return (
+    frames?.find(frame => frame.platform === eventPlatform)?.platform ??
+    frames?.find(frame => defined(frame.platform))?.platform ??
+    eventPlatform
+  );
 }
 
 export function inferPlatform(event: Event, thread?: Thread): PlatformKey {

--- a/static/app/utils/platform.spec.tsx
+++ b/static/app/utils/platform.spec.tsx
@@ -1,0 +1,50 @@
+import {isNativePlatform} from './platform';
+
+describe('isNativePlatform', () => {
+  test('returns true for native platforms', () => {
+    expect(isNativePlatform('c')).toBe(true);
+    expect(isNativePlatform('cocoa')).toBe(true);
+    expect(isNativePlatform('objc')).toBe(true);
+    expect(isNativePlatform('swift')).toBe(true);
+    expect(isNativePlatform('native')).toBe(true);
+    expect(isNativePlatform('nintendo-switch')).toBe(true);
+    expect(isNativePlatform('playstation')).toBe(true);
+    expect(isNativePlatform('xbox')).toBe(true);
+  });
+
+  test('returns false for non-native platforms', () => {
+    expect(isNativePlatform('java')).toBe(false);
+    expect(isNativePlatform('java-android')).toBe(false);
+    expect(isNativePlatform('java-spring')).toBe(false);
+    expect(isNativePlatform('kotlin')).toBe(false);
+    expect(isNativePlatform('javascript')).toBe(false);
+    expect(isNativePlatform('javascript-react')).toBe(false);
+    expect(isNativePlatform('node')).toBe(false);
+    expect(isNativePlatform('node-express')).toBe(false);
+    expect(isNativePlatform('python')).toBe(false);
+    expect(isNativePlatform('ruby')).toBe(false);
+    expect(isNativePlatform('php')).toBe(false);
+    expect(isNativePlatform('dart')).toBe(false);
+    expect(isNativePlatform('flutter')).toBe(false);
+    expect(isNativePlatform('elixir')).toBe(false);
+    expect(isNativePlatform('csharp')).toBe(false);
+    expect(isNativePlatform('dotnet')).toBe(false);
+  });
+
+  test('returns false for undefined or empty string', () => {
+    expect(isNativePlatform(undefined)).toBe(false);
+    expect(isNativePlatform('')).toBe(false);
+  });
+
+  test('handles mixed stacktraces correctly', () => {
+    // Mixed stacktraces (e.g., Android NDK) may have different platform values
+    // Event platform might be 'java-android', but individual frames have 'native' or 'java'
+    expect(isNativePlatform('java-android')).toBe(false); // Event platform
+    expect(isNativePlatform('native')).toBe(true); // Native frame
+    expect(isNativePlatform('java')).toBe(false); // Java frame
+    expect(isNativePlatform('kotlin')).toBe(false); // Kotlin frame
+
+    // Other non-native platforms that might appear in frames
+    expect(isNativePlatform('javascript')).toBe(false);
+  });
+});

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -40,7 +40,7 @@ export function platformToCategory(platform: PlatformKey | undefined): PlatformC
   return PlatformCategory.OTHER;
 }
 
-export function isNativePlatform(platform: string | undefined) {
+export function isNativePlatform(platform: string | undefined): boolean {
   switch (platform) {
     case 'cocoa':
     case 'objc':


### PR DESCRIPTION
In mixed stacktraces (e.g., Android NDK with both native and Java/Kotlin frames), native-specific attributes like package names and instruction addresses are not meaningful for non-native frames and add visual clutter.

This change conditionally displays these attributes based on the frame's platform. The `frame.platform` property takes precedence over the event platform when determining whether to show native debugging information, ensuring that Java, Kotlin, and JavaScript frames display cleanly without confusing native-only details.

**Changes:**
- Add `isNativePlatform()` utility to identify native platforms
- Conditionally render package and instruction address fields in `NativeFrame` component
- Add comprehensive test coverage for mixed stacktrace scenarios