### PR TITLE
feat(dashboards): Register categorical bar chart widget type

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -174,6 +174,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
     BIG_NUMBER = 6
     TOP_N = 7
     DETAILS = 8
+    CATEGORICAL_BAR_CHART = 9
     TYPES = [
         (LINE_CHART, "line"),
         (AREA_CHART, "area"),
@@ -183,6 +184,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
         (BIG_NUMBER, "big_number"),
         (TOP_N, "top_n"),
         (DETAILS, "details"),
+        (CATEGORICAL_BAR_CHART, "categorical_bar"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 


### PR DESCRIPTION
Adds `CATEGORICAL_BAR_CHART` as a new display type for dashboard widgets.

This is the backend registration for a new widget type that enables bar charts with categorical (non-time-series) x-axes. The frontend implementation will follow in a separate PR.

Refs DAIN-722