### PR TITLE
fix(ACI): Update sentry app installation receiver to disable Actions

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -95,6 +95,7 @@ def process_sentry_app_installation_deletes(
         region_name=region_name,
         status=ObjectStatus.DISABLED,
         sentry_app_install_uuid=payload["uuid"],
+        sentry_app_id=payload["sentry_app_id"],
     )
 
 

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -96,6 +96,7 @@ def process_sentry_app_installation_deletes(
         status=ObjectStatus.DISABLED,
         sentry_app_install_uuid=payload["uuid"],
         sentry_app_id=payload.get("sentry_app_id"),
+        organization_id=payload.get("organization_id"),
     )
 
 

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -95,7 +95,7 @@ def process_sentry_app_installation_deletes(
         region_name=region_name,
         status=ObjectStatus.DISABLED,
         sentry_app_install_uuid=payload["uuid"],
-        sentry_app_id=payload["sentry_app_id"],
+        sentry_app_id=payload.get("sentry_app_id"),
     )
 
 

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -148,6 +148,15 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         except SentryApp.DoesNotExist:
             return None
 
+    @property
+    def sentry_app_id(self) -> int | None:
+        from sentry.sentry_apps.models.sentry_app import SentryApp
+
+        try:
+            return self.sentry_app.id
+        except SentryApp.DoesNotExist:
+            return None
+
     def outbox_region_names(self) -> Collection[str]:
         return find_regions_for_orgs([self.organization_id])
 
@@ -164,7 +173,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
-                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app.id},
+                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app_id or 0},
             )
             for region_name in find_all_region_names()
         ]

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -152,7 +152,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         return find_regions_for_orgs([self.organization_id])
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        # Use 0 in case of bad relations from api_applicaiton_id -- the replication ordering for
+        # Use 0 in case of bad relations from api_application_id -- the replication ordering for
         # these isn't so important in that case.
         return super().outboxes_for_update(shard_identifier=self.api_application_id or 0)
 
@@ -164,7 +164,11 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
-                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app_id},
+                payload={
+                    "uuid": self.uuid,
+                    "sentry_app_id": self.sentry_app_id,
+                    "organization_id": self.organization_id,
+                },
             )
             for region_name in find_all_region_names()
         ]

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -164,7 +164,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
-                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app_id or 0},
+                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app_id},
             )
             for region_name in find_all_region_names()
         ]

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -164,7 +164,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
-                payload={"uuid": self.uuid},
+                payload={"uuid": self.uuid, "sentry_app_id": self.sentry_app.id},
             )
             for region_name in find_all_region_names()
         ]

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -148,15 +148,6 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         except SentryApp.DoesNotExist:
             return None
 
-    @property
-    def sentry_app_id(self) -> int | None:
-        from sentry.sentry_apps.models.sentry_app import SentryApp
-
-        try:
-            return self.sentry_app.id
-        except SentryApp.DoesNotExist:
-            return None
-
     def outbox_region_names(self) -> Collection[str]:
         return find_regions_for_orgs([self.organization_id])
 

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -37,7 +37,7 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int,
+        sentry_app_id: int = 0,
     ) -> None:
         Action.objects.filter(
             Q(config__target_identifier=sentry_app_install_uuid)
@@ -51,7 +51,7 @@ class DatabaseBackedActionService(ActionService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int,
+        sentry_app_id: int = 0,
     ) -> None:
         actions = Action.objects.filter(
             Q(config__target_identifier=sentry_app_install_uuid)

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -37,11 +37,11 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int,
+        sentry_app_id: str,
     ) -> None:
         Action.objects.filter(
             Q(config__target_identifier=sentry_app_install_uuid)
-            | Q(config__target_identifier=sentry_app_id),
+            | Q(config__target_identifier=str(sentry_app_id)),
             type=Action.Type.SENTRY_APP,
         ).update(status=status)
 
@@ -53,11 +53,12 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_install_uuid: str,
         sentry_app_id: int,
     ) -> None:
-        Action.objects.filter(
+        actions = Action.objects.filter(
             Q(config__target_identifier=sentry_app_install_uuid)
-            | Q(config__target_identifier=sentry_app_id),
+            | Q(config__target_identifier=str(sentry_app_id)),
             type=Action.Type.SENTRY_APP,
-        ).update(status=status)
+        )
+        actions.update(status=status)
 
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
@@ -66,7 +67,7 @@ class DatabaseBackedActionService(ActionService):
         status: int,
         sentry_app_id: int,
     ) -> None:
