### PR TITLE
feat(seer): Stop overriding enable_seer_coding when migrating from legacy to new seer plans

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 from sentry import features, quotas, tagstore
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.constants import DataCategory, ObjectStatus
+from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory, ObjectStatus
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
 from sentry.issues.grouptype import WebVitalsGroup
@@ -457,7 +457,7 @@ def _call_autofix(
                 "comment_on_pr_with_url": pr_to_comment_on_url,
                 "auto_run_source": auto_run_source,
                 "disable_coding_step": not group.organization.get_option(
-                    "sentry:enable_seer_coding", default=True
+                    "sentry:enable_seer_coding", default=ENABLE_SEER_CODING_DEFAULT
                 ),
                 "stopping_point": stopping_point,
             },

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -149,17 +149,20 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     Configure Seer settings for a new or existing organization migrating to new Seer pricing.
 
     Sets:
-    - Org-level: enable_seer_coding=True - to override old check
+    - Org-level: enable_seer_coding=True
     - Project-level (all projects): seer_scanner_automation=True, autofix_automation_tuning="medium" or "off"
     - Seer API (all projects): automated_run_stopping_point="code_changes" or "open_pr"
+
+    Ignores:
+    - Org-level: enable_seer_coding
     """
+
     organization = Organization.objects.get(id=organization_id)
 
     sentry_sdk.set_tag("organization_id", organization.id)
     sentry_sdk.set_tag("organization_slug", organization.slug)
 
     # Set org-level options
-    organization.update_option("sentry:enable_seer_coding", True)
     organization.update_option(
         "sentry:default_autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
     )

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -149,7 +149,6 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     Configure Seer settings for a new or existing organization migrating to new Seer pricing.
 
     Sets:
-    - Org-level: enable_seer_coding=True
     - Project-level (all projects): seer_scanner_automation=True, autofix_automation_tuning="medium" or "off"
     - Seer API (all projects): automated_run_stopping_point="code_changes" or "open_pr"
 

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -202,7 +202,6 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
         # Check org-level options
-        assert self.organization.get_option("sentry:enable_seer_coding") is True
         assert self.organization.get_option("sentry:default_autofix_automation_tuning") == "medium"
 
         # Check project-level options


### PR DESCRIPTION
Related to CW-731