### PR TITLE
chore(cross-event): Disable save and compare buttons

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -823,4 +823,30 @@ describe('ExploreToolbar', () => {
       expect(screen.getByText('Save')).toBeInTheDocument();
     });
   });
+
+  it('disables save as and compare when cross events are present', async () => {
+    render(<ExploreToolbar />, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+          },
+        },
+      },
+    });
+
+    const section = await screen.findByTestId('section-save-as');
+
+    // Save As button should be disabled
+    expect(within(section).getByRole('button', {name: 'Save as'})).toBeDisabled();
+
+    // Compare Queries button should be disabled (LinkButton renders with role="button")
+    expect(within(section).getByRole('button', {name: 'Compare'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
 });

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
   addErrorMessage,
@@ -34,6 +35,7 @@ import {useSpansSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {
   useQueryParamsAggregateSortBys,
+  useQueryParamsCrossEvents,
   useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsId,
@@ -272,6 +274,9 @@ export function ToolbarSaveAs() {
     pageFilters.selection.environments,
   ]);
 
+  const crossEvents = useQueryParamsCrossEvents();
+  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
+
   if (items.length === 0) {
     return null;
   }
@@ -279,49 +284,59 @@ export function ToolbarSaveAs() {
   return (
     <StyledToolbarSection data-test-id="section-save-as">
       <ButtonBar>
-        <DropdownMenu
-          items={items}
-          trigger={triggerProps => (
-            <SaveAsButton
-              {...triggerProps}
-              priority={shouldHighlightSaveButton ? 'primary' : 'default'}
-              aria-label={t('Save as')}
-              onClick={e => {
-                e.stopPropagation();
-                e.preventDefault();
-
-                triggerProps.onClick?.(e);
-              }}
-            >
-              {shouldHighlightSaveButton ? `${t('Save')}` : `${t('Save as')}\u2026`}
-            </SaveAsButton>
-          )}
-        />
-        <LinkButton
-          aria-label={t('Compare')}
-          onClick={() =>
-            trackAnalytics('trace_explorer.compare', {
-              organization,
-            })
-          }
-          to={generateExploreCompareRoute({
-            organization,
-            mode,
-            location,
-            queries: [
-              {
-                query,
-                groupBys,
-                sortBys,
-                yAxes: [visualizeYAxes[0]!],
-                chartType: visualizes[0]!.chartType,
-                caseInsensitive: caseInsensitive ? '1' : undefined,
-              },
-            ],
-          })}
+        <Tooltip
+          title={t('Saving cross event queries is not supported during early access.')}
         >
-          {`${t('Compare Queries')}`}
-        </LinkButton>
+          <DropdownMenu
+            isDisabled={hasCrossEvents}
+            items={items}
+            trigger={triggerProps => (
+              <SaveAsButton
+                {...triggerProps}
+                priority={shouldHighlightSaveButton ? 'primary' : 'default'}
+                aria-label={t('Save as')}
+                onClick={e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+
+                  triggerProps.onClick?.(e);
+                }}
+              >
+                {shouldHighlightSaveButton ? `${t('Save')}` : `${t('Save as')}\u2026`}
+              </SaveAsButton>
+            )}
+          />
+        </Tooltip>
+        <Tooltip
+          title={t('Comparing cross event queries is not supported during early access.')}
+        >
+          <LinkButton
+            aria-label={t('Compare')}
+            disabled={hasCrossEvents}
+            onClick={() =>
+              trackAnalytics('trace_explorer.compare', {
+                organization,
+              })
+            }
+            to={generateExploreCompareRoute({
+              organization,
+              mode,
+              location,
+              queries: [
+                {
+                  query,
+                  groupBys,
+                  sortBys,
+                  yAxes: [visualizeYAxes[0]!],
+                  chartType: visualizes[0]!.chartType,
+                  caseInsensitive: caseInsensitive ? '1' : undefined,
+                },
+              ],
+            })}
+          >
+            {`${t('Compare Queries')}`}
+          </LinkButton>
+        </Tooltip>
       </ButtonBar>
     </StyledToolbarSection>
   );

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -285,6 +285,7 @@ export function ToolbarSaveAs() {
     <StyledToolbarSection data-test-id="section-save-as">
       <ButtonBar>
         <Tooltip
+          disabled={!hasCrossEvents}
           title={t('Saving cross event queries is not supported during early access.')}
         >
           <DropdownMenu
@@ -308,6 +309,7 @@ export function ToolbarSaveAs() {
           />
         </Tooltip>
         <Tooltip
+          disabled={!hasCrossEvents}
           title={t('Comparing cross event queries is not supported during early access.')}
         >
           <LinkButton


### PR DESCRIPTION
This PR updates the "Save as...", and "Compare Queries" buttons on the traces page when the user is cross-event querying. 

For the time being we won't be allowing users to save and compare these queries while in EA.

Ticket: EXP-737