### PR TITLE
feat(ai-insights): Display alert prompting users to update sdk

### DIFF
--- a/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
@@ -75,13 +75,13 @@ describe('SDKUpdateAlert', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          "We've detected you're using @sentry/nextjs and a newer version (8.0.0) is available. Update for a better experience."
+          "We've detected you're using the @sentry/nextjs package, and a newer version (8.0.0) is available. Update for a better experience."
         )
       )
     ).toBeInTheDocument();
   });
 
-  it('renders alert without suggested version', async () => {
+  it('renders alert with specific package but without suggested version', async () => {
     renderMockRequests({
       sdkUpdates: [
         {
@@ -98,8 +98,29 @@ describe('SDKUpdateAlert', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          "We've detected you're using sentry-sdk and a newer version is available. Update for a better experience."
+          "We've detected you're using the sentry-sdk package, and a newer version is available. Update for a better experience."
         )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders generic alert when SDK name is not recognized', async () => {
+    renderMockRequests({
+      sdkUpdates: [
+        {
+          projectId: '1',
+          sdkName: 'sentry.unknown.sdk',
+          sdkVersion: '1.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '2.0.0'}],
+        },
+      ],
+    });
+
+    render(<SDKUpdateAlert />, {organization});
+
+    expect(
+      await screen.findByText(
+        'A newer version of the Sentry SDK is available. Update for a better experience.'
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
@@ -170,11 +170,10 @@ describe('SDKUpdateAlert', () => {
       ],
     });
 
-    expect(sdkUpdatesResponse).not.toHaveBeenCalled();
-
     const {container} = render(<SDKUpdateAlert />, {organization});
 
     expect(container).toBeEmptyDOMElement();
+    expect(sdkUpdatesResponse).not.toHaveBeenCalled();
   });
 
   it('dismisses alert and saves to localStorage when dismiss button is clicked', async () => {

--- a/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
@@ -1,0 +1,173 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+
+import {SDKUpdateAlert} from './sdkUpdateAlert';
+
+jest.mock('sentry/utils/useDismissAlert');
+
+const mockUseDismissAlert = jest.mocked(useDismissAlert);
+
+const organization = OrganizationFixture();
+
+function renderMockRequests({
+  projects = [1],
+  sdkUpdates = [],
+}: {
+  projects?: number[];
+  sdkUpdates?: Array<{
+    projectId: string;
+    sdkName: string;
+    sdkVersion: string;
+    suggestions: Array<{type: string; newSdkVersion?: string}>;
+  }>;
+} = {}) {
+  PageFiltersStore.onInitializeUrlState({
+    projects,
+    environments: [],
+    datetime: {start: null, end: null, period: '14d', utc: null},
+  });
+
+  const sdkUpdatesResponse = MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/sdk-updates/`,
+    body: sdkUpdates,
+  });
+
+  return {sdkUpdatesResponse};
+}
+
+describe('SDKUpdateAlert', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    mockUseDismissAlert.mockReturnValue({
+      dismiss: jest.fn(),
+      isDismissed: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders alert when SDK update is available for single project', async () => {
+    renderMockRequests({
+      sdkUpdates: [
+        {
+          projectId: '1',
+          sdkName: 'sentry.javascript.nextjs',
+          sdkVersion: '7.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '8.0.0'}],
+        },
+      ],
+    });
+
+    render(<SDKUpdateAlert />, {organization});
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'A newer version of @sentry/nextjs is available. Update to 8.0.0 for the best experience.'
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders alert without suggested version', async () => {
+    renderMockRequests({
+      sdkUpdates: [
+        {
+          projectId: '1',
+          sdkName: 'sentry.python',
+          sdkVersion: '1.0.0',
+          suggestions: [],
+        },
+      ],
+    });
+
+    render(<SDKUpdateAlert />, {organization});
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'A newer version of sentry-sdk is available. Update to the latest version for the best experience.'
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when multiple projects are selected', () => {
+    renderMockRequests({projects: [1, 2]});
+
+    const {container} = render(<SDKUpdateAlert />, {organization});
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when no SDK update is needed', async () => {
+    const {sdkUpdatesResponse} = renderMockRequests();
+
+    const {container} = render(<SDKUpdateAlert />, {organization});
+
+    await waitFor(() => expect(sdkUpdatesResponse).toHaveBeenCalled());
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when alert is dismissed', () => {
+    mockUseDismissAlert.mockReturnValue({
+      dismiss: jest.fn(),
+      isDismissed: true,
+    });
+
+    const {sdkUpdatesResponse} = renderMockRequests({
+      sdkUpdates: [
+        {
+          projectId: '1',
+          sdkName: 'sentry.javascript.react',
+          sdkVersion: '7.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '8.0.0'}],
+        },
+      ],
+    });
+
+    expect(sdkUpdatesResponse).not.toHaveBeenCalled();
+
+    const {container} = render(<SDKUpdateAlert />, {organization});
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls dismiss when dismiss button is clicked', async () => {
+    const dismiss = jest.fn();
+    mockUseDismissAlert.mockReturnValue({
+      dismiss,
+      isDismissed: false,
+    });
+
+    renderMockRequests({
+      sdkUpdates: [
+        {
+          projectId: '1',
+          sdkName: 'sentry.javascript.node',
+          sdkVersion: '7.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '8.0.0'}],
+        },
+      ],
+    });
+
+    render(<SDKUpdateAlert />, {organization});
+
+    const dismissButton = await screen.findByRole('button', {
+      name: /Dismiss banner for 30 days/,
+    });
+
+    await userEvent.click(dismissButton);
+
+    expect(dismiss).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate, textWithMarkupMatcher} from 'sentry-test/utils';
 
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import localStorage from 'sentry/utils/localStorage';
 
@@ -105,6 +106,14 @@ describe('SDKUpdateAlert', () => {
 
   it('does not render when multiple projects are selected', () => {
     renderMockRequests({projects: [1, 2]});
+
+    const {container} = render(<SDKUpdateAlert />, {organization});
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when "All Projects" is selected', () => {
+    renderMockRequests({projects: [ALL_ACCESS_PROJECTS]});
 
     const {container} = render(<SDKUpdateAlert />, {organization});
 

--- a/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.spec.tsx
@@ -75,7 +75,7 @@ describe('SDKUpdateAlert', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          'A newer version of @sentry/nextjs is available. Update to 8.0.0 for the best experience.'
+          "We've detected you're using @sentry/nextjs and a newer version (8.0.0) is available. Update for a better experience."
         )
       )
     ).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('SDKUpdateAlert', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          'A newer version of sentry-sdk is available. Update to the latest version for the best experience.'
+          "We've detected you're using sentry-sdk and a newer version is available. Update for a better experience."
         )
       )
     ).toBeInTheDocument();

--- a/static/app/views/insights/common/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.tsx
@@ -27,7 +27,7 @@ function getPackageNameFromSdkName(sdkName?: string): string {
 }
 
 const EXPIRATION_DAYS = 30;
-const LOCAL_STORAGE_KEY = 'ai-sdk-update-dismissed';
+export const LOCAL_STORAGE_KEY = 'ai-sdk-update-dismissed';
 
 /**
  * Displays an alert when a newer SDK version is available compared to the

--- a/static/app/views/insights/common/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.tsx
@@ -7,9 +7,9 @@ import useDismissAlert from 'sentry/utils/useDismissAlert';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
 
-function getPackageNameFromSdkName(sdkName?: string): string {
+function getPackageNameFromSdkName(sdkName?: string): string | null {
   if (!sdkName) {
-    return t('the Sentry SDK');
+    return null;
   }
 
   if (sdkName.startsWith('sentry.python')) {
@@ -24,7 +24,7 @@ function getPackageNameFromSdkName(sdkName?: string): string {
     }
   }
 
-  return t('the Sentry SDK');
+  return null;
 }
 
 const EXPIRATION_DAYS = 30;
@@ -78,17 +78,23 @@ export function SDKUpdateAlert() {
         />
       }
     >
-      {suggestedVersion
-        ? tct(
-            "We've detected you're using [packageName] and a newer version ([version]) is available. Update for a better experience.",
-            {
-              packageName: <code>{packageName}</code>,
-              version: <code>{suggestedVersion}</code>,
-            }
-          )
-        : tct(
-            "We've detected you're using [packageName] and a newer version is available. Update for a better experience.",
-            {packageName: <code>{packageName}</code>}
+      {packageName
+        ? suggestedVersion
+          ? tct(
+              "We've detected you're using the [packageName] package, and a newer version ([version]) is available. Update for a better experience.",
+              {
+                packageName: <code>{packageName}</code>,
+                version: <code>{suggestedVersion}</code>,
+              }
+            )
+          : tct(
+              "We've detected you're using the [packageName] package, and a newer version is available. Update for a better experience.",
+              {
+                packageName: <code>{packageName}</code>,
+              }
+            )
+        : t(
+            'A newer version of the Sentry SDK is available. Update for a better experience.'
           )}
     </Alert>
   );

--- a/static/app/views/insights/common/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.tsx
@@ -80,14 +80,14 @@ export function SDKUpdateAlert() {
     >
       {suggestedVersion
         ? tct(
-            'A newer version of [packageName] is available. Update to [version] for the best experience.',
+            "We've detected you're using [packageName] and a newer version ([version]) is available. Update for a better experience.",
             {
               packageName: <code>{packageName}</code>,
               version: <code>{suggestedVersion}</code>,
             }
           )
         : tct(
-            'A newer version of [packageName] is available. Update to the latest version for the best experience.',
+            "We've detected you're using [packageName] and a newer version is available. Update for a better experience.",
             {packageName: <code>{packageName}</code>}
           )}
     </Alert>

--- a/static/app/views/insights/common/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/common/components/sdkUpdateAlert.tsx
@@ -1,5 +1,6 @@
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
@@ -42,7 +43,8 @@ export function SDKUpdateAlert() {
   });
 
   const selectedProjectIds = selection.projects.map(id => id.toString());
-  const isSingleProject = selectedProjectIds.length === 1;
+  const isSingleProject =
+    selection.projects.length === 1 && !selection.projects.includes(ALL_ACCESS_PROJECTS);
 
   const {isFetching, needsUpdate, data} = useProjectSdkNeedsUpdate({
     projectId: selectedProjectIds,

--- a/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
+++ b/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
@@ -30,24 +30,16 @@ export function useOutdatedSDKProjects({enabled, projectId}: Options) {
   );
   const {data: availableUpdates} = response;
 
-  console.log({availableUpdates});
-
   const projects = (availableUpdates ?? [])
     .filter(update => {
       const platform = removeFlavorFromSDKName(update.sdkName);
-      console.log({platform});
       const minimumRequiredVersion = MIN_SDK_VERSION_BY_PLATFORM[platform];
-      console.log({minimumRequiredVersion});
 
       if (!minimumRequiredVersion) {
         // If a minimum version is not specified, assume that the platform
         // doesn't have any support at all
         return true;
       }
-
-      console.log({
-        blah: update.sdkVersion,
-      });
 
       return semverCompare(update.sdkVersion, minimumRequiredVersion) === -1;
     })

--- a/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
+++ b/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
@@ -30,16 +30,24 @@ export function useOutdatedSDKProjects({enabled, projectId}: Options) {
   );
   const {data: availableUpdates} = response;
 
+  console.log({availableUpdates});
+
   const projects = (availableUpdates ?? [])
     .filter(update => {
       const platform = removeFlavorFromSDKName(update.sdkName);
+      console.log({platform});
       const minimumRequiredVersion = MIN_SDK_VERSION_BY_PLATFORM[platform];
+      console.log({minimumRequiredVersion});
 
       if (!minimumRequiredVersion) {
         // If a minimum version is not specified, assume that the platform
         // doesn't have any support at all
         return true;
       }
+
+      console.log({
+        blah: update.sdkVersion,
+      });
 
       return semverCompare(update.sdkVersion, minimumRequiredVersion) === -1;
     })

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -143,9 +143,11 @@ function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
                 </ModuleLayout.Full>
               )}
 
-              <ModuleLayout.Full>
-                <SDKUpdateAlert />
-              </ModuleLayout.Full>
+              {!showOnboarding && (
+                <ModuleLayout.Full>
+                  <SDKUpdateAlert />
+                </ModuleLayout.Full>
+              )}
 
               <ModuleLayout.Full>
                 {showOnboarding ? (

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -29,6 +29,7 @@ import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/componen
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {SDKUpdateAlert} from 'sentry/views/insights/common/components/sdkUpdateAlert';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -141,6 +142,10 @@ function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
                   </Alert>
                 </ModuleLayout.Full>
               )}
+
+              <ModuleLayout.Full>
+                <SDKUpdateAlert />
+              </ModuleLayout.Full>
 
               <ModuleLayout.Full>
                 {showOnboarding ? (

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -30,6 +30,7 @@ import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/componen
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {SDKUpdateAlert} from 'sentry/views/insights/common/components/sdkUpdateAlert';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
@@ -138,6 +139,10 @@ function ConversationsOverviewPage({
                       source={SchemaHintsSources.CONVERSATIONS}
                     />
                   </Stack>
+                </ModuleLayout.Full>
+
+                <ModuleLayout.Full>
+                  <SDKUpdateAlert />
                 </ModuleLayout.Full>
 
                 <ModuleLayout.Full>

--- a/static/app/views/insights/pages/mcp/overview.tsx
+++ b/static/app/views/insights/pages/mcp/overview.tsx
@@ -85,9 +85,11 @@ function McpOverviewPage({datePageFilterProps}: McpOverviewPageProps) {
                 </ToolRibbon>
               </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                <SDKUpdateAlert />
-              </ModuleLayout.Full>
+              {!showOnboarding && (
+                <ModuleLayout.Full>
+                  <SDKUpdateAlert />
+                </ModuleLayout.Full>
+              )}
 
               <ModuleLayout.Full>
                 {showOnboarding ? (

--- a/static/app/views/insights/pages/mcp/overview.tsx
+++ b/static/app/views/insights/pages/mcp/overview.tsx
@@ -21,6 +21,7 @@ import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/componen
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {SDKUpdateAlert} from 'sentry/views/insights/common/components/sdkUpdateAlert';
 import McpTrafficWidget from 'sentry/views/insights/common/components/widgets/mcpTrafficWidget';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
@@ -82,6 +83,10 @@ function McpOverviewPage({datePageFilterProps}: McpOverviewPageProps) {
                     </Flex>
                   )}
                 </ToolRibbon>
+              </ModuleLayout.Full>
+
+              <ModuleLayout.Full>
+                <SDKUpdateAlert />
               </ModuleLayout.Full>
 
               <ModuleLayout.Full>

--- a/static/app/views/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/replays/detail/network/details/content.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('sentry/utils/useProjectSdkNeedsUpdate');
 function mockNeedsUpdate(needsUpdate: boolean) {
   jest
     .mocked(useProjectSdkNeedsUpdate)
-    .mockReturnValue({isError: false, isFetching: false, needsUpdate});
+    .mockReturnValue({isError: false, isFetching: false, needsUpdate, data: []});
 }
 
 const [

--- a/static/app/views/replays/detail/network/details/onboarding.spec.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.spec.tsx
@@ -23,7 +23,7 @@ const [MOCK_ITEM] = hydrateSpans(ReplayRecordFixture(), [
 describe('Setup', () => {
   jest
     .mocked(useProjectSdkNeedsUpdate)
-    .mockReturnValue({isError: false, isFetching: false, needsUpdate: false});
+    .mockReturnValue({isError: false, isFetching: false, needsUpdate: false, data: []});
 
   describe('Setup is not complete', () => {
     it('should render the full snippet when no setup is done yet', () => {

--- a/static/app/views/replays/list.spec.tsx
+++ b/static/app/views/replays/list.spec.tsx
@@ -96,6 +96,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: false,
+      data: [],
     });
 
     render(<ListPage />, {
@@ -116,6 +117,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: false,
+      data: [],
     });
 
     render(<ListPage />, {
@@ -136,6 +138,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: false,
+      data: [],
     });
 
     render(<ListPage />, {
@@ -156,6 +159,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: true,
+      data: [],
     });
 
     render(<ListPage />, {
@@ -178,6 +182,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: false,
+      data: [],
     });
 
     render(<ListPage />, {
@@ -203,6 +208,7 @@ describe('ReplayList', () => {
       isError: false,
       isFetching: false,
       needsUpdate: false,
+      data: [],
     });
 
     render(<ListPage />, {


### PR DESCRIPTION
Adds an SDK update alert banner to the AI Insights overview pages (Agents, Conversations, and MCP). When a user is viewing a _single project_ with an outdated SDK version, they'll see an informational alert prompting them to update to the latest version for the best experience.

Preview

<img width="1648" height="553" alt="image" src="https://github.com/user-attachments/assets/84d5b0b2-d40c-4561-845e-05b96539ba79" />


closes https://linear.app/getsentry/issue/TET-1583/ai-onboarding-detect-latest-sdk-version-in-selected-project-and-prompt