-        # look up all installs and disable - if the sentry app no longer exists, no related actions can fire
+        # look up all installs and disable the action - if the sentry app no longer exists, no related actions can fire
         installs = app_service.get_many(
             filter={
                 "sentry_app__id": sentry_app_id,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -37,7 +37,7 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: str,
+        sentry_app_id: int,
     ) -> None:
         Action.objects.filter(
             Q(config__target_identifier=sentry_app_install_uuid)
@@ -67,7 +67,7 @@ class DatabaseBackedActionService(ActionService):
         status: int,
         sentry_app_id: int,
     ) -> None:
-        # look up all installs and disable the action - if the sentry app no longer exists, no related actions can fire
+        # look up all installs for the sentry app and disable the action - if the sentry app no longer exists, no related actions can fire
         installs = app_service.get_many(
             filter={
                 "sentry_app__id": sentry_app_id,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -74,12 +74,19 @@ class DatabaseBackedActionService(ActionService):
                 type=Action.Type.SENTRY_APP,
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
-        installation_uuid_actions = Action.objects.filter(
-            config__target_identifier=sentry_app_install_uuid,
-            type=Action.Type.SENTRY_APP,
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
-            dataconditiongroupaction__condition_group__organization_id=organization_id,
-        )
+        if organization_id:
+            installation_uuid_actions = Action.objects.filter(
+                config__target_identifier=sentry_app_install_uuid,
+                type=Action.Type.SENTRY_APP,
+                config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
+            )
+        else:
+            installation_uuid_actions = Action.objects.filter(
+                config__target_identifier=sentry_app_install_uuid,
+                type=Action.Type.SENTRY_APP,
+                config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            )
 
         actions = sentry_app_id_actions | installation_uuid_actions
         if actions:

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -39,7 +39,7 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_id: int | None,
     ) -> None:
         actions = None
-        if sentry_app_id is not None:
+        if sentry_app_id:
             actions = Action.objects.filter(
                 Q(config__target_identifier=sentry_app_install_uuid)
                 | Q(config__target_identifier=str(sentry_app_id)),

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -37,13 +37,22 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int = 0,
+        sentry_app_id: int | None,
     ) -> None:
-        Action.objects.filter(
-            Q(config__target_identifier=sentry_app_install_uuid)
-            | Q(config__target_identifier=str(sentry_app_id)),
-            type=Action.Type.SENTRY_APP,
-        ).update(status=status)
+        actions = None
+        if sentry_app_id is not None:
+            actions = Action.objects.filter(
+                Q(config__target_identifier=sentry_app_install_uuid)
+                | Q(config__target_identifier=str(sentry_app_id)),
+                type=Action.Type.SENTRY_APP,
+            )
+        else:
+            actions = Action.objects.filter(
+                config__target_identifier=sentry_app_install_uuid, type=Action.Type.SENTRY_APP
+            )
+
+        if actions:
+            actions.update(status=status)
 
     def update_action_status_for_sentry_app_via_uuid__region(
         self,
@@ -51,14 +60,22 @@ class DatabaseBackedActionService(ActionService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int = 0,
+        sentry_app_id: int | None,
     ) -> None:
-        actions = Action.objects.filter(
-            Q(config__target_identifier=sentry_app_install_uuid)
-            | Q(config__target_identifier=str(sentry_app_id)),
-            type=Action.Type.SENTRY_APP,
-        )
-        actions.update(status=status)
+        actions = None
+        if sentry_app_id is not None:
+            actions = Action.objects.filter(
+                Q(config__target_identifier=sentry_app_install_uuid)
+                | Q(config__target_identifier=str(sentry_app_id)),
+                type=Action.Type.SENTRY_APP,
+            )
+        else:
+            actions = Action.objects.filter(
+                config__target_identifier=sentry_app_install_uuid, type=Action.Type.SENTRY_APP
+            )
+
+        if actions:
+            actions.update(status=status)
 
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -50,8 +50,7 @@ class DatabaseBackedActionService(ActionService):
                 config__target_identifier=sentry_app_install_uuid, type=Action.Type.SENTRY_APP
             )
 
-        if actions:
-            actions.update(status=status)
+        actions.update(status=status)
 
     def update_action_status_for_sentry_app_via_uuid__region(
         self,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -61,7 +61,7 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_id: int | None,
     ) -> None:
         actions = None
-        if sentry_app_id is not None:
+        if sentry_app_id:
             actions = Action.objects.filter(
                 Q(config__target_identifier=sentry_app_install_uuid)
                 | Q(config__target_identifier=str(sentry_app_id)),

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -46,6 +46,7 @@ class DatabaseBackedActionService(ActionService):
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
         installation_uuid_actions = Action.objects.filter(
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
             config__target_identifier=sentry_app_install_uuid,
             type=Action.Type.SENTRY_APP,
             dataconditiongroupaction__condition_group__organization_id=organization_id,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -36,7 +36,7 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_install_uuid: str,
         sentry_app_id: int | None = None,
     ) -> None:
-        sentry_app_id_actions = None
+        sentry_app_id_actions = Action.objects.none()
 
         if sentry_app_id:
             sentry_app_id_actions = Action.objects.filter(
@@ -64,7 +64,7 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int | None = None,
         sentry_app_id: int | None = None,
     ) -> None:
-        sentry_app_id_actions = None
+        sentry_app_id_actions = Action.objects.none()
 
         if sentry_app_id and organization_id:
             sentry_app_id_actions = Action.objects.filter(

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -36,7 +36,7 @@ class DatabaseBackedActionService(ActionService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int | None,
+        sentry_app_id: int | None = None,
     ) -> None:
         actions = None
         if sentry_app_id:
@@ -58,7 +58,7 @@ class DatabaseBackedActionService(ActionService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int | None,
+        sentry_app_id: int | None = None,
     ) -> None:
         actions = None
         if sentry_app_id:

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -70,7 +70,7 @@ class DatabaseBackedActionService(ActionService):
         # look up all installs for the sentry app and disable the action - if the sentry app no longer exists, no related actions can fire
         installs = app_service.get_many(
             filter={
-                "sentry_app__id": sentry_app_id,
+                "app_ids": [sentry_app_id],
                 "status": SentryAppInstallationStatus.INSTALLED,
             }
         )

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -44,10 +44,13 @@ class DatabaseBackedActionService(ActionService):
                 Q(config__target_identifier=sentry_app_install_uuid)
                 | Q(config__target_identifier=str(sentry_app_id)),
                 type=Action.Type.SENTRY_APP,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
         else:
             actions = Action.objects.filter(
-                config__target_identifier=sentry_app_install_uuid, type=Action.Type.SENTRY_APP
+                config__target_identifier=sentry_app_install_uuid,
+                type=Action.Type.SENTRY_APP,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
 
         actions.update(status=status)
@@ -58,6 +61,7 @@ class DatabaseBackedActionService(ActionService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
+        organization_id: int,
         sentry_app_id: int | None = None,
     ) -> None:
         actions = None
@@ -66,10 +70,13 @@ class DatabaseBackedActionService(ActionService):
                 Q(config__target_identifier=sentry_app_install_uuid)
                 | Q(config__target_identifier=str(sentry_app_id)),
                 type=Action.Type.SENTRY_APP,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
         else:
             actions = Action.objects.filter(
-                config__target_identifier=sentry_app_install_uuid, type=Action.Type.SENTRY_APP
+                config__target_identifier=sentry_app_install_uuid,
+                type=Action.Type.SENTRY_APP,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
 
         if actions:

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -61,11 +61,11 @@ class DatabaseBackedActionService(ActionService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        organization_id: int,
+        organization_id: int | None = None,
         sentry_app_id: int | None = None,
     ) -> None:
         actions = None
-        if sentry_app_id:
+        if sentry_app_id and organization_id:
             actions = Action.objects.filter(
                 Q(config__target_identifier=sentry_app_install_uuid)
                 | Q(config__target_identifier=str(sentry_app_id)),
@@ -73,10 +73,11 @@ class DatabaseBackedActionService(ActionService):
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
         else:
+            # we previously only used the installation id, so without the org id we can't do the sentry app id lookup
             actions = Action.objects.filter(
                 config__target_identifier=sentry_app_install_uuid,
                 type=Action.Type.SENTRY_APP,
-                dataconditiongroupaction__condition_group__organization_id=organization_id,
+                config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
             )
 
         if actions:

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -78,6 +78,7 @@ class DatabaseBackedActionService(ActionService):
             config__target_identifier=sentry_app_install_uuid,
             type=Action.Type.SENTRY_APP,
             config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            dataconditiongroupaction__condition_group__organization_id=organization_id,
         )
 
         actions = sentry_app_id_actions | installation_uuid_actions

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -42,7 +42,7 @@ class ActionService(RpcService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int,
+        sentry_app_id: int = 0,
     ) -> None:
         pass
 
@@ -54,7 +54,7 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int,
+        sentry_app_id: int = 0,
     ) -> None:
         pass
 

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -42,6 +42,7 @@ class ActionService(RpcService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
+        sentry_app_id: int,
     ) -> None:
         pass
 
@@ -53,6 +54,7 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
+        sentry_app_id: int,
     ) -> None:
         pass
 

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -42,7 +42,7 @@ class ActionService(RpcService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int = 0,
+        sentry_app_id: int | None,
     ) -> None:
         pass
 
@@ -54,7 +54,7 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int = 0,
+        sentry_app_id: int | None,
     ) -> None:
         pass
 

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -54,6 +54,7 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
+        organization_id: int,
         sentry_app_id: int | None,
     ) -> None:
         pass

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -54,7 +54,7 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        organization_id: int,
+        organization_id: int | None,
         sentry_app_id: int | None,
     ) -> None:
         pass

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -54,8 +54,8 @@ class ActionService(RpcService):
         region_name: str,
         status: int,
         sentry_app_install_uuid: str,
-        organization_id: int | None,
-        sentry_app_id: int | None,
+        organization_id: int | None = None,
+        sentry_app_id: int | None = None,
     ) -> None:
         pass
 

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -42,7 +42,7 @@ class ActionService(RpcService):
         organization_id: int,
         status: int,
         sentry_app_install_uuid: str,
