### PR TITLE
ref(grouping): Add params to `normalize_message_for_grouping`

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -26,7 +26,9 @@ def message_v1(
     # This is true for all but our test config
     if context["normalize_message"]:
         raw_message = interface.message or interface.formatted or ""
-        normalized = normalize_message_for_grouping(raw_message, event, trim_message=True)
+        normalized = normalize_message_for_grouping(
+            raw_message, event, source="message_component", trim_message=True
+        )
         hint = "stripped event-specific values" if raw_message != normalized else None
         return {variant_name: MessageGroupingComponent(values=[normalized], hint=hint)}
     else:

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -26,7 +26,7 @@ def message_v1(
     # This is true for all but our test config
     if context["normalize_message"]:
         raw_message = interface.message or interface.formatted or ""
-        normalized = normalize_message_for_grouping(raw_message, event)
+        normalized = normalize_message_for_grouping(raw_message, event, trim_message=True)
         hint = "stripped event-specific values" if raw_message != normalized else None
         return {variant_name: MessageGroupingComponent(values=[normalized], hint=hint)}
     else:

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -596,7 +596,7 @@ def single_exception(
 
         raw = exception.value
         if raw is not None:
-            normalized = normalize_message_for_grouping(raw, event)
+            normalized = normalize_message_for_grouping(raw, event, trim_message=True)
             hint = "stripped event-specific values" if raw != normalized else None
             if normalized:
                 value_component.update(values=[normalized], hint=hint)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -596,7 +596,9 @@ def single_exception(
 
         raw = exception.value
         if raw is not None:
-            normalized = normalize_message_for_grouping(raw, event, trim_message=True)
+            normalized = normalize_message_for_grouping(
+                raw, event, source="value_component", trim_message=True
+            )
             hint = "stripped event-specific values" if raw != normalized else None
             if normalized:
                 value_component.update(values=[normalized], hint=hint)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -44,6 +44,11 @@ def bool_from_string(value: str) -> bool | None:
     return None
 
 
+# TODO: We should strip whitespace no matter what, whether or not we're trimming. Right now we don't
+# do so in either case. (The `.strip()` used during trimming filters out empty lines, but doesn't
+# actually strip non-empty ones.) This will require a new grouping config, since unstripped and
+# stripped messages won't group together.
+#
 # TODO: Both here during trimming and in the message strategy (where we check if the message has
 # been changed), we assume the kind of change which has happened. Here we add "...", and there we
 # say we "stripped event-specific values," even if all we've done in either case is remove empty

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -78,9 +78,11 @@ def normalize_message_for_grouping(message: str, event: Event, *, trim_message: 
     else:
         normalized = parameterizer.parameterize_all(message)
 
-    for key, value in parameterizer.matches_counter.items():
-        # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
-        # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
-        metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
+    parameterization_counts = parameterizer.matches_counter.items()
+    if parameterization_counts:
+        for key, value in parameterization_counts:
+            # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
+            # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
+            metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
 
     return normalized

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -54,7 +54,9 @@ def bool_from_string(value: str) -> bool | None:
 # say we "stripped event-specific values," even if all we've done in either case is remove empty
 # lines.
 @metrics.wraps("grouping.normalize_message_for_grouping")
-def normalize_message_for_grouping(message: str, event: Event, *, trim_message: bool) -> str:
+def normalize_message_for_grouping(
+    message: str, event: Event, *, source: str, trim_message: bool
+) -> str:
     """
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -82,6 +82,8 @@ def normalize_message_for_grouping(
 
     parameterization_counts = parameterizer.matches_counter.items()
     if parameterization_counts:
+        metrics.incr("grouping.message_parameterized", tags={"source": source})
+
         for key, value in parameterization_counts:
             # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
             # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.


### PR DESCRIPTION
This adds two parameters to our `normalize_message_for_grouping` helper. The `source` parameter is a string indicating what part of our grouping code called the function, and is then used in a new metric tracking that. The `trim_message` parameter is a boolean controlling whether or not we trim the given message to two lines. Currently we do so in all the places we use the helper, but we won't when we use it for fingerprints (which is going to happen in an upcoming PR).