### PR TITLE
chore(aci): Search open period activity entries for event_id

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -153,7 +153,9 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         )
 
         if event_id_param:
-            open_periods = open_periods.filter(event_id=event_id_param)
+            open_periods = open_periods.filter(
+                groupopenperiodactivity__event_id=event_id_param
+            ).distinct()
 
         return self.paginate(
             request=request,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -481,13 +481,27 @@ class OrganizationOpenPeriodsTest(APITestCase):
             project=self.group.project,
             date_started=base_time,
             date_ended=base_time + timedelta(minutes=5),
-            event_id=event_id_1,
+            event_id="c" * 32,
         )
         open_period_2 = GroupOpenPeriod.objects.create(
             group=self.group,
             project=self.group.project,
             date_started=base_time + timedelta(minutes=6),
             date_ended=base_time + timedelta(minutes=10),
+            event_id="d" * 32,
+        )
+        GroupOpenPeriodActivity.objects.create(
+            date_added=base_time,
+            group_open_period=open_period_1,
+            type=OpenPeriodActivityType.OPENED,
+            value=self.group.priority,
+            event_id=event_id_1,
+        )
+        GroupOpenPeriodActivity.objects.create(
+            date_added=base_time + timedelta(minutes=6),
+            group_open_period=open_period_2,
+            type=OpenPeriodActivityType.OPENED,
+            value=self.group.priority,
             event_id=event_id_2,
         )
 


### PR DESCRIPTION
Closes ISWF-1981

Now that we are tracking `event_id` on the activity entries instead of the base object, we need to update the endpoint to look in the correct place when filtering by event ID.