### PR TITLE
ref(grouping): Move message normalization to utils

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -15,24 +15,6 @@ from sentry.interfaces.message import Message
 if TYPE_CHECKING:
     from sentry.services.eventstore.models import Event
 
-REGEX_PATTERN_KEYS = (
-    "email",
-    "url",
-    "hostname",
-    "ip",
-    "traceparent",
-    "uuid",
-    "sha1",
-    "md5",
-    "date",
-    "duration",
-    "hex",
-    "float",
-    "int",
-    "quoted_str",
-    "bool",
-)
-
 
 @strategy(ids=["message:v1"], interface=Message, score=0)
 @produces_variants(["default"])

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 from sentry.grouping.component import MessageGroupingComponent
-from sentry.grouping.parameterization import Parameterizer
 from sentry.grouping.strategies.base import (
     ComponentsByVariant,
     GroupingContext,
     produces_variants,
     strategy,
 )
+from sentry.grouping.utils import normalize_message_for_grouping
 from sentry.interfaces.message import Message
-from sentry.options.rollout import in_rollout_group
-from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.services.eventstore.models import Event
@@ -35,36 +32,6 @@ REGEX_PATTERN_KEYS = (
     "quoted_str",
     "bool",
 )
-
-
-@metrics.wraps("grouping.normalize_message_for_grouping")
-def normalize_message_for_grouping(message: str, event: Event) -> str:
-    """Replace values from a group's message with placeholders (to hide P.I.I. and
-    improve grouping when no stacktrace is available) and trim to at most 2 lines.
-    """
-    trimmed = "\n".join(
-        # If there are multiple lines, grab the first two non-empty ones.
-        islice(
-            (x for x in message.splitlines() if x.strip()),
-            2,
-        )
-    )
-    if trimmed != message:
-        trimmed += "..."
-
-    parameterizer = Parameterizer(
-        regex_pattern_keys=REGEX_PATTERN_KEYS,
-        experimental=in_rollout_group("grouping.experimental_parameterization", event.project_id),
-    )
-
-    normalized = parameterizer.parameterize_all(trimmed)
-
-    for key, value in parameterizer.matches_counter.items():
-        # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
-        # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
-        metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
-
-    return normalized
 
 
 @strategy(ids=["message:v1"], interface=Message, score=0)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -30,9 +30,8 @@ from sentry.grouping.strategies.base import (
     call_with_variants,
     strategy,
 )
-from sentry.grouping.strategies.message import normalize_message_for_grouping
 from sentry.grouping.strategies.utils import has_url_origin, remove_non_stacktrace_variants
-from sentry.grouping.utils import hash_from_values
+from sentry.grouping.utils import hash_from_values, normalize_message_for_grouping
 from sentry.interfaces.exception import Exception as ChainedException
 from sentry.interfaces.exception import Mechanism, SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -62,6 +62,10 @@ def bool_from_string(value: str) -> bool | None:
     return None
 
 
+# TODO: Both here during trimming and in the message strategy (where we check if the message has
+# been changed), we assume the kind of change which has happened. Here we add "...", and there we
+# say we "stripped event-specific values," even if all we've done in either case is remove empty
+# lines.
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(message: str, event: Event) -> str:
     """

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -68,8 +68,8 @@ def normalize_message_for_grouping(message: str, event: Event) -> str:
     Replace values from a event's message with placeholders (in order to improve grouping) and trim
     to at most 2 lines.
     """
+    # If there are multiple lines, grab the first two non-empty ones
     trimmed = "\n".join(
-        # If there are multiple lines, grab the first two non-empty ones.
         islice(
             (x for x in message.splitlines() if x.strip()),
             2,

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -68,6 +68,11 @@ def normalize_message_for_grouping(message: str, event: Event) -> str:
     Replace values from a event's message with placeholders (in order to improve grouping) and trim
     to at most 2 lines.
     """
+    parameterizer = Parameterizer(
+        regex_pattern_keys=REGEX_PATTERN_KEYS,
+        experimental=in_rollout_group("grouping.experimental_parameterization", event.project_id),
+    )
+
     # If there are multiple lines, grab the first two non-empty ones
     trimmed = "\n".join(
         islice(
@@ -77,11 +82,6 @@ def normalize_message_for_grouping(message: str, event: Event) -> str:
     )
     if trimmed != message:
         trimmed += "..."
-
-    parameterizer = Parameterizer(
-        regex_pattern_keys=REGEX_PATTERN_KEYS,
-        experimental=in_rollout_group("grouping.experimental_parameterization", event.project_id),
-    )
 
     normalized = parameterizer.parameterize_all(trimmed)
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -64,8 +64,9 @@ def bool_from_string(value: str) -> bool | None:
 
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(message: str, event: Event) -> str:
-    """Replace values from a group's message with placeholders (to hide P.I.I. and
-    improve grouping when no stacktrace is available) and trim to at most 2 lines.
+    """
+    Replace values from a event's message with placeholders (in order to improve grouping) and trim
+    to at most 2 lines.
     """
     trimmed = "\n".join(
         # If there are multiple lines, grab the first two non-empty ones.

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -9,13 +9,30 @@ from uuid import UUID
 from django.utils.encoding import force_bytes
 
 from sentry.grouping.parameterization import Parameterizer
-from sentry.grouping.strategies.message import REGEX_PATTERN_KEYS
 from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
     from sentry.services.eventstore.models import Event
+
+REGEX_PATTERN_KEYS = (
+    "email",
+    "url",
+    "hostname",
+    "ip",
+    "traceparent",
+    "uuid",
+    "sha1",
+    "md5",
+    "date",
+    "duration",
+    "hex",
+    "float",
+    "int",
+    "quoted_str",
+    "bool",
+)
 
 
 def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingComponent]) -> str:

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sentry.grouping.parameterization import Parameterizer
-from sentry.grouping.strategies.message import REGEX_PATTERN_KEYS
+from sentry.grouping.utils import REGEX_PATTERN_KEYS
 
 
 @pytest.fixture


### PR DESCRIPTION
This moves the `normalize_message_for_grouping` helper (and the `REGEX_PATTERN_KEYS` constant it uses) from the message strategy module to the utils module, since it is soon going to be used in more places besides just the message strategy. A few cosmetic changes (tweaking the docstring, initializing the parameterizer earlier, adding a TODO, etc.) have also been made.