### PR TITLE
feat(ai-conversations): display failed tool calls

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -15,6 +15,7 @@ import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {
   getGenAiOpType,
   getIsAiAgentNode,
+  hasError,
 } from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   getIsAiAgentSpan,
@@ -504,23 +505,6 @@ function getNodeInfo(node: AITraceSpanNode, colors: readonly string[]) {
   }
 
   return nodeInfo;
-}
-
-function hasError(node: AITraceSpanNode) {
-  if (node.errors.size > 0) {
-    return true;
-  }
-
-  const spanStatus = node.attributes?.[SpanFields.SPAN_STATUS] as string | undefined;
-  if (!!spanStatus && typeof spanStatus === 'string') {
-    return spanStatus.includes('error');
-  }
-  const status = node.attributes?.status;
-  if (!!status && typeof status === 'string') {
-    return status.includes('error');
-  }
-
-  return false;
 }
 
 const ListItemContainer = styled('div')<{

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -90,3 +90,18 @@ export const getIsAiNode = createGetIsAiNode(genAiOpType => Boolean(genAiOpType)
 export const getIsAiAgentNode = createGetIsAiNode(getIsAiAgentSpan);
 export const getIsAiGenerationNode = createGetIsAiNode(getIsAiGenerationSpan);
 export const getIsExecuteToolNode = createGetIsAiNode(getIsExecuteToolSpan);
+
+export function hasError(node: AITraceSpanNode): boolean {
+  if (node.errors.size > 0) {
+    return true;
+  }
+  const spanStatus = node.attributes?.[SpanFields.SPAN_STATUS] as string | undefined;
+  if (spanStatus && typeof spanStatus === 'string') {
+    return spanStatus.includes('error');
+  }
+  const status = node.attributes?.status;
+  if (status && typeof status === 'string') {
+    return status.includes('error');
+  }
+  return false;
+}

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -7,10 +7,11 @@ import {Text} from '@sentry/scraps/text';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EmptyMessage from 'sentry/components/emptyMessage';
-import {IconUser} from 'sentry/icons';
+import {IconFire, IconUser} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
 import {t} from 'sentry/locale';
 import {MarkedText} from 'sentry/utils/marked/markedText';
+import {hasError} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   getIsAiGenerationSpan,
   getIsExecuteToolSpan,
@@ -20,6 +21,7 @@ import {SpanFields} from 'sentry/views/insights/types';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 
 interface ToolCall {
+  hasError: boolean;
   name: string;
   nodeId: string;
 }
@@ -82,7 +84,7 @@ function findToolCallsBetween(
     })
     .map(span => {
       const name = span.attributes?.[SpanFields.GEN_AI_TOOL_NAME] as string | undefined;
-      return name ? {name, nodeId: span.id} : null;
+      return name ? {name, nodeId: span.id, hasError: hasError(span)} : null;
     })
     .filter((tc): tc is ToolCall => tc !== null);
 }
@@ -329,7 +331,9 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                       return (
                         <ClickableTag
                           key={tool.nodeId}
-                          variant="info"
+                          variant={tool.hasError ? 'danger' : 'info'}
+                          icon={tool.hasError ? <IconFire /> : undefined}
+                          hasError={tool.hasError}
                           isSelected={isToolSelected}
                           onClick={e => {
                             e.stopPropagation();
@@ -412,7 +416,7 @@ const ToolCallsFooter = styled(Flex)`
   border-top: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
-const ClickableTag = styled(Tag)<{isSelected?: boolean}>`
+const ClickableTag = styled(Tag)<{hasError?: boolean; isSelected?: boolean}>`
   cursor: pointer;
   &:hover {
     opacity: 0.8;
@@ -420,7 +424,7 @@ const ClickableTag = styled(Tag)<{isSelected?: boolean}>`
   ${p =>
     p.isSelected &&
     `
-    outline: 2px solid ${p.theme.tokens.focus.default};
+    outline: 2px solid ${p.hasError ? p.theme.tokens.content.danger : p.theme.tokens.focus.default};
     outline-offset: -2px;
   `}
 `;


### PR DESCRIPTION
- closes: https://linear.app/getsentry/issue/TET-1878/improve-visibility-of-tool-call-errors-in-conversations
- makes errored tool badges red and adds a fire icon to them

<img width="800" height="1120" alt="CleanShot 2026-02-02 at 14 22 31@2x" src="https://github.com/user-attachments/assets/936ababd-7f25-4a76-9dd4-bc72f185fd52" />
