### PR TITLE
fix(ACI): Look up sentry app id for Action in dual write

### DIFF
--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1103,11 +1103,8 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify that action type is set correctly
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
-            assert action.config.get("target_identifier") == install.uuid
-            assert (
-                action.config.get("sentry_app_identifier")
-                == SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
-            )
+            assert action.config.get("target_identifier") == str(install.sentry_app.id)
+            assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
 
     def test_dry_run_flag(self) -> None:
         """Test that the dry_run flag prevents database writes."""


### PR DESCRIPTION
I ran [a migration](https://github.com/getsentry/sentry/pull/107208/changes) look up the sentry app id from the installation uuid if that's what was stored to normalize the data, but unfortunately missed a spot in the dual write code where we would still be writing `Action`s with the installation uuid. This PR looks up the sentry app id and stores that instead so that we can stop having 2 different pieces of data stored. 