### PR TITLE
chore(aci): Start recording event_id field in GroupPeriodActivity

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -342,6 +342,7 @@ def save_issue_from_occurrence(
                 reason=PriorityChangeReason.ISSUE_PLATFORM,
                 project=project,
                 is_regression=is_regression,
+                event_id=occurrence.event_id,
             )
 
             open_period = get_latest_open_period(group)

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -41,6 +41,7 @@ def update_priority(
     actor: User | RpcUser | None = None,
     project: Project | None = None,
     is_regression: bool = False,
+    event_id: str | None = None,
 ) -> None:
     """
     Update the priority of a group and record the change in the activity and group history.
@@ -109,6 +110,7 @@ def update_priority(
                 group_open_period=open_period,
                 type=OpenPeriodActivityType.OPENED,
                 value=priority,
+                event_id=event_id,
             )
     else:
         # make a new activity entry
@@ -116,6 +118,7 @@ def update_priority(
             group_open_period=open_period,
             type=OpenPeriodActivityType.STATUS_CHANGE,
             value=priority,
+            event_id=event_id,
         )
 
 

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -216,6 +216,7 @@ def create_open_period(group: Group, start_time: datetime, event_id: str | None 
                 group_open_period=open_period,
                 type=OpenPeriodActivityType.OPENED,
                 value=group.priority,
+                event_id=event_id,
             )
 
 

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -715,6 +715,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert len(activity_updates) == 1
         assert activity_updates[0].type == OpenPeriodActivityType.OPENED
         assert activity_updates[0].value == PriorityLevel.MEDIUM
+        assert activity_updates[0].event_id == event.event_id
 
     def test_update_group_priority_open_period_activity_entry(self) -> None:
         fingerprint = ["some-fingerprint"]
@@ -748,9 +749,11 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert len(activity_updates) == 2
         assert activity_updates[0].type == OpenPeriodActivityType.OPENED
         assert activity_updates[0].value == PriorityLevel.MEDIUM
+        assert activity_updates[0].event_id == event.event_id
 
         assert activity_updates[1].type == OpenPeriodActivityType.STATUS_CHANGE
         assert activity_updates[1].value == PriorityLevel.HIGH
+        assert activity_updates[1].event_id == new_occurrence.event_id
 
     @mock.patch("sentry.issues.ingest._process_existing_aggregate")
     def test_update_group_priority_and_unresolve(self, mock_is_regression: mock.MagicMock) -> None:


### PR DESCRIPTION
Closes ISWF-1966

Followup to https://github.com/getsentry/sentry/pull/107305

Saves `event_id` data in the GroupOpenPeriodActivity when created