### PR TITLE
chore(cross-event): Limit date selection when cross event querying

### DIFF
--- a/static/app/utils/duration/statsPeriodToDays.tsx
+++ b/static/app/utils/duration/statsPeriodToDays.tsx
@@ -14,6 +14,9 @@ export function statsPeriodToDays(
   if (statsPeriod?.endsWith('m')) {
     return parseInt(statsPeriod.slice(0, -1), 10) / 1440;
   }
+  if (statsPeriod?.endsWith('w')) {
+    return parseInt(statsPeriod.slice(0, -1), 10) * 7;
+  }
   if (start && end) {
     return (new Date(end).getTime() - new Date(start).getTime()) / (24 * 60 * 60 * 1000);
   }

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,3 +1,4 @@
+import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -121,5 +122,5 @@ export const SENTRY_TRACEMETRIC_NUMBER_TAGS: string[] = [];
 
 export const MAX_CROSS_EVENT_QUERIES = 2;
 // We want a maximum of 7 days for cross events to avoid overwhelming the backend.
-export const MAX_DAYS_FOR_CROSS_EVENTS = 7;
 export const MAX_PERIOD_FOR_CROSS_EVENTS = '7d';
+export const MAX_DAYS_FOR_CROSS_EVENTS = statsPeriodToDays(MAX_PERIOD_FOR_CROSS_EVENTS);

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -120,3 +120,5 @@ export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [
 export const SENTRY_TRACEMETRIC_NUMBER_TAGS: string[] = [];
 
 export const MAX_CROSS_EVENT_QUERIES = 2;
+// We want a maximum of 7 days for cross events to avoid overwhelming the backend.
+export const MAX_DAYS_FOR_CROSS_EVENTS = 7;

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -122,3 +122,4 @@ export const SENTRY_TRACEMETRIC_NUMBER_TAGS: string[] = [];
 export const MAX_CROSS_EVENT_QUERIES = 2;
 // We want a maximum of 7 days for cross events to avoid overwhelming the backend.
 export const MAX_DAYS_FOR_CROSS_EVENTS = 7;
+export const MAX_PERIOD_FOR_CROSS_EVENTS = '7d';

--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -158,6 +158,9 @@ describe('ExploreContent', () => {
       await waitFor(() => {
         expect(pageFiltersActionCreators.updateDateTime).toHaveBeenCalledWith({
           period: '7d',
+          start: null,
+          end: null,
+          utc: null,
         });
       });
     });

--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -1,0 +1,213 @@
+import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as pageFiltersActionCreators from 'sentry/actionCreators/pageFilters';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+
+import {ExploreContent} from './content';
+
+jest.mock('sentry/actionCreators/pageFilters', () => ({
+  ...jest.requireActual('sentry/actionCreators/pageFilters'),
+  updateDateTime: jest.fn(),
+}));
+
+describe('ExploreContent', () => {
+  const {organization, project} = initializeOrg({
+    organization: {
+      features: ['gen-ai-features', 'traces-page-cross-event-querying'],
+    },
+  });
+
+  beforeEach(() => {
+    // Suppress console errors from CompactSelect async updates
+    jest.spyOn(console, 'error').mockImplementation();
+
+    PageFiltersStore.init();
+
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {
+        timeSeries: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/traces/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
+      body: AutofixSetupFixture({
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'number'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'project',
+          name: 'project',
+          attributeSource: {source_type: 'sentry'},
+        },
+      ],
+      match: [MockApiClient.matchQuery({attributeType: 'string'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      method: 'GET',
+      body: [project],
+    });
+    MockApiClient.addMockResponse({
+      url: `/assistant/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  describe('cross events date restriction', () => {
+    it('renders with cross events and applies 7 day date restriction', async () => {
+      PageFiltersStore.onInitializeUrlState({
+        projects: [project].map(p => parseInt(p.id, 10)),
+        environments: [],
+        datetime: {period: '7d', start: null, end: null, utc: null},
+      });
+
+      render(<ExploreContent />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+            },
+          },
+        },
+      });
+
+      // Component renders successfully with cross events
+      expect(await screen.findByText('Traces')).toBeInTheDocument();
+
+      // The add cross event button should be visible
+      expect(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      ).toBeInTheDocument();
+    });
+
+    it('auto-adjusts period to 7d when cross events present and period exceeds 7 days', async () => {
+      PageFiltersStore.onInitializeUrlState({
+        projects: [project].map(p => parseInt(p.id, 10)),
+        environments: [],
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      });
+
+      render(<ExploreContent />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+            },
+          },
+        },
+      });
+
+      await waitFor(() => {
+        expect(pageFiltersActionCreators.updateDateTime).toHaveBeenCalledWith({
+          period: '7d',
+        });
+      });
+    });
+
+    it('does not adjust period when cross events present and period is within 7 days', async () => {
+      PageFiltersStore.onInitializeUrlState({
+        projects: [project].map(p => parseInt(p.id, 10)),
+        environments: [],
+        datetime: {period: '7d', start: null, end: null, utc: null},
+      });
+
+      render(<ExploreContent />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+            },
+          },
+        },
+      });
+
+      // Wait for component to fully render
+      await screen.findByText('Traces');
+
+      expect(pageFiltersActionCreators.updateDateTime).not.toHaveBeenCalled();
+    });
+
+    it('does not adjust period when no cross events present', async () => {
+      PageFiltersStore.onInitializeUrlState({
+        projects: [project].map(p => parseInt(p.id, 10)),
+        environments: [],
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      });
+
+      render(<ExploreContent />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {},
+          },
+        },
+      });
+
+      // Wait for component to fully render
+      await screen.findByText('Traces');
+
+      expect(pageFiltersActionCreators.updateDateTime).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -24,7 +24,10 @@ import {
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
-import {MAX_DAYS_FOR_CROSS_EVENTS} from 'sentry/views/explore/constants';
+import {
+  MAX_DAYS_FOR_CROSS_EVENTS,
+  MAX_PERIOD_FOR_CROSS_EVENTS,
+} from 'sentry/views/explore/constants';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {
@@ -47,7 +50,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 
 const CROSS_EVENTS_DATE_OVERRIDE: MaxPickableDaysOptions = {
-  defaultPeriod: '7d',
+  defaultPeriod: MAX_PERIOD_FOR_CROSS_EVENTS,
   maxPickableDays: MAX_DAYS_FOR_CROSS_EVENTS,
   maxUpgradableDays: MAX_DAYS_FOR_CROSS_EVENTS,
 };
@@ -117,7 +120,12 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
     );
 
     if (days > MAX_DAYS_FOR_CROSS_EVENTS) {
-      updateDateTime({period: '7d', start: null, end: null, utc: null});
+      updateDateTime({
+        period: MAX_PERIOD_FOR_CROSS_EVENTS,
+        start: null,
+        end: null,
+        utc: null,
+      });
     }
   }, [
     hasCrossEvents,

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -124,7 +124,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
         period: MAX_PERIOD_FOR_CROSS_EVENTS,
         start: null,
         end: null,
-        utc: null,
+        utc: pageFilters.selection.datetime.utc,
       });
     }
   }, [
@@ -133,6 +133,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
     pageFilters.selection.datetime.end,
     pageFilters.selection.datetime.period,
     pageFilters.selection.datetime.start,
+    pageFilters.selection.datetime.utc,
   ]);
 
   return (

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -111,7 +111,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
   const hasCrossEvents = useHasCrossEvents();
 
   useEffect(() => {
-    if (!hasCrossEvents) return;
+    if (!pageFilters.isReady || !hasCrossEvents) return;
 
     const days = statsPeriodToDays(
       pageFilters.selection.datetime.period,
@@ -129,6 +129,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
     }
   }, [
     hasCrossEvents,
+    pageFilters.isReady,
     pageFilters.selection.datetime.end,
     pageFilters.selection.datetime.period,
     pageFilters.selection.datetime.start,

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -117,7 +117,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
     );
 
     if (days > MAX_DAYS_FOR_CROSS_EVENTS) {
-      updateDateTime({period: '7d', start: null, end: null});
+      updateDateTime({period: '7d', start: null, end: null, utc: null});
     }
   }, [
     hasCrossEvents,

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -52,6 +52,11 @@ const CROSS_EVENTS_DATE_OVERRIDE: MaxPickableDaysOptions = {
   maxUpgradableDays: MAX_DAYS_FOR_CROSS_EVENTS,
 };
 
+function useHasCrossEvents() {
+  const crossEvents = useQueryParamsCrossEvents();
+  return defined(crossEvents) && crossEvents.length > 0;
+}
+
 export function ExploreContent() {
   Sentry.setTag('explore.visited', 'yes');
 
@@ -64,13 +69,11 @@ export function ExploreContent() {
 
 function ExploreContentInner() {
   const organization = useOrganization();
+  const hasCrossEvents = useHasCrossEvents();
   const onboardingProject = useOnboardingProject();
   const dataCategoryMaxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.SPANS],
   });
-
-  const crossEvents = useQueryParamsCrossEvents();
-  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
 
   const maxPickableDays = hasCrossEvents
     ? CROSS_EVENTS_DATE_OVERRIDE
@@ -102,8 +105,7 @@ function ExploreContentInner() {
 
 function SpansTabWrapper({children}: SpansTabContextProps) {
   const pageFilters = usePageFilters();
-  const crossEvents = useQueryParamsCrossEvents();
-  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
+  const hasCrossEvents = useHasCrossEvents();
 
   useEffect(() => {
     if (!hasCrossEvents) return;

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -115,7 +115,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
     );
 
     if (days > MAX_DAYS_FOR_CROSS_EVENTS) {
-      updateDateTime({period: '7d'});
+      updateDateTime({period: '7d', start: null, end: null});
     }
   }, [
     hasCrossEvents,


### PR DESCRIPTION
This PR adds in limits to the period select to 7 days when cross-event querying.

Ticket: EXP-738