-        sentry_app_id: int | None,
+        sentry_app_id: int | None = None,
     ) -> None:
         pass
 

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -128,6 +128,8 @@ class TestSentryAppInstallationDeletionTask(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg = self.create_data_condition_group(organization=self.org)
+        self.create_data_condition_group_action(action=action, condition_group=dcg)
         other_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -136,6 +138,8 @@ class TestSentryAppInstallationDeletionTask(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg2 = self.create_data_condition_group(organization=self.org)
+        self.create_data_condition_group_action(action=action, condition_group=dcg2)
         deletions.exec_sync(self.install)
         with outbox_runner():
             pass

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -139,7 +139,7 @@ class TestSentryAppInstallationDeletionTask(TestCase):
             },
         )
         dcg2 = self.create_data_condition_group(organization=self.org)
-        self.create_data_condition_group_action(action=action, condition_group=dcg2)
+        self.create_data_condition_group_action(action=other_action, condition_group=dcg2)
         deletions.exec_sync(self.install)
         with outbox_runner():
             pass

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -134,6 +134,8 @@ class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg = self.create_data_condition_group(organization=self.org)
+        self.create_data_condition_group_action(action=action, condition_group=dcg)
 
         with self.tasks():
             run_scheduled_deletions_control()

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -255,11 +255,19 @@ class TestActionService(TestCase):
             slug=self.sentry_app.slug,
             organization=self.organization,
         )
