### PR TITLE
feat(seer): Add trigger_at timestamp to PR review requests

### DIFF
--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -50,7 +50,7 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_user: str | None = None
     trigger_user_id: int | None = None
     trigger_at: datetime
-    trigger_received_at: datetime  # When Sentry received the webhook
+    sentry_received_trigger_at: datetime  # When Sentry received the webhook
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
@@ -48,6 +49,7 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_comment_type: Literal["issue_comment"] | None = None
     trigger_user: str | None = None
     trigger_user_id: int | None = None
+    trigger_at: datetime | None = None
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -50,6 +50,7 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_user: str | None = None
     trigger_user_id: int | None = None
     trigger_at: datetime
+    trigger_received_at: datetime  # When Sentry received the webhook
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -49,7 +49,7 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_comment_type: Literal["issue_comment"] | None = None
     trigger_user: str | None = None
     trigger_user_id: int | None = None
-    trigger_at: datetime | None = None
+    trigger_at: datetime
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 from collections.abc import Mapping
+from datetime import datetime
 from enum import Enum, StrEnum
 from typing import Any
 
@@ -121,13 +122,16 @@ def _get_trigger_metadata_for_pull_request(event_payload: Mapping[str, Any]) -> 
     # triggers an event (e.g., collaborator pushes commits, admin closes PR
     # or makes ready for review)
     sender = event_payload.get("sender", {})
-    pr_author = event_payload.get("pull_request", {}).get("user", {})
+    pull_request = event_payload.get("pull_request", {})
+    pr_author = pull_request.get("user", {})
+    updated_at = pull_request.get("updated_at")
 
     return {
         "trigger_user": sender.get("login") or pr_author.get("login"),
         "trigger_user_id": sender.get("id") or pr_author.get("id"),
         "trigger_comment_id": None,
         "trigger_comment_type": None,
+        "trigger_at": datetime.fromisoformat(updated_at) if updated_at else None,
     }
 
 
@@ -135,12 +139,16 @@ def _get_trigger_metadata_for_issue_comment(event_payload: Mapping[str, Any]) ->
     """Extract trigger metadata for issue_comment events."""
     comment = event_payload.get("comment", {})
     comment_user = comment.get("user", {})
+    # Use updated_at to support both "created" and potential future "edited" triggers.
+    # For newly created comments, updated_at equals created_at.
+    trigger_at = comment.get("updated_at") or comment.get("created_at")
 
     return {
         "trigger_user": comment_user.get("login"),
         "trigger_user_id": comment_user.get("id"),
         "trigger_comment_id": comment.get("id"),
         "trigger_comment_type": "issue_comment",
+        "trigger_at": datetime.fromisoformat(trigger_at) if trigger_at else None,
     }
 
 
