### PR TITLE
chore(tracemetrics): Rework Save As button for multi-agg

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -1,49 +1,74 @@
 import {Button} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {useSaveAsMetricItems} from 'sentry/views/explore/metrics/useSaveAsMetricItems';
 
 export function MetricSaveAs() {
   const [interval] = useChartInterval();
   const items = useSaveAsMetricItems({interval});
+  const metricQueries = useMultiMetricsQueryParams();
 
   const hasMultiVisualize = useOrganization().features.includes(
     'tracemetrics-overlay-charts-ui'
   );
 
-  if (items.length === 0 || hasMultiVisualize) {
+  const hasMultiAggregate = metricQueries.some(
+    query => query.queryParams.visualizes.length > 1
+  );
+
+  const isMultiVisDisabled = hasMultiVisualize && hasMultiAggregate;
+
+  if (items.length === 0) {
     return null;
   }
 
   if (items.length === 1 && 'onAction' in items[0]! && !('children' in items[0])) {
     const item = items[0];
     return (
-      <Button size="sm" onClick={item.onAction} aria-label={item.textValue}>
-        {t('Save as')}…
-      </Button>
+      <Tooltip
+        disabled={!isMultiVisDisabled}
+        title={t('Saving multi-aggregate metrics is not supported during early access.')}
+      >
+        <Button
+          size="sm"
+          onClick={item.onAction}
+          aria-label={item.textValue}
+          disabled={isMultiVisDisabled}
+        >
+          {t('Save as')}…
+        </Button>
+      </Tooltip>
     );
   }
 
   return (
-    <DropdownMenu
-      items={items}
-      trigger={triggerProps => (
-        <Button
-          {...triggerProps}
-          size="sm"
-          aria-label={t('Save as')}
-          onClick={e => {
-            e.stopPropagation();
-            e.preventDefault();
-            triggerProps.onClick?.(e);
-          }}
-        >
-          {t('Save as')}…
-        </Button>
-      )}
-    />
+    <Tooltip
+      disabled={!isMultiVisDisabled}
+      title={t('Saving multi-aggregate metrics is not supported during early access.')}
+    >
+      <DropdownMenu
+        isDisabled={isMultiVisDisabled}
+        items={items}
+        trigger={triggerProps => (
+          <Button
+            {...triggerProps}
+            size="sm"
+            aria-label={t('Save as')}
+            onClick={e => {
+              e.stopPropagation();
+              e.preventDefault();
+              triggerProps.onClick?.(e);
+            }}
+          >
+            {t('Save as')}…
+          </Button>
+        )}
+      />
+    </Tooltip>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -57,6 +57,7 @@ export function MetricSaveAs() {
         trigger={triggerProps => (
           <Button
             {...triggerProps}
+            disabled={isMultiVisDisabled}
             size="sm"
             aria-label={t('Save as')}
             onClick={e => {


### PR DESCRIPTION
We'll we are rolling out, and validating multi-aggregate support for metrics, we want to stop users from saving these queries as we're still validating which combinations of aggregates users will be able to use.

Ticket: LOGS-559

Example:

<img width="296" height="129" alt="Screenshot 2026-02-02 at 14 12 54" src="https://github.com/user-attachments/assets/e2c0fb9e-e6f4-4198-b546-ef21b5c0de7b" />