### PR TITLE
fix(auth): Fix test cookie race condition in multi-tab login

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -135,6 +135,10 @@ class AuthenticationForm(forms.Form):
                 extra={"ip_address": self.request.META["REMOTE_ADDR"]},
             )
             raise forms.ValidationError(self.error_messages["no_cookies"])
+        # Note: We intentionally don't call delete_test_cookie() here.
+        # Deleting it causes a race condition when users have multiple login
+        # tabs open - the first successful login would delete the cookie,
+        # causing subsequent tabs to fail with a "cookies not enabled" error.
 
     def get_user_id(self):
         if self.user_cache:

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -135,8 +135,6 @@ class AuthenticationForm(forms.Form):
                 extra={"ip_address": self.request.META["REMOTE_ADDR"]},
             )
             raise forms.ValidationError(self.error_messages["no_cookies"])
-        else:
-            self.request.session.delete_test_cookie()
 
     def get_user_id(self):
         if self.user_cache:

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -130,6 +130,10 @@ class AuthenticationForm(forms.Form):
 
     def check_for_test_cookie(self):
         if not self.request.session.test_cookie_worked():
+            logger.info(
+                "user.auth.no-cookies",
+                extra={"ip_address": self.request.META["REMOTE_ADDR"]},
+            )
             raise forms.ValidationError(self.error_messages["no_cookies"])
         else:
             self.request.session.delete_test_cookie()


### PR DESCRIPTION
## Summary

Fixes a race condition where logging into Sentry with multiple tabs open would cause the second tab to fail with a "cookies not enabled" error.

**The problem:** When a user successfully logs in on Tab A, `delete_test_cookie()` removes the test cookie from the session. When Tab B tries to submit its login form, `test_cookie_worked()` returns False because Tab A already deleted it - even though cookies are working fine.

**The fix:** Stop deleting the test cookie after successful login. The test cookie is just a small string (`"worked"`) stored in the session, so leaving it there is harmless.

Also adds logging when the test cookie check fails to help debug any remaining cookie-related login issues.