### PR TITLE
Assignee permission error UI

### DIFF
--- a/static/app/components/group/assigneeSelector.spec.tsx
+++ b/static/app/components/group/assigneeSelector.spec.tsx
@@ -1,0 +1,81 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as groupActionCreators from 'sentry/actionCreators/group';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {useHandleAssigneeChange} from 'sentry/components/group/assigneeSelector';
+import type RequestError from 'sentry/utils/requestError/requestError';
+
+jest.mock('sentry/actionCreators/indicator');
+jest.mock('sentry/actionCreators/group');
+
+describe('useHandleAssigneeChange', () => {
+  const group = GroupFixture({id: '1337'});
+  const organization = OrganizationFixture();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows specific error message when assignee update fails with permission error', async () => {
+    const permissionError: Partial<RequestError> = {
+      responseJSON: {
+        assignedTo: 'You do not have permission to assign this owner',
+      },
+    };
+
+    jest
+      .spyOn(groupActionCreators, 'assignToActor')
+      .mockRejectedValue(permissionError);
+
+    const {result} = renderHookWithProviders(() =>
+      useHandleAssigneeChange({
+        group,
+        organization,
+      })
+    );
+
+    result.current.handleAssigneeChange({
+      id: '123',
+      name: 'Test User',
+      type: 'user',
+      assignee: {id: '123', name: 'Test User', type: 'user'},
+    });
+
+    await waitFor(() => {
+      expect(addErrorMessage).toHaveBeenCalledWith(
+        'You do not have permission to assign this owner'
+      );
+    });
+  });
+
+  it('shows generic error message when assignee update fails without specific error', async () => {
+    const genericError: Partial<RequestError> = {
+      responseJSON: {},
+    };
+
+    jest
+      .spyOn(groupActionCreators, 'assignToActor')
+      .mockRejectedValue(genericError);
+
+    const {result} = renderHookWithProviders(() =>
+      useHandleAssigneeChange({
+        group,
+        organization,
+      })
+    );
+
+    result.current.handleAssigneeChange({
+      id: '123',
+      name: 'Test User',
+      type: 'user',
+      assignee: {id: '123', name: 'Test User', type: 'user'},
+    });
+
+    await waitFor(() => {
+      expect(addErrorMessage).toHaveBeenCalledWith('Failed to update assignee');
+    });
+  });
+});

--- a/static/app/components/group/assigneeSelector.spec.tsx
+++ b/static/app/components/group/assigneeSelector.spec.tsx
@@ -26,9 +26,7 @@ describe('useHandleAssigneeChange', () => {
       },
     };
 
-    jest
-      .spyOn(groupActionCreators, 'assignToActor')
-      .mockRejectedValue(permissionError);
+    jest.spyOn(groupActionCreators, 'assignToActor').mockRejectedValue(permissionError);
 
     const {result} = renderHookWithProviders(() =>
       useHandleAssigneeChange({
@@ -56,9 +54,7 @@ describe('useHandleAssigneeChange', () => {
       responseJSON: {},
     };
 
-    jest
-      .spyOn(groupActionCreators, 'assignToActor')
-      .mockRejectedValue(genericError);
+    jest.spyOn(groupActionCreators, 'assignToActor').mockRejectedValue(genericError);
 
     const {result} = renderHookWithProviders(() =>
       useHandleAssigneeChange({

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -62,8 +62,10 @@ export function useHandleAssigneeChange({
       }
       onSuccess?.(updatedGroup.assignedTo);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
+    onError: (error: any) => {
+      const errorMessage =
+        error?.responseJSON?.assignedTo ?? t('Failed to update assignee');
+      addErrorMessage(errorMessage);
     },
   });
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -355,8 +355,10 @@ function StreamGroup({
       }
       onAssigneeChange?.(newAssignee);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
+    onError: (error: any) => {
+      const errorMessage =
+        error?.responseJSON?.assignedTo ?? t('Failed to update assignee');
+      addErrorMessage(errorMessage);
     },
   });
 


### PR DESCRIPTION
Fixes ID-1308.

This PR improves the user experience by providing more descriptive error messages when an issue assignee update fails due to permission issues. Instead of a generic "Failed to update assignee", the UI will now display the specific error message from the API (e.g., "You do not have permission to assign this owner").

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1308](https://linear.app/getsentry/issue/ID-1308/non-descriptive-ui-error)

<a href="https://cursor.com/background-agent?bcId=bc-92b97781-63e4-4785-810a-5b32a115cc7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92b97781-63e4-4785-810a-5b32a115cc7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

