### PR TITLE
Sentry valkey compatibility

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -344,7 +344,9 @@ def check_cluster_versions(
         # NOTE: This assumes there is no routing magic going on here, and
         # all requests to this host are being served by the same database.
         key = f"{host.host}:{host.port}"
-        versions[key] = Version([int(part) for part in info["redis_version"].split(".", 3)])
+        # Valkey (Redis fork) may return version as float (7.2) instead of string ("7.2.0")
+        # Convert to string to ensure split() works correctly
+        versions[key] = Version([int(part) for part in str(info["redis_version"]).split(".", 3)])
 
     check_versions(
         "Redis" if label is None else f"Redis ({label})", versions, required, recommended


### PR DESCRIPTION
Fixes ID-1311: Resolve Redis version incompatibility with Valkey.

Valkey, a Redis fork, can report its `redis_version` as a float (e.g., `7.2`) or a short string (e.g., `"7.2"`) in the `INFO` command output, instead of the expected "X.Y.Z" string format. This caused a `ConfigurationError` because Sentry's `check_cluster_versions` attempted to call `.split()` directly on a float, leading to an `AttributeError`.

This PR ensures that the `redis_version` is always converted to a string before parsing, allowing Sentry to correctly interpret Valkey's version format and maintain compatibility with standard Redis versions.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1311](https://linear.app/getsentry/issue/ID-1311/redis-version-incompatibility-with-valkey)

<a href="https://cursor.com/background-agent?bcId=bc-5c57028d-8585-4a7c-a8b3-82215de71a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c57028d-8585-4a7c-a8b3-82215de71a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

