### PR TITLE
ref(perf-detectors): Pass detector-specific settings to PerformanceDetector constructors

### DIFF
--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -60,12 +60,12 @@ class PerformanceDetector(ABC):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        self.settings = settings[self.settings_key]
+        self.settings = settings
         self._event = event
         self.stored_problems: dict[str, PerformanceProblem] = {}
         self.organization = organization

--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -94,10 +94,7 @@ class PerformanceDetector(ABC):
     def event(self) -> dict[str, Any]:
         return self._event
 
-    @property
-    @abstractmethod
-    def settings_key(self) -> DetectorType:
-        raise NotImplementedError
+    settings_key: ClassVar[DetectorType]
 
     @abstractmethod
     def visit_span(self, span: Span) -> None:

--- a/src/sentry/issue_detection/detectors/consecutive_db_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_db_detector.py
@@ -85,15 +85,15 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         if not len(self.independent_db_spans):
             return
 
-        exceeds_count_threshold = len(self.consecutive_db_spans) >= self.settings.get(
-            "consecutive_count_threshold"
+        exceeds_count_threshold = (
+            len(self.consecutive_db_spans) >= self.settings["consecutive_count_threshold"]
         )
         if not exceeds_count_threshold:
             return
 
         exceeds_span_duration_threshold = all(
             get_span_duration(span).total_seconds() * 1000
-            > self.settings.get("span_duration_threshold")
+            > self.settings["span_duration_threshold"]
             for span in self.independent_db_spans
         )
         if not exceeds_span_duration_threshold:
@@ -101,14 +101,14 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
         time_saved = self._calculate_time_saved(self.independent_db_spans)
         total_time = get_total_span_duration(self.consecutive_db_spans)
-        exceeds_time_saved_threshold = time_saved >= self.settings.get("min_time_saved")
+        exceeds_time_saved_threshold = time_saved >= self.settings["min_time_saved"]
         if not exceeds_time_saved_threshold:
             return
 
         exceeds_time_saved_threshold_ratio = False
         if total_time > 0:
-            exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
-                "min_time_saved_ratio"
+            exceeds_time_saved_threshold_ratio = (
+                time_saved / total_time >= self.settings["min_time_saved_ratio"]
             )
         if not exceeds_time_saved_threshold_ratio:
             return

--- a/src/sentry/issue_detection/detectors/consecutive_db_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_db_detector.py
@@ -60,7 +60,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -33,7 +33,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -63,7 +63,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             return
 
         span_duration = get_span_duration(span).total_seconds() * 1000
-        if span_duration < self.settings.get("span_duration_threshold"):
+        if span_duration < self.settings["span_duration_threshold"]:
             return
 
         if self._overlaps_last_span(span):
@@ -76,16 +76,16 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         self.consecutive_http_spans.append(span)
 
     def _validate_and_store_performance_problem(self) -> None:
-        exceeds_count_threshold = len(self.consecutive_http_spans) >= self.settings.get(
-            "consecutive_count_threshold"
+        exceeds_count_threshold = (
+            len(self.consecutive_http_spans) >= self.settings["consecutive_count_threshold"]
         )
         if not exceeds_count_threshold:
             return
 
         exceeds_min_time_saved_duration = False
         if self.consecutive_http_spans:
-            exceeds_min_time_saved_duration = self._calculate_time_saved() >= self.settings.get(
-                "min_time_saved"
+            exceeds_min_time_saved_duration = (
+                self._calculate_time_saved() >= self.settings["min_time_saved"]
             )
         if not exceeds_min_time_saved_duration:
             return
@@ -94,7 +94,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             get_duration_between_spans(
                 self.consecutive_http_spans[idx - 1], self.consecutive_http_spans[idx]
             )
-            < self.settings.get("max_duration_between_spans")
+            < self.settings["max_duration_between_spans"]
             for idx in range(1, len(self.consecutive_http_spans))
         )
         if not subceeds_duration_between_spans_threshold:

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -129,7 +129,7 @@ class HTTPOverheadDetector(PerformanceDetector):
         return True
 
     def _store_performance_problem(self, location: str) -> None:
-        delay_threshold = self.settings.get("http_request_delay_threshold")
+        delay_threshold = self.settings["http_request_delay_threshold"]
 
         max_delay = -1.0
         chain = None

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -53,7 +53,7 @@ class HTTPOverheadDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -40,7 +40,7 @@ class BaseIOMainThreadDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,
@@ -217,7 +217,7 @@ class DBMainThreadDetector(BaseIOMainThreadDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -57,7 +57,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if not encoded_body_size:
             return
 
-        payload_size_threshold = self.settings.get("payload_size_threshold")
+        payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
             encoded_body_size = int(encoded_body_size)
@@ -118,9 +118,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if not op.startswith("http"):
             return False
 
-        if get_span_duration(span) < timedelta(
-            milliseconds=self.settings.get("minimum_span_duration")
-        ):
+        if get_span_duration(span) < timedelta(milliseconds=self.settings["minimum_span_duration"]):
             return False
 
         normalized_description = description.strip().upper()

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -31,7 +31,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -394,7 +394,7 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
@@ -44,7 +44,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -162,7 +162,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             return
 
         # Do we have enough spans?
-        count = self.settings.get("count")
+        count = self.settings["count"]
         if len(self.n_spans) < count:
             return
 
@@ -235,7 +235,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             )
 
     def _is_slower_than_threshold(self) -> bool:
-        duration_threshold = self.settings.get("duration_threshold")
+        duration_threshold = self.settings["duration_threshold"]
         return total_span_time(self.n_spans) >= duration_threshold
 
     def _metrics_for_extra_matching_spans(self) -> None:

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -58,7 +58,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/query_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/query_injection_detector.py
@@ -24,7 +24,7 @@ class QueryInjectionDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -46,12 +46,8 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         fcp_value = fcp_hash.get("value")
         if fcp_value and ("unit" not in fcp_hash or fcp_hash["unit"] == "millisecond"):
             fcp = timedelta(milliseconds=fcp_value)
-            fcp_minimum_threshold = timedelta(
-                milliseconds=self.settings.get("fcp_minimum_threshold")
-            )
-            fcp_maximum_threshold = timedelta(
-                milliseconds=self.settings.get("fcp_maximum_threshold")
-            )
+            fcp_minimum_threshold = timedelta(milliseconds=self.settings["fcp_minimum_threshold"])
+            fcp_maximum_threshold = timedelta(milliseconds=self.settings["fcp_maximum_threshold"])
             if fcp >= fcp_minimum_threshold and fcp < fcp_maximum_threshold:
                 self.fcp = fcp
                 self.fcp_value = fcp_value
@@ -152,7 +148,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
             return False
 
         span_duration = get_span_duration(span)
-        fcp_ratio_threshold = self.settings.get("fcp_ratio_threshold")
+        fcp_ratio_threshold = self.settings["fcp_ratio_threshold"]
         return span_duration / self.fcp > fcp_ratio_threshold
 
     def _fingerprint(self, span: Span) -> str:

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -28,7 +28,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/sql_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/sql_injection_detector.py
@@ -78,7 +78,7 @@ class SQLInjectionDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -50,7 +50,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         if not op:
             return
 
-        allowed_span_ops = self.settings.get("allowed_span_ops")
+        allowed_span_ops = self.settings["allowed_span_ops"]
         if op not in allowed_span_ops:
             return
 
@@ -82,7 +82,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             return
 
         # Ignore assets that aren't big enough to worry about.
-        size_threshold_bytes = self.settings.get("size_threshold_bytes")
+        size_threshold_bytes = self.settings["size_threshold_bytes"]
         if encoded_body_size < size_threshold_bytes:
             return
 
@@ -93,9 +93,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             return
 
         # Ignore assets under a certain duration threshold
-        if get_span_duration(span).total_seconds() * 1000 <= self.settings.get(
-            "duration_threshold"
-        ):
+        if get_span_duration(span).total_seconds() * 1000 <= self.settings["duration_threshold"]:
             return
 
         fingerprint = self._fingerprint(span)

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -35,7 +35,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
 
     def __init__(
         self,
-        settings: dict[DetectorType, Any],
+        settings: dict[str, Any],
         event: dict[str, Any],
         organization: Organization | None = None,
         detector_id: int | None = None,

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -360,7 +360,7 @@ def _detect_performance_problems(
 
     with sentry_sdk.start_span(op="initialize", name="PerformanceDetector"):
         detectors: list[PerformanceDetector] = [
-            detector_class(detection_settings, data, organization)
+            detector_class(detection_settings[detector_class.settings_key], data, organization)
             for detector_class in DETECTOR_CLASSES
             if detector_class.is_detection_allowed_for_system()
         ]

--- a/tests/sentry/issue_detection/test_consecutive_db_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_db_detector.py
@@ -30,7 +30,9 @@ class ConsecutiveDbDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = ConsecutiveDBSpanDetector(self._settings, event)
+        detector = ConsecutiveDBSpanDetector(
+            self._settings[ConsecutiveDBSpanDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -247,7 +249,9 @@ class ConsecutiveDbDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = ConsecutiveDBSpanDetector(settings, event)
+        detector = ConsecutiveDBSpanDetector(
+            settings[ConsecutiveDBSpanDetector.settings_key], event
+        )
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -258,7 +262,9 @@ class ConsecutiveDbDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = ConsecutiveDBSpanDetector(settings, event)
+        detector = ConsecutiveDBSpanDetector(
+            settings[ConsecutiveDBSpanDetector.settings_key], event
+        )
 
         assert not detector.is_creation_allowed_for_project(project)
 

--- a/tests/sentry/issue_detection/test_consecutive_http_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_http_detector.py
@@ -30,7 +30,9 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = ConsecutiveHTTPSpanDetector(self._settings, event)
+        detector = ConsecutiveHTTPSpanDetector(
+            self._settings[ConsecutiveHTTPSpanDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -366,7 +368,9 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         event = self.create_issue_event()
 
         settings = get_detection_settings(project.id)
-        detector = ConsecutiveHTTPSpanDetector(settings, event)
+        detector = ConsecutiveHTTPSpanDetector(
+            settings[ConsecutiveHTTPSpanDetector.settings_key], event
+        )
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -377,7 +381,9 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = ConsecutiveHTTPSpanDetector(settings, event)
+        detector = ConsecutiveHTTPSpanDetector(
+            settings[ConsecutiveHTTPSpanDetector.settings_key], event
+        )
 
         assert not detector.is_creation_allowed_for_project(project)
 

--- a/tests/sentry/issue_detection/test_db_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_db_main_thread_detector.py
@@ -23,7 +23,7 @@ class DBMainThreadDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = DBMainThreadDetector(self._settings, event)
+        detector = DBMainThreadDetector(self._settings[DBMainThreadDetector.settings_key], event)
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -55,7 +55,7 @@ class DBMainThreadDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = DBMainThreadDetector(settings, event)
+        detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -66,7 +66,7 @@ class DBMainThreadDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = DBMainThreadDetector(settings, event)
+        detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)
 

--- a/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
@@ -46,7 +46,9 @@ class FileIOMainThreadDetectorTest(TestCase):
             create_files_from_dif_zip(f, project=self.project)
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = FileIOMainThreadDetector(self._settings, event)
+        detector = FileIOMainThreadDetector(
+            self._settings[FileIOMainThreadDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -56,7 +58,7 @@ class FileIOMainThreadDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = FileIOMainThreadDetector(settings, event)
+        detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -67,7 +69,7 @@ class FileIOMainThreadDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = FileIOMainThreadDetector(settings, event)
+        detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)
 

--- a/tests/sentry/issue_detection/test_http_overhead_detector.py
+++ b/tests/sentry/issue_detection/test_http_overhead_detector.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.http_overhead_detector import HTTPOverheadDetector
 from sentry.issue_detection.performance_detection import (
     get_detection_settings,
@@ -66,9 +65,7 @@ def _valid_http_overhead_event(url: str) -> dict[str, Any]:
     }
 
 
-def find_problems(
-    settings: dict[DetectorType, Any], event: dict[str, Any]
-) -> list[PerformanceProblem]:
+def find_problems(settings: dict[str, Any], event: dict[str, Any]) -> list[PerformanceProblem]:
     detector = HTTPOverheadDetector(settings, event)
     run_detector_on_data(detector, event)
     return list(detector.stored_problems.values())
@@ -81,7 +78,7 @@ class HTTPOverheadDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        return find_problems(self._settings, event)
+        return find_problems(self._settings[HTTPOverheadDetector.settings_key], event)
 
     def test_detects_http_overhead(self) -> None:
         event = _valid_http_overhead_event("/api/endpoint/123")

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -24,7 +24,9 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = LargeHTTPPayloadDetector(self._settings, event)
+        detector = LargeHTTPPayloadDetector(
+            self._settings[LargeHTTPPayloadDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -83,7 +85,9 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
+        detector = LargeHTTPPayloadDetector(
+            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
+        )
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -94,7 +98,9 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
+        detector = LargeHTTPPayloadDetector(
+            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
+        )
 
         assert not detector.is_creation_allowed_for_project(project)
 
@@ -328,7 +334,9 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
+        detector = LargeHTTPPayloadDetector(
+            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
+        )
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
@@ -356,7 +364,9 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
+        detector = LargeHTTPPayloadDetector(
+            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
+        )
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 1
 
@@ -375,6 +385,8 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(settings, event, self.organization)
+        detector = LargeHTTPPayloadDetector(
+            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
+        )
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -37,7 +37,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         self, event: dict[str, Any], settings: dict[DetectorType, Any] | None = None
     ) -> list[PerformanceProblem]:
         detector_settings = settings or self._settings
-        detector = self.detector(detector_settings, event)
+        detector = self.detector(detector_settings[self.detector.settings_key], event)
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -220,7 +220,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = self.detector(settings, event)
+        detector = self.detector(settings[self.detector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -231,7 +231,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = self.detector(settings, event)
+        detector = self.detector(settings[self.detector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)
 

--- a/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
@@ -456,7 +456,8 @@ def test_parameterizes_url(url: str, parameterized_url: str) -> None:
 )
 @pytest.mark.django_db
 def test_allows_eligible_spans(span: Span) -> None:
-    detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
+    settings = get_detection_settings()[NPlusOneAPICallsDetector.settings_key]
+    detector = NPlusOneAPICallsDetector(settings, {})
     assert detector._is_span_eligible(span)
 
 
@@ -516,7 +517,8 @@ def test_allows_eligible_spans(span: Span) -> None:
 )
 @pytest.mark.django_db
 def test_rejects_ineligible_spans(span: Span) -> None:
-    detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
+    settings = get_detection_settings()[NPlusOneAPICallsDetector.settings_key]
+    detector = NPlusOneAPICallsDetector(settings, {})
     assert not detector._is_span_eligible(span)
 
 

--- a/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
@@ -29,7 +29,9 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = NPlusOneAPICallsDetector(self._settings, event)
+        detector = NPlusOneAPICallsDetector(
+            self._settings[NPlusOneAPICallsDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 

--- a/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
@@ -34,7 +34,9 @@ class NPlusOneDBSpanDetectorTest(unittest.TestCase):
             for option_name, value in setting_overides.items():
                 self._settings[DetectorType.N_PLUS_ONE_DB_QUERIES][option_name] = value
 
-        detector = NPlusOneDBSpanDetector(self._settings, event)
+        detector = NPlusOneDBSpanDetector(
+            self._settings[NPlusOneDBSpanDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -403,7 +405,7 @@ class NPlusOneDbSettingTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = NPlusOneDBSpanDetector(settings, event)
+        detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -414,6 +416,6 @@ class NPlusOneDbSettingTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = NPlusOneDBSpanDetector(settings, event)
+        detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_query_injection_detector.py
+++ b/tests/sentry/issue_detection/test_query_injection_detector.py
@@ -22,7 +22,9 @@ class QueryInjectionDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = QueryInjectionDetector(self._settings, event)
+        detector = QueryInjectionDetector(
+            self._settings[QueryInjectionDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 

--- a/tests/sentry/issue_detection/test_slow_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_slow_db_span_detector.py
@@ -23,7 +23,7 @@ class SlowDBQueryDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = SlowDBQueryDetector(self._settings, event)
+        detector = SlowDBQueryDetector(self._settings[SlowDBQueryDetector.settings_key], event)
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -141,7 +141,7 @@ class SlowDBQueryDetectorTest(TestCase):
         slow_span_event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = SlowDBQueryDetector(settings, slow_span_event)
+        detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -152,6 +152,6 @@ class SlowDBQueryDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = SlowDBQueryDetector(settings, slow_span_event)
+        detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
         assert not detector.is_creation_allowed_for_project(project)

--- a/tests/sentry/issue_detection/test_sql_injection_detector.py
+++ b/tests/sentry/issue_detection/test_sql_injection_detector.py
@@ -22,7 +22,7 @@ class SQLInjectionDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = SQLInjectionDetector(self._settings, event)
+        detector = SQLInjectionDetector(self._settings[SQLInjectionDetector.settings_key], event)
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 

--- a/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
+++ b/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
@@ -47,7 +47,9 @@ class UncompressedAssetsDetectorTest(TestCase):
         self._settings = get_detection_settings()
 
     def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
-        detector = UncompressedAssetSpanDetector(self._settings, event)
+        detector = UncompressedAssetSpanDetector(
+            self._settings[UncompressedAssetSpanDetector.settings_key], event
+        )
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
@@ -417,7 +419,9 @@ class UncompressedAssetsDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project.id)
-        detector = UncompressedAssetSpanDetector(settings, event)
+        detector = UncompressedAssetSpanDetector(
+            settings[UncompressedAssetSpanDetector.settings_key], event
+        )
 
         assert detector.is_creation_allowed_for_project(project)
 
@@ -428,6 +432,8 @@ class UncompressedAssetsDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project.id)
-        detector = UncompressedAssetSpanDetector(settings, event)
+        detector = UncompressedAssetSpanDetector(
+            settings[UncompressedAssetSpanDetector.settings_key], event
+        )
 
         assert not detector.is_creation_allowed_for_project(project)


### PR DESCRIPTION
Previously, each PerformanceDetector received the full settings dict for all detector types and extracted its own config in `__init__`. This meant every detector had visibility into other detectors' configuration, even though none actually used it.

Now the caller extracts the specific detector's settings before instantiation, so each detector only receives its own config dict, and we can be confident configs are independent.
