### PR TITLE
fix(alerts): Ensure project_id is an int in OrganizationEventsAnomaliesEndpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -24,6 +24,7 @@ from sentry.seer.anomaly_detection.get_historical_anomalies import (
     get_historical_anomaly_data_from_seer_preview,
 )
 from sentry.seer.anomaly_detection.types import DetectAnomaliesResponse, TimeSeriesPoint
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 @region_silo_endpoint
@@ -77,9 +78,9 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
         current_data = self._format_historical_data(request.data.get("current_data"))
 
         config = request.data.get("config")
-        project_id = request.data.get("project_id")
+        raw_project_id = request.data.get("project_id")
 
-        if project_id is None or not config or not historical_data or not current_data:
+        if raw_project_id is None or not config or not historical_data or not current_data:
             return Response(
                 {
                     "detail": "Unable to get historical anomaly data: missing required argument(s) project_id, config, historical_data, and/or current_data"
@@ -87,6 +88,7 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
                 status=400,
             )
 
+        project_id = to_valid_int_id("project_id", raw_project_id)
         projects = self.get_projects(request, organization, project_ids={project_id})
         if not projects:
             return Response({"detail": "Invalid project"}, status=400)

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -46,7 +46,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
     def get_test_data(self, project_id: int) -> dict:
         return {
-            "project_id": project_id,
+            "project_id": str(project_id),  # UI provides project_id as str
             "config": self.config,
             "historical_data": [
                 [self.historical_timestamp_1, {"count": 5}],


### PR DESCRIPTION
Whether the project ID comes to us as a string (as it does in some of our UI) or as an int, we want to make sure it is an int before it is passed to get_projects so the internal set operations work properly.