### PR TITLE
fix(dashboards): dashboard remounts on url changes

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1000,6 +1000,7 @@ class DashboardDetail extends Component<Props, State> {
                     organization={organization}
                     eventView={EventView.fromLocation(location)}
                     location={location}
+                    hideLoadingIndicator
                   >
                     {metricsDataSide => (
                       <MEPSettingProvider
@@ -1176,6 +1177,7 @@ class DashboardDetail extends Component<Props, State> {
                           organization={organization}
                           eventView={eventView}
                           location={location}
+                          hideLoadingIndicator
                         >
                           {metricsDataSide => (
                             <MEPSettingProvider

--- a/static/app/views/performance/landing/metricsDataSwitcher.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.tsx
@@ -60,7 +60,7 @@ export function MetricsDataSwitcher(props: MetricDataSwitchProps) {
       <MetricsSwitchHandler
         eventView={props.eventView}
         location={props.location}
-        outcome={metricsCardinality.outcome ?? {forceTransactionsOnly: true}}
+        outcome={metricsCardinality.outcome ?? {forceTransactionsOnly: false}}
         switcherChildren={props.children}
       />
     </Fragment>

--- a/static/app/views/performance/landing/metricsDataSwitcher.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.tsx
@@ -53,22 +53,14 @@ export function MetricsDataSwitcher(props: MetricDataSwitchProps) {
     );
   }
 
-  if (!metricsCardinality.outcome) {
-    return (
-      <Fragment>
-        {props.children({
-          forceTransactionsOnly: true,
-        })}
-      </Fragment>
-    );
-  }
-
+  // Always use MetricsSwitchHandler for consistent component structure
+  // to prevent remounting children when outcome changes
   return (
     <Fragment>
       <MetricsSwitchHandler
         eventView={props.eventView}
         location={props.location}
-        outcome={metricsCardinality.outcome}
+        outcome={metricsCardinality.outcome ?? {forceTransactionsOnly: true}}
         switcherChildren={props.children}
       />
     </Fragment>


### PR DESCRIPTION
It seems that sometimes the url would change trigger the `Dashboard` component to remount, this would sometimes result in widget queries being cancelled by useQuery. 

The reason for remounting is because when the project filter changed, metricsCardinality would briefly have `outcome: undefined`, and then get a new outcome. This resulted in the component tree being updated.