### PR TITLE
fix(notifications): Use plural form for QUOTA_SIZE_ANALYSIS enum value

### DIFF
--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -35,7 +35,7 @@ class NotificationSettingEnum(ValueEqualityEnum):
     QUOTA_SPEND_ALLOCATIONS = "quotaSpendAllocations"
     QUOTA_LOG_BYTES = "quotaLogBytes"
     QUOTA_SEER_USERS = "quotaSeerUsers"
-    QUOTA_SIZE_ANALYSIS = "quotaSizeAnalysis"
+    QUOTA_SIZE_ANALYSIS = "quotaSizeAnalyses"
     SPIKE_PROTECTION = "spikeProtection"
     MISSING_MEMBERS = "missingMembers"
     REPORTS = "reports"

--- a/tests/sentry/notifications/api/endpoints/test_notification_defaults.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_defaults.py
@@ -35,6 +35,6 @@ class NotificationDefaultTest(APITestCase):
                 "workflow": "subscribe_only",
                 "brokenMonitors": "always",
                 "quotaSeerUsers": "always",
-                "quotaSizeAnalysis": "always",
+                "quotaSizeAnalyses": "always",
             },
         }


### PR DESCRIPTION
## Summary

Fixes 400 error when users try to update Size Analysis spend notification preferences via `PUT /api/0/users/me/notification-options/`.

The frontend dynamically generates notification field names in `fields2.tsx` using:
```javascript
name: 'quota' + upperFirst(categoryInfo.plural)
```

For Size Analysis, `categoryInfo.plural` is `'sizeAnalyses'` (from `DataCategory.SIZE_ANALYSIS` in `static/app/types/core.tsx`), producing `quotaSizeAnalyses`.

However, PR #106939 introduced the backend enum value as `quotaSizeAnalysis` (singular), causing a validation mismatch.

**Changes:**
- Update `NotificationSettingEnum.QUOTA_SIZE_ANALYSIS` from `"quotaSizeAnalysis"` to `"quotaSizeAnalyses"`
- Update corresponding test expectation

## Test Plan

- [x] `test_notification_defaults.py` - 1 test passed
- [x] `test_user_notification_settings_options.py` - 8 tests passed
- [x] Pre-commit hooks passed