### PR TITLE
fix(ui): Display specific API error messages for assignment failures

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -101,7 +101,7 @@ export function assignToActor({
       return data;
     })
     .catch(data => {
-      GroupStore.onAssignToSuccess(guid, id, data);
+      GroupStore.onAssignToError(guid, id, data);
       throw data;
     });
 }

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {assignToActor, clearAssignment} from 'sentry/actionCreators/group';
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {AssigneeBadge} from 'sentry/components/assigneeBadge';
 import AssigneeSelectorDropdown, {
   type AssignableEntity,
@@ -62,9 +61,8 @@ export function useHandleAssigneeChange({
       }
       onSuccess?.(updatedGroup.assignedTo);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
-    },
+    // Error is already handled by GroupStore.onAssignToError which shows an alert
+    onError: () => {},
   });
 
   return {handleAssigneeChange, assigneeLoading};

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -6,7 +6,6 @@ import type {LocationDescriptor} from 'history';
 import {Stack} from '@sentry/scraps/layout';
 
 import {assignToActor, clearAssignment} from 'sentry/actionCreators/group';
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {AssignableEntity} from 'sentry/components/assigneeSelectorDropdown';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import GroupStatusChart from 'sentry/components/charts/groupStatusChart';
@@ -355,9 +354,8 @@ function StreamGroup({
       }
       onAssigneeChange?.(newAssignee);
     },
-    onError: () => {
-      addErrorMessage('Failed to update assignee');
-    },
+    // Error is already handled by GroupStore.onAssignToError which shows an alert
+    onError: () => {},
   });
 
   const clickHasBeenHandled = useCallback(

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -331,7 +331,7 @@ const storeConfig: GroupStoreDefinition = {
     } else if (typeof assignedToError === 'string') {
       showAlert(assignedToError, 'error');
     } else if (error.responseJSON?.detail) {
-showAlert(error.responseJSON?.detail, 'error');
+      showAlert(error.responseJSON?.detail, 'error');
     } else {
       showAlert(t('Unable to change assignee. Please try again.'), 'error');
     }

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -325,7 +325,12 @@ const storeConfig: GroupStoreDefinition = {
   // TODO(dcramer): This is not really the best place for this
   onAssignToError(_changeId, itemId, error) {
     this.clearStatus(itemId, 'assignTo');
-    if (error.responseJSON?.detail === 'Cannot assign to non-team member') {
+    const assignedToError = error.responseJSON?.assignedTo;
+    if (Array.isArray(assignedToError) && assignedToError.length > 0) {
+      showAlert(assignedToError[0], 'error');
+    } else if (typeof assignedToError === 'string') {
+      showAlert(assignedToError, 'error');
+    } else if (error.responseJSON?.detail === 'Cannot assign to non-team member') {
       showAlert(t('Cannot assign to non-team member'), 'error');
     } else {
       showAlert(t('Unable to change assignee. Please try again.'), 'error');

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import IndicatorStore from 'sentry/stores/indicatorStore';
 import type {Activity, BaseGroup, Group, GroupStats} from 'sentry/types/group';
 import toArray from 'sentry/utils/array/toArray';
+import parseApiError from 'sentry/utils/parseApiError';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
 import SelectedGroupStore from './selectedGroupStore';
@@ -331,7 +332,7 @@ const storeConfig: GroupStoreDefinition = {
     } else if (typeof assignedToError === 'string') {
       showAlert(assignedToError, 'error');
     } else if (error.responseJSON?.detail) {
-      showAlert(error.responseJSON?.detail, 'error');
+      showAlert(parseApiError(error), 'error');
     } else {
       showAlert(t('Unable to change assignee. Please try again.'), 'error');
     }

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -330,8 +330,8 @@ const storeConfig: GroupStoreDefinition = {
       showAlert(assignedToError[0], 'error');
     } else if (typeof assignedToError === 'string') {
       showAlert(assignedToError, 'error');
-    } else if (error.responseJSON?.detail === 'Cannot assign to non-team member') {
-      showAlert(t('Cannot assign to non-team member'), 'error');
+    } else if (error.responseJSON?.detail) {
+showAlert(error.responseJSON?.detail, 'error');
     } else {
       showAlert(t('Unable to change assignee. Please try again.'), 'error');
     }


### PR DESCRIPTION
The front-end half of https://github.com/getsentry/sentry/pull/107333 
- Extract error from responseJSON.assignedTo or responseJSON.detail
- Fix incorrect method call in group actionCreator error handler
- Shows descriptive error instead of generic 'Failed to update assignee'