### PR TITLE
fix(uptime): Preserve null assertions when editing monitors with feature flag off

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -208,6 +208,12 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
         if (!methodHasBody(formModel)) {
           formModel.setValue('body', null);
         }
+        // When assertions feature is disabled, the UptimeAssertionsField isn't rendered,
+        // so the field's getValue transform doesn't run. Preserve the original assertion
+        // value to avoid overwriting null assertions with the empty default structure.
+        if (!organization.features.includes('uptime-runtime-assertions')) {
+          formModel.setValue('assertion', rule?.assertion ?? null);
+        }
       }}
       extraButton={
         <Flex gap="md">

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -22,7 +22,7 @@ import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryPro
 import TextareaField from 'sentry/components/forms/fields/textareaField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import FormModel from 'sentry/components/forms/model';
+import FormModel, {type FieldValue} from 'sentry/components/forms/model';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
@@ -212,7 +212,7 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
         // so the field's getValue transform doesn't run. Preserve the original assertion
         // value to avoid overwriting null assertions with the empty default structure.
         if (!organization.features.includes('uptime-runtime-assertions')) {
-          formModel.setValue('assertion', rule?.assertion ?? null);
+          formModel.setValue('assertion', (rule?.assertion ?? null) as FieldValue);
         }
       }}
       extraButton={

--- a/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.spec.tsx
@@ -174,6 +174,40 @@ describe('uptimeFormDataToEndpointPayload', () => {
     expect(payload.config.recoveryThreshold).toBe(UPTIME_DEFAULT_RECOVERY_THRESHOLD);
     expect(payload.config.downtimeThreshold).toBe(UPTIME_DEFAULT_DOWNTIME_THRESHOLD);
   });
+
+  it('converts empty assertion structure to null', () => {
+    // When the assertions field isn't rendered (feature flag off), the empty
+    // assertion structure from savedDetectorToFormData persists. This should
+    // be converted to null before sending to the API.
+    const formData = {
+      name: 'Test Monitor',
+      owner: 'user:1',
+      projectId: '123',
+      workflowIds: [],
+      description: null,
+      intervalSeconds: 60,
+      method: 'GET',
+      timeoutMs: 10000,
+      traceSampling: false,
+      url: 'https://example.com',
+      headers: [],
+      body: '',
+      assertion: {
+        root: {
+          op: 'and' as const,
+          id: 'empty-root',
+          children: [],
+        },
+      },
+      recoveryThreshold: 1,
+      downtimeThreshold: 3,
+      environment: 'production',
+    };
+
+    const payload = uptimeFormDataToEndpointPayload(formData);
+
+    expect(payload.dataSources[0]?.assertion).toBeNull();
+  });
 });
 
 describe('uptimeSavedDetectorToFormData', () => {

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -72,6 +72,12 @@ export function useUptimeDetectorFormField<T extends UptimeDetectorFormFieldName
 export function uptimeFormDataToEndpointPayload(
   data: UptimeDetectorFormData
 ): UptimeDetectorUpdatePayload {
+  // Convert empty assertion structure to null. This handles the case when:
+  // 1. The assertions field isn't rendered (feature flag off) - the field's getValue
+  //    transform doesn't run, so the empty structure from savedDetectorToFormData persists
+  // 2. The user deleted all assertions (getValue in the field also does this conversion)
+  const assertion = data.assertion?.root?.children?.length === 0 ? null : data.assertion;
+
   return {
     type: 'uptime_domain_failure',
     name: data.name || 'New Monitor',
@@ -88,7 +94,7 @@ export function uptimeFormDataToEndpointPayload(
         url: data.url,
         headers: data.headers,
         body: data.body || null,
-        assertion: data.assertion,
+        assertion,
       },
     ],
     config: {


### PR DESCRIPTION
## Summary
- When editing uptime monitors with the `uptime-runtime-assertions` feature flag disabled, null assertions were being overwritten with an empty default structure
- This fix preserves null assertions by adding checks in both the uptime alert form and detector form flows

## Root Cause
When the feature flag is OFF:
1. The `UptimeAssertionsField` component is not rendered
2. The field's `getValue` transform (which converts empty children to null) never runs
3. The empty assertion structure from `getFormDataFromRule`/`uptimeSavedDetectorToFormData` gets submitted to the backend

## Changes
1. **uptimeAlertForm.tsx**: Added `onPreSubmit` logic to restore the original assertion value when the feature flag is off
2. **fields.tsx**: Added conversion of empty assertion structures to null in `uptimeFormDataToEndpointPayload`

Fixes [NEW-724](https://linear.app/getsentry/issue/NEW-724)

## Test plan
- [x] Existing tests pass
- [ ] Manually verify editing an uptime monitor with null assertions preserves null when feature flag is off