### PR TITLE
feat(grouping): Add `{{ message }}` fingerprint test input

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/custom-fingerprint-message-parameterization.json
+++ b/tests/sentry/grouping/grouping_inputs/custom-fingerprint-message-parameterization.json
@@ -1,0 +1,12 @@
+{
+  "fingerprint": ["{{ message }}", "dogs are great"],
+  "exception": {
+    "values": [
+      {
+        "type": "FailedToFetchError",
+        "value": "FailedToFetchError: Charlie didn't bring 2 balls back!"
+      }
+    ]
+  },
+  "platform": "javascript"
+}

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,26 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: fingerprint
+hashing_metadata: {
+  "client_fingerprint": "['{{ message }}', 'dogs are great']",
+  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring 2 balls back!\", 'dogs are great']",
+  "fingerprint_source": "client",
+  "is_hybrid_fingerprint": false
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "fingerprint",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.fingerprint": {
+    "fingerprint_source": "client"
+  }
+}
+---
+contributing variants:
+  custom_fingerprint*
+    hash: "69d81763f9ec386fc0c0607ef62cabfa"
+    fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
+    values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,26 @@
+---
+source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_variants
+---
+hash_basis: fingerprint
+hashing_metadata: {
+  "client_fingerprint": "['{{ message }}', 'dogs are great']",
+  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring 2 balls back!\", 'dogs are great']",
+  "fingerprint_source": "client",
+  "is_hybrid_fingerprint": false
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "fingerprint",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.fingerprint": {
+    "fingerprint_source": "client"
+  }
+}
+---
+contributing variants:
+  custom_fingerprint*
+    hash: "69d81763f9ec386fc0c0607ef62cabfa"
+    fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
+    values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,73 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_exception_message": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because custom client fingerprint takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "FailedToFetchError"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": "stripped event-specific values",
+                "id": "value",
+                "name": null,
+                "values": [
+                  "FailedToFetchError: Charlie didn't bring <int> balls back!"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": []
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "exception message",
+      "hash": null,
+      "hint": "ignored because custom client fingerprint takes precedence",
+      "key": "app_exception_message",
+      "type": "component"
+    },
+    "custom_fingerprint": {
+      "client_values": [
+        "{{ message }}",
+        "dogs are great"
+      ],
+      "contributes": true,
+      "description": "custom fingerprint",
+      "hash": "69d81763f9ec386fc0c0607ef62cabfa",
+      "hint": null,
+      "key": "custom_fingerprint",
+      "type": "custom_fingerprint",
+      "values": [
+        "FailedToFetchError: Charlie didn't bring 2 balls back!",
+        "dogs are great"
+      ]
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,73 @@
+---
+source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
+---
+{
+  "grouping_config": "newstyle:2026-01-20",
+  "variants": {
+    "app_exception_message": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because custom client fingerprint takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "FailedToFetchError"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": "stripped event-specific values",
+                "id": "value",
+                "name": null,
+                "values": [
+                  "FailedToFetchError: Charlie didn't bring <int> balls back!"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": []
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "exception message",
+      "hash": null,
+      "hint": "ignored because custom client fingerprint takes precedence",
+      "key": "app_exception_message",
+      "type": "component"
+    },
+    "custom_fingerprint": {
+      "client_values": [
+        "{{ message }}",
+        "dogs are great"
+      ],
+      "contributes": true,
+      "description": "custom fingerprint",
+      "hash": "69d81763f9ec386fc0c0607ef62cabfa",
+      "hint": null,
+      "key": "custom_fingerprint",
+      "type": "custom_fingerprint",
+      "values": [
+        "FailedToFetchError: Charlie didn't bring 2 balls back!",
+        "dogs are great"
+      ]
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,19 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: exception
+  hint: ignored because custom client fingerprint takes precedence
+  root_component:
+    app (ignored because custom client fingerprint takes precedence)
+      exception*
+        type*
+          "FailedToFetchError"
+        value* (stripped event-specific values)
+          "FailedToFetchError: Charlie didn't bring <int> balls back!"
+--------------------------------------------------------------------------
+custom_fingerprint:
+  hash: "69d81763f9ec386fc0c0607ef62cabfa"
+  fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
+  values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -1,0 +1,19 @@
+---
+source: tests/sentry/grouping/test_variants.py::test_variants
+---
+app:
+  hash: null
+  contributing component: exception
+  hint: ignored because custom client fingerprint takes precedence
+  root_component:
+    app (ignored because custom client fingerprint takes precedence)
+      exception*
+        type*
+          "FailedToFetchError"
+        value* (stripped event-specific values)
+          "FailedToFetchError: Charlie didn't bring <int> balls back!"
+--------------------------------------------------------------------------
+custom_fingerprint:
+  hash: "69d81763f9ec386fc0c0607ef62cabfa"
+  fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
+  values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]


### PR DESCRIPTION
This adds a new test input for grouping to illustrate what happens when a custom fingerprint includes the `{{ message }}` variable. Right now we don't parameterize the message, which can lead to a million different custom fingerprints being created. This is soon to be fixed, and already having this test in place will make it easier to see the effects of the change when it happens.