### PR TITLE
fix(ai-conversations): ignore statsPeriod for conversation details endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -57,8 +57,9 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             return Response(status=404)
 
         # Ignore statsPeriod so old links don't fail when opened later
-        request.GET = request.GET.copy()
-        request.GET.pop("statsPeriod", None)
+        mutable_query = request.GET.copy()
+        mutable_query.pop("statsPeriod", None)
+        request.GET = mutable_query  # type: ignore[assignment]
 
         try:
             snuba_params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -56,6 +56,10 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
 
+        # Ignore statsPeriod so old links don't fail when opened later
+        request.GET = request.GET.copy()
+        request.GET.pop("statsPeriod", None)
+
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:


### PR DESCRIPTION
This is a temporal fix to ignore `statsPeriod` paremeter in request to make sure it doesn't influence the period of scanned data.

Since this endpoint is only available to internal organizations, we will roll this change out and see if it is fast enough to keep it like this.
