### PR TITLE
feat(seer): Add `Enable Code Generation` to org-wide seer settings page

### DIFF
--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -37,6 +37,7 @@ export default function SeerAutomationSettings() {
 
           // Third section
           enableSeerEnhancedAlerts: organization.enableSeerEnhancedAlerts ?? true,
+          enableSeerCoding: organization.enableSeerCoding ?? true,
         }}
       >
         <JsonForm

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -155,6 +155,14 @@ export default function SeerAutomationSettings() {
                   help: t('Seer will provide extra context in supported alerts.'),
                   type: 'boolean',
                 },
+                {
+                  name: 'enableSeerCoding',
+                  label: t('Enable Code Generation'),
+                  help: t(
+                    'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input. Read more: docs & legal.'
+                  ),
+                  type: 'boolean',
+                },
               ],
             },
           ]}

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -158,8 +158,25 @@ export default function SeerAutomationSettings() {
                 {
                   name: 'enableSeerCoding',
                   label: t('Enable Code Generation'),
-                  help: t(
-                    'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input. Read more: docs & legal.'
+                  help: (
+                    <Flex gap="sm">
+                      <span>
+                        {tct(
+                          'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. [docs:Read the docs] to learn more.',
+                          {
+                            docs: (
+                              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#disabling-generative-ai-features" />
+                            ),
+                          }
+                        )}
+                      </span>
+                      <QuestionTooltip
+                        size="xs"
+                        title={t(
+                          'This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input.'
+                        )}
+                      />
+                    </Flex>
                   ),
                   type: 'boolean',
                   defaultValue: true, // See ENABLE_SEER_CODING_DEFAULT in sentry/src/sentry/constants.py

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -162,6 +162,7 @@ export default function SeerAutomationSettings() {
                     'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input. Read more: docs & legal.'
                   ),
                   type: 'boolean',
+                  defaultValue: true, // See ENABLE_SEER_CODING_DEFAULT in sentry/src/sentry/constants.py
                 },
               ],
             },


### PR DESCRIPTION
Still need to sort out links to docs, and get final copy.
This will be the last PR in the set to be merged; it depends on all the other checks being in first

<img width="608" height="236" alt="Screenshot 2026-01-30 at 2 40 52 PM" src="https://github.com/user-attachments/assets/5eba7f44-3870-4759-8b87-f495b45a8459" />

The link points to here: https://docs.sentry.io/product/ai-in-sentry/#disabling-generative-ai-features

---

Some related docs links:
- https://docs.sentry.io/organization/integrations/integration-platform/webhooks/seer/#code-generation
- TODO: There's nothing about Seer in this '[Account Settings > Organization Settings](https://docs.sentry.io/organization/)' doc page?
    - There is a link to [> Integrations > Cursor](https://docs.sentry.io/organization/integrations/cursor/) deep in there.
- https://docs.sentry.io/product/ai-in-sentry/#disabling-generative-ai-features


Fixes CW-730