### PR TITLE
feat(view-hierarchy): Allow forcing absolute positioning

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -80,6 +80,7 @@ export type ViewHierarchyWindow = {
 export type ViewHierarchyData = {
   rendering_system: string;
   windows: ViewHierarchyWindow[];
+  positioning?: 'absolute' | 'relative';
 };
 
 export type ViewHierarchyNodeField = 'type' | 'name';
@@ -237,6 +238,7 @@ function ViewHierarchy({
               selectedNode={userHasSelected ? selectedNode : undefined}
               onNodeSelect={onWireframeNodeSelect}
               platform={platform}
+              positioning={viewHierarchy.positioning}
             />
           </Right>
         )}

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -57,7 +57,8 @@ function Wireframe({
     () =>
       getHierarchyDimensions(
         hierarchy,
-        positioning === 'absolute' || ['flutter', 'dart-flutter'].includes(platform ?? '')
+        positioning === 'absolute' ||
+          (!positioning && ['flutter', 'dart-flutter'].includes(platform ?? ''))
       ),
     [hierarchy, platform, positioning]
   );

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -30,10 +30,17 @@ type WireframeProps = {
   hierarchy: ViewHierarchyWindow[];
   onNodeSelect: (node?: ViewHierarchyWindow) => void;
   platform?: string;
+  positioning?: 'absolute' | 'relative';
   selectedNode?: ViewHierarchyWindow;
 };
 
-function Wireframe({hierarchy, selectedNode, onNodeSelect, platform}: WireframeProps) {
+function Wireframe({
+  hierarchy,
+  selectedNode,
+  onNodeSelect,
+  positioning,
+  platform,
+}: WireframeProps) {
   const theme = useTheme();
   const [canvasRef, setCanvasRef] = useState<HTMLCanvasElement | null>(null);
   const [overlayRef, setOverlayRef] = useState<HTMLCanvasElement | null>(null);
@@ -50,9 +57,9 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect, platform}: WireframeP
     () =>
       getHierarchyDimensions(
         hierarchy,
-        ['flutter', 'dart-flutter'].includes(platform ?? '')
+        positioning === 'absolute' || ['flutter', 'dart-flutter'].includes(platform ?? '')
       ),
-    [hierarchy, platform]
+    [hierarchy, platform, positioning]
   );
   const nodeLookupMap = useMemo(() => {
     const map = new Map<ViewHierarchyWindow, ViewNode>();


### PR DESCRIPTION
- Ref https://github.com/getsentry/rfcs/pull/150
- cc @Lms24 

Currently relative/absolute positioning for View Hierarchy wireframes is always relative unless the platform matches a predefined list:
https://github.com/getsentry/sentry/blob/e07092c0583191c0a85e3f70a8d918920a569870/static/app/components/events/viewHierarchy/wireframe.tsx#L51-L54

This PR allows overriding the platform defaults via the root `positioning` property in the hierarchy data.