### PR TITLE
Fix for Open Team Membership in OwnerActorField and error messaging

### DIFF
--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -80,7 +80,7 @@ class OwnerActorField(ActorField):
 
         # Fail closed
         if not user:
-            raise serializers.ValidationError("You do not have permission to assign this owner")
+            raise serializers.ValidationError("You can only assign teams you are a member of")
 
         # Check if user is a member of the target team
         user_is_target_team_member = OrganizationMemberTeam.objects.filter(
@@ -103,4 +103,4 @@ class OwnerActorField(ActorField):
             if user_is_current_team_member:
                 return
 
-        raise serializers.ValidationError("You do not have permission to assign this owner")
+        raise serializers.ValidationError("You can only assign teams you are a member of")

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -1074,7 +1074,7 @@ def validate_bulk_reassignment(
     user = user or getattr(request, "user", None)
     if not user or not getattr(user, "is_authenticated", False):
         raise serializers.ValidationError(
-            {"assignedTo": "You do not have permission to assign this owner"}
+            {"assignedTo": "You can only assign teams you are a member of"}
         )
 
     user_is_target_team_member = OrganizationMemberTeam.objects.filter(
@@ -1100,7 +1100,7 @@ def validate_bulk_reassignment(
         # Some groups are either unassigned or assigned to users (not teams)
         # User cannot reassign these to a team they're not a member of
         raise serializers.ValidationError(
-            {"assignedTo": "You do not have permission to assign this owner"}
+            {"assignedTo": "You can only assign teams you are a member of"}
         )
 
     current_team_ids = {
@@ -1118,7 +1118,7 @@ def validate_bulk_reassignment(
     # If any group is assigned to a team the user is not a member of, deny
     if current_team_ids - user_team_memberships:
         raise serializers.ValidationError(
-            {"assignedTo": "You do not have permission to assign this owner"}
+            {"assignedTo": "You can only assign teams you are a member of"}
         )
 
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -1052,6 +1052,7 @@ def validate_bulk_reassignment(
     Validate that the user has permission to assign a team to all groups.
 
     When assigning to a team, a user is permitted if any of the following are true:
+    - Open Team Membership is enabled for the organization, OR
     - They have team:admin scope, OR
     - They are a member of the target team, OR
     - ALL groups are currently assigned to teams the user is a member of
@@ -1059,6 +1060,12 @@ def validate_bulk_reassignment(
     """
     if assigned_actor is None or not assigned_actor.is_team:
         return
+
+    # If Open Team Membership is enabled, users can assign any team
+    if group_list:
+        organization = group_list[0].project.organization
+        if organization.flags.allow_joinleave:
+            return
 
     access = getattr(request, "access", None)
     if access and access.has_scope("team:admin"):

--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -101,7 +101,7 @@ export function assignToActor({
       return data;
     })
     .catch(data => {
-      GroupStore.onAssignToSuccess(guid, id, data);
+      GroupStore.onAssignToError(guid, id, data);
       throw data;
     });
 }

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -15,6 +15,7 @@ import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useMutation} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 
 interface AssigneeSelectorProps {
   assigneeLoading: boolean;
@@ -62,8 +63,17 @@ export function useHandleAssigneeChange({
       }
       onSuccess?.(updatedGroup.assignedTo);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
+    onError: (error: RequestError) => {
+      // Extract specific error message from API response
+      const assignedToError = error?.responseJSON?.assignedTo;
+      const detailError = error?.responseJSON?.detail;
+      const errorMessage =
+        typeof assignedToError === 'string'
+          ? assignedToError
+          : typeof detailError === 'string'
+            ? detailError
+            : t('Failed to update assignee');
+      addErrorMessage(errorMessage);
     },
   });
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -355,8 +355,17 @@ function StreamGroup({
       }
       onAssigneeChange?.(newAssignee);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
+    onError: (error: RequestError) => {
+      // Extract specific error message from API response
+      const assignedToError = error?.responseJSON?.assignedTo;
+      const detailError = error?.responseJSON?.detail;
+      const errorMessage =
+        typeof assignedToError === 'string'
+          ? assignedToError
+          : typeof detailError === 'string'
+            ? detailError
+            : t('Failed to update assignee');
+      addErrorMessage(errorMessage);
     },
   });
 

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -325,7 +325,11 @@ const storeConfig: GroupStoreDefinition = {
   // TODO(dcramer): This is not really the best place for this
   onAssignToError(_changeId, itemId, error) {
     this.clearStatus(itemId, 'assignTo');
-    if (error.responseJSON?.detail === 'Cannot assign to non-team member') {
+    // Handle field-specific validation errors (e.g., {"assignedTo": "error message"})
+    const assignedToError = error.responseJSON?.assignedTo;
+    if (typeof assignedToError === 'string') {
+      showAlert(assignedToError, 'error');
+    } else if (error.responseJSON?.detail === 'Cannot assign to non-team member') {
       showAlert(t('Cannot assign to non-team member'), 'error');
     } else {
       showAlert(t('Unable to change assignee. Please try again.'), 'error');

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -697,7 +697,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             **payload,
         )
         assert "owner" in response.data
-        assert str(response.data["owner"][0]) == "You do not have permission to assign this owner"
+        assert str(response.data["owner"][0]) == "You can only assign teams you are a member of"
 
     def test_team_owner_not_member_with_team_admin_scope(self) -> None:
         """Test that users with team:admin scope can assign a team they're not a member of as the owner"""

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -567,7 +567,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
         assert "owner" in response.data
-        assert str(response.data["owner"][0]) == "You do not have permission to assign this owner"
+        assert str(response.data["owner"][0]) == "You can only assign teams you are a member of"
 
     def test_team_owner_not_member_with_team_admin_scope(self) -> None:
         """Test that users with team:admin scope can assign a team they're not a member of as the owner"""

--- a/tests/sentry/api/fields/test_actor.py
+++ b/tests/sentry/api/fields/test_actor.py
@@ -112,7 +112,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -143,7 +143,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -164,7 +164,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -213,7 +213,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -249,7 +249,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1929,7 +1929,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         data["owner"] = f"team:{other_team.id}"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
-        assert resp.data == {"owner": ["You do not have permission to assign this owner"]}
+        assert resp.data == {"owner": ["You can only assign teams you are a member of"]}
 
     def test_owner_team_member_allowed(self) -> None:
         """

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -748,7 +748,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         assert response.data == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -379,7 +379,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         assert resp.data == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1286,7 +1286,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             **data,
             status_code=400,
         )
-        assert response.data == {"owner": ["You do not have permission to assign this owner"]}
+        assert response.data == {"owner": ["You can only assign teams you are a member of"]}
 
     def test_owner_team_member_allowed(self) -> None:
         """

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1265,6 +1265,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         Test that members cannot assign a team they are not a member of as owner.
         This is a regression test for an IDOR vulnerability.
         """
+        # Disable Open Team Membership so validation applies
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         other_team = self.create_team(organization=self.organization, name="other-team")
 
         user_with_team = self.create_user(is_superuser=False)
@@ -1320,6 +1324,34 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             teams=[self.team],
         )
         self.login_as(admin_user)
+
+        data = {**self.valid_data, "owner": f"team:{other_team.id}"}
+        response = self.get_success_response(
+            self.organization.slug,
+            **data,
+            status_code=201,
+        )
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.owner_team_id == other_team.id
+
+    def test_owner_team_open_membership_allows_any_team(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can assign any team as owner.
+        """
+        # Enable Open Team Membership
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
 
         data = {**self.valid_data, "owner": f"team:{other_team.id}"}
         response = self.get_success_response(

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1431,7 +1431,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         # Should fail because user is not a member of other_team
         assert response.status_code == 400, response.content
-        assert "do not have permission" in str(response.data) or "permission" in str(response.data)
+        assert "only assign teams you are a member of" in str(response.data)
         assert not GroupAssignee.objects.filter(group=group, team=other_team).exists()
 
     def test_assign_team_not_member_of_with_team_admin_scope(self) -> None:
@@ -1530,7 +1530,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         response = self.client.put(url, data={"assignedTo": f"team:{third_team.id}"})
 
         assert response.status_code == 400, response.content
-        assert "do not have permission" in str(response.data) or "permission" in str(response.data)
+        assert "only assign teams you are a member of" in str(response.data)
         # Issue should still be assigned to other_team
         assert GroupAssignee.objects.filter(group=group, team=other_team).exists()
         assert not GroupAssignee.objects.filter(group=group, team=third_team).exists()
@@ -1570,7 +1570,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         # Should fail - can't piggyback unassigned group on assigned group's permission
         assert response.status_code == 400, response.content
-        assert "do not have permission" in str(response.data) or "permission" in str(response.data)
+        assert "only assign teams you are a member of" in str(response.data)
         assert GroupAssignee.objects.filter(group=group1, team=member_team).exists()
         assert not GroupAssignee.objects.filter(group=group2).exists()
 

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1574,6 +1574,40 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert GroupAssignee.objects.filter(group=group1, team=member_team).exists()
         assert not GroupAssignee.objects.filter(group=group2).exists()
 
+    def test_assign_team_when_open_membership_enabled(self) -> None:
+        """
+        Test that a user CAN assign an issue to any team when Open Team Membership
+        is enabled, even if they are not a member of that team.
+        """
+        # Enable Open Membership
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        group = self.create_group()
+
+        # Create a member user who only belongs to a specific team
+        member_user = self.create_user("member@example.com")
+        member_team = self.create_team(organization=group.project.organization, name="member-team")
+        self.create_member(
+            user=member_user, organization=self.organization, role="member", teams=[member_team]
+        )
+        group.project.add_team(member_team)
+
+        # Create a second team that the member is NOT a member of
+        other_team = self.create_team(organization=group.project.organization, name="other-team")
+        group.project.add_team(other_team)
+
+        self.login_as(user=member_user)
+
+        url = f"{self.path}?id={group.id}"
+        response = self.client.put(url, data={"assignedTo": f"team:{other_team.id}"})
+
+        # Should succeed because Open Team Membership is enabled
+        assert response.status_code == 200, response.content
+        assert response.data["assignedTo"]["id"] == str(other_team.id)
+        assert response.data["assignedTo"]["type"] == "team"
+        assert GroupAssignee.objects.filter(group=group, team=other_team).exists()
+
     def test_discard(self) -> None:
         group1 = self.create_group(is_public=True)
         group2 = self.create_group(is_public=True)


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/106074 wasn't properly handling for open team membership despite the intention. This intends to resolve https://github.com/getsentry/sentry/issues/107226 & https://github.com/getsentry/sentry/issues/107326 by:
- Accounting for Open Team Membership being enabled OwnerActorField._validate_team_assignment() and validate_bulk_assignment() in the group index helpers
- Improving the UI messaging when the behavior is prevented by the access control
- Updating existing tests and adding new ones to ensure they're verified

Error messaging isn't perfect here because the OwnerActorField spans Issues, Monitors, Alerts, and Detectors but "You can only assign teams you are a member of" is still an improvement.