### PR TITLE
Events after issue deletion

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1319,9 +1319,7 @@ def assign_event_to_group(
 
     # If we've found one, great. No need to do any more calculations
     if primary.existing_grouphash:
-        group_info = handle_existing_grouphash(
-            job, primary.existing_grouphash, primary.grouphashes
-        )
+        group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
         # If handle_existing_grouphash returns None (e.g., group is being deleted), create a new group
         if group_info:
             result = "found_primary"
@@ -1358,9 +1356,7 @@ def assign_event_to_group(
             )
 
             if seer_matched_grouphash:
-                group_info = handle_existing_grouphash(
-                    job, seer_matched_grouphash, all_grouphashes
-                )
+                group_info = handle_existing_grouphash(job, seer_matched_grouphash, all_grouphashes)
                 # If handle_existing_grouphash returns None (e.g., group is being deleted), create a new group
                 if not group_info:
                     group_info = create_group_with_grouphashes(job, all_grouphashes)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1323,7 +1323,9 @@ def assign_event_to_group(
         # If handle_existing_grouphash returns None (e.g., group is being deleted), create a new group
         if group_info:
             result = "found_primary"
-            maybe_send_seer_for_new_model_training(event, primary.existing_grouphash, primary.variants)
+            maybe_send_seer_for_new_model_training(
+                event, primary.existing_grouphash, primary.variants
+            )
         else:
             group_info = create_group_with_grouphashes(job, primary.grouphashes)
             result = "no_match"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1443,6 +1443,12 @@ def handle_existing_grouphash(
     # well as GH-5085.
     group = Group.objects.get(id=existing_grouphash.group_id)
 
+    # If the group is pending deletion or currently being deleted, treat it as if we didn't find
+    # a group. This prevents new events from being assigned to groups that are being deleted,
+    # which would cause those events to be dropped.
+    if group.status in (GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS):
+        return None
+
     # As far as we know this has never happened, but in theory at least, the error event hashing
     # algorithm and other event hashing algorithms could come up with the same hash value in the
     # same project and our hash could have matched to a non-error group. Just to be safe, we make

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1319,7 +1319,9 @@ def assign_event_to_group(
 
     # If we've found one, great. No need to do any more calculations
     if primary.existing_grouphash:
-        group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
+        group_info = handle_existing_grouphash(
+            job, primary.existing_grouphash, primary.grouphashes
+        )
         # If handle_existing_grouphash returns None (e.g., group is being deleted), create a new group
         if group_info:
             result = "found_primary"
@@ -1356,7 +1358,9 @@ def assign_event_to_group(
             )
 
             if seer_matched_grouphash:
-                group_info = handle_existing_grouphash(job, seer_matched_grouphash, all_grouphashes)
+                group_info = handle_existing_grouphash(
+                    job, seer_matched_grouphash, all_grouphashes
+                )
                 # If handle_existing_grouphash returns None (e.g., group is being deleted), create a new group
                 if not group_info:
                     group_info = create_group_with_grouphashes(job, all_grouphashes)


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes ID-1310: Events were being dropped when they arrived during the window between an issue being marked for deletion (`PENDING_DELETION` or `DELETION_IN_PROGRESS`) and its `GroupHash` records being fully removed. These events were incorrectly assigned to the "deleted" group and subsequently lost.

This PR modifies `handle_existing_grouphash` to prevent events from being assigned to groups that are in `PENDING_DELETION` or `DELETION_IN_PROGRESS` status. If a matching `GroupHash` points to such a group, `None` is returned, forcing the creation of a new group for the incoming event. This ensures events are not dropped due to race conditions during issue deletion, improving data integrity.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1310](https://linear.app/getsentry/issue/ID-1310/events-appear-to-be-dropped-after-issue-deletion)

<a href="https://cursor.com/background-agent?bcId=bc-870da732-3e77-4bd2-8873-aff5fd52da67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-870da732-3e77-4bd2-8873-aff5fd52da67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

