### PR TITLE
fix(ai-conversations): misaligned border in active message bubble

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -379,7 +379,7 @@ const MessageBubble = styled('div')<{
   isClickable?: boolean;
   isSelected?: boolean;
 }>`
-  border: 1px solid ${p => p.theme.tokens.border.primary};
+  position: relative;
   border-radius: ${p => p.theme.radius.md};
   overflow: hidden;
   width: 90%;
@@ -388,12 +388,22 @@ const MessageBubble = styled('div')<{
     p.role === 'user'
       ? p.theme.tokens.background.secondary
       : p.theme.tokens.background.primary};
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 1px solid ${p => p.theme.tokens.border.primary};
+    border-radius: inherit;
+    pointer-events: none;
+  }
   ${p =>
     p.isClickable &&
     `
     cursor: pointer;
-    &:hover {
+    &:hover::after {
       border-color: ${p.theme.tokens.border.accent.moderate};
+    }
+    &:hover {
       background-color: ${p.theme.tokens.interactive.transparent.neutral.background.hover};
     }
     &:active {

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -380,6 +380,7 @@ const MessageBubble = styled('div')<{
   isSelected?: boolean;
 }>`
   position: relative;
+  z-index: 0;
   border-radius: ${p => p.theme.radius.md};
   overflow: hidden;
   width: 90%;
@@ -394,6 +395,8 @@ const MessageBubble = styled('div')<{
     inset: 0;
     border: 1px solid ${p => p.theme.tokens.border.primary};
     border-radius: inherit;
+    box-sizing: border-box;
+    z-index: 1;
     pointer-events: none;
   }
   ${p =>
@@ -413,8 +416,13 @@ const MessageBubble = styled('div')<{
   ${p =>
     p.isSelected &&
     `
-    outline: 2px solid ${p.theme.tokens.focus.default};
-    outline-offset: -2px;
+    &::after {
+      border-color: ${p.theme.tokens.focus.default};
+      border-width: 2px;
+    }
+    &:hover::after {
+      border-color: ${p.theme.tokens.focus.default};
+    }
   `}
 `;
 


### PR DESCRIPTION
Fixes an issue where the message bubble's border was being obscured by a child element's gradient. The border is now rendered using an `::after` pseudo-element to ensure it always appears on top.

Closes: https://linear.app/getsentry/issue/TET-1883/misaligned-borders-in-active-chat-bubble

Before:
<img width="700" height="538" alt="CleanShot 2026-02-03 at 11 41 05@2x" src="https://github.com/user-attachments/assets/57d7d433-9011-4a41-9257-f098bf00127e" />

After:
<img width="700" height="536" alt="CleanShot 2026-02-03 at 11 40 40@2x" src="https://github.com/user-attachments/assets/26ed1d7a-40fe-46f7-82fe-58fcd044234f" />

