### PR TITLE
feat(tracemetrics): Add react-native to metrics constants

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -472,6 +472,7 @@ export const limitedMetricsSupportPrefixes: Set<string> = new Set([
   'node',
   'python',
   'php',
+  'react-native',
   'ruby',
 ]);
 


### PR DESCRIPTION
Exposes the metrics UI if we detect a react-native project as well. The docs aren't complete for react-native yet so we will use the default fallbacks