-        action = self.create_action(
+        installation_uuid_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": sentry_app_installation.uuid,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        sentry_app_id_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -272,19 +280,29 @@ class TestActionService(TestCase):
         )
 
         with assume_test_silo_mode(SiloMode.REGION):
-            action.refresh_from_db()
-            assert action.status == ObjectStatus.DISABLED
+            installation_uuid_action.refresh_from_db()
+            sentry_app_id_action.refresh_from_db()
+            assert installation_uuid_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_sentry_app__installation_uuid__region(self) -> None:
         sentry_app_installation = self.create_sentry_app_installation(
             slug=self.sentry_app.slug,
             organization=self.organization,
         )
-        action = self.create_action(
+        installation_uuid_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": sentry_app_installation.uuid,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        sentry_app_id_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -295,10 +313,25 @@ class TestActionService(TestCase):
             status=ObjectStatus.DISABLED,
         )
         with assume_test_silo_mode(SiloMode.REGION):
-            action.refresh_from_db()
-            assert action.status == ObjectStatus.DISABLED
+            installation_uuid_action.refresh_from_db()
+            sentry_app_id_action.refresh_from_db()
+            assert installation_uuid_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        installation_uuid_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": sentry_app_installation.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -315,7 +348,9 @@ class TestActionService(TestCase):
 
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
+            installation_uuid_action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
+            assert installation_uuid_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_webhook_via_sentry_app_slug(self) -> None:
         action = self.create_action(

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -263,6 +263,11 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg = self.create_data_condition_group()
+        self.create_data_condition_group_action(
+            action=installation_uuid_action, condition_group=dcg
+        )
+
         sentry_app_id_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -271,6 +276,25 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg2 = self.create_data_condition_group()
+        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg2)
+
+        # make a new org to ensure we are not disabling actions related to the same sentry app based on a different installation being removed
+        org2 = self.create_organization()
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=org2,
+        )
+        sentry_app_id_action2 = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg3 = self.create_data_condition_group(organization=org2)
+        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg3)
 
         action_service.update_action_status_for_sentry_app_via_uuid(
             organization_id=self.organization.id,
@@ -282,8 +306,10 @@ class TestActionService(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             installation_uuid_action.refresh_from_db()
             sentry_app_id_action.refresh_from_db()
+            sentry_app_id_action2.refresh_from_db()
             assert installation_uuid_action.status == ObjectStatus.DISABLED
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
 
     def test_update_action_status_for_sentry_app__installation_uuid__region(self) -> None:
         sentry_app_installation = self.create_sentry_app_installation(
@@ -298,6 +324,10 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg = self.create_data_condition_group()
+        self.create_data_condition_group_action(
+            action=installation_uuid_action, condition_group=dcg
+        )
         sentry_app_id_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -306,17 +336,40 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        dcg2 = self.create_data_condition_group()
+        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg2)
+
+        # make a new org to ensure we are not disabling actions related to the same sentry app
+        org2 = self.create_organization()
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=org2,
+        )
+        sentry_app_id_action2 = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg3 = self.create_data_condition_group(organization=org2)
+        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg3)
+
         action_service.update_action_status_for_sentry_app_via_uuid__region(
             region_name="us",
             sentry_app_install_uuid=sentry_app_installation.uuid,
             sentry_app_id=sentry_app_installation.sentry_app.id,
+            organization_id=self.organization.id,
             status=ObjectStatus.DISABLED,
         )
         with assume_test_silo_mode(SiloMode.REGION):
             installation_uuid_action.refresh_from_db()
             sentry_app_id_action.refresh_from_db()
