### PR TITLE
fix(notifications): Fix Size Analysis feature flag filter typo

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -250,7 +250,7 @@ export function NotificationSettingsByType({notificationType}: Props) {
       if (field.name.startsWith('quotaSeerUsers') && !hasSeerUserBilling) {
         return false;
       }
-      if (field.name.startsWith('quotaSizeAnalysis') && !includeSizeAnalysis) {
+      if (field.name.startsWith('quotaSize') && !includeSizeAnalysis) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary

Fixes a bug introduced in PR #106940 where the Size Analysis notification setting was appearing for all users regardless of the `expose-category-size-analysis` feature flag.

The issue was a typo in the feature flag filter:
- Filter checked for `quotaSizeAnalysis` (singular, with 'i')
- Actual field name is `quotaSizeAnalyses` (plural, with 'e')

Since `'quotaSizeAnalyses'.startsWith('quotaSizeAnalysis')` returns `false`, the filter never matched.

Simplified the filter to `quotaSize` to prevent similar typos in the future.

## Test plan

- [x] Existing notification settings tests pass (13 tests)
- [x] Pre-commit hooks pass