### PR TITLE
chore(preprod): Unify diff section headers with anchor links

### DIFF
--- a/static/app/views/preprod/buildComparison/main/diffSectionHeader.tsx
+++ b/static/app/views/preprod/buildComparison/main/diffSectionHeader.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
+import {Heading} from '@sentry/scraps/text';
+
+import {IconLink} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface DiffSectionHeaderProps {
+  /**
+   * Unique identifier for the section, used for anchor links
+   */
+  id: string;
+  /**
+   * Title displayed in the section header
+   */
+  title: string;
+  /**
+   * Content to render to the right of the title
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared header component for diff sections with anchor link support.
+ * Renders a separator, heading with copy-link button, and optional trailing content.
+ */
+export function DiffSectionHeader({id, title, children}: DiffSectionHeaderProps) {
+  const handleAnchorClick = () => {
+    const url = new URL(window.location.href);
+    url.hash = id;
+    window.history.replaceState(null, '', url.toString());
+    navigator.clipboard.writeText(url.toString());
+  };
+
+  return (
+    <Stack gap="xl">
+      <Separator orientation="horizontal" border="primary" />
+      <Flex align="center" justify="between" gap="md" id={id}>
+        <TitleWrapper align="center" gap="sm">
+          <Heading as="h2">{title}</Heading>
+          <CopyLinkButton
+            priority="transparent"
+            size="xs"
+            onClick={handleAnchorClick}
+            aria-label={t('Copy link to %s', title)}
+            title={t('Copy link')}
+          >
+            <IconLink size="xs" />
+          </CopyLinkButton>
+        </TitleWrapper>
+        {children}
+      </Flex>
+    </Stack>
+  );
+}
+
+const CopyLinkButton = styled(Button)`
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+`;
+
+const TitleWrapper = styled(Flex)`
+  &:hover ${CopyLinkButton} {
+    opacity: 1;
+  }
+`;

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -1,11 +1,10 @@
 import {useMemo, useState} from 'react';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
-import {Separator} from '@sentry/scraps/separator';
-import {Heading} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
+import {DiffSectionHeader} from 'sentry/views/preprod/buildComparison/main/diffSectionHeader';
 import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/fileInsightDiffTable';
 import {GroupInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/groupInsightDiffTable';
 import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/insightDiffRow';
@@ -171,68 +170,58 @@ export function InsightComparisonSection({
   }
 
   return (
-    <Stack gap="xl">
-      <Separator orientation="horizontal" border="primary" />
-
+    <Stack gap="md">
+      <DiffSectionHeader id="insights" title={t('Insights')}>
+        <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
+          {statusCounts.all > 0 ? (
+            <SegmentedControl.Item key="all">
+              {t('All (%s)', statusCounts.all)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.new > 0 ? (
+            <SegmentedControl.Item key="new">
+              {t('New (%s)', statusCounts.new)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.unresolved > 0 ? (
+            <SegmentedControl.Item key="unresolved">
+              {t('Unresolved (%s)', statusCounts.unresolved)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.resolved > 0 ? (
+            <SegmentedControl.Item key="resolved">
+              {t('Resolved (%s)', statusCounts.resolved)}
+            </SegmentedControl.Item>
+          ) : null}
+        </SegmentedControl>
+      </DiffSectionHeader>
       <Stack gap="md">
-        <Flex direction="column" gap="md">
-          <Heading as="h2">{t('Insights')}</Heading>
-          <Flex align="center" gap="sm" wrap="wrap">
-            <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
-              {statusCounts.all > 0 ? (
-                <SegmentedControl.Item key="all">
-                  {t('All (%s)', statusCounts.all)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.new > 0 ? (
-                <SegmentedControl.Item key="new">
-                  {t('New (%s)', statusCounts.new)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.unresolved > 0 ? (
-                <SegmentedControl.Item key="unresolved">
-                  {t('Unresolved (%s)', statusCounts.unresolved)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.resolved > 0 ? (
-                <SegmentedControl.Item key="resolved">
-                  {t('Resolved (%s)', statusCounts.resolved)}
-                </SegmentedControl.Item>
-              ) : null}
-            </SegmentedControl>
-          </Flex>
-        </Flex>
-
-        <Stack gap="md">
-          {filteredInsights.map(insight => {
-            if (FILE_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
-              return (
-                <InsightDiffRow
-                  key={insight.insight_type}
-                  insight={insight}
-                  totalInstallSizeBytes={totalInstallSizeBytes}
-                >
-                  <FileInsightItemDiffTable fileDiffItems={insight.file_diffs} />
-                </InsightDiffRow>
-              );
-            }
-            if (GROUP_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
-              return (
-                <InsightDiffRow
-                  key={insight.insight_type}
-                  insight={insight}
-                  totalInstallSizeBytes={totalInstallSizeBytes}
-                >
-                  <GroupInsightItemDiffTable groupDiffItems={insight.group_diffs} />
-                </InsightDiffRow>
-              );
-            }
-            return null;
-          })}
-        </Stack>
+        {filteredInsights.map(insight => {
+          if (FILE_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
+            return (
+              <InsightDiffRow
+                key={insight.insight_type}
+                insight={insight}
+                totalInstallSizeBytes={totalInstallSizeBytes}
+              >
+                <FileInsightItemDiffTable fileDiffItems={insight.file_diffs} />
+              </InsightDiffRow>
+            );
+          }
+          if (GROUP_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
+            return (
+              <InsightDiffRow
+                key={insight.insight_type}
+                insight={insight}
+                totalInstallSizeBytes={totalInstallSizeBytes}
+              >
+                <GroupInsightItemDiffTable groupDiffItems={insight.group_diffs} />
+              </InsightDiffRow>
+            );
+          }
+          return null;
+        })}
       </Stack>
-
-      <Separator orientation="horizontal" border="primary" />
     </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -6,11 +6,11 @@ import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconChevron, IconRefresh, IconSearch} from 'sentry/icons';
+import {IconRefresh, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import parseApiError from 'sentry/utils/parseApiError';
@@ -23,6 +23,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildComparisonMetricCards} from 'sentry/views/preprod/buildComparison/main/buildComparisonMetricCards';
+import {DiffSectionHeader} from 'sentry/views/preprod/buildComparison/main/diffSectionHeader';
 import {InsightComparisonSection} from 'sentry/views/preprod/buildComparison/main/insightComparisonSection';
 import {SizeCompareItemDiffTable} from 'sentry/views/preprod/buildComparison/main/sizeCompareItemDiffTable';
 import {SizeCompareSelectedBuilds} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectedBuilds';
@@ -53,7 +54,6 @@ export function SizeCompareMainContent() {
   const organization = useOrganization();
   const navigate = useNavigate();
   const theme = useTheme();
-  const [isFilesExpanded, setIsFilesExpanded] = useState(true);
   const [hideSmallChanges, setHideSmallChanges] = useQueryState(
     'hideSmallChanges',
     parseAsBoolean.withDefault(true)
@@ -327,73 +327,51 @@ export function SizeCompareMainContent() {
         )}
 
       {/* Items Changed Section */}
-      <Container background="primary" radius="lg" padding="0" border="primary">
-        <Flex direction="column" gap="0">
-          <Flex align="center" justify="between" padding="xl">
-            <Flex align="center" gap="sm">
-              <Heading as="h2">
-                {t('Items Changed: %s', comparisonDataQuery.data?.diff_items.length)}
-              </Heading>
-            </Flex>
-            <Flex align="center" gap="sm">
-              <Button
-                priority="transparent"
-                size="sm"
-                onClick={() => setIsFilesExpanded(!isFilesExpanded)}
-                aria-label={isFilesExpanded ? t('Collapse items') : t('Expand items')}
-              >
-                <IconChevron
-                  direction={isFilesExpanded ? 'up' : 'down'}
-                  size="sm"
-                  style={{
-                    transition: 'transform 0.2s ease',
-                  }}
+      <Stack gap="md">
+        <DiffSectionHeader
+          id="items-changed"
+          title={t('Items Changed: %s', comparisonDataQuery.data?.diff_items.length)}
+        />
+        <Container
+          background="primary"
+          radius="lg"
+          padding="0"
+          border="primary"
+          overflow="hidden"
+        >
+          <Flex direction="column" gap="0">
+            <Flex align="center" gap="xl" padding="xl" wrap="wrap">
+              <InputGroup style={{width: '100%', minWidth: '200px'}}>
+                <InputGroup.LeadingItems>
+                  <IconSearch />
+                </InputGroup.LeadingItems>
+                <InputGroup.Input
+                  placeholder={t('Search')}
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
                 />
-              </Button>
-            </Flex>
-          </Flex>
-          {isFilesExpanded && (
-            <Stack>
-              <Flex
-                align="center"
-                gap="xl"
-                paddingLeft="xl"
-                paddingRight="xl"
-                paddingBottom="xl"
-                wrap="wrap"
-              >
-                <InputGroup style={{width: '100%', minWidth: '200px'}}>
-                  <InputGroup.LeadingItems>
-                    <IconSearch />
-                  </InputGroup.LeadingItems>
-                  <InputGroup.Input
-                    placeholder={t('Search')}
-                    value={searchQuery}
-                    onChange={e => setSearchQuery(e.target.value)}
-                  />
-                </InputGroup>
-                <Flex align="center" gap="lg" wrap="nowrap">
-                  <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
-                  <Switch
-                    checked={hideSmallChanges}
-                    size="sm"
-                    title={t('Hide < 500B')}
-                    onChange={() => setHideSmallChanges(!hideSmallChanges)}
-                    aria-label={
-                      hideSmallChanges ? t('Show small changes') : t('Hide small changes')
-                    }
-                  />
-                </Flex>
+              </InputGroup>
+              <Flex align="center" gap="lg" wrap="nowrap">
+                <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
+                <Switch
+                  checked={hideSmallChanges}
+                  size="sm"
+                  title={t('Hide < 500B')}
+                  onChange={() => setHideSmallChanges(!hideSmallChanges)}
+                  aria-label={
+                    hideSmallChanges ? t('Show small changes') : t('Hide small changes')
+                  }
+                />
               </Flex>
-              <SizeCompareItemDiffTable
-                diffItems={filteredDiffItems}
-                originalItemCount={comparisonDataQuery.data?.diff_items.length ?? 0}
-                disableHideSmallChanges={() => setHideSmallChanges(false)}
-              />
-            </Stack>
-          )}
-        </Flex>
-      </Container>
+            </Flex>
+            <SizeCompareItemDiffTable
+              diffItems={filteredDiffItems}
+              originalItemCount={comparisonDataQuery.data?.diff_items.length ?? 0}
+              disableHideSmallChanges={() => setHideSmallChanges(false)}
+            />
+          </Flex>
+        </Container>
+      </Stack>
 
       {/* Treemap Diff Section */}
       {comparisonDataQuery.data?.diff_items &&

--- a/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
@@ -5,12 +5,12 @@ import type {ECharts, TreemapSeriesOption} from 'echarts';
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {useRenderToString} from '@sentry/scraps/renderToString';
-import {Separator} from '@sentry/scraps/separator';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
 import {IconContract} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {DiffSectionHeader} from 'sentry/views/preprod/buildComparison/main/diffSectionHeader';
 import {getAppSizeDiffCategoryInfo} from 'sentry/views/preprod/components/visualizations/appSizeTreemapTheme';
 import {TreemapControlButtons} from 'sentry/views/preprod/components/visualizations/treemapControlButtons';
 import type {DiffItem, TreemapDiffElement} from 'sentry/views/preprod/types/appSizeTypes';
@@ -229,41 +229,37 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
   };
 
   return (
-    <Stack gap="xl">
-      <Separator orientation="horizontal" border="primary" />
-
-      <Stack gap="md">
-        <Heading as="h2">{t('X-Ray Diff')}</Heading>
-        <Stack paddingBottom="xl">
-          <Container
-            height="400px"
-            width="100%"
-            position="relative"
-            onMouseDown={handleContainerMouseDown}
-            style={{minHeight: 0}}
-          >
-            <BaseChart
-              height={400}
-              renderer="canvas"
-              xAxis={null}
-              yAxis={null}
-              series={series}
-              tooltip={tooltip}
-              onChartReady={handleChartReady}
-            />
-            <TreemapControlButtons
-              buttons={[
-                {
-                  ariaLabel: t('Recenter View'),
-                  title: t('Recenter'),
-                  icon: <IconContract />,
-                  onClick: handleRecenter,
-                  disabled: !isZoomed,
-                },
-              ]}
-            />
-          </Container>
-        </Stack>
+    <Stack gap="md">
+      <DiffSectionHeader id="xray-diff" title={t('X-Ray Diff')} />
+      <Stack paddingBottom="xl">
+        <Container
+          height="400px"
+          width="100%"
+          position="relative"
+          onMouseDown={handleContainerMouseDown}
+          style={{minHeight: 0}}
+        >
+          <BaseChart
+            height={400}
+            renderer="canvas"
+            xAxis={null}
+            yAxis={null}
+            series={series}
+            tooltip={tooltip}
+            onChartReady={handleChartReady}
+          />
+          <TreemapControlButtons
+            buttons={[
+              {
+                ariaLabel: t('Recenter View'),
+                title: t('Recenter'),
+                icon: <IconContract />,
+                onClick: handleRecenter,
+                disabled: !isZoomed,
+              },
+            ]}
+          />
+        </Container>
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
Add shared DiffSectionHeader component for consistent styling across build comparison page sections. Each section now has:
- Separator + heading pattern
- Anchor link for direct linking (appears on hover)

EME-798