### PR TITLE
fix(darkmode): code snippet background color

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -30,7 +30,7 @@ const prismStyles = (theme: Theme, darkTheme: Theme) => css`
   /* Use dark Prism theme for code snippets imported from Sentry Docs */
   .gatsby-highlight,
   .prism-dark {
-    ${generateThemePrismVariables(darkTheme, darkTheme.tokens.background.primary)};
+    ${generateThemePrismVariables(darkTheme, darkTheme.tokens.background.secondary)};
   }
 
   pre[class*='language-'] {


### PR DESCRIPTION
– Use `darkTheme.tokens.background.secondary` instead of `darkTheme.tokens.background.primary` for the background color of code snippets to set them off visually

Before: 
<img width="404" height="451" alt="Screenshot 2026-02-02 at 08 34 55" src="https://github.com/user-attachments/assets/e347c04a-67aa-4967-9221-9b2853450904" />

After:
<img width="407" height="468" alt="Screenshot 2026-02-02 at 08 34 25" src="https://github.com/user-attachments/assets/011f752c-76c2-4d7c-91c2-57dc2ba7eb3b" />
