### PR TITLE
ref(autopilot): Break trace propagation for spawned detector tasks

### DIFF
--- a/src/sentry/autopilot/tasks.py
+++ b/src/sentry/autopilot/tasks.py
@@ -283,8 +283,14 @@ def run_missing_sdk_integration_detector_for_organization(organization: Organiza
         )
 
         if repo_config:
-            run_missing_sdk_integration_detector_for_project_task.delay(
-                organization.id, project.id, repo_config.repository.name, repo_config.source_root
+            run_missing_sdk_integration_detector_for_project_task.apply_async(
+                args=(
+                    organization.id,
+                    project.id,
+                    repo_config.repository.name,
+                    repo_config.source_root,
+                ),
+                headers={"sentry-propagate-traces": False},
             )
 
 


### PR DESCRIPTION
When the `run_missing_sdk_integration_detector` task spawns per-project
`run_missing_sdk_integration_detector_for_project_task` tasks, each child
task now starts its own independent trace instead of inheriting the parent's
trace context.

This prevents all spawned tasks from being grouped under a single trace,
which makes it easier to analyze individual task performance and avoids
creating excessively large traces when processing many projects.

Uses `apply_async()` with `headers={"sentry-propagate-traces": False}` 
instead of `delay()` to disable trace propagation.