### PR TITLE
feat(dashboards): adds a new additionalDatasets attribute to linked dashboards to allow creating dashboard filters on multiple datasets

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -166,7 +166,7 @@ describe('getFieldRenderer', () => {
             {
               dashboardId: '123',
               field: 'transaction',
-              additionalDatasets: [WidgetType.ISSUE],
+              additionalGlobalFilterDatasetTargets: [WidgetType.ISSUE],
             },
           ],
           aggregates: [],

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -157,6 +157,49 @@ describe('getFieldRenderer', () => {
     );
   });
 
+  it('can render dashboard links to additional datasets', () => {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          linkedDashboards: [
+            {
+              dashboardId: '123',
+              field: 'transaction',
+              additionalDatasets: [WidgetType.ISSUE],
+            },
+          ],
+          aggregates: [],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+        },
+      ],
+    });
+    const dashboardFilters: DashboardFilters = {};
+
+    const renderer = getFieldRenderer(
+      'transaction',
+      {transaction: 'string'},
+      undefined,
+      widget,
+      dashboardFilters
+    );
+
+    render(
+      renderer(data, {
+        location,
+        organization,
+        theme,
+      }) as React.ReactElement<any, any>
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/dashboard/123/?globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22transaction%22%2C%22name%22%3A%22transaction%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22transaction%3A%5Bapi.do_things%5D%22%2C%22isTemporary%22%3Atrue%7D&globalFilter=%7B%22dataset%22%3A%22issue%22%2C%22tag%22%3A%7B%22key%22%3A%22transaction%22%2C%22name%22%3A%22transaction%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22transaction%3A%5Bapi.do_things%5D%22%2C%22isTemporary%22%3Atrue%7D'
+    );
+  });
   describe('rate', () => {
     it('can render null rate', () => {
       const renderer = getFieldRenderer(

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1429,12 +1429,16 @@ function getDashboardUrl(
       linkedDashboard => linkedDashboard.field === field
     );
     if (dashboardLink && dashboardLink.dashboardId !== '-1') {
+      const datasetsToApplyFiltersTo = dashboardLink.additionalDatasets ?? [
+        widget.widgetType,
+      ];
+
       const newTemporaryFilters: GlobalFilter[] = [
         ...(dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? []),
       ].filter(
         filter =>
           Boolean(filter.value) &&
-          !(filter.tag.key === field && filter.dataset === widget.widgetType)
+          !(filter.tag.key === field && datasetsToApplyFiltersTo.includes(filter.dataset))
       );
 
       // Format the value as a proper filter condition string
@@ -1442,11 +1446,6 @@ function getDashboardUrl(
       const formattedValue = mutableSearch
         .addFilterValueList(field, [data[field]])
         .toString();
-
-      const datasetsToApplyFiltersTo = [
-        widget.widgetType,
-        ...(dashboardLink.additionalDatasets ?? []),
-      ];
 
       datasetsToApplyFiltersTo.forEach(dataset => {
         newTemporaryFilters.push({

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1443,11 +1443,18 @@ function getDashboardUrl(
         .addFilterValueList(field, [data[field]])
         .toString();
 
-      newTemporaryFilters.push({
-        dataset: widget.widgetType,
-        tag: {key: field, name: field, kind: FieldKind.TAG},
-        value: formattedValue,
-        isTemporary: true,
+      const datasetsToApplyFiltersTo = [
+        widget.widgetType,
+        ...(dashboardLink.additionalDatasets ?? []),
+      ];
+
+      datasetsToApplyFiltersTo.forEach(dataset => {
+        newTemporaryFilters.push({
+          dataset,
+          tag: {key: field, name: field, kind: FieldKind.TAG},
+          value: formattedValue,
+          isTemporary: true,
+        });
       });
 
       // Preserve project, environment, and time range query params

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1429,8 +1429,9 @@ function getDashboardUrl(
       linkedDashboard => linkedDashboard.field === field
     );
     if (dashboardLink && dashboardLink.dashboardId !== '-1') {
-      const datasetsToApplyFiltersTo = dashboardLink.additionalDatasets ?? [
+      const datasetsToApplyFiltersTo = [
         widget.widgetType,
+        ...(dashboardLink.additionalDatasets ?? []),
       ];
 
       const newTemporaryFilters: GlobalFilter[] = [

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1431,7 +1431,7 @@ function getDashboardUrl(
     if (dashboardLink && dashboardLink.dashboardId !== '-1') {
       const datasetsToApplyFiltersTo = [
         widget.widgetType,
-        ...(dashboardLink.additionalDatasets ?? []),
+        ...(dashboardLink.additionalGlobalFilterDatasetTargets ?? []),
       ];
 
       const newTemporaryFilters: GlobalFilter[] = [

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -81,6 +81,9 @@ export type LinkedDashboard = {
   // The destination dashboard id, set this to '-1' for prebuilt dashboards that link to other prebuilt dashboards
   dashboardId: string;
   field: string;
+  // List of additional datasets to apply new dashboard filters to.
+  // Typically we only apply filters to the same dataset as the widget, but this allows us to apply to other datasets when needed.
+  additionalDatasets?: WidgetType[];
   // Used for static dashboards that are not saved to the database
   staticDashboardId?: PrebuiltDashboardId;
 };

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -83,7 +83,7 @@ export type LinkedDashboard = {
   field: string;
   // List of additional datasets to apply new dashboard filters to.
   // Typically we only apply filters to the same dataset as the widget, but this allows us to apply to other datasets when needed.
-  additionalDatasets?: WidgetType[];
+  additionalGlobalFilterDatasetTargets?: WidgetType[];
   // Used for static dashboards that are not saved to the database
   staticDashboardId?: PrebuiltDashboardId;
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
@@ -537,7 +537,7 @@ export const WEB_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
               dashboardId: '-1',
               field: SpanFields.TRANSACTION,
               staticDashboardId: 7,
-              additionalDatasets: [WidgetType.ISSUE],
+              additionalGlobalFilterDatasetTargets: [WidgetType.ISSUE],
             },
           ],
         },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
@@ -537,6 +537,7 @@ export const WEB_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
               dashboardId: '-1',
               field: SpanFields.TRANSACTION,
               staticDashboardId: 7,
+              additionalDatasets: [WidgetType.ISSUE],
             },
           ],
         },


### PR DESCRIPTION
When navigating using dashboard links, we currently only apply a single global dashboard filter on a single dataset (the widget dataset). This is an issue because some dashboards use multiple datasets for a filterable field like `transaction`. Updates `linkedDashboards` to allow an `additionalDatasets` attribute to specify what datasets to also apply the global filter to.