### PR TITLE
Annotate tests based on `staff.ga-rollout` status

### DIFF
--- a/tests/sentry/relocation/api/endpoints/artifacts/test_details.py
+++ b/tests/sentry/relocation/api/endpoints/artifacts/test_details.py
@@ -96,6 +96,7 @@ class GetRelocationArtifactDetailsGoodTest(GetRelocationArtifactDetailsTest):
             pem=self.pub_key_pem.decode("utf-8")
         )
 
+    @override_options({"staff.ga-rollout": False})
     @patch("sentry.backup.crypto.KeyManagementServiceClient")
     def test_good_unencrypted_with_superuser(self, fake_kms_client: mock.Mock) -> None:
         self.mock_kms_client(fake_kms_client)
@@ -108,6 +109,7 @@ class GetRelocationArtifactDetailsGoodTest(GetRelocationArtifactDetailsTest):
             response.data["contents"] == f'"runs/{self.relocation.uuid}/somedir/file.json"'.encode()
         )
 
+    @override_options({"staff.ga-rollout": False})
     @patch("sentry.backup.crypto.KeyManagementServiceClient")
     def test_good_encrypted_with_superuser(self, fake_kms_client: mock.Mock) -> None:
         self.mock_kms_client(fake_kms_client)
@@ -163,6 +165,7 @@ class GetRelocationArtifactDetailsBadTest(GetRelocationArtifactDetailsTest):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), "somedir", "file.json", status_code=403)
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_disabled(self) -> None:
         self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.superuser, superuser=False)
@@ -180,6 +183,7 @@ class GetRelocationArtifactDetailsBadTest(GetRelocationArtifactDetailsTest):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), "somedir", "file.json", status_code=403)
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_has_superuser_but_no_relocation_admin_permission(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
 

--- a/tests/sentry/relocation/api/endpoints/artifacts/test_index.py
+++ b/tests/sentry/relocation/api/endpoints/artifacts/test_index.py
@@ -73,6 +73,7 @@ class GetRelocationArtifactsGoodTest(GetRelocationArtifactsTest):
         self.relocation_storage.save(f"{dir}/out/baseline-config.tar", StringIO("1234567890abcd"))
         self.relocation_storage.save(f"{dir}/out/colliding-users.tar", StringIO("1234567890abcde"))
 
+    @override_options({"staff.ga-rollout": False})
     def test_good_with_superuser(self) -> None:
         self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.superuser, superuser=True)
@@ -108,6 +109,7 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
         self.get_error_response(str(self.relocation.uuid), status_code=403)
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_disabled(self) -> None:
         self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.superuser, superuser=False)
