### PR TITLE
ref(grouping): Make fingerprint helpers take event directly

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -401,7 +401,7 @@ def get_grouping_variants_for_event(
         if fingerprint_type == "default"
         else resolve_fingerprint_values(
             raw_fingerprint,
-            event.data,
+            event,
             use_legacy_unknown_variable_handling=use_legacy_unknown_variable_handling,
         )
     )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -477,7 +477,7 @@ def _apply_custom_title_if_needed(
 
     if custom_title_template:
         resolved_title = expand_title_template(
-            custom_title_template, event.data, use_legacy_unknown_variable_handling
+            custom_title_template, event, use_legacy_unknown_variable_handling
         )
         event.data["title"] = resolved_title
 

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -5,7 +5,6 @@ import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
-from sentry.db.models.fields.node import NodeData
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -207,50 +206,50 @@ def get_fingerprint_type(
 
 def resolve_fingerprint_variable(
     variable_key: str,
-    event_data: NodeData | Mapping[str, Any],
+    event: Event,
     use_legacy_unknown_variable_handling: bool,
 ) -> str | None:
     if variable_key == "transaction":
-        return event_data.get("transaction") or "<no-transaction>"
+        return event.data.get("transaction") or "<no-transaction>"
 
     elif variable_key == "message":
         message = (
-            get_path(event_data, "logentry", "formatted")
-            or get_path(event_data, "logentry", "message")
-            or get_path(event_data, "exception", "values", -1, "value")
+            get_path(event.data, "logentry", "formatted")
+            or get_path(event.data, "logentry", "message")
+            or get_path(event.data, "exception", "values", -1, "value")
         )
         return message or "<no-message>"
 
     elif variable_key in ("type", "error.type"):
-        exception_type = get_path(event_data, "exception", "values", -1, "type")
+        exception_type = get_path(event.data, "exception", "values", -1, "type")
         return exception_type or "<no-type>"
 
     elif variable_key in ("value", "error.value"):
-        value = get_path(event_data, "exception", "values", -1, "value")
+        value = get_path(event.data, "exception", "values", -1, "value")
         return value or "<no-value>"
 
     elif variable_key in ("function", "stack.function"):
-        frame = get_crash_frame_from_event_data(event_data)
+        frame = get_crash_frame_from_event_data(event.data)
         func = frame.get("function") if frame else None
         return func or "<no-function>"
 
     elif variable_key in ("path", "stack.abs_path"):
-        frame = get_crash_frame_from_event_data(event_data)
+        frame = get_crash_frame_from_event_data(event.data)
         abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
         return abs_path or "<no-abs-path>"
 
     elif variable_key == "stack.filename":
-        frame = get_crash_frame_from_event_data(event_data)
+        frame = get_crash_frame_from_event_data(event.data)
         filename = frame.get("filename") or frame.get("abs_path") if frame else None
         return filename or "<no-filename>"
 
     elif variable_key in ("module", "stack.module"):
-        frame = get_crash_frame_from_event_data(event_data)
+        frame = get_crash_frame_from_event_data(event.data)
         module = frame.get("module") if frame else None
         return module or "<no-module>"
 
     elif variable_key in ("package", "stack.package"):
-        frame = get_crash_frame_from_event_data(event_data)
+        frame = get_crash_frame_from_event_data(event.data)
         pkg = frame.get("package") if frame else None
         if pkg:
             # If the package is formatted as either a POSIX or Windows path, grab the last segment
@@ -258,15 +257,15 @@ def resolve_fingerprint_variable(
         return pkg or "<no-package>"
 
     elif variable_key == "level":
-        return event_data.get("level") or "<no-level>"
+        return event.data.get("level") or "<no-level>"
 
     elif variable_key == "logger":
-        return event_data.get("logger") or "<no-logger>"
+        return event.data.get("logger") or "<no-logger>"
 
     elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
         requested_tag = variable_key[5:]
-        for tag_name, tag_value in event_data.get("tags") or ():
+        for tag_name, tag_value in event.data.get("tags") or ():
             if tag_name == requested_tag and tag_value is not None:
                 return tag_value
         return "<no-value-for-tag-%s>" % requested_tag
@@ -295,7 +294,7 @@ def resolve_fingerprint_values(
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`
         resolved_value = resolve_fingerprint_variable(
-            variable_key, event.data, use_legacy_unknown_variable_handling
+            variable_key, event, use_legacy_unknown_variable_handling
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
@@ -316,7 +315,7 @@ def expand_title_template(
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`
         resolved_value = resolve_fingerprint_variable(
-            variable_key, event.data, use_legacy_unknown_variable_handling
+            variable_key, event, use_legacy_unknown_variable_handling
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -308,7 +308,7 @@ def resolve_fingerprint_values(
 
 
 def expand_title_template(
-    template: str, event_data: Mapping[str, Any], use_legacy_unknown_variable_handling: bool = False
+    template: str, event: Event, use_legacy_unknown_variable_handling: bool = False
 ) -> str:
     def _handle_match(match: re.Match[str]) -> str:
         variable_key = match.group(1)
@@ -316,7 +316,7 @@ def expand_title_template(
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`
         resolved_value = resolve_fingerprint_variable(
-            variable_key, event_data, use_legacy_unknown_variable_handling
+            variable_key, event.data, use_legacy_unknown_variable_handling
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Mapping
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from sentry.db.models.fields.node import NodeData
 from sentry.stacktraces.functions import get_function_name_for_frame
@@ -12,6 +12,10 @@ from sentry.stacktraces.processing import get_crash_frame_from_event_data
 from sentry.utils.event_frames import find_stack_frames
 from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
+
+if TYPE_CHECKING:
+    from sentry.services.eventstore.models import Event
+
 
 logger = logging.getLogger("sentry.events.grouping")
 
@@ -278,7 +282,7 @@ def resolve_fingerprint_variable(
 
 
 def resolve_fingerprint_values(
-    fingerprint: list[str], event_data: NodeData, use_legacy_unknown_variable_handling: bool = False
+    fingerprint: list[str], event: Event, use_legacy_unknown_variable_handling: bool = False
 ) -> list[str]:
     def _resolve_single_entry(entry: str) -> str:
         variable_key = parse_fingerprint_entry_as_variable(entry)
@@ -291,7 +295,7 @@ def resolve_fingerprint_values(
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`
         resolved_value = resolve_fingerprint_variable(
-            variable_key, event_data, use_legacy_unknown_variable_handling
+            variable_key, event.data, use_legacy_unknown_variable_handling
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -96,8 +96,12 @@ class GroupingInput:
 
         # Technically handling custom titles happens during grouping, not before it, but we're not
         # running grouping until later, and the title needs to be set before we get metadata below.
+        # (The fact that this is happening out of order is why we need to create the dummy `Event`
+        # object to wrap the data, since that's what `expand_title_template` expects.)
         if custom_title_template:
-            resolved_title = expand_title_template(custom_title_template, data)
+            resolved_title = expand_title_template(
+                custom_title_template, Event(project_id=1, event_id="11211231", data=data)
+            )
             data["title"] = resolved_title
 
         event_type = get_event_type(data)
@@ -332,8 +336,14 @@ class FingerprintInput:
         fingerprint_info = data.get("_fingerprint_info", {})
         custom_title_template = get_path(fingerprint_info, "matched_rule", "attributes", "title")
 
+        # Technically handling custom titles happens during grouping, not before it, but we're not
+        # running grouping until later, and the title needs to be set before we get metadata below.
+        # (The fact that this is happening out of order is why we need to create the dummy `Event`
+        # object to wrap the data, since that's what `expand_title_template` expects.)
         if custom_title_template:
-            resolved_title = expand_title_template(custom_title_template, data)
+            resolved_title = expand_title_template(
+                custom_title_template, Event(project_id=1, event_id="11211231", data=data)
+            )
             data["title"] = resolved_title
 
         event_type = get_event_type(data)

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from sentry.conf.server import FALL_2025_GROUPING_CONFIG, WINTER_2023_GROUPING_CONFIG
-from sentry.db.models.fields.node import NodeData
 from sentry.grouping.api import (
     _apply_custom_title_if_needed,
     get_default_grouping_config_dict,
@@ -271,7 +270,7 @@ release:foo                                     -> release-foo
 def test_variable_resolution() -> None:
     # TODO: This should be fleshed out to test way more cases, at which point we'll need to add some
     # actual data here
-    event_data = NodeData(id="11211231")
+    event = Event(project_id=908415, event_id="11211231", data={})
 
     for fingerprint_entry, expected_resolved_value in [
         ("{{ default }}", "{{ default }}"),
@@ -279,7 +278,7 @@ def test_variable_resolution() -> None:
         ("{{  default }}", "{{ default }}"),
         ("{{ dog }}", "<unrecognized-variable-dog>"),
     ]:
-        assert resolve_fingerprint_values([fingerprint_entry], event_data) == [
+        assert resolve_fingerprint_values([fingerprint_entry], event) == [
             expected_resolved_value
         ], f"Entry {fingerprint_entry} resolved incorrectly"
 
@@ -323,7 +322,7 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
             is True
         )
         assert resolve_fingerprint_values(
-            fingerprint, NodeData(event_data), use_legacy_unknown_variable_handling=True
+            fingerprint, event, use_legacy_unknown_variable_handling=True
         ) == ["{{ dog }}"]
 
     # Under the new config, we ask for non-legacy behavior, and as a result the unknown fingerprint
@@ -351,7 +350,7 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
             is False
         )
         assert resolve_fingerprint_values(
-            fingerprint, NodeData(event_data), use_legacy_unknown_variable_handling=False
+            fingerprint, event, use_legacy_unknown_variable_handling=False
         ) == ["<unrecognized-variable-dog>"]
 
 


### PR DESCRIPTION
This is a small refactor to a few of our fingerprinting helpers, switching them from taking event data to taking a full `Event` object, in order to enable changes in an upcoming PR. No behavior changes.