### PR TITLE
feat(code-review): Send experiment assignment to Seer

### DIFF
--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -136,6 +136,7 @@ class SeerCodeReviewRequestForPrReview(BaseModel):
     more_readable_repos: list[SeerCodeReviewRepoForPrReview] = Field(default_factory=list)
     bug_prediction_specific_information: BugPredictionSpecificInformation
     config: SeerCodeReviewConfig | None = None
+    experiment_enabled: bool = False
 
 
 class SeerCodeReviewRequestForPrClosed(BaseModel):

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -13,6 +13,7 @@ from urllib3.exceptions import HTTPError
 
 from sentry import features
 from sentry.integrations.github.client import GitHubReaction
+from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.organization import Organization
@@ -242,7 +243,10 @@ def _common_codegen_request_payload(
             "organization_id": organization.id,
             "organization_slug": organization.slug,
         },
-        "config": {"features": {"bug_prediction": True}},
+        "config": {
+            "features": {"bug_prediction": True},
+            "github_rate_limit_sensitive": is_github_rate_limit_sensitive(organization),
+        },
     }
 
     # Add experiment_enabled flag ONLY for pr-review requests

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -13,7 +13,6 @@ from urllib3.exceptions import HTTPError
 
 from sentry import features
 from sentry.integrations.github.client import GitHubReaction
-from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.organization import Organization
@@ -237,21 +236,24 @@ def _common_codegen_request_payload(
     target_commit_sha: str,
     organization: Organization,
 ) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "repo": _build_repo_definition(repo, target_commit_sha),
+        "bug_prediction_specific_information": {
+            "organization_id": organization.id,
+            "organization_slug": organization.slug,
+        },
+        "config": {"features": {"bug_prediction": True}},
+    }
+
+    # Add experiment_enabled flag ONLY for pr-review requests
+    if request_type == SeerCodeReviewRequestType.PR_REVIEW:
+        data["experiment_enabled"] = is_org_enabled_for_code_review_experiments(organization)
+
     return {
         # In Seer,src/seer/routes/automation_request.py:overwatch_request_endpoint
         "request_type": request_type.value,
         "external_owner_id": repo.external_id,
-        "data": {
-            "repo": _build_repo_definition(repo, target_commit_sha),
-            "bug_prediction_specific_information": {
-                "organization_id": organization.id,
-                "organization_slug": organization.slug,
-            },
-            "config": {
-                "features": {"bug_prediction": True},
-                "github_rate_limit_sensitive": is_github_rate_limit_sensitive(organization),
-            },
-        },
+        "data": data,
     }
 
 

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -25,6 +25,7 @@ from sentry.seer.code_review.utils import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.features import with_feature
 from sentry.users.models.user import User
 from sentry.utils import json
 
@@ -413,6 +414,100 @@ class TestTransformWebhookToCodegenRequest:
 
         # This would fail if trigger_at is a datetime object instead of string
         json.dumps(result)  # Should not raise TypeError
+
+    @with_feature("organizations:code-review-experiments-enabled")
+    def test_pr_closed_does_not_include_experiment_enabled(
+        self,
+        setup_entities: tuple[User, Organization, Project, Repository],
+    ) -> None:
+        _, organization, _, repo = setup_entities
+
+        event_payload = {
+            "pull_request": {"number": 42},
+            "sender": {"login": "test-user"},
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.PULL_REQUEST,
+            "closed",
+            event_payload,
+            organization,
+            repo,
+            "abc123sha",
+        )
+
+        assert result is not None
+        assert "experiment_enabled" not in result["data"]
+
+    @with_feature("organizations:code-review-experiments-enabled")
+    def test_issue_comment_includes_experiment_enabled(
+        self,
+        setup_entities: tuple[User, Organization, Project, Repository],
+    ) -> None:
+        _, organization, _, repo = setup_entities
+
+        event_payload = {
+            "issue": {"number": 42},
+            "comment": {
+                "id": 12345,
+                "user": {"login": "commenter", "id": 99999},
+            },
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.ISSUE_COMMENT,
+            "created",
+            event_payload,
+            organization,
+            repo,
+            "def456sha",
+        )
+
+        assert result is not None
+        assert result["data"]["experiment_enabled"] is True
+
+    @with_feature("organizations:code-review-experiments-enabled")
+    def test_pr_review_includes_experiment_enabled_when_feature_enabled(
+        self,
+        setup_entities: tuple[User, Organization, Project, Repository],
+    ) -> None:
+        _, organization, _, repo = setup_entities
+
+        event_payload = {
+            "pull_request": {"number": 42},
+            "sender": {"login": "test-user"},
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.PULL_REQUEST,
+            "opened",
+            event_payload,
+            organization,
+            repo,
+            "abc123sha",
+        )
+
+        assert result is not None
+        assert result["data"]["experiment_enabled"] is True
+
+    def test_pr_review_includes_experiment_enabled_false_when_feature_disabled(
+        self,
+        setup_entities: tuple[User, Organization, Project, Repository],
+    ) -> None:
+        _, organization, _, repo = setup_entities
+
+        event_payload = {
+            "pull_request": {"number": 42},
+            "sender": {"login": "test-user"},
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.PULL_REQUEST,
+            "opened",
+            event_payload,
+            organization,
+            repo,
+            "abc123sha",
+        )
+
+        assert result is not None
+        assert result["data"]["experiment_enabled"] is False
 
 
 class TestExtractGithubInfo:


### PR DESCRIPTION
## Summary

Adds experiment assignment to code review payloads sent to Seer. This allows Seer to apply different experimental behaviors (e.g., different prompts, features) based on whether an organization is enrolled in A/B testing experiments.

## Changes

- Add `experiment_enabled` field to `SeerCodeReviewRequestForPrReview` model
- Conditionally include `experiment_enabled` in payload for PR review requests only (not PR closed)
- Add explicit type annotation to prevent mypy errors
- Add comprehensive test coverage using `@with_feature` decorator

## Implementation Details

The monolith checks the feature flag `organizations:code-review-experiments-enabled` and includes the boolean flag in the request payload sent to Seer. The field is only included for `pr-review` request types, not `pr-closed` events.

**Payload structure:**
```json
{
  "request_type": "pr-review",
  "external_owner_id": "...",
  "data": {
    "repo": {...},
    "bug_prediction_specific_information": {...},
    "config": {...},
    "experiment_enabled": true  // <-- New field
  }
}
```

## Dependencies

Requires: https://github.com/getsentry/sentry/pull/107478 (CW-696 - feature flag registration)


## References

Linear: CW-697