### PR TITLE
feat(tracemetrics): Pull multiple aggregates into table

### DIFF
--- a/static/app/views/explore/metrics/hooks/testUtils.tsx
+++ b/static/app/views/explore/metrics/hooks/testUtils.tsx
@@ -1,16 +1,32 @@
 import type {ReactNode} from 'react';
 
-import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  defaultMetricQuery,
+  type BaseMetricQuery,
+  type TraceMetric,
+} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 
-export function MockMetricQueryParamsContext({children}: {children: ReactNode}) {
-  const mockQueryParams = defaultMetricQuery();
+interface MockMetricQueryParamsContextProps {
+  children: ReactNode;
+  metricQuery?: Partial<BaseMetricQuery>;
+  traceMetric?: TraceMetric;
+}
+
+export function MockMetricQueryParamsContext({
+  children,
+  metricQuery,
+  traceMetric = {name: 'mockMetric', type: 'counter'},
+}: MockMetricQueryParamsContextProps) {
+  const defaultQuery = defaultMetricQuery();
+  const queryParams = metricQuery?.queryParams ?? defaultQuery.queryParams;
+
   return (
     <MultiMetricsQueryParamsProvider>
       <MetricsQueryParamsProvider
-        traceMetric={{name: 'mockMetric', type: 'counter'}}
-        queryParams={mockQueryParams.queryParams}
+        traceMetric={traceMetric}
+        queryParams={queryParams}
         setQueryParams={() => {}}
         setTraceMetric={() => {}}
         removeMetric={() => {}}

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
@@ -3,9 +3,13 @@ import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 jest.mock('sentry/utils/usePageFilters');
 
@@ -41,20 +45,17 @@ describe('useMetricAggregatesTable', () => {
       ],
       method: 'GET',
     });
-    renderHookWithProviders(
-      () =>
-        useMetricAggregatesTable({
-          traceMetric: {
-            name: 'test metric',
-            type: 'counter',
-          },
-          limit: 100,
-          enabled: true,
-        }),
-      {
-        additionalWrapper: MockMetricQueryParamsContext,
-      }
-    );
+    renderHookWithProviders(useMetricAggregatesTable, {
+      initialProps: {
+        traceMetric: {
+          name: 'test metric',
+          type: 'counter',
+        },
+        limit: 100,
+        enabled: true,
+      },
+      additionalWrapper: MockMetricQueryParamsContext,
+    });
 
     expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);
     expect(mockNormalRequestUrl).toHaveBeenCalledWith(
@@ -74,6 +75,134 @@ describe('useMetricAggregatesTable', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
+        }),
+      })
+    );
+  });
+
+  it('includes multiple yAxis fields when multiple visualizes are configured', async () => {
+    const visualize1 = new VisualizeFunction('avg(value)');
+    const visualize2 = new VisualizeFunction('sum(value)');
+    const visualize3 = new VisualizeFunction('count(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [visualize1, visualize2, visualize3],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{id: '1'}],
+        meta: {fields: {}},
+      },
+      method: 'GET',
+    });
+
+    renderHookWithProviders(useMetricAggregatesTable, {
+      initialProps: {
+        traceMetric: {name: 'test-metric', type: 'counter'},
+        limit: 100,
+        enabled: true,
+      },
+      additionalWrapper: ({children}) => (
+        <MockMetricQueryParamsContext
+          metricQuery={{queryParams}}
+          traceMetric={{name: 'test-metric', type: 'counter'}}
+        >
+          {children}
+        </MockMetricQueryParamsContext>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    // Verify all three yAxis fields are included in the request
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          field: expect.arrayContaining([
+            'avg(value)',
+            'sum(value)',
+            'count(value)',
+            // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
+            expect.stringMatching(/^count\(metric\.name,test-metric,counter,-\)$/),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('includes groupBys and all visualize yAxes in fields', async () => {
+    const groupBy1: GroupBy = {groupBy: 'environment'};
+    const groupBy2: GroupBy = {groupBy: 'service'};
+    const visualize1 = new VisualizeFunction('avg(value)');
+    const visualize2 = new VisualizeFunction('p95(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [groupBy1, groupBy2, visualize1, visualize2],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{id: '1'}],
+        meta: {fields: {}},
+      },
+      method: 'GET',
+    });
+
+    renderHookWithProviders(useMetricAggregatesTable, {
+      initialProps: {
+        traceMetric: {name: 'test-metric', type: 'distribution'},
+        limit: 100,
+        enabled: true,
+      },
+      additionalWrapper: ({children}) => (
+        <MockMetricQueryParamsContext
+          metricQuery={{queryParams}}
+          traceMetric={{name: 'test-metric', type: 'distribution'}}
+        >
+          {children}
+        </MockMetricQueryParamsContext>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    // Verify groupBys come first, then visualize yAxes, plus the count aggregate
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          field: expect.arrayContaining([
+            'environment',
+            'service',
+            'avg(value)',
+            'p95(value)',
+            // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
+            expect.stringMatching(/^count\(metric\.name,test-metric,distribution,-\)$/),
+          ]),
         }),
       })
     );

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
@@ -81,9 +81,9 @@ describe('useMetricAggregatesTable', () => {
   });
 
   it('includes multiple yAxis fields when multiple visualizes are configured', async () => {
-    const visualize1 = new VisualizeFunction('avg(value)');
-    const visualize2 = new VisualizeFunction('sum(value)');
-    const visualize3 = new VisualizeFunction('count(value)');
+    const visualize1 = new VisualizeFunction('avg(value,test-metric,-)');
+    const visualize2 = new VisualizeFunction('sum(value,test-metric,-)');
+    const visualize3 = new VisualizeFunction('count(value,test-metric,-)');
 
     const queryParams = new ReadableQueryParams({
       extrapolate: true,
@@ -132,9 +132,9 @@ describe('useMetricAggregatesTable', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           field: expect.arrayContaining([
-            'avg(value)',
-            'sum(value)',
-            'count(value)',
+            'avg(value,test-metric,-)',
+            'sum(value,test-metric,-)',
+            'count(value,test-metric,-)',
             // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
             expect.stringMatching(/^count\(metric\.name,test-metric,counter,-\)$/),
           ]),
@@ -146,8 +146,8 @@ describe('useMetricAggregatesTable', () => {
   it('includes groupBys and all visualize yAxes in fields', async () => {
     const groupBy1: GroupBy = {groupBy: 'environment'};
     const groupBy2: GroupBy = {groupBy: 'service'};
-    const visualize1 = new VisualizeFunction('avg(value)');
-    const visualize2 = new VisualizeFunction('p95(value)');
+    const visualize1 = new VisualizeFunction('avg(value,test-metric,-)');
+    const visualize2 = new VisualizeFunction('p95(value,test-metric,-)');
 
     const queryParams = new ReadableQueryParams({
       extrapolate: true,
@@ -158,7 +158,7 @@ describe('useMetricAggregatesTable', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [groupBy1, groupBy2, visualize1, visualize2],
-      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+      aggregateSortBys: [{field: 'avg(value,test-metric,-)', kind: 'desc'}],
     });
 
     const mockRequest = MockApiClient.addMockResponse({
@@ -198,8 +198,8 @@ describe('useMetricAggregatesTable', () => {
           field: expect.arrayContaining([
             'environment',
             'service',
-            'avg(value)',
-            'p95(value)',
+            'avg(value,test-metric,-)',
+            'p95(value,test-metric,-)',
             // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
             expect.stringMatching(/^count\(metric\.name,test-metric,distribution,-\)$/),
           ]),

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -11,7 +11,7 @@ import {
   type RPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {useMetricVisualizes} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
 import {
@@ -81,7 +81,8 @@ function useMetricAggregatesTableImp({
   queryExtras,
 }: UseMetricAggregatesTableOptions): MetricAggregatesTableResult {
   const {selection} = usePageFilters();
-  const visualize = useMetricVisualize();
+  const visualizes = useMetricVisualizes();
+
   const groupBys = useQueryParamsGroupBys();
   const query = useQueryParamsQuery();
   const sortBys = useQueryParamsAggregateSortBys();
@@ -97,12 +98,14 @@ function useMetricAggregatesTableImp({
     }
 
     // Add the yAxis aggregate
-    if (visualize.yAxis && !allFields.includes(visualize.yAxis)) {
-      allFields.push(visualize.yAxis);
+    for (const visualize of visualizes) {
+      if (visualize.yAxis && !allFields.includes(visualize.yAxis)) {
+        allFields.push(visualize.yAxis);
+      }
     }
 
     return allFields.filter(Boolean);
-  }, [groupBys, visualize.yAxis]);
+  }, [groupBys, visualizes]);
 
   const eventView = useMemo(() => {
     const discoverQuery: NewQuery = {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -1,0 +1,241 @@
+import type {ReactNode} from 'react';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {
+  createTraceMetricFixtures,
+  initializeTraceMetricsTest,
+} from 'sentry-fixture/tracemetrics';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+jest.mock('sentry/utils/usePageFilters');
+
+function createWrapper({
+  queryParams,
+  traceMetric,
+}: {
+  queryParams: ReadableQueryParams;
+  traceMetric: TraceMetric;
+}) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return (
+      <MultiMetricsQueryParamsProvider>
+        <MetricsQueryParamsProvider
+          traceMetric={traceMetric}
+          queryParams={queryParams}
+          setQueryParams={() => {}}
+          setTraceMetric={() => {}}
+          removeMetric={() => {}}
+        >
+          {children}
+        </MetricsQueryParamsProvider>
+      </MultiMetricsQueryParamsProvider>
+    );
+  };
+}
+
+describe('AggregatesTab', () => {
+  const {organization, project, setupPageFilters, setupEventsMock} =
+    initializeTraceMetricsTest({
+      orgFeatures: ['tracemetrics-enabled'],
+    });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+    setupPageFilters();
+
+    // Mock the trace-items attributes endpoint
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('renders table with only aggregate columns', async () => {
+    const traceMetric: TraceMetric = {name: 'test-metric', type: 'distribution'};
+    const visualize1 = new VisualizeFunction('avg(value)');
+    const visualize2 = new VisualizeFunction('sum(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [visualize1, visualize2],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-aggregates-table',
+      }),
+    ]);
+
+    render(<AggregatesTab traceMetric={traceMetric} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    // Wait for the table to render with header cells
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', {name: /avg/i})).toBeInTheDocument();
+    });
+
+    // Both aggregate columns should be present
+    expect(screen.getByRole('columnheader', {name: /sum/i})).toBeInTheDocument();
+  });
+
+  it('renders table with groupBys and aggregate columns', async () => {
+    const traceMetric: TraceMetric = {name: 'test-metric', type: 'distribution'};
+    const groupBy1: GroupBy = {groupBy: 'environment'};
+    const groupBy2: GroupBy = {groupBy: 'service'};
+    const visualize1 = new VisualizeFunction('avg(value)');
+    const visualize2 = new VisualizeFunction('p95(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [groupBy1, groupBy2, visualize1, visualize2],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupEventsMock(
+      metricFixtures.detailedFixtures.map(f => ({
+        ...f,
+        environment: 'production',
+        service: 'api',
+      })),
+      [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ]
+    );
+
+    render(<AggregatesTab traceMetric={traceMetric} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    // Wait for the table to render
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', {name: /environment/i})
+      ).toBeInTheDocument();
+    });
+
+    // GroupBy columns
+    expect(screen.getByRole('columnheader', {name: /service/i})).toBeInTheDocument();
+
+    // Aggregate columns
+    expect(screen.getByRole('columnheader', {name: /avg/i})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: /p95/i})).toBeInTheDocument();
+  });
+
+  it('shows empty state when no data is returned', async () => {
+    const traceMetric: TraceMetric = {name: 'test-metric', type: 'distribution'};
+    const visualize1 = new VisualizeFunction('avg(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [visualize1],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    // Return empty data
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [],
+        meta: {fields: {}, dataScanned: 'full'},
+      },
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ],
+    });
+
+    render(<AggregatesTab traceMetric={traceMetric} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    // Wait for the empty state
+    await waitFor(() => {
+      expect(screen.getByText('No aggregates found')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when request fails', async () => {
+    const traceMetric: TraceMetric = {name: 'test-metric', type: 'distribution'};
+    const visualize1 = new VisualizeFunction('avg(value)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [visualize1],
+      aggregateSortBys: [{field: 'avg(value)', kind: 'desc'}],
+    });
+
+    // Return error response
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      statusCode: 500,
+      body: {detail: 'Internal Server Error'},
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ],
+    });
+
+    render(<AggregatesTab traceMetric={traceMetric} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    // Wait for the error state
+    await waitFor(() => {
+      expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -80,16 +80,30 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 
   const meta = result.meta ?? {};
 
+  // Count how many groupBy fields are actually in the fields array
+  const groupByFieldCount = groupBys.filter(g => g && fields.includes(g)).length;
+
   const tableStyle = useMemo(() => {
+    const aggregateFieldCount = fields.length - groupByFieldCount;
+
+    // First aggregate column gets 1fr, pushing remaining aggregates to the right
+    if (groupByFieldCount > 0 && aggregateFieldCount > 0) {
+      // groupBys: auto ... auto | aggregates: 1fr auto ... auto
+      const groupByColumns = `repeat(${groupByFieldCount}, auto)`;
+      const aggregateColumns =
+        aggregateFieldCount > 1 ? `1fr repeat(${aggregateFieldCount - 1}, auto)` : '1fr';
+      return {gridTemplateColumns: `${groupByColumns} ${aggregateColumns}`};
+    }
+    if (aggregateFieldCount > 1) {
+      // Only aggregates: 1fr auto ... auto
+      return {gridTemplateColumns: `1fr repeat(${aggregateFieldCount - 1}, auto)`};
+    }
+    // Single column or only groupBys
     return {
       gridTemplateColumns:
-        groupBys.length > 1
-          ? `repeat(${groupBys.length - 1}, auto) auto 1fr`
-          : groupBys.length === 1
-            ? 'auto 1fr'
-            : '1fr',
+        fields.length > 1 ? `repeat(${fields.length - 1}, auto) 1fr` : '1fr',
     };
-  }, [groupBys.length]);
+  }, [fields.length, groupByFieldCount]);
 
   const firstColumnOffset = useMemo(() => {
     return groupBys.length > 0 ? '15px' : '8px';
@@ -97,6 +111,21 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 
   const isLastColumn = (index: number) => {
     return index === fields.length - 1;
+  };
+
+  // Dividers: between last groupBy and first aggregate, and between all aggregates
+  const shouldShowDivider = (index: number) => {
+    // Last groupBy before aggregates
+    if (index > 0 && index < groupByFieldCount) {
+      return true;
+    }
+
+    // Between aggregate columns (not the last one), we use fields here because we need the total number of columns
+    if (index > groupByFieldCount && index < fields.length) {
+      return true;
+    }
+
+    return false;
   };
 
   // Detect horizontal scroll to conditionally show sticky column shadow
@@ -182,8 +211,9 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           return (
             <StickyCompatibleStyledHeaderCell
               key={i}
-              divider={!isLastColumn(i)}
+              divider={shouldShowDivider(i)}
               data-sticky-column={isLastColumn(i) ? 'true' : 'false'}
+              isAggregate={Boolean(func)}
               isSticky={isLastColumn(i)}
               sort={direction}
               handleSortClick={updateSort}
@@ -211,6 +241,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
                 <StickyCompatibleStyledRowCell
                   key={j}
                   data-sticky-column={isLastColumn(j) ? 'true' : 'false'}
+                  isAggregate={Boolean(parseFunction(field))}
                   isSticky={isLastColumn(j)}
                   offset={j === 0 ? firstColumnOffset : undefined}
                 >
@@ -252,9 +283,10 @@ const StickyCompatibleStyledHeader = styled(StyledSimpleTableHeader)`
 `;
 
 const StickyCompatibleStyledHeaderCell = styled(StyledSimpleTableHeaderCell)<{
+  isAggregate: boolean;
   isSticky: boolean;
 }>`
-  justify-content: ${p => (p.isSticky ? 'flex-end' : 'flex-start')};
+  justify-content: ${p => (p.isAggregate ? 'flex-end' : 'flex-start')};
   padding: ${p => (p.noPadding ? 0 : p.theme.space.lg)};
   padding-top: ${p => (p.noPadding ? 0 : p.theme.space.xs)};
   padding-bottom: ${p => (p.noPadding ? 0 : p.theme.space.xs)};
@@ -270,9 +302,15 @@ const StickyCompatibleStyledHeaderCell = styled(StyledSimpleTableHeaderCell)<{
 `;
 
 const StickyCompatibleStyledRowCell = styled(StyledSimpleTableRowCell)<{
+  isAggregate: boolean;
   isSticky: boolean;
   offset?: string;
 }>`
+  ${p =>
+    p.isAggregate &&
+    css`
+      justify-content: flex-end;
+    `}
   ${p =>
     p.offset &&
     css`

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -80,12 +80,10 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 
   const meta = result.meta ?? {};
 
-  // Count how many groupBy fields are actually in the fields array
-  const groupByFieldCount = groupBys.filter(g => g && fields.includes(g)).length;
+  const groupByFieldCount = groupBys.length;
+  const aggregateFieldCount = fields.length - groupByFieldCount;
 
   const tableStyle = useMemo(() => {
-    const aggregateFieldCount = fields.length - groupByFieldCount;
-
     // First aggregate column gets 1fr, pushing remaining aggregates to the right
     if (groupByFieldCount > 0 && aggregateFieldCount > 0) {
       // groupBys: auto ... auto | aggregates: 1fr auto ... auto
@@ -103,7 +101,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
       gridTemplateColumns:
         fields.length > 1 ? `repeat(${fields.length - 1}, auto) 1fr` : '1fr',
     };
-  }, [fields.length, groupByFieldCount]);
+  }, [aggregateFieldCount, fields.length, groupByFieldCount]);
 
   const firstColumnOffset = useMemo(() => {
     return groupBys.length > 0 ? '15px' : '8px';


### PR DESCRIPTION
This PR updates the aggregates hook and table for metrics to pull in multiple aggregates when they're present. Just to note, clicking on any of the aggregate headers does update the ordering of the data.

Ticket: LOGS-557

Example:
<img width="492" height="348" alt="Screenshot 2026-01-30 at 14 27 47" src="https://github.com/user-attachments/assets/b05c730e-18ef-42c9-b933-a05e1528ea41" />