### PR TITLE
feat(replay): Add `project` when filtering by user email/tags

### DIFF
--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
@@ -93,6 +93,7 @@ function ReplayBadge({replay}: {replay: ReplayRecord}) {
         }),
         query: {
           query: searchQuery,
+          project: replay.project_id,
         },
       }
     : null;

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -64,11 +64,11 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/replays/?query=foo%3A%22bar%22'
+      '/organizations/org-slug/explore/replays/?project=6273278&query=foo%3A%22bar%22'
     );
     expect(screen.getByText('baz').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/replays/?query=foo%3A%22baz%22'
+      '/organizations/org-slug/explore/replays/?project=6273278&query=foo%3A%22baz%22'
     );
   });
 
@@ -77,7 +77,7 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('a wordy value').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/replays/?query=my_custom_tag%3A%22a%20wordy%20value%22'
+      '/organizations/org-slug/explore/replays/?project=6273278&query=my_custom_tag%3A%22a%20wordy%20value%22'
     );
   });
 

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -61,9 +61,10 @@ export default function TagPanel() {
       query: {
         // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax, whether `name` is a tag or not.
         query: `${name}:"${value}"`,
+        project: replayRecord?.project_id,
       },
     }),
-    [organization]
+    [organization, replayRecord?.project_id]
   );
 
   if (!replayRecord) {


### PR DESCRIPTION
## Description

This PR adds the `project` query param to search queries when filtering replays by user and/or tags (e.g. from clicking user email in replay details header or clicking tags)


## Motivation

These changes ensure that when users click through to search from the replay details view (either via the user badge or tag panel), the search results are filtered to the current project rather than potentially showing results from all projects. This improves the user experience by providing more relevant and contextual search results.

https://claude.ai/code/session_01Ka1eD1XjidwJ5D7LFrcoE4