### PR TITLE
feat(dashboards): Add performance_score to equations allowlist

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -195,6 +195,7 @@ class ArithmeticVisitor(NodeVisitor):
         "count_miserable",
         "count_web_vitals",
         "percentile_range",
+        "performance_score",
     }
 
     def __init__(self, max_operators: int | None, custom_measurements: set[str] | None):

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -246,6 +246,12 @@ def test_field_values(a, op, b) -> None:
         ("p50(transaction.duration)", "/", "p100(transaction.duration)"),
         ("count_if(user.email,equals,test@example.com)", "/", 2),
         (100, "-", 'count_if(some_tag,notEquals,"something(really)annoying,like\\"this\\"")'),
+        (
+            "performance_score(measurements.score.lcp)",
+            "+",
+            "performance_score(measurements.score.fcp)",
+        ),
+        (100, "*", "performance_score(measurements.score.cls)"),
     ],
 )
 def test_function_values(lhs, op, rhs) -> None:


### PR DESCRIPTION
Adds `performance_score` to the function allow list for equations. This is needed because web vitals dashboard widgets can link to explore, and equations are required to apply weights.