### PR TITLE
fix(dashboards): fixes transaction field renderer overwriting linked dashboard config

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -272,7 +272,12 @@ export const SpansConfig: DatasetConfig<
     if (field === 'trace') {
       return renderTraceAsLinkable(widget);
     }
-    if (field === 'transaction') {
+    if (
+      field === SpanFields.TRANSACTION &&
+      !widget?.queries?.[0]?.linkedDashboards?.some(
+        linkedDashboard => linkedDashboard.field === SpanFields.TRANSACTION
+      )
+    ) {
       return renderTransactionAsLinkable;
     }
     return getFieldRenderer(field, meta, false, widget, dashboardFilters);


### PR DESCRIPTION
The spans dataset always calls `renderTransactionAsLinkable` on transaction fields, which causes the field to not respect `linkedDashboards` configs. Updates condition to check for a `linkedDashboards`.