### PR TITLE
feat(SearchQueryBuilder): Re-add memoized refs

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -349,7 +349,7 @@ export function SearchQueryBuilderCombobox<
 >({
   children,
   description,
-  fullQuery,
+  fullQuery = '',
   items,
   inputValue,
   filterValue = inputValue,
@@ -589,10 +589,8 @@ export function SearchQueryBuilderCombobox<
     return () => {};
   }, [inputRef, popoverRef, isOpen, customMenu]);
 
-  /**
-   * Trigger autosize when the full query or input value changes.
-   */
-  const autosizeInput = useAutosizeInput({value: fullQuery + inputValue});
+  // Triggers resize when either the full query or input value changes.
+  const autosizeInput = useAutosizeInput({value: `${fullQuery}${inputValue}`});
 
   const memoizedInputRef = useMemo(() => {
     return mergeRefs(

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -81,6 +81,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   description?: ReactNode;
   filterValue?: string;
   /**
+   * The full query of the input, rather than just the filter value.
+   * Useful for autosizing the input after the root input has been updated.
+   */
+  fullQuery?: string;
+  /**
    * When passing `isOpen`, the open state is controlled by the parent.
    */
   isOpen?: boolean;
@@ -344,6 +349,7 @@ export function SearchQueryBuilderCombobox<
 >({
   children,
   description,
+  fullQuery,
   items,
   inputValue,
   filterValue = inputValue,
@@ -583,19 +589,26 @@ export function SearchQueryBuilderCombobox<
     return () => {};
   }, [inputRef, popoverRef, isOpen, customMenu]);
 
-  const autosizeInput = useAutosizeInput({value: inputValue});
+  /**
+   * Trigger autosize when the full query or input value changes.
+   */
+  const autosizeInput = useAutosizeInput({value: fullQuery + inputValue});
+
+  const memoizedInputRef = useMemo(() => {
+    return mergeRefs(
+      ref,
+      inputRef,
+      autosizeInput,
+      triggerProps.ref as React.Ref<HTMLInputElement>
+    );
+  }, [ref, inputRef, autosizeInput, triggerProps.ref]);
 
   return (
     <Flex align="stretch" width="100%" height="100%" position="relative">
       <UnstyledInput
         {...inputProps}
         size="md"
-        ref={mergeRefs(
-          ref,
-          inputRef,
-          autosizeInput,
-          triggerProps.ref as React.Ref<HTMLInputElement>
-        )}
+        ref={memoizedInputRef}
         type="text"
         placeholder={placeholder}
         onClick={handleInputClick}

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -357,10 +357,13 @@ export function SearchQueryBuilderParametersCombobox({
     ]
   );
 
+  const fullQuery = [...state.collection].map(itemState => itemState.textValue).join(' ');
+
   return (
     <SearchQueryBuilderCombobox
       ref={inputRef}
       items={items}
+      fullQuery={fullQuery}
       placeholder={placeholder}
       onOptionSelected={handleOptionSelected}
       onCustomValueBlurred={handleInputValueConfirmed}

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -425,6 +425,8 @@ function SearchQueryBuilderInputInternal({
     []
   );
 
+  const fullQuery = [...state.collection].map(itemState => itemState.textValue).join(' ');
+
   return (
     <Fragment>
       <HiddenText
@@ -439,6 +441,7 @@ function SearchQueryBuilderInputInternal({
         ref={inputRef}
         items={items}
         placeholder={query === '' ? placeholder : undefined}
+        fullQuery={fullQuery}
         onOptionSelected={option => {
           if (handleOptionSelected) {
             handleOptionSelected(option);


### PR DESCRIPTION
In #107082 i memoized these refs, then discovered when the input is controlled not from user input we still need to trigger a resize on all elements. So i reverted part of the changes in #107206

This passes in the full query which acts as key to trigger a resize which should prevent calling resize on every scroll event.
