### PR TITLE
fix(alerts): Use tracemetrics dataset for TRACE_ITEM_METRIC alerts

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -334,6 +334,12 @@ def build_metric_alert_chart(
         ):
             query_params["dataset"] = "logs"
         elif (
+            query_type == SnubaQuery.Type.PERFORMANCE
+            and dataset == Dataset.EventsAnalyticsPlatform
+            and snuba_query.event_types == [SnubaQueryEventType.EventType.TRACE_ITEM_METRIC]
+        ):
+            query_params["dataset"] = "tracemetrics"
+        elif (
             query_type == SnubaQuery.Type.PERFORMANCE and dataset == Dataset.EventsAnalyticsPlatform
         ):
             query_params["dataset"] = "spans"

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -134,6 +134,100 @@ class BuildMetricAlertChartTest(TestCase):
         assert mock_client_get.call_args[1]["params"]["dataset"] == "spans"
         assert mock_client_get.call_args[1]["params"]["query"] == "span.op:pageload"
 
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    @patch("sentry.incidents.charts.client.get")
+    def test_eap_log_alert(
+        self, mock_client_get: MagicMock, mock_generate_chart: MagicMock
+    ) -> None:
+        from sentry.snuba.models import SnubaQueryEventType
+
+        mock_client_get.return_value.data = {"data": []}
+        alert_rule = self.create_alert_rule(
+            query="severity:error",
+            dataset=Dataset.EventsAnalyticsPlatform,
+            aggregate="count()",
+            event_types=[SnubaQueryEventType.EventType.TRACE_ITEM_LOG],
+        )
+        incident = self.create_incident(
+            status=2,
+            organization=self.organization,
+            projects=[self.project],
+            alert_rule=alert_rule,
+            date_started=timezone.now() - datetime.timedelta(minutes=2),
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+
+        alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
+            alert_rule, None, AlertRuleSerializer()
+        )
+        incident_serialized_response: DetailedIncidentSerializerResponse = serialize(
+            incident, None, DetailedIncidentSerializer()
+        )
+
+        url = build_metric_alert_chart(
+            self.organization,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            snuba_query=alert_rule.snuba_query,
+            open_period_context=OpenPeriodContext.from_incident(incident),
+            selected_incident_serialized=incident_serialized_response,
+        )
+
+        assert url == "chart-url"
+        mock_client_get.assert_called()
+        mock_generate_chart.assert_called()
+        assert mock_client_get.call_args[1]["params"]["dataset"] == "logs"
+
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    @patch("sentry.incidents.charts.client.get")
+    def test_eap_trace_metric_alert(
+        self, mock_client_get: MagicMock, mock_generate_chart: MagicMock
+    ) -> None:
+        from sentry.snuba.models import SnubaQueryEventType
+
+        mock_client_get.return_value.data = {"data": []}
+        alert_rule = self.create_alert_rule(
+            query="",
+            dataset=Dataset.EventsAnalyticsPlatform,
+            aggregate="count(span.duration)",
+            event_types=[SnubaQueryEventType.EventType.TRACE_ITEM_METRIC],
+        )
+        incident = self.create_incident(
+            status=2,
+            organization=self.organization,
+            projects=[self.project],
+            alert_rule=alert_rule,
+            date_started=timezone.now() - datetime.timedelta(minutes=2),
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+
+        alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
+            alert_rule, None, AlertRuleSerializer()
+        )
+        incident_serialized_response: DetailedIncidentSerializerResponse = serialize(
+            incident, None, DetailedIncidentSerializer()
+        )
+
+        url = build_metric_alert_chart(
+            self.organization,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            snuba_query=alert_rule.snuba_query,
+            open_period_context=OpenPeriodContext.from_incident(incident),
+            selected_incident_serialized=incident_serialized_response,
+        )
+
+        assert url == "chart-url"
+        mock_client_get.assert_called()
+        mock_generate_chart.assert_called()
+        assert mock_client_get.call_args[1]["params"]["dataset"] == "tracemetrics"
+
 
 class FetchOpenPeriodsTest(BaseMetricIssueTest):
     @freeze_time(frozen_time)


### PR DESCRIPTION
This was previously uncovered by tests, and was falling through to the default spans case.

