### PR TITLE
fix(identities): Use GitHub logo for GitHub Copilot identity

### DIFF
--- a/static/app/views/settings/components/identityIcon.tsx
+++ b/static/app/views/settings/components/identityIcon.tsx
@@ -27,6 +27,7 @@ const IDENTITY_ICONS = {
   bitbucket,
   bitbucket_server: bitbucketserver,
   github,
+  github_copilot: github,
   github_enterprise: githubEnterprise,
   gitlab,
   google,


### PR DESCRIPTION
## Summary
Add github_copilot mapping to IDENTITY_ICONS so the GitHub Copilot identity displays the GitHub logo instead of the generic placeholder.

Split out from #107443 for independent deployment.

## Test plan
- Visual verification that GitHub Copilot identity shows GitHub logo on the identities page