### PR TITLE
ref(grouping): Add default value for message regex keys

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -231,11 +231,13 @@ class ParameterizationCallable:
 class Parameterizer:
     def __init__(
         self,
-        regex_pattern_keys: Sequence[str],
+        regex_pattern_keys: Sequence[str] | None = None,
         experimental: bool = False,
     ):
         self._experimental = experimental
-        self._parameterization_regex = self._make_regex_from_patterns(regex_pattern_keys)
+        self._parameterization_regex = self._make_regex_from_patterns(
+            regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()
+        )
         self.matches_counter: defaultdict[str, int] = defaultdict(int)
 
     def _make_regex_from_patterns(self, pattern_keys: Sequence[str]) -> re.Pattern[str]:

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 
 __all__ = [
     "ParameterizationCallable",
@@ -240,7 +240,7 @@ class Parameterizer:
         )
         self.matches_counter: defaultdict[str, int] = defaultdict(int)
 
-    def _make_regex_from_patterns(self, pattern_keys: Sequence[str]) -> re.Pattern[str]:
+    def _make_regex_from_patterns(self, pattern_keys: Iterable[str]) -> re.Pattern[str]:
         """
         Takes list of pattern keys and returns a compiled regex pattern that matches any of them.
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -16,24 +16,6 @@ if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
     from sentry.services.eventstore.models import Event
 
-REGEX_PATTERN_KEYS = (
-    "email",
-    "url",
-    "hostname",
-    "ip",
-    "traceparent",
-    "uuid",
-    "sha1",
-    "md5",
-    "date",
-    "duration",
-    "hex",
-    "float",
-    "int",
-    "quoted_str",
-    "bool",
-)
-
 
 def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingComponent]) -> str:
     """
@@ -73,7 +55,6 @@ def normalize_message_for_grouping(message: str, event: Event) -> str:
     to at most 2 lines.
     """
     parameterizer = Parameterizer(
-        regex_pattern_keys=REGEX_PATTERN_KEYS,
         experimental=in_rollout_group("grouping.experimental_parameterization", event.project_id),
     )
 

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -1,17 +1,16 @@
 import pytest
 
 from sentry.grouping.parameterization import Parameterizer
-from sentry.grouping.utils import REGEX_PATTERN_KEYS
 
 
 @pytest.fixture
 def parameterizer() -> Parameterizer:
-    return Parameterizer(regex_pattern_keys=REGEX_PATTERN_KEYS, experimental=False)
+    return Parameterizer(experimental=False)
 
 
 @pytest.fixture
 def experimental_parameterizer() -> Parameterizer:
-    return Parameterizer(regex_pattern_keys=REGEX_PATTERN_KEYS, experimental=True)
+    return Parameterizer(experimental=True)
 
 
 standard_cases = [


### PR DESCRIPTION
This adds a default value for the message parameterizer's `regex_pattern_keys` value. Rather than relying on a hard-coded list, it pulls keys from our default set of regexes. This currently amounts to the same thing, but saves us from having to remember to update a the hard-coded list in case we add a new parameterization type.