### PR TITLE
fix(tests): Remove incorrect message.parameter.0 expectation

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -199,7 +199,6 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 organization=self.organization,
                 project=self.project,
                 attributes={
-                    "sentry.message.parameter.0": {"bool_value": 1},
                     "sentry.message.parameter.1": {"int_value": 5},
                     "sentry.message.parameter.2": {"double_value": 10},
                     "sentry.message.parameter.value": {"double_value": 15},

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -299,14 +299,6 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 "secondaryAliases": ["log.severity_number"],
             },
             {
-                "key": "tags[message.parameter.0,number]",
-                "name": "message.parameter.0",
-                "attributeSource": {
-                    "source_type": "sentry",
-                    "is_transformed_alias": True,
-                },
-            },
-            {
                 "key": "tags[message.parameter.1,number]",
                 "name": "message.parameter.1",
                 "attributeSource": {


### PR DESCRIPTION
## Summary
- Remove incorrect `message.parameter.0` expectation from the trace item attributes logs test
- This is in relation to stop double writing bools as floats in Snuba https://github.com/getsentry/snuba/pull/7689

## Test plan
- CI should pass with updated test expectations