### PR TITLE
fix(trace): Improve trace performance

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import sentry_sdk
@@ -138,54 +139,65 @@ class Spans(rpc_dataset_common.RPCBase):
         start_time = int(time.time())
         MAX_ITERATIONS = options.get("performance.traces.pagination.max-iterations")
         MAX_TIMEOUT = options.get("performance.traces.pagination.max-timeout")
-        for _ in range(MAX_ITERATIONS):
-            response = snuba_rpc.get_trace_rpc(request)
-            with sentry_sdk.start_span(op="process.rpc_response"):
-                columns_by_name = {col.proto_definition.name: col for col in columns}
-                for item_group in response.item_groups:
-                    for span_item in item_group.items:
-                        span: dict[str, Any] = {
-                            "id": span_item.id,
-                            "children": [],
-                            "errors": [],
-                            "occurrences": [],
-                            "event_type": "span",
-                        }
-                        for attribute in span_item.attributes:
-                            resolved_column = columns_by_name[attribute.key.name]
-                            if resolved_column.proto_definition.type == STRING:
-                                span[resolved_column.public_alias] = attribute.value.val_str
-                            elif resolved_column.proto_definition.type == DOUBLE:
-                                span[resolved_column.public_alias] = attribute.value.val_double
-                            elif resolved_column.search_type == "boolean":
-                                span[resolved_column.public_alias] = (
-                                    attribute.value.val_bool or attribute.value.val_int == 1
-                                )
-                            elif resolved_column.proto_definition.type == BOOLEAN:
-                                span[resolved_column.public_alias] = attribute.value.val_bool
 
-                            elif resolved_column.proto_definition.type == INT:
-                                span[resolved_column.public_alias] = attribute.value.val_int
-                                if resolved_column.public_alias == "project.id":
-                                    span["project.slug"] = resolver.params.project_id_map.get(
-                                        span[resolved_column.public_alias], "Unknown"
-                                    )
-                        spans.append(span)
-                if response.page_token.end_pagination:
-                    break
-                if MAX_TIMEOUT > 0 and time.time() - start_time > MAX_TIMEOUT:
-                    # If timeout is not set then logging this is not helpful
-                    rpc_debug_json = json.loads(MessageToJson(request))
-                    logger.info(
-                        "running a trace query timed out while paginating",
-                        extra={
-                            "rpc_query": rpc_debug_json,
-                            "referrer": request.meta.referrer,
-                            "trace_item_type": request.meta.trace_item_type,
-                        },
-                    )
-                    break
-                request.page_token.CopyFrom(response.page_token)
+        @sentry_sdk.tracing.trace
+        def process_item_groups(item_groups):
+            for item_group in response.item_groups:
+                for span_item in item_group.items:
+                    span: dict[str, Any] = {
+                        "id": span_item.id,
+                        "children": [],
+                        "errors": [],
+                        "occurrences": [],
+                        "event_type": "span",
+                    }
+                    for attribute in span_item.attributes:
+                        resolved_column = columns_by_name[attribute.key.name]
+                        if resolved_column.proto_definition.type == STRING:
+                            span[resolved_column.public_alias] = attribute.value.val_str
+                        elif resolved_column.proto_definition.type == DOUBLE:
+                            span[resolved_column.public_alias] = attribute.value.val_double
+                        elif resolved_column.search_type == "boolean":
+                            span[resolved_column.public_alias] = (
+                                attribute.value.val_bool or attribute.value.val_int == 1
+                            )
+                        elif resolved_column.proto_definition.type == BOOLEAN:
+                            span[resolved_column.public_alias] = attribute.value.val_bool
+
+                        elif resolved_column.proto_definition.type == INT:
+                            span[resolved_column.public_alias] = attribute.value.val_int
+                            if resolved_column.public_alias == "project.id":
+                                span["project.slug"] = resolver.params.project_id_map.get(
+                                    span[resolved_column.public_alias], "Unknown"
+                                )
+                    spans.append(span)
+
+        response = snuba_rpc.get_trace_rpc(request)
+        for _ in range(MAX_ITERATIONS):
+            columns_by_name = {col.proto_definition.name: col for col in columns}
+            thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=2)
+            if response.page_token.end_pagination:
+                # always need to process the last response
+                process_item_groups(response.item_groups)
+                break
+            if MAX_TIMEOUT > 0 and time.time() - start_time > MAX_TIMEOUT:
+                # If timeout is not set then logging this is not helpful
+                rpc_debug_json = json.loads(MessageToJson(request))
+                logger.info(
+                    "running a trace query timed out while paginating",
+                    extra={
+                        "rpc_query": rpc_debug_json,
+                        "referrer": request.meta.referrer,
+                        "trace_item_type": request.meta.trace_item_type,
+                    },
+                )
+                break
+            request.page_token.CopyFrom(response.page_token)
+            # We want to process the spans while querying the next page
+            with thread_pool:
+                _ = thread_pool.submit(process_item_groups, response.item_groups)
+                response_future = thread_pool.submit(snuba_rpc.get_trace_rpc, request)
+            response = response_future.result()
         return spans
 
     @classmethod

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -285,8 +285,8 @@ class OrganizationEventsTraceEndpointTest(
     @override_options(
         {
             "performance.traces.pagination.max-iterations": 30,
-            "performance.traces.pagination.max-timeout": 15,
-            "performance.traces.pagination.query-limit": 5,
+            "performance.traces.pagination.max-timeout": 150,
+            "performance.traces.pagination.query-limit": 1,
         }
     )
     def test_pagination(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -285,7 +285,7 @@ class OrganizationEventsTraceEndpointTest(
     @override_options(
         {
             "performance.traces.pagination.max-iterations": 30,
-            "performance.traces.pagination.max-timeout": 150,
+            "performance.traces.pagination.max-timeout": 15,
             "performance.traces.pagination.query-limit": 1,
         }
     )


### PR DESCRIPTION
- Process spans while querying the next page so that we're not doing all the work in serial, which should give us a minor speed up
- in the example below we should save ~2s since the `process.rpc_response` spans would happen during the `snuba_rpc.run` spans
<img width="1738" height="371" alt="image" src="https://github.com/user-attachments/assets/8fdb45dc-d2c7-410a-8c62-9fbbc7615664" />
