### PR TITLE
chore(external-issue): add 'type to search' placeholder for dropdown fields

### DIFF
--- a/static/app/components/externalIssues/externalIssueForm.spec.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.spec.tsx
@@ -309,6 +309,14 @@ describe('ExternalIssueForm', () => {
       expect(getFormConfigRequest).toHaveBeenCalled();
     });
 
+    it('shows placeholder for async select fields', async () => {
+      await renderComponent('Link');
+
+      // The Issue field has a url property (async select), so it should display our placeholder
+      expect(screen.getByRole('textbox', {name: 'Issue'})).toBeInTheDocument();
+      expect(screen.getByText('Type to search')).toBeInTheDocument();
+    });
+
     describe('options loaded', () => {
       beforeEach(() => {
         MockApiClient.addMockResponse({

--- a/static/app/components/externalIssues/utils.tsx
+++ b/static/app/components/externalIssues/utils.tsx
@@ -6,7 +6,7 @@ import {Client} from 'sentry/api';
 import type FormModel from 'sentry/components/forms/model';
 import type {FieldValue} from 'sentry/components/forms/types';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Choices, SelectValue} from 'sentry/types/core';
 import type {IntegrationIssueConfig, IssueConfigField} from 'sentry/types/integrations';
 
@@ -226,6 +226,7 @@ export function getFieldProps({
     onBlurResetsInput: false,
     onCloseResetsInput: false,
     onSelectResetsInput: false,
+    placeholder: t('Type to search'),
   };
 }
 


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/ISWF-1992/increase-entries-in-jira-project-dropdown-for-better-access

Example
<img width="603" height="158" alt="Screenshot 2026-02-03 at 11 48 13" src="https://github.com/user-attachments/assets/02573a3f-c140-43c8-a468-b71209e67303" />