### PR TITLE
fix(agents): Use correct node attribute to fetch message length

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -77,6 +77,7 @@ export function getTraceNodeAttribute(
   attributes?: TraceItemResponseAttribute[]
 ): string | number | boolean | undefined {
   const attributeObject = ensureAttributeObject(node, event, attributes);
+  console.log({attributeObject});
   return attributeObject?.[name];
 }
 

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -77,7 +77,6 @@ export function getTraceNodeAttribute(
   attributes?: TraceItemResponseAttribute[]
 ): string | number | boolean | undefined {
   const attributeObject = ensureAttributeObject(node, event, attributes);
-  console.log({attributeObject});
   return attributeObject?.[name];
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -7,7 +7,7 @@ import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {Button} from 'sentry/components/core/button';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -453,8 +453,9 @@ function MessagesArrayRenderer({
     <Container paddingBottom="lg">
       <Alert variant="muted">
         {tct(
-          'Due to [link:size limitations], the oldest messages got dropped from the history.',
+          'Due to [link:size limitations], the oldest [count] got dropped from the history.',
           {
+            count: tn('message', '%s messages', truncatedMessages),
             link: (
               <ExternalLink href="https://develop.sentry.dev/sdk/expected-features/data-handling/#variable-size" />
             ),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -357,7 +357,7 @@ export function AIInputSection({
 }) {
   const shouldRender = getIsAiNode(node) && hasAIInputAttribute(node, attributes, event);
   const originalMessagesLength = getTraceNodeAttribute(
-    'gen_ai.request.messages.original_length',
+    'sdk_meta.gen_ai.input.messages.original_length',
     node,
     event,
     attributes


### PR DESCRIPTION
It seems that `sdk_meta.gen_ai.input.messages.original_length` is the correct attribute for this and not the one previously added in the [PR](https://github.com/getsentry/sentry/pull/105030) . Also since the sdks are now reporting the correct number, I am reverting the change introduced in the [PR](https://github.com/getsentry/sentry/pull/104315/changes).

<img width="472" height="112" alt="image" src="https://github.com/user-attachments/assets/ee233030-ae58-43ec-8e1f-4efa0d0b9db7" />

**Preview**


<img width="1509" height="617" alt="image" src="https://github.com/user-attachments/assets/fcb62781-7ec7-41d1-8a00-7d3428570c33" />


closes https://linear.app/getsentry/issue/TET-1630/show-message-in-ui-when-we-truncated-messages-based-on-gen