### PR TITLE
ref(admin): Migrate invoice endpoints to cell-scoped URLs

### DIFF
--- a/static/gsAdmin/views/invoiceDetails.spec.tsx
+++ b/static/gsAdmin/views/invoiceDetails.spec.tsx
@@ -145,11 +145,12 @@ describe('InvoiceDetails', () => {
       });
 
       const updateMock = MockApiClient.addMockResponse({
-        url: `/customers/${mockOrg.slug}/invoices/${invoice.id}/retry-payment/`,
+        url: `/_admin/cells/us/invoices/${invoice.id}/retry-payment/`,
         method: 'PUT',
         body: InvoiceFixture({
           nextChargeAttempt: '2020-11-10T10:29:07.724283Z',
         }),
+        host: 'https://us.sentry.io',
       });
 
       render(<InvoiceDetails />, {

--- a/static/gsAdmin/views/invoiceDetails.tsx
+++ b/static/gsAdmin/views/invoiceDetails.tsx
@@ -30,7 +30,7 @@ import {InvoiceStatus} from 'getsentry/types';
 const ERR_MESSAGE = 'There was an internal error updating this invoice';
 
 export default function InvoiceDetails() {
-  const {invoiceId, orgId, region} = useParams<{
+  const {invoiceId, region} = useParams<{
     invoiceId: string;
     orgId: string;
     region: string;
@@ -90,9 +90,10 @@ export default function InvoiceDetails() {
   const handleRetry = async () => {
     try {
       const updatedInvoice = await api.requestPromise(
-        `/customers/${orgId}/invoices/${invoiceId}/retry-payment/`,
+        `/_admin/cells/${region}/invoices/${invoiceId}/retry-payment/`,
         {
           method: 'PUT',
+          host: regionInfo ? regionInfo.url : '',
         }
       );
       updateCache(updatedInvoice);
@@ -105,9 +106,10 @@ export default function InvoiceDetails() {
   const handleEffectiveAt = async (effectiveAt: string) => {
     try {
       const updatedInvoice = await api.requestPromise(
-        `/customers/${orgId}/invoices/${invoiceId}/effective-at/`,
+        `/_admin/cells/${region}/invoices/${invoiceId}/effective-at/`,
         {
           method: 'PUT',
+          host: regionInfo ? regionInfo.url : '',
           data: {effectiveAt},
         }
       );

--- a/static/gsAdmin/views/invoices.tsx
+++ b/static/gsAdmin/views/invoices.tsx
@@ -117,7 +117,7 @@ export default function Invoices() {
       </Panel>
       <ResultGrid
         inPanel
-        isRegional
+        isCellScoped
         path="/_admin/invoices/"
         endpoint="/invoices/"
         method="GET"


### PR DESCRIPTION
Use cell endpoint for invoice details. Similar to https://github.com/getsentry/sentry/pull/106445. Cell URL was added here: https://github.com/getsentry/getsentry/issues/18975