### PR TITLE
feat(seer): Add analytics tracking for coding integration CTA buttons

### DIFF
--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -13,8 +13,10 @@ import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 interface CursorIntegrationCtaProps {
   project: Project;
@@ -22,6 +24,7 @@ interface CursorIntegrationCtaProps {
 
 export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
   const organization = useOrganization();
+  const user = useUser();
 
   const {preference, isFetching: isLoadingPreferences} =
     useProjectSeerPreferences(project);
@@ -42,10 +45,26 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
     project.seerScannerAutomation !== false && project.autofixAutomationTuning !== 'off';
   const isConfigured = Boolean(preference?.automation_handoff) && isAutomationEnabled;
 
+  const handleInstallClick = useCallback(() => {
+    trackAnalytics('coding_integration.install_clicked', {
+      organization,
+      project_slug: project.slug,
+      provider: 'cursor',
+      user_id: user.id,
+    });
+  }, [organization, project.slug, user.id]);
+
   const handleSetupClick = useCallback(async () => {
     if (!cursorIntegration?.id) {
       throw new Error('Cursor integration not found');
     }
+
+    trackAnalytics('coding_integration.setup_handoff_clicked', {
+      organization,
+      project_slug: project.slug,
+      provider: 'cursor',
+      user_id: user.id,
+    });
 
     const isAutomationDisabled =
       project.seerScannerAutomation === false ||
@@ -68,12 +87,15 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       },
     });
   }, [
+    organization,
+    project.slug,
     project.seerScannerAutomation,
     project.autofixAutomationTuning,
     updateProjectSeerPreferences,
     updateProjectAutomation,
     preference?.repositories,
     cursorIntegration,
+    user.id,
   ]);
 
   if (!hasCursorIntegrationFeatureFlag) {
@@ -113,6 +135,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
               href="/settings/integrations/cursor/"
               priority="default"
               size="sm"
+              onClick={handleInstallClick}
             >
               {t('Install Cursor Integration')}
             </LinkButton>

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -17,6 +17,18 @@ export type SeerAnalyticsEventsParameters = {
     setup_integration: boolean;
     setup_write_integration?: boolean;
   };
+  'coding_integration.install_clicked': {
+    organization: Organization;
+    project_slug: string;
+    provider: string;
+    user_id: string;
+  };
+  'coding_integration.setup_handoff_clicked': {
+    organization: Organization;
+    project_slug: string;
+    provider: string;
+    user_id: string;
+  };
   'seer.autofix.feedback_submitted': {
     autofix_run_id: string;
     group_id: string;
@@ -58,6 +70,8 @@ type SeerAnalyticsEventKey = keyof SeerAnalyticsEventsParameters;
 export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null> = {
   'autofix.coding_agent.launch_from_root_cause':
     'Autofix: Coding Agent Launch From Root Cause',
+  'coding_integration.install_clicked': 'Coding Integration: Install Clicked',
+  'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
   'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',


### PR DESCRIPTION
## Summary
Add analytics events to track user interactions with the coding integration CTA component:
- `coding_integration.install_clicked` - fired when user clicks "Install Cursor Integration"
- `coding_integration.setup_handoff_clicked` - fired when user clicks "Set Seer to hand off to Cursor"

Both events include:
- `organization` - the current organization
- `project_slug` - the project slug
- `provider` - the integration provider (e.g., "cursor")
- `user_id` - the current user's ID

## Test plan
- [ ] Verify analytics events fire correctly when clicking the buttons
- [ ] Confirm event data includes expected properties