### PR TITLE
chore(aci): Add eventId to GroupOpenPeriodActivity serializer

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -36,6 +36,7 @@ class GroupOpenPeriodActivitySerializer(Serializer):
             type=OpenPeriodActivityType(obj.type).to_str(),
             value=PriorityLevel(obj.value).to_str() if obj.value else None,
             dateCreated=obj.date_added,
+            eventId=obj.event_id,
         )
 
 

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -15,6 +15,7 @@ class GroupOpenPeriodActivityResponse(TypedDict):
     type: str
     value: str | None
     dateCreated: datetime
+    eventId: str | None
 
 
 class GroupOpenPeriodResponse(TypedDict):

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -108,6 +108,7 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             group_open_period=self.group_open_period,
             type=OpenPeriodActivityType.OPENED,
             value=self.group.priority,
+            event_id=self.event.id,
         )
         serialized_incident = serialize(
             self.group_open_period,
@@ -121,4 +122,5 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": gopa.date_added,
+            "eventId": self.event.id,
         }

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -108,7 +108,7 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             group_open_period=self.group_open_period,
             type=OpenPeriodActivityType.OPENED,
             value=self.group.priority,
-            event_id=self.event.id,
+            event_id="a" * 32,
         )
         serialized_incident = serialize(
             self.group_open_period,
@@ -122,5 +122,5 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": gopa.date_added,
-            "eventId": self.event.id,
+            "eventId": "a" * 32,
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -74,6 +74,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": self.opened_gopa.date_added,
+            "eventId": None,
         }
 
     def test_open_periods_group_id(self) -> None:
@@ -123,12 +124,14 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": self.opened_gopa.date_added,
+            "eventId": None,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
             "dateCreated": closed_gopa.date_added,
+            "eventId": None,
         }
 
     def test_open_periods_unresolved_group(self) -> None:
@@ -209,12 +212,14 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": opened_gopa2.date_added,
+            "eventId": None,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa2.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
             "dateCreated": closed_gopa2.date_added,
+            "eventId": None,
         }
 
         assert resp2["id"] == str(open_period.id)
@@ -228,12 +233,14 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": self.opened_gopa.date_added,
+            "eventId": None,
         }
         assert resp2["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
             "dateCreated": closed_gopa.date_added,
+            "eventId": None,
         }
 
     def test_open_periods_limit(self) -> None:
@@ -435,6 +442,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             group_open_period=self.group_open_period,
             type=OpenPeriodActivityType.STATUS_CHANGE,
             value=self.group.priority,
+            event_id="a" * 32,
         )
         update_gopa.date_added = curr_time - timedelta(minutes=6)
         update_gopa.save()
@@ -462,6 +470,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "type": OpenPeriodActivityType.STATUS_CHANGE.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
             "dateCreated": update_gopa.date_added,
+            "eventId": "a" * 32,
         }
 
     def test_filter_by_event_id(self) -> None:


### PR DESCRIPTION
Simple change - we added `event_id` to the model, but the serializer needs to be updated as well: https://github.com/getsentry/sentry/pull/107305