@@ -255,6 +263,7 @@ def transform_issue_comment_to_codegen_request(
     config["trigger_user_id"] = trigger_metadata["trigger_user_id"]
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
+    config["trigger_at"] = trigger_metadata["trigger_at"]
     return payload
 
 
@@ -295,6 +304,7 @@ def transform_pull_request_to_codegen_request(
     config["trigger_user_id"] = trigger_metadata["trigger_user_id"]
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
+    config["trigger_at"] = trigger_metadata["trigger_at"]
     return payload
 
 

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -274,7 +274,7 @@ def transform_issue_comment_to_codegen_request(
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
     config["trigger_at"] = trigger_metadata["trigger_at"]
-    config["trigger_received_at"] = datetime.now(timezone.utc).isoformat()
+    config["sentry_received_trigger_at"] = datetime.now(timezone.utc).isoformat()
     return payload
 
 
@@ -316,7 +316,7 @@ def transform_pull_request_to_codegen_request(
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
     config["trigger_at"] = trigger_metadata["trigger_at"]
-    config["trigger_received_at"] = datetime.now(timezone.utc).isoformat()
+    config["sentry_received_trigger_at"] = datetime.now(timezone.utc).isoformat()
     return payload
 
 

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -274,6 +274,7 @@ def transform_issue_comment_to_codegen_request(
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
     config["trigger_at"] = trigger_metadata["trigger_at"]
+    config["trigger_received_at"] = datetime.now(timezone.utc).isoformat()
     return payload
 
 
@@ -315,6 +316,7 @@ def transform_pull_request_to_codegen_request(
     config["trigger_comment_id"] = trigger_metadata["trigger_comment_id"]
     config["trigger_comment_type"] = trigger_metadata["trigger_comment_type"]
     config["trigger_at"] = trigger_metadata["trigger_at"]
+    config["trigger_received_at"] = datetime.now(timezone.utc).isoformat()
     return payload
 
 

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -124,9 +124,11 @@ def _get_trigger_metadata_for_pull_request(event_payload: Mapping[str, Any]) -> 
     sender = event_payload.get("sender", {})
     pull_request = event_payload.get("pull_request", {})
     pr_author = pull_request.get("user", {})
-    trigger_at_str = pull_request.get("updated_at") or pull_request.get("created_at")
+    # Return ISO string for Celery serialization; Pydantic will parse to datetime
     trigger_at = (
-        datetime.fromisoformat(trigger_at_str) if trigger_at_str else datetime.now(timezone.utc)
+        pull_request.get("updated_at")
+        or pull_request.get("created_at")
+        or datetime.now(timezone.utc).isoformat()
     )
 
     return {
@@ -144,9 +146,11 @@ def _get_trigger_metadata_for_issue_comment(event_payload: Mapping[str, Any]) ->
     comment_user = comment.get("user", {})
     # Use updated_at to support both "created" and potential future "edited" triggers.
     # For newly created comments, updated_at equals created_at.
-    trigger_at_str = comment.get("updated_at") or comment.get("created_at")
+    # Return ISO string for Celery serialization; Pydantic will parse to datetime
     trigger_at = (
-        datetime.fromisoformat(trigger_at_str) if trigger_at_str else datetime.now(timezone.utc)
+        comment.get("updated_at")
+        or comment.get("created_at")
+        or datetime.now(timezone.utc).isoformat()
     )
 
     return {

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum, StrEnum
 from typing import Any
 
@@ -124,14 +124,17 @@ def _get_trigger_metadata_for_pull_request(event_payload: Mapping[str, Any]) -> 
     sender = event_payload.get("sender", {})
     pull_request = event_payload.get("pull_request", {})
     pr_author = pull_request.get("user", {})
-    updated_at = pull_request.get("updated_at")
+    trigger_at_str = pull_request.get("updated_at") or pull_request.get("created_at")
+    trigger_at = (
+        datetime.fromisoformat(trigger_at_str) if trigger_at_str else datetime.now(timezone.utc)
+    )
 
     return {
         "trigger_user": sender.get("login") or pr_author.get("login"),
         "trigger_user_id": sender.get("id") or pr_author.get("id"),
         "trigger_comment_id": None,
         "trigger_comment_type": None,
-        "trigger_at": datetime.fromisoformat(updated_at) if updated_at else None,
+        "trigger_at": trigger_at,
     }
 
 
@@ -141,14 +144,17 @@ def _get_trigger_metadata_for_issue_comment(event_payload: Mapping[str, Any]) ->
     comment_user = comment.get("user", {})
     # Use updated_at to support both "created" and potential future "edited" triggers.
     # For newly created comments, updated_at equals created_at.
-    trigger_at = comment.get("updated_at") or comment.get("created_at")
+    trigger_at_str = comment.get("updated_at") or comment.get("created_at")
+    trigger_at = (
+        datetime.fromisoformat(trigger_at_str) if trigger_at_str else datetime.now(timezone.utc)
+    )
 
     return {
         "trigger_user": comment_user.get("login"),
         "trigger_user_id": comment_user.get("id"),
         "trigger_comment_id": comment.get("id"),
         "trigger_comment_type": "issue_comment",
-        "trigger_at": datetime.fromisoformat(trigger_at) if trigger_at else None,
+        "trigger_at": trigger_at,
     }
 
 

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -257,6 +257,9 @@ class TestTransformWebhookToCodegenRequest:
             result["data"]["config"]["trigger"] == SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value
         )
         assert result["data"]["config"]["trigger_at"] == "2024-01-15T10:30:00Z"
+        # trigger_received_at is set to current time when transform happens
+        assert isinstance(result["data"]["config"]["trigger_received_at"], str)
+        datetime.fromisoformat(result["data"]["config"]["trigger_received_at"])
 
     def test_issue_comment_on_pr(
         self, setup_entities: tuple[User, Organization, Project, Repository]
@@ -296,6 +299,9 @@ class TestTransformWebhookToCodegenRequest:
         assert config["trigger_user"] == "commenter"
         assert config["trigger_comment_type"] == "issue_comment"
         assert config["trigger_at"] == "2024-01-15T14:00:00Z"
+        # trigger_received_at is set to current time when transform happens
+        assert isinstance(config["trigger_received_at"], str)
+        datetime.fromisoformat(config["trigger_received_at"])
 
     def test_invalid_repo_name_format_raises(
         self, setup_entities: tuple[User, Organization, Project, Repository]

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -257,9 +257,9 @@ class TestTransformWebhookToCodegenRequest:
             result["data"]["config"]["trigger"] == SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value
         )
         assert result["data"]["config"]["trigger_at"] == "2024-01-15T10:30:00Z"
-        # trigger_received_at is set to current time when transform happens
-        assert isinstance(result["data"]["config"]["trigger_received_at"], str)
-        datetime.fromisoformat(result["data"]["config"]["trigger_received_at"])
+        # sentry_received_trigger_at is set to current time when transform happens
+        assert isinstance(result["data"]["config"]["sentry_received_trigger_at"], str)
+        datetime.fromisoformat(result["data"]["config"]["sentry_received_trigger_at"])
 
     def test_issue_comment_on_pr(
         self, setup_entities: tuple[User, Organization, Project, Repository]
@@ -299,9 +299,9 @@ class TestTransformWebhookToCodegenRequest:
         assert config["trigger_user"] == "commenter"
         assert config["trigger_comment_type"] == "issue_comment"
         assert config["trigger_at"] == "2024-01-15T14:00:00Z"
-        # trigger_received_at is set to current time when transform happens
-        assert isinstance(config["trigger_received_at"], str)
-        datetime.fromisoformat(config["trigger_received_at"])
+        # sentry_received_trigger_at is set to current time when transform happens
+        assert isinstance(config["sentry_received_trigger_at"], str)
+        datetime.fromisoformat(config["sentry_received_trigger_at"])
 
     def test_invalid_repo_name_format_raises(
         self, setup_entities: tuple[User, Organization, Project, Repository]

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -43,7 +43,7 @@ class TestGetTriggerMetadata:
         assert result["trigger_comment_type"] == "issue_comment"
         assert result["trigger_at"] == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
 
-    def test_extracts_issue_comment_trigger_at_when_missing(self) -> None:
+    def test_extracts_issue_comment_trigger_at_defaults_to_now_when_missing(self) -> None:
         event_payload = {
             "comment": {
                 "id": 12345,
@@ -51,7 +51,8 @@ class TestGetTriggerMetadata:
             }
         }
         result = _get_trigger_metadata_for_issue_comment(event_payload)
-        assert result["trigger_at"] is None
+        assert isinstance(result["trigger_at"], datetime)
+        assert result["trigger_at"].tzinfo is not None
 
     def test_issue_comment_falls_back_to_created_at(self) -> None:
         event_payload = {
@@ -93,13 +94,14 @@ class TestGetTriggerMetadata:
         assert result["trigger_comment_type"] is None
         assert result["trigger_at"] == datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-    def test_pull_request_no_data_returns_none_values(self) -> None:
+    def test_pull_request_no_data_defaults_trigger_at_to_now(self) -> None:
         result = _get_trigger_metadata_for_pull_request({})
         assert result["trigger_comment_id"] is None
         assert result["trigger_comment_type"] is None
         assert result["trigger_user"] is None
         assert result["trigger_user_id"] is None
-        assert result["trigger_at"] is None
+        assert isinstance(result["trigger_at"], datetime)
+        assert result["trigger_at"].tzinfo is not None
 
 
 class GetTargetCommitShaTest(TestCase):

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -462,6 +462,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_type": None,
                     "trigger_user": None,
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -512,6 +513,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_type": None,
                     "trigger_user": None,
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -568,6 +570,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -610,6 +613,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -657,6 +661,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -704,6 +709,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
+                    "trigger_received_at": "2024-01-15T10:30:00Z",
                 },
             },
         }

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -461,6 +461,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -510,6 +511,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -565,6 +567,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -606,6 +609,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -652,6 +656,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -698,6 +703,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -462,7 +462,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_type": None,
                     "trigger_user": None,
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -513,7 +513,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_type": None,
                     "trigger_user": None,
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -570,7 +570,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -613,7 +613,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -661,7 +661,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -709,7 +709,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
                     "trigger_at": "2024-01-15T10:30:00Z",
-                    "trigger_received_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -170,5 +170,5 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
             )
-            # trigger_received_at is set to current time when transform happens
-            assert isinstance(payload["data"]["config"]["trigger_received_at"], datetime)
+            # sentry_received_trigger_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -170,3 +170,5 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
             )
+            # trigger_received_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["trigger_received_at"], datetime)

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -166,6 +166,7 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "test-user"
             assert payload["data"]["config"]["trigger_comment_id"] == 123456789
             assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
+            # After Pydantic validation, trigger_at is a datetime object
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
             )

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -69,6 +70,7 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             "comment": {
                 "body": comment_body,
                 "id": comment_id,
+                "created_at": "2024-01-15T10:30:00Z",
             },
             "issue": {
                 "number": 42,
@@ -164,3 +166,6 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "test-user"
             assert payload["data"]["config"]["trigger_comment_id"] == 123456789
             assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
+            assert payload["data"]["config"]["trigger_at"] == datetime(
+                2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
+            )

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -257,8 +257,8 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
             )
-            # trigger_received_at is set to current time when transform happens
-            assert isinstance(payload["data"]["config"]["trigger_received_at"], datetime)
+            # sentry_received_trigger_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)
             self.mock_reaction.assert_not_called()
 
     def test_pull_request_opened_filtered_when_trigger_disabled_post_ga(self) -> None:

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -257,6 +257,8 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
             )
+            # trigger_received_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["trigger_received_at"], datetime)
             self.mock_reaction.assert_not_called()
 
     def test_pull_request_opened_filtered_when_trigger_disabled_post_ga(self) -> None:

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import orjson
@@ -252,6 +253,9 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "baxterthehacker"
             assert payload["data"]["config"]["trigger_comment_id"] is None
             assert payload["data"]["config"]["trigger_comment_type"] is None
+            assert payload["data"]["config"]["trigger_at"] == datetime(
+                2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
+            )
             self.mock_reaction.assert_not_called()
 
     def test_pull_request_opened_filtered_when_trigger_disabled_post_ga(self) -> None:

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -253,6 +253,7 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "baxterthehacker"
             assert payload["data"]["config"]["trigger_comment_id"] is None
             assert payload["data"]["config"]["trigger_comment_type"] is None
+            # After Pydantic validation, trigger_at is a datetime object
             assert payload["data"]["config"]["trigger_at"] == datetime(
                 2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
             )


### PR DESCRIPTION
## Summary

Add timestamp fields to `SeerCodeReviewConfig` to enable accurate latency measurement for PR reviews:

- **`trigger_at`**: When the triggering event occurred on GitHub (from webhook payload)
- **`sentry_received_trigger_at`**: When Sentry received the webhook

This enables Seer to calculate:
- GitHub-side delay: `sentry_received_trigger_at - trigger_at`
- Sentry processing time: `completed_at - sentry_received_trigger_at`
- Total end-to-end latency: `completed_at - trigger_at`

**Changes:**
- Add `trigger_at: datetime` field (mandatory) to `SeerCodeReviewConfig`
- Add `sentry_received_trigger_at: datetime` field (mandatory) to `SeerCodeReviewConfig`
- Extract `trigger_at` from GitHub webhook payload:
  - For `pull_request` events: uses `updated_at` with fallback to `created_at`
  - For `issue_comment` events: uses `updated_at` with fallback to `created_at`
  - Falls back to current time if timestamps unavailable
- Set `sentry_received_trigger_at` to current time when processing webhook
- Return ISO strings from transform functions for Celery JSON serialization (Pydantic parses to datetime)

## Test plan

- [x] Unit tests for trigger metadata extraction
- [x] Unit tests for fallback behavior when timestamps missing
- [x] JSON serialization tests to verify Celery compatibility
- [x] Integration tests verify both timestamps in payload

Part of CW-706
Seer PR: https://github.com/getsentry/seer/pull/4710