@@ -127,6 +129,7 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
         self.get_error_response(str(self.relocation.uuid), status_code=403)
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_has_superuser_but_no_relocation_admin_permission(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
 

--- a/tests/sentry/relocation/api/endpoints/test_abort.py
+++ b/tests/sentry/relocation/api/endpoints/test_abort.py
@@ -45,6 +45,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
+    @override_options({"staff.ga-rollout": False})
     def test_good_superuser_abort_in_progress(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -64,6 +65,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
+    @override_options({"staff.ga-rollout": False})
     def test_good_superuser_abort_paused(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -83,6 +85,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_already_succeeded(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
@@ -102,6 +105,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_already_failed(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
@@ -117,6 +121,7 @@ class AbortRelocationTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_not_found(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
@@ -127,9 +132,11 @@ class AbortRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.get_error_response(self.relocation.uuid, status_code=403)
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_no_auth(self) -> None:
         self.get_error_response(self.relocation.uuid, status_code=401)
 
-    def test_bad_no_superuser(self) -> None:
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_no_staff(self) -> None:
         self.login_as(user=self.superuser, superuser=False)
         self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/relocation/api/endpoints/test_cancel.py
+++ b/tests/sentry/relocation/api/endpoints/test_cancel.py
@@ -24,10 +24,10 @@ class CancelRelocationTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.IN_PROGRESS.value,
             step=Relocation.Step.PREPROCESSING.value,
@@ -49,16 +49,18 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_cancel_in_progress_at_next_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
 
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_cancel_paused_at_next_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
         response = self.get_success_response(self.relocation.uuid, status_code=200)
@@ -67,8 +69,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_cancel_in_progress_at_specified_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
@@ -77,8 +80,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_cancel_paused_at_specified_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
         response = self.get_success_response(
@@ -89,8 +93,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_cancel_at_future_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.relocation.uuid, atStep=Relocation.Step.NOTIFYING.name, status_code=200
         )
@@ -99,8 +104,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.NOTIFYING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_already_cancelled(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.scheduled_cancel_at_step = Relocation.Step.IMPORTING.value
         self.relocation.save()
         response = self.get_success_response(
@@ -111,8 +117,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
+    @override_options({"staff.ga-rollout": True})
     def test_good_already_failed(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
         response = self.get_success_response(
@@ -123,13 +130,15 @@ class CancelRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert not response.data["scheduledCancelAtStep"]
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_not_found(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(does_not_exist_uuid, status_code=404)
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_already_succeeded(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -137,8 +146,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_CANCELLABLE_STATUS
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_invalid_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep="nonexistent", status_code=400
         )
@@ -148,8 +158,9 @@ class CancelRelocationTest(APITestCase):
             step="nonexistent"
         )
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_unknown_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.UNKNOWN.name, status_code=400
         )
@@ -159,8 +170,9 @@ class CancelRelocationTest(APITestCase):
             step=Relocation.Step.UNKNOWN.name
         )
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_current_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.PREPROCESSING.name, status_code=400
         )
@@ -168,8 +180,9 @@ class CancelRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_past_step(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.UPLOADING.name, status_code=400
         )
@@ -179,8 +192,9 @@ class CancelRelocationTest(APITestCase):
             step=Relocation.Step.UPLOADING.name
         )
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_last_step_specified(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.COMPLETED.name, status_code=400
         )
@@ -190,8 +204,9 @@ class CancelRelocationTest(APITestCase):
             step=Relocation.Step.COMPLETED.name
         )
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_last_step_automatic(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.NOTIFYING.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -199,9 +214,11 @@ class CancelRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_no_auth(self) -> None:
         self.get_error_response(self.relocation.uuid, status_code=401)
 
-    def test_bad_no_superuser(self) -> None:
-        self.login_as(user=self.superuser, superuser=False)
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_no_staff(self) -> None:
+        self.login_as(user=self.staff_user, staff=False)
         self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/relocation/api/endpoints/test_public_key.py
+++ b/tests/sentry/relocation/api/endpoints/test_public_key.py
@@ -27,10 +27,10 @@ class GetRelocationPublicKeyTest(APITestCase):
             pem=self.pub_key_pem.decode("utf-8")
         )
 
-    @override_options({"relocation.enabled": True})
-    def test_good_superuser_when_feature_enabled(self, fake_kms_client: mock.Mock) -> None:
-        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
-        self.login_as(user=superuser, superuser=True)
+    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
+    def test_good_staff_user_when_feature_enabled(self, fake_kms_client: mock.Mock) -> None:
+        staff_user = self.create_user("staff_user", is_staff=True, is_active=True)
+        self.login_as(user=staff_user, staff=True)
         self.mock_kms_client(fake_kms_client)
         response = self.get_success_response(status_code=200)
 
@@ -38,9 +38,10 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data["public_key"].encode() == self.pub_key_pem
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
-    def test_good_superuser_when_feature_disabled(self, fake_kms_client: mock.Mock) -> None:
-        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
-        self.login_as(user=superuser, superuser=True)
+    @override_options({"staff.ga-rollout": True})
+    def test_good_staff_user_when_feature_disabled(self, fake_kms_client: mock.Mock) -> None:
+        staff_user = self.create_user("staff_user", is_staff=True, is_active=True)
+        self.login_as(user=staff_user, staff=True)
         self.mock_kms_client(fake_kms_client)
         response = self.get_success_response(status_code=200)
 
@@ -70,7 +71,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data["public_key"].encode() == self.pub_key_pem
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
-    @override_options({"relocation.enabled": True})
+    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
     def test_good_regular_user_when_feature_enabled(self, fake_kms_client: mock.Mock) -> None:
         self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
@@ -80,6 +81,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data["public_key"].encode() == self.pub_key_pem
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
+    @override_options({"staff.ga-rollout": True})
     def test_bad_regular_user_when_feature_disabled(self, fake_kms_client: mock.Mock) -> None:
         self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
@@ -89,7 +91,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
         assert fake_kms_client.return_value.get_public_key.call_count == 0
 
-    @override_options({"relocation.enabled": True})
+    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
     def test_bad_kms_network_error(self, fake_kms_client: mock.Mock) -> None:
         self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
@@ -99,13 +101,14 @@ class GetRelocationPublicKeyTest(APITestCase):
 
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
-    @override_options({"relocation.enabled": True})
+    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
     def test_bad_no_auth(self, fake_kms_client: mock.Mock) -> None:
         self.mock_kms_client(fake_kms_client)
         self.get_error_response(status_code=401)
 
         assert fake_kms_client.return_value.get_public_key.call_count == 0
 
+    @override_options({"staff.ga-rollout": False})
     def test_bad_superuser_missing_cookie_when_feature_disabled(
         self, fake_kms_client: mock.Mock
     ) -> None:

--- a/tests/sentry/relocation/api/endpoints/test_unpause.py
+++ b/tests/sentry/relocation/api/endpoints/test_unpause.py
@@ -24,11 +24,10 @@ class UnpauseRelocationTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(is_superuser=True)
         self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.PAUSE.value,
             step=Relocation.Step.PREPROCESSING.value,
@@ -55,9 +54,10 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_good_unpause_until_validating(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.relocation.uuid, untilStep=Relocation.Step.VALIDATING.name, status_code=200
         )
@@ -69,9 +69,10 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.validating_start.delay")
     def test_good_unpause_until_importing(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.VALIDATING.value
         self.relocation.save()
         response = self.get_success_response(
@@ -85,9 +86,10 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.importing.delay")
     def test_good_unpause_until_postprocessing(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.IMPORTING.value
         self.relocation.save()
         response = self.get_success_response(
@@ -101,9 +103,10 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.postprocessing.delay")
     def test_good_unpause_until_notifying(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.POSTPROCESSING.value
         self.relocation.save()
         response = self.get_success_response(
@@ -117,9 +120,10 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_good_change_pending_pause_later(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.IN_PROGRESS.value
         self.relocation.step = Relocation.Step.VALIDATING.value
         self.relocation.scheduled_pause_at_step = Relocation.Step.POSTPROCESSING.value
@@ -134,9 +138,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_good_change_pending_pause_sooner(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.IN_PROGRESS.value
         self.relocation.step = Relocation.Step.VALIDATING.value
         self.relocation.scheduled_pause_at_step = Relocation.Step.POSTPROCESSING.value
@@ -151,9 +156,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_good_remove_pending_pause(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.IN_PROGRESS.value
         self.relocation.step = Relocation.Step.VALIDATING.value
         self.relocation.scheduled_pause_at_step = Relocation.Step.POSTPROCESSING.value
@@ -167,9 +173,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.notifying_unhide.delay")
     def test_good_unpause_no_follow_up_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.NOTIFYING.value
         self.relocation.save()
         response = self.get_success_response(self.relocation.uuid, status_code=200)
@@ -182,15 +189,17 @@ class UnpauseRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_not_found(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(does_not_exist_uuid, status_code=404)
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_already_completed(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -202,9 +211,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_already_paused(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.IN_PROGRESS.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -216,9 +226,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_invalid_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, untilStep="nonexistent", status_code=400
         )
@@ -230,9 +241,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_unknown_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, untilStep=Relocation.Step.UNKNOWN.name, status_code=400
         )
@@ -244,9 +256,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_current_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, untilStep=Relocation.Step.PREPROCESSING.name, status_code=400
         )
@@ -258,9 +271,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_past_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, untilStep=Relocation.Step.UPLOADING.name, status_code=400
         )
@@ -272,9 +286,10 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_last_step(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, untilStep=Relocation.Step.COMPLETED.name, status_code=400
         )
@@ -286,15 +301,17 @@ class UnpauseRelocationTest(APITestCase):
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_bad_no_auth(self, async_task_scheduled: Mock) -> None:
         self.get_error_response(self.relocation.uuid, status_code=401)
 
         assert async_task_scheduled.call_count == 0
 
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
-    def test_bad_no_superuser(self, async_task_scheduled: Mock) -> None:
-        self.login_as(user=self.superuser, superuser=False)
+    def test_bad_no_staff(self, async_task_scheduled: Mock) -> None:
+        self.login_as(user=self.staff_user, staff=False)
         self.get_error_response(self.relocation.uuid, status_code=403)
 
         assert async_task_scheduled.call_count == 0

--- a/tests/sentry/relocation/api/serializers/test_relocation.py
+++ b/tests/sentry/relocation/api/serializers/test_relocation.py
@@ -18,10 +18,8 @@ class RelocationSerializerTest(TestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
-        self.login_as(user=self.superuser, superuser=True)
+        self.staff_user = self.create_user("staff_user", is_staff=True, is_active=True)
+        self.login_as(user=self.staff_user, staff=True)
 
         self.first_imported_user = self.create_user(email="first@example.com")
         self.second_imported_user = self.create_user(email="second@example.com")
@@ -57,7 +55,7 @@ class RelocationSerializerTest(TestCase):
     def test_in_progress(self) -> None:
         relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.IN_PROGRESS.value,
             step=Relocation.Step.UPLOADING.value,
@@ -73,9 +71,9 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
-        assert result["creator"]["id"] == str(self.superuser.id)
-        assert result["creator"]["email"] == str(self.superuser.email)
-        assert result["creator"]["username"] == str(self.superuser.username)
+        assert result["creator"]["id"] == str(self.staff_user.id)
+        assert result["creator"]["email"] == str(self.staff_user.email)
+        assert result["creator"]["username"] == str(self.staff_user.username)
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
@@ -96,7 +94,7 @@ class RelocationSerializerTest(TestCase):
     def test_pause(self) -> None:
         relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.PAUSE.value,
             step=Relocation.Step.IMPORTING.value,
@@ -112,9 +110,9 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
-        assert result["creator"]["id"] == str(self.superuser.id)
-        assert result["creator"]["email"] == str(self.superuser.email)
-        assert result["creator"]["username"] == str(self.superuser.username)
+        assert result["creator"]["id"] == str(self.staff_user.id)
+        assert result["creator"]["email"] == str(self.staff_user.email)
+        assert result["creator"]["username"] == str(self.staff_user.username)
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
@@ -138,7 +136,7 @@ class RelocationSerializerTest(TestCase):
     def test_success(self) -> None:
         relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.SUCCESS.value,
             step=Relocation.Step.COMPLETED.value,
@@ -155,9 +153,9 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
-        assert result["creator"]["id"] == str(self.superuser.id)
-        assert result["creator"]["email"] == str(self.superuser.email)
-        assert result["creator"]["username"] == str(self.superuser.username)
+        assert result["creator"]["id"] == str(self.staff_user.id)
+        assert result["creator"]["email"] == str(self.staff_user.email)
+        assert result["creator"]["username"] == str(self.staff_user.username)
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
@@ -181,7 +179,7 @@ class RelocationSerializerTest(TestCase):
     def test_failure(self) -> None:
         relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.FAILURE.value,
             step=Relocation.Step.VALIDATING.value,
@@ -198,9 +196,9 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
-        assert result["creator"]["id"] == str(self.superuser.id)
-        assert result["creator"]["email"] == str(self.superuser.email)
-        assert result["creator"]["username"] == str(self.superuser.username)
+        assert result["creator"]["id"] == str(self.staff_user.id)
+        assert result["creator"]["email"] == str(self.staff_user.email)
+        assert result["creator"]["username"] == str(self.staff_user.username)
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)

--- a/tests/sentry/relocation/tasks/test_process.py
+++ b/tests/sentry/relocation/tasks/test_process.py
@@ -125,12 +125,12 @@ class RelocationTaskTestCase(TestCase):
         self.owner = self.create_user(
             email="owner@example.com", is_superuser=False, is_staff=False, is_active=True
         )
-        self.superuser = self.create_user(
-            email="superuser@example.com", is_superuser=True, is_staff=True, is_active=True
+        self.staff_user = self.create_user(
+            email="staff_user@example.com", is_staff=True, is_active=True
         )
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation: Relocation = Relocation.objects.create(
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             want_org_slugs=[self.requested_org_slug],
             step=Relocation.Step.UPLOADING.value,
@@ -229,10 +229,10 @@ class UploadingStartTest(RelocationTaskTestCase):
         self.owner = self.create_user(
             email="owner@example.com", is_superuser=False, is_staff=False, is_active=True
         )
-        self.superuser = self.create_user(
+        self.staff_superuser = self.create_user(
             email="superuser@example.com", is_superuser=True, is_staff=True, is_active=True
         )
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_superuser, staff=True)
 
         with assume_test_silo_mode(SiloMode.REGION, region_name=EXPORTING_TEST_REGION):
             self.requested_org_slug = "testing"
@@ -248,7 +248,7 @@ class UploadingStartTest(RelocationTaskTestCase):
 
         with assume_test_silo_mode(SiloMode.REGION, region_name=REQUESTING_TEST_REGION):
             self.relocation: Relocation = Relocation.objects.create(
-                creator_id=self.superuser.id,
+                creator_id=self.staff_superuser.id,
                 owner_id=self.owner.id,
                 want_org_slugs=[self.requested_org_slug],
                 step=Relocation.Step.UPLOADING.value,
@@ -375,7 +375,7 @@ class UploadingStartTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_superuser.email]
         )
 
         assert uploading_complete_mock.call_count == 0
@@ -450,7 +450,7 @@ class UploadingStartTest(RelocationTaskTestCase):
             assert fake_message_builder.call_count == 1
             assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
             fake_message_builder.return_value.send_async.assert_called_once_with(
-                to=[self.owner.email, self.superuser.email]
+                to=[self.owner.email, self.staff_superuser.email]
             )
 
         assert fake_kms_client.return_value.get_public_key.call_count == 1
@@ -516,7 +516,7 @@ class UploadingCompleteTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_scan_mock.call_count == 0
@@ -550,7 +550,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.started"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 1
@@ -648,7 +648,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -672,7 +672,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -702,7 +702,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 1
@@ -726,7 +726,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -749,7 +749,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -771,7 +771,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -794,7 +794,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -818,7 +818,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -843,7 +843,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -870,7 +870,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_transfer_mock.call_count == 0
@@ -932,7 +932,7 @@ class PreprocessingTransferTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_baseline_config_mock.call_count == 0
@@ -980,10 +980,10 @@ class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
             )
         assert len(json_models) > 0
 
-        # Only user `superuser` is an admin, so only they should be exported.
+        # Only user `staff_user` is an admin, so only they should be exported.
         for json_model in json_models:
             if NormalizedModelName(json_model["model"]) == get_model_name(User):
-                assert json_model["fields"]["username"] in "superuser@example.com"
+                assert json_model["fields"]["username"] in "staff_user@example.com"
 
     def test_retry_if_attempts_left(
         self,
@@ -1035,7 +1035,7 @@ class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_colliding_users_mock.call_count == 0
@@ -1135,7 +1135,7 @@ class PreprocessingCollidingUsersTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert preprocessing_complete_mock.call_count == 0
@@ -1219,7 +1219,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert validating_start_mock.call_count == 0
@@ -1631,7 +1631,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert validating_poll_mock.call_count == 0
@@ -1740,7 +1740,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert importing_mock.call_count == 0
@@ -1795,7 +1795,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert importing_mock.call_count == 0
@@ -2154,7 +2154,7 @@ class PostprocessingTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert relocated_signal_mock.call_count == 1
@@ -2385,7 +2385,7 @@ class NotifyingUsersTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
         assert notifying_owner_mock.call_count == 0
 
@@ -2430,7 +2430,7 @@ class NotifyingOwnerTest(RelocationTaskTestCase):
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.succeeded"
         assert fake_message_builder.call_args.kwargs["context"]["orgs"] == self.imported_orgs
         fake_message_builder.return_value.send_async.assert_called_once_with(
-            to=[self.owner.email, self.superuser.email]
+            to=[self.owner.email, self.staff_user.email]
         )
 
         assert completed_mock.call_count == 1

--- a/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
@@ -290,6 +290,7 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
         assert_security_email_sent("recovery-codes-regenerated")
 
+    @override_options({"staff.ga-rollout": False})
     def test_delete_superuser(self) -> None:
         user = self.create_user(email="a@example.com", is_superuser=True)
 
@@ -309,6 +310,7 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
             assert_security_email_sent("mfa-removed")
 
+    @override_options({"staff.ga-rollout": True})
     def test_delete_staff(self) -> None:
         staff_user = self.create_user(email="a@example.com", is_staff=True)
 
@@ -369,6 +371,7 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
         assert len(mail.outbox) == 0
 
+    @override_options({"staff.ga-rollout": False})
     def test_require_2fa__can_delete_last_auth_superuser(self) -> None:
         self._require_2fa_for_organization()
 

--- a/tests/sentry/users/api/endpoints/test_user_details_analytics.py
+++ b/tests/sentry/users/api/endpoints/test_user_details_analytics.py
@@ -22,6 +22,7 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         self.staff_user = self.create_user(email="staff@example.com", is_staff=True)
         self.login_as(self.staff_user, staff=True)
 
+    @override_options({"staff.ga-rollout": True})
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.users.api.endpoints.user_details.capture_security_activity")
     def test_soft_delete_records_analytics_and_security(
@@ -104,6 +105,7 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         call_args = mock_analytics.call_args[0][0]
         assert call_args.deletion_request_datetime == call_args.deletion_datetime
 
+    @override_options({"staff.ga-rollout": True})
     @mock.patch("sentry.analytics.record")
     def test_soft_delete_timestamps_differ_by_30_days(self, mock_analytics: mock.MagicMock) -> None:
         self.get_success_response(self.user.id, organizations=[], status_code=204)

--- a/tests/sentry/users/api/endpoints/test_user_index.py
+++ b/tests/sentry/users/api/endpoints/test_user_index.py
@@ -10,53 +10,57 @@ class UserListTest(APITestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.superuser = self.create_user("bar@example.com", is_superuser=True)
+        self.staff_user = self.create_user("bar@example.com", is_staff=True)
         self.normal_user = self.create_user("foo@example.com", is_superuser=False)
 
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
 
+    @override_options({"staff.ga-rollout": True})
     def test_normal_user_fails(self) -> None:
         self.login_as(self.normal_user)
         self.get_error_response(status_code=403)
 
     @override_options({"staff.ga-rollout": True})
     def test_staff_simple(self) -> None:
-        self.staff_user = self.create_user(is_staff=True)
-        self.login_as(self.staff_user, staff=True)
-
-        response = self.get_success_response()
-        assert len(response.data) == 3
-
-    def test_superuser_simple(self) -> None:
         response = self.get_success_response()
         assert len(response.data) == 2
 
+    @override_options({"staff.ga-rollout": False})
+    def test_superuser_simple(self) -> None:
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+        response = self.get_success_response()
+        assert len(response.data) == 3
+
+    @override_options({"staff.ga-rollout": True})
     def test_generic_query(self) -> None:
         response = self.get_success_response(qs_params={"query": "@example.com"})
         assert len(response.data) == 2
 
         response = self.get_success_response(qs_params={"query": "bar"})
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(self.superuser.id)
+        assert response.data[0]["id"] == str(self.staff_user.id)
 
         response = self.get_success_response(qs_params={"query": "foobar"})
         assert len(response.data) == 0
 
-    def test_superuser_query(self) -> None:
+    @override_options({"staff.ga-rollout": True})
+    def test_staff_query(self) -> None:
         response = self.get_success_response(qs_params={"query": "is:superuser"})
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(self.superuser.id)
+        assert len(response.data) == 0
 
+    @override_options({"staff.ga-rollout": True})
     def test_email_query(self) -> None:
         response = self.get_success_response(qs_params={"query": "email:bar@example.com"})
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(self.superuser.id)
+        assert response.data[0]["id"] == str(self.staff_user.id)
 
         response = self.get_success_response(qs_params={"query": "email:foobar"})
         assert len(response.data) == 0
 
+    @override_options({"staff.ga-rollout": True})
     def test_basic_query(self) -> None:
-        UserPermission.objects.create(user=self.superuser, permission="broadcasts.admin")
+        UserPermission.objects.create(user=self.staff_user, permission="broadcasts.admin")
 
         response = self.get_success_response(qs_params={"query": "permission:broadcasts.admin"})
         assert len(response.data) == 1
@@ -64,15 +68,17 @@ class UserListTest(APITestCase):
         response = self.get_success_response(qs_params={"query": "permission:foobar"})
         assert len(response.data) == 0
 
+    @override_options({"staff.ga-rollout": True})
     def test_id_query_with_invalid_values(self) -> None:
         self.get_error_response(qs_params={"query": "id:"}, status_code=400)
         self.get_error_response(qs_params={"query": "id:invalid-text"}, status_code=400)
         self.get_error_response(
-            qs_params={"query": f"id:{self.superuser.id} id:invalid"}, status_code=400
+            qs_params={"query": f"id:{self.staff_user.id} id:invalid"}, status_code=400
         )
 
+    @override_options({"staff.ga-rollout": True})
     def test_id_query_with_me(self) -> None:
         """Test that 'me' special value still works"""
         response = self.get_success_response(qs_params={"query": "id:me"})
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(self.superuser.id)
+        assert response.data[0]["id"] == str(self.staff_user.id)

--- a/tests/sentry/users/api/endpoints/test_user_permissions.py
+++ b/tests/sentry/users/api/endpoints/test_user_permissions.py
@@ -14,6 +14,7 @@ class UserPermissionsTest(APITestCase):
 class UserPermissionsGetTest(UserPermissionsTest):
     method = "GET"
 
+    @override_options({"staff.ga-rollout": False})
     def test_superuser_lookup_self(self) -> None:
         self.superuser = self.create_user(is_superuser=True)
         self.login_as(user=self.superuser, superuser=True)

--- a/tests/sentry/users/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/users/api/endpoints/test_user_permissions_config.py
@@ -14,6 +14,7 @@ class UserPermissionsConfigTest(APITestCase):
 class UserPermissionsConfigGetTest(UserPermissionsConfigTest):
     method = "GET"
 
+    @override_options({"staff.ga-rollout": False})
     def test_superuser_lookup_self(self) -> None:
         self.superuser = self.create_user(is_superuser=True)
         self.login_as(user=self.superuser, superuser=True)


### PR DESCRIPTION
My attempt to clean up the feature flag resulted in a lot of changed files (https://github.com/getsentry/sentry/pull/106966) . I'm opening up smaller PRs to migrate the tests more slowly. Then end goal is to change as many of the tests' functionality to use the staff flag (to preserve test coverage), then tag the tests that I can just delete in the migration (specific `superuser` tests). 

I'm starting with tests in the following directories:

- `tests/sentry/relocation`
- `tests/sentry/users/api`

I'll probably have followups to do the tagging more slowly.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
