### PR TITLE
fix(preprod): restrict attributes available on mobile builds page

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Allowed search keys for the builds endpoint (size view).
+ * Allowed search keys for the builds dashboard.
  * Keep in sync with src/sentry/preprod/api/endpoints/builds.py allowed_keys
  */
 export const MOBILE_BUILDS_ALLOWED_KEYS = [

--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Allowed search keys for the builds endpoint (size view).
+ * Keep in sync with src/sentry/preprod/api/endpoints/builds.py allowed_keys
+ */
+export const MOBILE_BUILDS_ALLOWED_KEYS = [
+  'app_id',
+  'app_name',
+  'build_configuration_name',
+  'build_number',
+  'build_version',
+  'download_count',
+  'download_size',
+  'git_base_ref',
+  'git_base_sha',
+  'git_head_ref',
+  'git_head_sha',
+  'git_pr_number',
+  'install_size',
+  'installable',
+  'platform_name',
+];

--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -2,6 +2,7 @@ import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
+import {MOBILE_BUILDS_ALLOWED_KEYS} from 'sentry/components/preprod/constants';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
@@ -30,6 +31,12 @@ interface PreprodBuildsSearchControlsProps {
    */
   projects: number[];
   /**
+   * List of attribute keys to show in the search bar. When provided, only these
+   * keys will be available. When omitted, all keys except HIDDEN_PREPROD_ATTRIBUTES
+   * are shown.
+   */
+  allowedKeys?: string[];
+  /**
    * Called on every keystroke (for controlled input with debounce)
    */
   onChange?: (query: string, state: {queryIsValid: boolean}) => void;
@@ -47,6 +54,7 @@ export function PreprodBuildsSearchControls({
   initialQuery,
   display,
   projects,
+  allowedKeys = MOBILE_BUILDS_ALLOWED_KEYS,
   onChange,
   onSearch,
   onDisplayChange,
@@ -66,6 +74,7 @@ export function PreprodBuildsSearchControls({
       <Container flex="1">
         <PreprodSearchBar
           initialQuery={initialQuery}
+          allowedKeys={allowedKeys}
           onChange={onChange}
           onSearch={onSearch}
           projects={projects}


### PR DESCRIPTION
Resolves EME-816

I thought about consolidating some of the `allowedKeys` props used in the settings page too, but it seems fairly local to whatever feature is displaying the search bar so I held off for now.