### PR TITLE
feat(identities): Add GitHub Copilot identity to account identities page

### DIFF
--- a/src/sentry/integrations/services/github_copilot_identity/__init__.py
+++ b/src/sentry/integrations/services/github_copilot_identity/__init__.py
@@ -1,9 +1,15 @@
+from sentry.integrations.services.github_copilot_identity.model import (
+    GitHubCopilotIdentityFilterArgs,
+    RpcGitHubCopilotIdentity,
+)
 from sentry.integrations.services.github_copilot_identity.service import (
     GitHubCopilotIdentityService,
     github_copilot_identity_service,
 )
 
 __all__ = [
+    "GitHubCopilotIdentityFilterArgs",
     "GitHubCopilotIdentityService",
+    "RpcGitHubCopilotIdentity",
     "github_copilot_identity_service",
 ]

--- a/src/sentry/integrations/services/github_copilot_identity/model.py
+++ b/src/sentry/integrations/services/github_copilot_identity/model.py
@@ -1,0 +1,22 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from typing import Any, TypedDict
+
+from sentry.hybridcloud.rpc import RpcModel
+
+
+class RpcGitHubCopilotIdentity(RpcModel):
+    id: int
+    user_id: int
+    github_id: str
+    data: dict[str, Any]
+    date_added: str | None = None
+
+
+class GitHubCopilotIdentityFilterArgs(TypedDict, total=False):
+    id: int
+    user_id: int
+    github_id: str

--- a/src/sentry/integrations/services/github_copilot_identity/service.py
+++ b/src/sentry/integrations/services/github_copilot_identity/service.py
@@ -8,6 +8,10 @@ import abc
 from django.conf import settings
 
 from sentry.hybridcloud.rpc.service import RpcService, rpc_method
+from sentry.integrations.services.github_copilot_identity.model import (
+    GitHubCopilotIdentityFilterArgs,
+    RpcGitHubCopilotIdentity,
+)
 from sentry.silo.base import SiloMode
 from sentry.utils.imports import import_string
 
@@ -29,10 +33,35 @@ class GitHubCopilotIdentityService(RpcService):
     def get_access_token_for_user(self, *, user_id: int) -> str | None:
         pass
 
+    @rpc_method
+    def get_one_or_none(
+        self, *, filter: GitHubCopilotIdentityFilterArgs
+    ) -> RpcGitHubCopilotIdentity | None:
+        """
+        Returns a single GitHub Copilot identity matching the filter criteria, or None.
+        """
+        return None
+
+    @rpc_method
+    def delete(self, *, identity_id: int, user_id: int) -> bool:
+        """
+        Delete a GitHub Copilot identity by ID, scoped to the user.
+        Returns True if deleted, False if not found or not owned by user.
+        """
+        return False
+
 
 class _DefaultGitHubCopilotIdentityService(GitHubCopilotIdentityService):
     def get_access_token_for_user(self, *, user_id: int) -> str | None:
         return None
+
+    def get_one_or_none(
+        self, *, filter: GitHubCopilotIdentityFilterArgs
+    ) -> RpcGitHubCopilotIdentity | None:
+        return None
+
+    def delete(self, *, identity_id: int, user_id: int) -> bool:
+        return False
 
 
 github_copilot_identity_service = GitHubCopilotIdentityService.create_delegation()


### PR DESCRIPTION
## Summary

Adds support for viewing and disconnecting GitHub Copilot identities from the account identities page at `/settings/account/identities/`.

This PR adds the Sentry-side infrastructure for the GitHub Copilot identity feature:

- `RpcGitHubCopilotIdentity` model for the hybrid cloud service interface
- `get_one_or_none` and `delete` methods to `GitHubCopilotIdentityService`
- `wrap_github_copilot` method to `UserIdentityConfig` serializer
- GitHub Copilot identity fetching in the `get_identities` endpoint
- Special handling for GitHub Copilot identity deletion via the service

The default service implementation returns `None`/`False`, so identities will only appear when getsentry is configured with the real service implementation.

**Note**: This requires a corresponding PR in getsentry to implement the actual service.

## Test plan

- [x] Existing tests pass (`pytest -svv --reuse-db tests/sentry/users/api/endpoints/test_user_identity_config.py`)
- [x] With devserver running and getsentry configured, navigate to `/settings/account/identities/` and verify GitHub Copilot identity appears
- [x] Test disconnecting the identity