### PR TITLE
feat(ci): Add `ruff` as dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ dev = [
     "pytest-xdist>=3.0.2",
     "pyupgrade>=3.19.1",
     "responses>=0.23.1",
+    "ruff>=0.14.0",
     "selenium>=4.16.0",
     "sentry-cli>=2.16.0",
     "sentry-covdefaults-disable-branch-coverage>=1.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1910,6 +1910,16 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.14.10"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/ruff-0.14.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d85713d522348837ef9df8efca33ccb8bd6fcfc86a2cde3ccb4bc9d28a18003d" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/ruff-0.14.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6987ebe0501ae4f4308d7d24e2d0fe3d7a98430f5adfd0f1fead050a740a3a77" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/ruff-0.14.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59aabd2e2c4fd614d2862e7939c34a532c04f1084476d6833dddef4afab87e9f" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.10.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -2077,6 +2087,7 @@ dev = [
     { name = "pytest-xdist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyupgrade", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "responses", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "selenium", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sentry-cli", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sentry-covdefaults-disable-branch-coverage", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2244,6 +2255,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.0.2" },
     { name = "pyupgrade", specifier = ">=3.19.1" },
     { name = "responses", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.14.0" },
     { name = "selenium", specifier = ">=4.16.0" },
     { name = "sentry-cli", specifier = ">=2.16.0" },
     { name = "sentry-covdefaults-disable-branch-coverage", specifier = ">=1.0.2" },


### PR DESCRIPTION
Adding `ruff` as a dev dependency in `sentry`, as a precursor to https://github.com/getsentry/getsentry/pull/19255 and the corresponding migration in the `sentry` repo.

`ruff` is already in the pypi mirror, so I think we're good there.

Followed [these docs](https://develop.sentry.dev/development-infrastructure/python-dependencies/):
- Added `ruff>=0.14.0` as a dev dependency in `pyproject.toml` (latest version is `0.14.14`)
- Ran `uv lock`