### PR TITLE
chore(cross-event): Remove metrics option

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -66,7 +66,6 @@ export type TracingEventParameters = {
     visualizes_count: number;
     attribute_breakdowns_mode?: 'breakdowns' | 'cohort_comparison';
     cross_event_log_query_count?: number;
-    cross_event_metric_query_count?: number;
     cross_event_span_query_count?: number;
   };
   'trace.explorer.schema_hints_click': {

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -154,7 +154,6 @@ function useTrackAnalytics({
       gave_seer_consent: gaveSeerConsent,
       version: 2,
       cross_event_log_query_count: crossEventQueries?.logQuery?.length ?? 0,
-      cross_event_metric_query_count: crossEventQueries?.metricQuery?.length ?? 0,
       cross_event_span_query_count: crossEventQueries?.spanQuery?.length ?? 0,
     });
 
@@ -176,7 +175,6 @@ function useTrackAnalytics({
       page_source: ${page_source}
       gave_seer_consent: ${gaveSeerConsent}
       cross_event_log_query_count: ${crossEventQueries?.logQuery?.length ?? 0}
-      cross_event_metric_query_count: ${crossEventQueries?.metricQuery?.length ?? 0}
       cross_event_span_query_count: ${crossEventQueries?.spanQuery?.length ?? 0}
     `,
       {isAnalytics: true}
@@ -188,7 +186,6 @@ function useTrackAnalytics({
     aggregatesTableResult.result.isPending,
     aggregatesTableResult.result.meta?.dataScanned,
     crossEventQueries?.logQuery,
-    crossEventQueries?.metricQuery,
     crossEventQueries?.spanQuery,
     dataset,
     hasExceededPerformanceUsageLimit,
@@ -254,7 +251,6 @@ function useTrackAnalytics({
       version: 2,
       attribute_breakdowns_mode: attributeBreakdownsMode,
       cross_event_log_query_count: crossEventQueries?.logQuery?.length ?? 0,
-      cross_event_metric_query_count: crossEventQueries?.metricQuery?.length ?? 0,
       cross_event_span_query_count: crossEventQueries?.spanQuery?.length ?? 0,
     });
 
@@ -275,13 +271,11 @@ function useTrackAnalytics({
       gave_seer_consent: ${gaveSeerConsent}
       attribute_breakdowns_mode: ${attributeBreakdownsMode}
       cross_event_log_query_count: ${crossEventQueries?.logQuery?.length ?? 0}
-      cross_event_metric_query_count: ${crossEventQueries?.metricQuery?.length ?? 0}
       cross_event_span_query_count: ${crossEventQueries?.spanQuery?.length ?? 0}
     `);
   }, [
     attributeBreakdownsMode,
     crossEventQueries?.logQuery,
-    crossEventQueries?.metricQuery,
     crossEventQueries?.spanQuery,
     dataset,
     fields,
@@ -349,7 +343,6 @@ function useTrackAnalytics({
       version: 2,
       attribute_breakdowns_mode: attributeBreakdownsMode,
       cross_event_log_query_count: crossEventQueries?.logQuery?.length ?? 0,
-      cross_event_metric_query_count: crossEventQueries?.metricQuery?.length ?? 0,
       cross_event_span_query_count: crossEventQueries?.spanQuery?.length ?? 0,
     });
 
@@ -370,13 +363,11 @@ function useTrackAnalytics({
       gave_seer_consent: ${gaveSeerConsent}
       attribute_breakdowns_mode: ${attributeBreakdownsMode}
       cross_event_log_query_count: ${crossEventQueries?.logQuery?.length ?? 0}
-      cross_event_metric_query_count: ${crossEventQueries?.metricQuery?.length ?? 0}
       cross_event_span_query_count: ${crossEventQueries?.spanQuery?.length ?? 0}
     `);
   }, [
     attributeBreakdownsMode,
     crossEventQueries?.logQuery,
-    crossEventQueries?.metricQuery,
     crossEventQueries?.spanQuery,
     dataset,
     hasExceededPerformanceUsageLimit,
@@ -454,12 +445,10 @@ function useTrackAnalytics({
       gave_seer_consent: gaveSeerConsent,
       version: 2,
       cross_event_log_query_count: crossEventQueries?.logQuery?.length ?? 0,
-      cross_event_metric_query_count: crossEventQueries?.metricQuery?.length ?? 0,
       cross_event_span_query_count: crossEventQueries?.spanQuery?.length ?? 0,
     });
   }, [
     crossEventQueries?.logQuery,
-    crossEventQueries?.metricQuery,
     crossEventQueries?.spanQuery,
     dataset,
     hasExceededPerformanceUsageLimit,

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -76,7 +76,7 @@ describe('useCrossEventQueries', () => {
     const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
       additionalWrapper: Wrapper([
         {type: 'logs', query: 'test:a'},
-        {type: 'metrics', query: 'test:b'},
+        {type: 'spans', query: 'test:b'},
         {type: 'spans', query: 'test:c'},
       ]),
     });
@@ -84,8 +84,7 @@ describe('useCrossEventQueries', () => {
     // Since MAX_CROSS_EVENT_QUERIES is 2, the third query ('spans') will be dropped.
     expect(result.current).toStrictEqual({
       logQuery: ['test:a'],
-      metricQuery: ['test:b'],
-      spanQuery: [],
+      spanQuery: ['test:b'],
     });
   });
 
@@ -101,7 +100,6 @@ describe('useCrossEventQueries', () => {
     // Only first 2 are kept
     expect(result.current).toStrictEqual({
       logQuery: [],
-      metricQuery: [],
       spanQuery: ['test:a', 'test:b'],
     });
   });
@@ -117,7 +115,6 @@ describe('useCrossEventQueries', () => {
 
     expect(result.current).toStrictEqual({
       logQuery: ['test:a'],
-      metricQuery: [],
       spanQuery: ['test:c'],
     });
   });

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -30,10 +30,10 @@ export function useCrossEventQueries() {
         case 'logs':
           logQuery.push(crossEvent.query);
           break;
-        case 'metrics':
-          // Temporary disabled metrics cross event querying
-          // metricQuery.push(crossEvent.query);
-          break;
+        // case 'metrics':
+        // Temporary disabled metrics cross event querying
+        // metricQuery.push(crossEvent.query);
+        // break;
         default:
           break;
       }

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -30,10 +30,6 @@ export function useCrossEventQueries() {
         case 'logs':
           logQuery.push(crossEvent.query);
           break;
-        // case 'metrics':
-        // Temporary disabled metrics cross event querying
-        // metricQuery.push(crossEvent.query);
-        // break;
         default:
           break;
       }

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -20,7 +20,6 @@ export function useCrossEventQueries() {
       .slice(0, MAX_CROSS_EVENT_QUERIES);
 
     const logQuery: string[] = [];
-    const metricQuery: string[] = [];
     const spanQuery: string[] = [];
 
     for (const crossEvent of slicedCrossEvents) {
@@ -32,13 +31,14 @@ export function useCrossEventQueries() {
           logQuery.push(crossEvent.query);
           break;
         case 'metrics':
-          metricQuery.push(crossEvent.query);
+          // Temporary disabled metrics cross event querying
+          // metricQuery.push(crossEvent.query);
           break;
         default:
           break;
       }
     }
 
-    return {spanQuery, logQuery, metricQuery};
+    return {spanQuery, logQuery};
   }, [crossEvents]);
 }

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -2,7 +2,7 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 
-export type CrossEventType = 'logs' | 'spans' | 'metrics';
+export type CrossEventType = 'logs' | 'spans' /* | 'metrics' */;
 
 export interface CrossEvent {
   query: string;

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -33,7 +33,8 @@ export function getCrossEventsFromLocation(
 }
 
 export function isCrossEventType(value: string): value is CrossEventType {
-  return value === 'logs' || value === 'spans' || value === 'metrics';
+  // We're temporarily disabling metrics cross event querying for EA
+  return value === 'logs' || value === 'spans' /* || value === 'metrics' */;
 }
 
 function isCrossEvent(value: any): value is CrossEvent {

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -2,7 +2,7 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 
-export type CrossEventType = 'logs' | 'spans' /* | 'metrics' */;
+export type CrossEventType = 'logs' | 'spans';
 
 export interface CrossEvent {
   query: string;
@@ -33,8 +33,7 @@ export function getCrossEventsFromLocation(
 }
 
 export function isCrossEventType(value: string): value is CrossEventType {
-  // We're temporarily disabling metrics cross event querying for EA
-  return value === 'logs' || value === 'spans' /* || value === 'metrics' */;
+  return value === 'logs' || value === 'spans';
 }
 
 function isCrossEvent(value: any): value is CrossEvent {

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -655,7 +655,7 @@ describe('SpansTabContent', () => {
               crossEvents: JSON.stringify([
                 {query: '', type: 'spans'},
                 {query: '', type: 'logs'},
-                {query: '', type: 'metrics'},
+                {query: '', type: 'logs'},
               ]),
             },
           },

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -519,8 +519,6 @@ describe('SpansTabContent', () => {
 
       expect(screen.getByRole('menuitemradio', {name: 'Spans'})).toBeInTheDocument();
       expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
-      // We're temporarily disabling metrics cross event querying for EA
-      // expect(screen.getByRole('menuitemradio', {name: 'Metrics'})).toBeInTheDocument();
     });
 
     it('adds a cross event query', async () => {

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -519,7 +519,8 @@ describe('SpansTabContent', () => {
 
       expect(screen.getByRole('menuitemradio', {name: 'Spans'})).toBeInTheDocument();
       expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
-      expect(screen.getByRole('menuitemradio', {name: 'Metrics'})).toBeInTheDocument();
+      // We're temporarily disabling metrics cross event querying for EA
+      // expect(screen.getByRole('menuitemradio', {name: 'Metrics'})).toBeInTheDocument();
     });
 
     it('adds a cross event query', async () => {
@@ -625,21 +626,21 @@ describe('SpansTabContent', () => {
         initialRouterConfig: {
           location: {
             pathname: '/organizations/org-slug/explore/traces/',
-            query: {crossEvents: JSON.stringify([{query: '', type: 'logs'}])},
+            query: {crossEvents: JSON.stringify([{query: '', type: 'spans'}])},
           },
         },
       });
 
-      await userEvent.click(screen.getByRole('button', {name: /Logs/}));
-      await userEvent.click(screen.getByRole('option', {name: 'Metrics'}));
+      await userEvent.click(screen.getByRole('button', {name: /Spans/}));
+      await userEvent.click(screen.getByRole('option', {name: 'Logs'}));
 
       expect(
-        screen.getByPlaceholderText('Search for metrics, users, tags, and more')
+        screen.getByPlaceholderText('Search for logs, users, tags, and more')
       ).toBeInTheDocument();
 
       expect(trackAnalytics).toHaveBeenCalledWith(
         'trace.explorer.cross_event_changed',
-        expect.objectContaining({new_type: 'metrics', old_type: 'logs'})
+        expect.objectContaining({new_type: 'logs', old_type: 'spans'})
       );
     });
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -64,8 +64,6 @@ import {findSuggestedColumns} from 'sentry/views/explore/utils';
 const crossEventDropdownItems: DropdownMenuProps['items'] = [
   {key: 'spans', label: t('Spans')},
   {key: 'logs', label: t('Logs')},
-  // We're temporarily disabling metrics cross event querying for EA
-  // {key: 'metrics', label: t('Metrics')},
 ];
 
 function CrossEventQueryingDropdown() {
@@ -138,10 +136,6 @@ const SpansTabCrossEventSearchBar = memo(
     if (type === 'logs') {
       traceItemType = TraceItemDataset.LOGS;
     }
-    // Temporary disabled metrics cross event querying
-    // else if (crossEvent.type === 'metrics') {
-    //   traceItemType = TraceItemDataset.TRACEMETRICS;
-    // }
 
     const eapSpanSearchQueryBuilderProps = useMemo(
       () => ({
@@ -242,10 +236,6 @@ function SpansTabCrossEventSearchBars() {
     if (crossEvent.type === 'logs') {
       traceItemType = TraceItemDataset.LOGS;
     }
-    // Temporary disabled metrics cross event querying
-    // else if (crossEvent.type === 'metrics') {
-    //   traceItemType = TraceItemDataset.TRACEMETRICS;
-    // }
 
     const maxCrossEventQueriesReached = index >= MAX_CROSS_EVENT_QUERIES;
 
@@ -265,8 +255,6 @@ function SpansTabCrossEventSearchBars() {
               options={[
                 {value: 'spans', label: t('Spans')},
                 {value: 'logs', label: t('Logs')},
-                // We're temporarily disabling metrics cross event querying for EA
-                // {value: 'metrics', label: t('Metrics')},
               ]}
               onChange={({value: newValue}) => {
                 if (!isCrossEventType(newValue)) return;

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -64,7 +64,8 @@ import {findSuggestedColumns} from 'sentry/views/explore/utils';
 const crossEventDropdownItems: DropdownMenuProps['items'] = [
   {key: 'spans', label: t('Spans')},
   {key: 'logs', label: t('Logs')},
-  {key: 'metrics', label: t('Metrics')},
+  // We're temporarily disabling metrics cross event querying for EA
+  // {key: 'metrics', label: t('Metrics')},
 ];
 
 function CrossEventQueryingDropdown() {
@@ -260,7 +261,8 @@ function SpansTabCrossEventSearchBars() {
               options={[
                 {value: 'spans', label: t('Spans')},
                 {value: 'logs', label: t('Logs')},
-                {value: 'metrics', label: t('Metrics')},
+                // We're temporarily disabling metrics cross event querying for EA
+                // {value: 'metrics', label: t('Metrics')},
               ]}
               onChange={({value: newValue}) => {
                 if (!isCrossEventType(newValue)) return;

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -134,12 +134,14 @@ const SpansTabCrossEventSearchBar = memo(
     const {tags: stringAttributes, secondaryAliases: stringSecondaryAliases} =
       useTraceItemTags('string');
 
-    const traceItemType =
-      type === 'spans'
-        ? TraceItemDataset.SPANS
-        : type === 'logs'
-          ? TraceItemDataset.LOGS
-          : TraceItemDataset.TRACEMETRICS;
+    let traceItemType = TraceItemDataset.SPANS;
+    if (type === 'logs') {
+      traceItemType = TraceItemDataset.LOGS;
+    }
+    // Temporary disabled metrics cross event querying
+    // else if (crossEvent.type === 'metrics') {
+    //   traceItemType = TraceItemDataset.TRACEMETRICS;
+    // }
 
     const eapSpanSearchQueryBuilderProps = useMemo(
       () => ({
@@ -236,12 +238,14 @@ function SpansTabCrossEventSearchBars() {
   }
 
   return crossEvents.map((crossEvent, index) => {
-    const traceItemType =
-      crossEvent.type === 'spans'
-        ? TraceItemDataset.SPANS
-        : crossEvent.type === 'logs'
-          ? TraceItemDataset.LOGS
-          : TraceItemDataset.TRACEMETRICS;
+    let traceItemType = TraceItemDataset.SPANS;
+    if (crossEvent.type === 'logs') {
+      traceItemType = TraceItemDataset.LOGS;
+    }
+    // Temporary disabled metrics cross event querying
+    // else if (crossEvent.type === 'metrics') {
+    //   traceItemType = TraceItemDataset.TRACEMETRICS;
+    // }
 
     const maxCrossEventQueriesReached = index >= MAX_CROSS_EVENT_QUERIES;
 


### PR DESCRIPTION
This PR removes the "Metrics" option from cross-event querying, as we're removing this for initial EA launch.

Ticket: EXP-739