### PR TITLE
Fix for Open Team Membership in OwnerActorField and error messaging

### DIFF
--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -544,8 +544,10 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         assert rule.owner_user_id is None
 
     def test_team_owner_not_member(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         team = self.create_team(organization=self.organization)
-        # Create a non-privileged member user (without team:admin scope)
         member_user = self.create_user()
         self.create_member(
             user=member_user,
@@ -567,7 +569,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
         assert "owner" in response.data
-        assert str(response.data["owner"][0]) == "You do not have permission to assign this owner"
+        assert str(response.data["owner"][0]) == "You can only assign teams you are a member of"
 
     def test_team_owner_not_member_with_team_admin_scope(self) -> None:
         """Test that users with team:admin scope can assign a team they're not a member of as the owner"""

--- a/tests/sentry/api/fields/test_actor.py
+++ b/tests/sentry/api/fields/test_actor.py
@@ -62,7 +62,8 @@ class OwnerActorFieldTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # Create a second team that self.user is NOT a member of
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
         self.other_team = self.create_team(organization=self.organization, name="other-team")
 
     def test_accepts_user_owner_without_restriction(self) -> None:
@@ -109,7 +110,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -140,7 +141,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -161,7 +162,7 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -210,7 +211,41 @@ class OwnerActorFieldTest(TestCase):
         assert serializer.errors == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
+                    code="invalid",
+                )
+            ]
+        }
+
+    def test_open_team_membership_allows_any_team_assignment(self) -> None:
+        """When Open Team Membership is enabled, users can assign any team."""
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        request = self.make_request(user=self.user)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.other_team.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["owner"].id == self.other_team.id
+        assert serializer.validated_data["owner"].is_team
+
+    def test_open_team_membership_disabled_requires_membership(self) -> None:
+        """When Open Team Membership is disabled, membership validation applies."""
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        request = self.make_request(user=self.user)
+        serializer = DummyOwnerSerializer(
+            data={"owner": f"team:{self.other_team.id}"},
+            context={"organization": self.organization, "request": request},
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "owner": [
+                ErrorDetail(
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -722,6 +722,9 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         Test that members cannot assign a team they are not a member of as owner.
         This is a regression test for an IDOR vulnerability.
         """
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         other_team = self.create_team(organization=self.organization, name="other-team")
 
         user_with_team = self.create_user(is_superuser=False)
@@ -744,7 +747,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         assert response.data == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -788,6 +791,35 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
             teams=[self.team],
         )
         self.login_as(admin_user)
+
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+            "owner": f"team:{other_team.id}",
+        }
+        response = self.get_success_response(self.organization.slug, **data)
+        monitor = Monitor.objects.get(slug=response.data["slug"])
+        assert monitor.owner_team_id == other_team.id
+
+    def test_owner_team_open_membership_allows_any_team(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can assign any team as owner.
+        """
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
 
         data = {
             "project": self.project.slug,

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -348,10 +348,11 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         Test that members cannot assign a team they are not a member of as owner.
         This is a regression test for an IDOR vulnerability.
         """
-        # Create a second team that the user is NOT a member of
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         other_team = self.create_team(organization=self.organization, name="other-team")
 
-        # Create a user who is only a member of the project's team
         user_with_team = self.create_user(is_superuser=False)
         self.create_member(
             user=user_with_team,
@@ -361,7 +362,6 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         )
         self.login_as(user_with_team)
 
-        # Attempt to create an uptime monitor with the other team as owner
         resp = self.get_error_response(
             self.organization.slug,
             self.project.slug,
@@ -375,7 +375,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         assert resp.data == {
             "owner": [
                 ErrorDetail(
-                    string="You do not have permission to assign this owner",
+                    string="You can only assign teams you are a member of",
                     code="invalid",
                 )
             ]
@@ -385,7 +385,6 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         """
         Test that members CAN assign a team they are a member of as owner.
         """
-        # Create a user who is a member of the project's team
         user_with_team = self.create_user(is_superuser=False)
         self.create_member(
             user=user_with_team,
@@ -395,7 +394,6 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         )
         self.login_as(user_with_team)
 
-        # Should succeed since user is a member of self.team
         resp = self.get_success_response(
             self.organization.slug,
             self.project.slug,
@@ -412,10 +410,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         """
         Test that users with team:admin scope CAN assign any team as owner.
         """
-        # Create a second team that the user is NOT a member of
         other_team = self.create_team(organization=self.organization, name="other-team")
 
-        # Create a user with admin role (has team:admin scope)
         admin_user = self.create_user(is_superuser=False)
         self.create_member(
             user=admin_user,
@@ -425,7 +421,36 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         )
         self.login_as(admin_user)
 
-        # Admin should be able to assign any team as owner
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            url="http://sentry.io",
+            interval_seconds=60,
+            timeout_ms=1500,
+            owner=f"team:{other_team.id}",
+        )
+        detector = Detector.objects.get(id=resp.data["id"])
+        assert detector.owner_team_id == other_team.id
+
+    def test_owner_team_open_membership_allows_any_team(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can assign any team as owner.
+        """
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+
+        user_with_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_with_team,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user_with_team)
+
         resp = self.get_success_response(
             self.organization.slug,
             self.project.slug,


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/106074 wasn't properly handling for open team membership despite the intention. This intends to resolve https://github.com/getsentry/sentry/issues/107226 & https://github.com/getsentry/sentry/issues/107326 by:
- Accounting for Open Team Membership being enabled OwnerActorField._validate_team_assignment() and validate_bulk_assignment() in the group index helpers
- Improving the UI messaging when the behavior is prevented by the access control
- Updating existing tests and adding new ones to ensure they're verified

Error messaging isn't perfect here because the OwnerActorField spans Issues, Monitors, Alerts, and Detectors but "You can only assign teams you are a member of" is still an improvement.

Front end change to follow it 