+            sentry_app_id_action2.refresh_from_db()
             assert installation_uuid_action.status == ObjectStatus.DISABLED
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
 
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
         self.create_sentry_app_installation(

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -267,6 +267,7 @@ class TestActionService(TestCase):
         action_service.update_action_status_for_sentry_app_via_uuid(
             organization_id=self.organization.id,
             sentry_app_install_uuid=sentry_app_installation.uuid,
+            sentry_app_id=sentry_app_installation.sentry_app.id,
             status=ObjectStatus.DISABLED,
         )
 
@@ -290,6 +291,7 @@ class TestActionService(TestCase):
         action_service.update_action_status_for_sentry_app_via_uuid__region(
             region_name="us",
             sentry_app_install_uuid=sentry_app_installation.uuid,
+            sentry_app_id=sentry_app_installation.sentry_app.id,
             status=ObjectStatus.DISABLED,
         )
         with assume_test_silo_mode(SiloMode.REGION):

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -323,6 +323,10 @@ class TestActionService(TestCase):
             slug=self.sentry_app.slug,
             organization=self.organization,
         )
+        self.create_sentry_app_installation(
+            slug=self.sentry_app_2.slug,
+            organization=self.organization,
+        )
         installation_uuid_action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -340,6 +344,14 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        other_sentry_app_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app_2.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
         action_service.update_action_status_for_sentry_app_via_sentry_app_id(
             region_name="us",
             sentry_app_id=self.sentry_app.id,
@@ -349,8 +361,10 @@ class TestActionService(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
             installation_uuid_action.refresh_from_db()
+            other_sentry_app_action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
             assert installation_uuid_action.status == ObjectStatus.DISABLED
+            assert other_sentry_app_action.status == ObjectStatus.ACTIVE
 
     def test_update_action_status_for_webhook_via_sentry_app_slug(self) -> None:
         action = self.create_action(

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -319,21 +319,9 @@ class TestActionService(TestCase):
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
-        sentry_app_installation = self.create_sentry_app_installation(
-            slug=self.sentry_app.slug,
-            organization=self.organization,
-        )
         self.create_sentry_app_installation(
             slug=self.sentry_app_2.slug,
             organization=self.organization,
-        )
-        installation_uuid_action = self.create_action(
-            type=Action.Type.SENTRY_APP,
-            config={
-                "target_identifier": sentry_app_installation.uuid,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
-                "target_type": ActionTarget.SENTRY_APP,
-            },
         )
 
         action = self.create_action(
@@ -360,10 +348,8 @@ class TestActionService(TestCase):
 
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
-            installation_uuid_action.refresh_from_db()
             other_sentry_app_action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
-            assert installation_uuid_action.status == ObjectStatus.DISABLED
             assert other_sentry_app_action.status == ObjectStatus.ACTIVE
 
     def test_update_action_status_for_webhook_via_sentry_app_slug(self) -> None:


### PR DESCRIPTION
Update the sentry app installation deletion receiver to disable `Action`s using either the sentry app id or the sentry app installation uuid. Previously the sentry app installation deletion receiver was failing to update `Actions` that use the sentry app id (which is any single written `Action` or any `Action` that was dual written from a metric alert).

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>63ffa9a</u></sup><!-- /BUGBOT_STATUS -->