### PR TITLE
fix(preprod): Add back attributes to featureFilter

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -19,12 +19,12 @@ import {useFeatureFilter} from './useFeatureFilter';
 
 const EXAMPLE_BUILDS_COUNT = 5;
 const FEATURE_FILTER_ALLOWED_KEYS = [
-  // 'app_id',
-  // 'app_name',
+  'app_id',
+  'app_name',
   'build_configuration_name',
-  // 'platform_name',
-  // 'build_number',
-  // 'build_version',
+  'platform_name',
+  'build_number',
+  'build_version',
   'git_head_ref',
   'git_base_ref',
   'git_head_sha',


### PR DESCRIPTION
Now the filtering has moved to later in the pipeline we can reenable the attributes that
depend on preprocessing.