### PR TITLE
fix(ai-insights): normalize explore params

### DIFF
--- a/static/app/views/alerts/rules/utils.spec.tsx
+++ b/static/app/views/alerts/rules/utils.spec.tsx
@@ -76,7 +76,7 @@ describe('getExploreUrl', () => {
       projectId: '1',
     });
     expect(url).toBe(
-      '/organizations/slug/explore/traces/?end=2017-10-19T12%3A00%3A00.000Z&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&start=2017-10-12T12%3A00%3A00.000Z&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
+      '/organizations/slug/explore/traces/?end=2017-10-19T12%3A00%3A00.000&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&start=2017-10-12T12%3A00%3A00.000&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
     );
   });
 });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -98,8 +98,8 @@ export function getExploreUrl({
     project: projects?.length === 0 ? '' : projects,
     environment: environments,
     statsPeriod,
-    start,
-    end,
+    start: normalizeDateTimeString(start),
+    end: normalizeDateTimeString(end),
     interval,
     mode,
     query,
@@ -219,8 +219,8 @@ export function getExploreMultiQueryUrl({
     project: projects.length === 0 ? '' : projects,
     environment: environments,
     statsPeriod,
-    start,
-    end,
+    start: normalizeDateTimeString(start),
+    end: normalizeDateTimeString(end),
     interval,
     queries: queries.map(
       ({chartType, fields, groupBys, query, sortBys, yAxes, caseInsensitive}) =>


### PR DESCRIPTION
Fixes [TET-1885: Links to explore have different date time params](https://linear.app/getsentry/issue/TET-1885/links-to-explore-have-different-date-time-params)