### PR TITLE
Codeowners frame prioritization

### DIFF
--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -107,7 +107,7 @@ class Rule(namedtuple("Rule", "matcher owners")):
     ) -> int | bool:
         """
         Test if this rule matches the event data and return the frame index.
-        
+
         Returns:
             - int: Frame index if a frame-based match (path, module, codeowners)
             - True: If a non-frame match (url, tags)
@@ -173,7 +173,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
     ) -> int | bool:
         """
         Test if this matcher matches the event data and return the frame index.
-        
+
         Returns:
             - int: Frame index if a frame-based match (path, module, codeowners)
             - True: If a non-frame match (url, tags)

--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -196,9 +196,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
                 # As such we need to match it using gitignore logic.
                 # See syntax documentation here:
                 # https://docs.github.com/en/github/creating-cloning-and-archoring-repositories/creating-a-repository-on-github/about-code-owners
-                match_frame_value_func=lambda val, pattern: bool(
-                    codeowners_match(val, pattern)
-                ),
+                match_frame_value_func=lambda val, pattern: bool(codeowners_match(val, pattern)),
                 match_frame_func=lambda frame: frame.get("in_app") is not False,
             )
         return False

--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -181,14 +181,14 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         """
         if self.type == URL:
             # URL matching doesn't have frame context, return True for backwards compatibility
-            return True if self.test_url(data) else False
+            return self.test_url(data)
         elif self.type == PATH:
             return self.test_frames(*munged_data)
         elif self.type == MODULE:
             return self.test_frames(find_stack_frames(data), ["module"])
         elif self.type.startswith("tags."):
             # Tag matching doesn't have frame context, return True for backwards compatibility
-            return True if self.test_tag(data) else False
+            return self.test_tag(data)
         elif self.type == CODEOWNERS:
             return self.test_frames(
                 *munged_data,
@@ -196,7 +196,9 @@ class Matcher(namedtuple("Matcher", "type pattern")):
                 # As such we need to match it using gitignore logic.
                 # See syntax documentation here:
                 # https://docs.github.com/en/github/creating-cloning-and-archoring-repositories/creating-a-repository-on-github/about-code-owners
-                match_frame_value_func=lambda val, pattern: bool(codeowners_match(val, pattern)),
+                match_frame_value_func=lambda val, pattern: bool(
+                    codeowners_match(val, pattern)
+                ),
                 match_frame_func=lambda frame: frame.get("in_app") is not False,
             )
         return False

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -441,7 +441,8 @@ class ProjectOwnership(Model):
         # Collect rules with their matched frame index
         matching_rules: list[tuple[Rule, int | bool, int]] = []
         for rule_index, rule in enumerate(rules):
-            frame_index_or_bool = rule.test(data, munged_data)
+            frame_index_or_bool = rule.test_with_frame_index(data, munged_data)
+            # Check explicitly for False to handle frame index 0 correctly
             if frame_index_or_bool is not False:
                 matching_rules.append((rule, frame_index_or_bool, rule_index))
 

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -958,12 +958,8 @@ class ResolveActorsTestCase(TestCase):
         """
         Test that when multiple rules match the SAME frame, the last rule wins.
         """
-        team1 = self.create_team(
-            organization=self.organization, slug="team1", members=[self.user]
-        )
-        team2 = self.create_team(
-            organization=self.organization, slug="team2", members=[self.user2]
-        )
+        team1 = self.create_team(organization=self.organization, slug="team1", members=[self.user])
+        team2 = self.create_team(organization=self.organization, slug="team2", members=[self.user2])
         project = self.create_project(organization=self.organization, teams=[team1, team2])
 
         # Two rules that match the same file pattern
@@ -999,14 +995,14 @@ class ResolveActorsTestCase(TestCase):
         Test frame prioritization with CODEOWNERS rules combined with ownership rules.
         """
         code_mapping = self.create_code_mapping(project=self.project)
-        
+
         integrations_team = self.create_team(
             organization=self.organization, slug="integrations-team", members=[self.user]
         )
         tasks_team = self.create_team(
             organization=self.organization, slug="tasks-team", members=[self.user2]
         )
-        
+
         # CODEOWNERS rule for tasks (would be "last rule wins" in old behavior)
         codeowners_rule = Rule(
             Matcher("codeowners", "app/tasks/*"), [Owner("team", tasks_team.slug)]
@@ -1017,7 +1013,7 @@ class ResolveActorsTestCase(TestCase):
             raw="app/tasks/* @tasks-team",
             schema=dump_schema([codeowners_rule]),
         )
-        
+
         # Ownership rule for integrations (appears after in combined schema)
         ownership_rule = Rule(
             Matcher("path", "app/integrations/*"), [Owner("team", integrations_team.slug)]


### PR DESCRIPTION
This PR resolves ID-1309 by implementing frame-based prioritization for issue ownership assignment.

Previously, ownership was determined solely by the rule's position in the CODEOWNERS file ("last rule wins"), ignoring the stack frame where the match occurred. This could lead to incorrect assignments where a deeper utility frame's rule overrode a more relevant rule matching a topmost frame.

With this change:
*   Rules are now prioritized by the stack frame they match: the topmost (closest to the error) in-app frame wins.
*   If multiple rules match the *same* frame, the existing "last rule wins" logic is applied.
*   Ownership rules are prioritized over CODEOWNERS rules when matching the same frame.

This ensures that issue ownership is assigned to the team responsible for the code where the error truly originated, aligning with user expectations.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1309](https://linear.app/getsentry/issue/ID-1309/prioritize-codeowners-assignment-by-stack-frame-position)

<a href="https://cursor.com/background-agent?bcId=bc-785ecd97-e8f5-4090-92ca-c44a7bebed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-785ecd97-e8f5-4090-92ca-c44a7bebed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

