### PR TITLE
fix(dashboards): query limit not being applied on releases dataset

### DIFF
--- a/static/app/types/sessions.tsx
+++ b/static/app/types/sessions.tsx
@@ -14,6 +14,7 @@ export enum SessionField {
   SESSION = 'session',
   SESSION_DURATION = 'session.duration',
   USER = 'user',
+  STATUS = 'session.status',
 }
 
 export type SessionsOperation =

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
@@ -461,9 +461,9 @@ describe('useReleasesTableQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['session.status', `sum(${SessionField.SESSION})`],
+          fields: [SessionField.STATUS, `sum(${SessionField.SESSION})`],
           aggregates: [`sum(${SessionField.SESSION})`],
-          columns: ['session.status'],
+          columns: [SessionField.STATUS],
           conditions: '',
           orderby: '',
         },

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
@@ -453,4 +453,48 @@ describe('useReleasesTableQuery', () => {
       );
     });
   });
+
+  it('passes per_page to sessions endpoint when using session.status grouping', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      limit: 6,
+      queries: [
+        {
+          name: 'test',
+          fields: ['session.status', `sum(${SessionField.SESSION})`],
+          aggregates: [`sum(${SessionField.SESSION})`],
+          columns: ['session.status'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sessions/',
+      body: SessionsFieldFixture(`sum(${SessionField.SESSION})`),
+    });
+
+    renderHook(
+      () =>
+        useReleasesTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/sessions/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            per_page: 6,
+          }),
+        })
+      );
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetCard/hooks/utils/releases.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/utils/releases.tsx
@@ -129,7 +129,7 @@ export function getReleasesRequestData(
       end,
       environment: environments,
       groupBy: columns,
-      limit: undefined,
+      limit,
       orderBy: '', // Orderby not supported with session.status
       interval,
       project: projects,


### PR DESCRIPTION
Fixes issue where query limit isn't being respected in the widget builder for releases