### PR TITLE
fix(context-picker): Prevent layout shift when loading projects

### DIFF
--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -59,7 +59,6 @@ describe('ContextPickerModal', () => {
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
       closeModal={jest.fn()}
-      organizations={[]}
       {...props}
     />
   );
@@ -182,7 +181,6 @@ describe('ContextPickerModal', () => {
         needOrg: true,
         needProject: true,
         nextPath: '/test/:orgId/path/:projectId/',
-        organizations,
       })
     );
 

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -46,7 +46,9 @@ describe('ContextPickerModal', () => {
     jest.clearAllMocks();
   });
 
-  const getComponent = (props = {}) => (
+  const getComponent = (
+    props: Partial<React.ComponentProps<typeof ContextPickerModal>> = {}
+  ) => (
     <ContextPickerModal
       Header={() => <div />}
       Body={ModalBody}
@@ -57,6 +59,7 @@ describe('ContextPickerModal', () => {
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
       closeModal={jest.fn()}
+      organizations={[]}
       {...props}
     />
   );
@@ -145,8 +148,11 @@ describe('ContextPickerModal', () => {
     // Should see 1 selected, and 1 as an option
     expect(screen.getAllByText('org-slug')).toHaveLength(2);
 
-    expect(screen.getByRole('textbox')).toHaveFocus();
+    // Wait for projects to load before checking focus
     expect(await screen.findByText('My Projects')).toBeInTheDocument();
+    // Project selector should have focus (there are two textboxes: org and project)
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[1]).toHaveFocus();
     expect(screen.getByText(project.slug)).toBeInTheDocument();
     expect(screen.getByText(project2.slug)).toBeInTheDocument();
     expect(screen.getByText('All Projects')).toBeInTheDocument();

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -2,6 +2,7 @@ import {Component, Fragment, useState, type Dispatch, type SetStateAction} from 
 import styled from '@emotion/styled';
 import type {Query} from 'history';
 
+import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {StylesConfig} from '@sentry/scraps/select';
@@ -9,7 +10,6 @@ import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -257,7 +257,7 @@ class ContextPickerModal extends Component<Props> {
 
     if (projectsLoading) {
       return (
-        <Flex justify="center" align="center" minHeight="320px">
+        <Flex justify="center" align="center" minHeight="345px">
           <LoadingIndicator />
         </Flex>
       );

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -2,13 +2,14 @@ import {Component, Fragment, useState, type Dispatch, type SetStateAction} from 
 import styled from '@emotion/styled';
 import type {Query} from 'history';
 
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {StylesConfig} from '@sentry/scraps/select';
 import {Select} from '@sentry/scraps/select';
+import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
-import IdBadge from 'sentry/components/idBadge';
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
@@ -49,13 +50,16 @@ type SharedProps = ModalRenderProps & {
    */
   onFinish: (path: string | {pathname: string; query?: Query}) => number | void;
 
+  /**
+   * List of available organizations
+   */
+  organizations: Organization[];
+
   allowAllProjectsSelection?: boolean;
 };
 
 type Props = SharedProps & {
   integrationConfigs: Integration[];
-
-  loading: boolean;
 
   /**
    * Callback for when organization is selected
@@ -67,12 +71,12 @@ type Props = SharedProps & {
    */
   organization: string | undefined;
 
-  /**
-   * List of available organizations
-   */
-  organizations: Organization[];
-
   projects: Project[];
+
+  /**
+   * Whether projects are still loading
+   */
+  projectsLoading?: boolean;
 };
 
 function autoFocusReactSelect(reactSelectRef: any) {
@@ -230,25 +234,6 @@ class ContextPickerModal extends Component<Props> {
     return [memberProjects, nonMemberProjects];
   };
 
-  // TODO(TS): Fix typings
-  customOptionProject = ({label, ...props}: any) => {
-    const project = this.props.projects.find(({slug}) => props.value === slug);
-    if (!project) {
-      return null;
-    }
-    return (
-      <components.Option label={label} {...props}>
-        <ProjectBadgeOption
-          project={project}
-          avatarSize={20}
-          displayName={label}
-          avatarProps={{consistentWidth: true}}
-          disableLink
-        />
-      </components.Option>
-    );
-  };
-
   get headerText() {
     const {needOrg, needProject, integrationConfigs} = this.props;
     if (needOrg && needProject) {
@@ -268,7 +253,16 @@ class ContextPickerModal extends Component<Props> {
   }
 
   renderProjectSelectOrMessage() {
-    const {projects, allowAllProjectsSelection} = this.props;
+    const {projects, allowAllProjectsSelection, projectsLoading} = this.props;
+
+    if (projectsLoading) {
+      return (
+        <Flex justify="center" align="center" minHeight="320px">
+          <LoadingIndicator />
+        </Flex>
+      );
+    }
+
     const [memberProjects, nonMemberProjects] = this.getMemberProjects();
     const {isSuperuser} = ConfigStore.get('user') || {};
 
@@ -281,6 +275,7 @@ class ContextPickerModal extends Component<Props> {
           value: p.slug,
           label: p.slug,
           disabled: false,
+          leadingItems: <ProjectAvatar project={p} size={20} />,
         })),
       },
       {
@@ -289,6 +284,7 @@ class ContextPickerModal extends Component<Props> {
           value: p.slug,
           label: p.slug,
           disabled: allowAllProjectsSelection ? false : !isSuperuser,
+          leadingItems: <ProjectAvatar project={p} size={20} />,
         })),
       },
     ];
@@ -314,7 +310,7 @@ class ContextPickerModal extends Component<Props> {
         name="project"
         options={projectOptions}
         onChange={this.handleSelectProject}
-        components={{Option: this.customOptionProject, DropdownIndicator: null}}
+        components={{DropdownIndicator: null}}
         styles={selectStyles}
         menuIsOpen
       />
@@ -333,10 +329,10 @@ class ContextPickerModal extends Component<Props> {
         options: integrationConfigs.map(config => ({
           value: config.id,
           label: (
-            <StyledIntegrationItem>
+            <Grid columns="32px auto" rows="1fr">
               <IntegrationIcon size={22} integration={config} />
               <span>{config.domainName}</span>
-            </StyledIntegrationItem>
+            </Grid>
           ),
           disabled: isSuperuser ? false : true,
         })),
@@ -362,14 +358,13 @@ class ContextPickerModal extends Component<Props> {
       needProject,
       organization,
       organizations,
-      loading,
       Header,
       Body,
       integrationConfigs,
     } = this.props;
     const {isSuperuser} = ConfigStore.get('user') || {};
 
-    const shouldShowProjectSelector = organization && needProject && !loading;
+    const shouldShowProjectSelector = organization && needProject;
 
     const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;
 
@@ -386,10 +381,9 @@ class ContextPickerModal extends Component<Props> {
     return (
       <Fragment>
         <Header closeButton>
-          <h5>{this.headerText}</h5>
+          <Heading as="h5">{this.headerText}</Heading>
         </Header>
         <Body>
-          {loading && <StyledLoadingIndicator overlay />}
           {needOrg && (
             <StyledSelectControl
               ref={shouldShowProjectSelector ? undefined : autoFocusReactSelect}
@@ -450,7 +444,7 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
           <ContextPickerModal
             {...sharedProps}
             projects={projects as Project[]}
-            loading={!initiallyLoaded}
+            projectsLoading={!initiallyLoaded}
             organizations={organizations}
             organization={selectedOrgSlug}
             onSelectOrganization={setSelectedOrgSlug}
@@ -465,7 +459,6 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
     <ContextPickerModal
       {...sharedProps}
       projects={[]}
-      loading
       organizations={organizations}
       organization={selectedOrgSlug}
       onSelectOrganization={setSelectedOrgSlug}
@@ -502,7 +495,6 @@ function ConfigUrlContainer(
     <ContextPickerModal
       {...sharedProps}
       projects={[]}
-      loading={isPending}
       organizations={organizations}
       organization={selectedOrgSlug}
       onSelectOrganization={setSelectedOrgSlug}
@@ -513,18 +505,4 @@ function ConfigUrlContainer(
 
 const StyledSelectControl = styled(Select)`
   margin-top: ${space(1)};
-`;
-
-const ProjectBadgeOption = styled(IdBadge)`
-  margin: ${space(1)};
-`;
-
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  z-index: 1;
-`;
-
-const StyledIntegrationItem = styled('div')`
-  display: grid;
-  grid-template-columns: ${space(4)} auto;
-  grid-template-rows: 1fr;
 `;

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -50,11 +50,6 @@ type SharedProps = ModalRenderProps & {
    */
   onFinish: (path: string | {pathname: string; query?: Query}) => number | void;
 
-  /**
-   * List of available organizations
-   */
-  organizations: Organization[];
-
   allowAllProjectsSelection?: boolean;
 };
 
@@ -70,6 +65,11 @@ type Props = SharedProps & {
    * Organization slug
    */
   organization: string | undefined;
+
+  /**
+   * List of available organizations
+   */
+  organizations: Organization[];
 
   projects: Project[];
 


### PR DESCRIPTION
splits loading state into different props so they can be rendered when needed. Also prepares this giant class component to be split into functional components.

- Fixes layout issues while loading
- Fixes hover state
- Fix prop not in the right "shared" props

before
<img width="702" height="183" alt="image" src="https://github.com/user-attachments/assets/a759efec-2b91-4f0e-bbca-115030fa6fcb" />

after
<img width="645" height="500" alt="image" src="https://github.com/user-attachments/assets/5eee8d8e-2266-4fd0-89ac-83a8b198d509" />

