### PR TITLE
ref(workflow_engine): Pull CacheAccess into it's own file

### DIFF
--- a/src/sentry/workflow_engine/caches/__init__.py
+++ b/src/sentry/workflow_engine/caches/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["CacheAccess"]
+
+from .cache_access import CacheAccess

--- a/src/sentry/workflow_engine/caches/cache_access.py
+++ b/src/sentry/workflow_engine/caches/cache_access.py
@@ -1,0 +1,22 @@
+from abc import abstractmethod
+
+from sentry.utils.cache import cache
+
+
+class CacheAccess[T]:
+    """
+    Base class for type-safe naive cache access.
+    """
+
+    @abstractmethod
+    def key(self) -> str:
+        raise NotImplementedError
+
+    def get(self) -> T | None:
+        return cache.get(self.key())
+
+    def set(self, value: T, timeout: float | None) -> None:
+        cache.set(self.key(), value, timeout)
+
+    def delete(self) -> bool:
+        return cache.delete(self.key())

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import Any, Literal
 
 from sentry import tagstore
@@ -13,26 +12,10 @@ from sentry.rules.filters.latest_release import (
 from sentry.search.utils import get_latest_release
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
-from sentry.utils.cache import cache
+from sentry.workflow_engine.caches import CacheAccess
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
-
-
-class CacheAccess[T]:
-    """
-    Base class for type-safe naive cache access.
-    """
-
-    @abstractmethod
-    def key(self) -> str:
-        raise NotImplementedError
-
-    def get(self) -> T | None:
-        return cache.get(self.key())
-
-    def set(self, value: T, timeout: float | None) -> None:
-        cache.set(self.key(), value, timeout)
 
 
 class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):

--- a/tests/sentry/workflow_engine/caches/test_cache_access.py
+++ b/tests/sentry/workflow_engine/caches/test_cache_access.py
@@ -1,0 +1,50 @@
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.caches.cache_access import CacheAccess
+
+
+class _TestCacheAccess(CacheAccess[str]):
+    """Concrete implementation for testing the abstract CacheAccess class."""
+
+    def __init__(self, cache_key: str):
+        self._cache_key = cache_key
+
+    def key(self) -> str:
+        return self._cache_key
+
+
+class TestCacheAccess(TestCase):
+    def setUp(self) -> None:
+        self.cache_key = "test_cache_key"
+        self.cache_access = _TestCacheAccess(self.cache_key)
+
+    def test_key(self) -> None:
+        assert self.cache_access.key() == self.cache_key
+
+    def test_get__returns_none_when_not_set(self) -> None:
+        assert self.cache_access.get() is None
+
+    def test_get__returns_value_when_set(self) -> None:
+        self.cache_access.set("test_value", 60)
+        assert self.cache_access.get() == "test_value"
+
+    def test_set__stores_value(self) -> None:
+        self.cache_access.set("stored_value", 60)
+        assert self.cache_access.get() == "stored_value"
+
+    def test_set__overwrites_existing_value(self) -> None:
+        self.cache_access.set("first_value", 60)
+        self.cache_access.set("second_value", 60)
+        assert self.cache_access.get() == "second_value"
+
+    def test_delete__removes_value(self) -> None:
+        self.cache_access.set("value_to_delete", 60)
+        assert self.cache_access.get() == "value_to_delete"
+
+        result = self.cache_access.delete()
+
+        assert result is True
+        assert self.cache_access.get() is None
+
+    def test_delete__returns_false_when_key_not_exists(self) -> None:
+        result = self.cache_access.delete()
+        assert result is False


### PR DESCRIPTION
## Description
Moving the CacheAccess class to `caches/cache_access.py` this will become the basis for interacting with the Workflow / Detector caches.