### PR TITLE
fix(spans-migration): map span.module to span.category

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -145,6 +145,7 @@ def column_switcheroo(term):
         "timestamp.to_day": "timestamp",
         "timestamp.to_hour": "timestamp",
         "platform.name": "platform",
+        "span.module": "span.category",
         # parsed MRI column names that need to be swapped
         "duration": "span.duration",
         "exclusive_time": "span.self_time",

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -86,6 +86,10 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "platform.name:python",
             "(platform:python) AND is_transaction:1",
         ),
+        pytest.param(
+            "span.module:db",
+            "(span.category:db) AND is_transaction:1",
+        ),
     ],
 )
 def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
@@ -174,6 +178,11 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
         pytest.param(
             ["platform.name", "count()"],
             ["platform", "count(span.duration)"],
+            [],
+        ),
+        pytest.param(
+            ["span.module"],
+            ["span.category"],
             [],
         ),
     ],


### PR DESCRIPTION
`span.module` is not surfaced in explore and seems to be doing the same thing as `span.category` so i've just mapped it over 🤩 