### PR TITLE
feat(uptime): Enable response capture for preview checks

### DIFF
--- a/src/sentry/uptime/checker_api.py
+++ b/src/sentry/uptime/checker_api.py
@@ -19,6 +19,8 @@ def create_preview_check(validated_data, region: UptimeRegionConfig) -> CheckCon
         # We're only going to run in the one specified region.
         "active_regions": [region.slug],
         "region_schedule_mode": UptimeRegionScheduleMode.ROUND_ROBIN.value,
+        # Always capture response body/headers for preview checks (needed for assertion suggestions)
+        "always_capture_response": True,
     }
 
     if validated_data.get("method") is not None:

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -119,6 +119,12 @@ class CheckConfig(TypedDict, total=False):
     Whether to capture response body and headers on check failures.
     """
 
+    always_capture_response: bool
+    """
+    Whether to always capture response body and headers regardless of success/failure.
+    Used for preview checks that need response data for assertion suggestions.
+    """
+
 
 class IncidentStatus(IntEnum):
     """

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -195,6 +195,10 @@ export interface PreviewCheckResponse {
       http_status_code: number | null;
       request_type: string;
       url: string;
+      /** Base64-encoded response body, captured when always_capture_response is enabled */
+      response_body?: string | null;
+      /** Response headers as [key, value] tuples, captured when always_capture_response is enabled */
+      response_headers?: Array<[string, string]> | null;
     } | null;
   };
 }


### PR DESCRIPTION
## Summary

- Adds `always_capture_response` field to `CheckConfig` TypedDict
- Sets `always_capture_response=True` in preview check config so uptime-checker returns response body/headers regardless of success/failure

## Motivation

This enables features like AI-powered assertion suggestions (NEW-699), which need to analyze the response body from successful preview checks.

## Changes

- **src/sentry/uptime/types.py**: Add `always_capture_response: bool` field to `CheckConfig` TypedDict
- **src/sentry/uptime/checker_api.py**: Set `always_capture_response: True` in `create_preview_check()`

## Dependencies

Requires uptime-checker PR: https://github.com/getsentry/uptime-checker/pull/475

## Test plan

- [ ] Once uptime-checker PR is merged, verify preview checks return response body on success

## Related

Fixes NEW-728
Related to NEW-699 (Seer-powered assertion suggestions)