### PR TITLE
fix(discover): Disable context menu for starred transaction cell

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -197,6 +197,12 @@ function makeCellActions({
     return null;
   }
 
+  // Starred transaction has it's own action on click
+  // so we don't want it to collide with the context menu
+  if (column.name === 'is_starred_transaction') {
+    return null;
+  }
+
   let value = dataRow[column.name];
 
   // error.handled is a strange field where null = true.


### PR DESCRIPTION
## Summary
- Disables the context menu (view samples, open in explore) for the starred transaction cell
- The starred transaction cell has its own click action to star/unstar transactions, so the context menu was interfering with this behavior

## Test plan
- Click on a starred transaction cell in the discover table
- Verify no context menu appears (previously showed "view samples", "open in explore" options)
- Verify the star/unstar functionality still works as expected