### PR TITLE
feat(aci): Update metric issue open periods list to display activities

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -988,8 +988,9 @@ export interface BaseGroup {
   substatus?: GroupSubstatus | null;
 }
 
-interface GroupOpenPeriodActivity {
+export interface GroupOpenPeriodActivity {
   dateCreated: string;
+  eventId: string | null;
   id: string;
   type: 'opened' | 'status_change' | 'closed';
   value: 'high' | 'medium' | null;
@@ -999,7 +1000,6 @@ export interface GroupOpenPeriod {
   activities: GroupOpenPeriodActivity[];
   duration: string;
   end: string;
-  eventId: string | null;
   id: string;
   isOpen: boolean;
   lastChecked: string;

--- a/static/app/views/detectors/hooks/useOpenPeriods.tsx
+++ b/static/app/views/detectors/hooks/useOpenPeriods.tsx
@@ -27,6 +27,7 @@ type UseOpenPeriodsParams =
 
 function makeOpenPeriodsQueryKey({
   orgSlug,
+  limit,
   ...params
 }: UseOpenPeriodsParams & {orgSlug: string}): ApiQueryKey {
   return [
@@ -34,7 +35,10 @@ function makeOpenPeriodsQueryKey({
       path: {organizationIdOrSlug: orgSlug},
     }),
     {
-      query: params,
+      query: {
+        ...params,
+        per_page: limit,
+      },
     },
   ];
 }

--- a/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
@@ -1,0 +1,96 @@
+import {
+  GroupOpenPeriodActivityFixture,
+  GroupOpenPeriodFixture,
+} from 'sentry-fixture/groupOpenPeriod';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, within, type RouterConfig} from 'sentry-test/reactTestingLibrary';
+
+import {getShortEventId} from 'sentry/utils/events';
+import GroupOpenPeriods from 'sentry/views/issueDetails/groupOpenPeriods';
+
+describe('GroupOpenPeriods', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const groupId = '123';
+  const initialRouterConfig: RouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/issues/${groupId}/open-periods/`,
+    },
+    route: '/organizations/:orgId/issues/:groupId/open-periods/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders open period activity rows', async () => {
+    const statusChangeEventId = 'event-2';
+    const openedEventId = 'event-1';
+    const openPeriod = GroupOpenPeriodFixture({
+      id: 'open-period-1',
+      activities: [
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-1',
+          type: 'opened',
+          value: 'medium',
+          dateCreated: '2024-01-01T00:00:00Z',
+          eventId: openedEventId,
+        }),
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-2',
+          type: 'status_change',
+          value: 'high',
+          dateCreated: '2024-01-01T00:02:00Z',
+          eventId: statusChangeEventId,
+        }),
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-3',
+          type: 'closed',
+          value: null,
+          dateCreated: '2024-01-01T00:03:00Z',
+          eventId: null,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/open-periods/`,
+      body: [openPeriod],
+      match: [MockApiClient.matchQuery({groupId, per_page: 10})],
+    });
+
+    render(<GroupOpenPeriods />, {organization, initialRouterConfig});
+
+    expect(await screen.findByText('All Open Periods')).toBeInTheDocument();
+    for (const column of ['Open Period', 'Event ID', 'Description', 'Start', 'End']) {
+      expect(screen.getByText(column)).toBeInTheDocument();
+    }
+
+    const rows = screen.getAllByTestId('grid-body-row');
+
+    // There should be 2 rows: the first is the status changeevent , the second is the period open event
+    expect(rows).toHaveLength(2);
+    const [statusRow, openedRow] = rows as [HTMLElement, HTMLElement];
+
+    expect(within(statusRow).getByText('Priority updated to high')).toBeInTheDocument();
+    expect(within(statusRow).queryByText('#open-period-1')).not.toBeInTheDocument();
+    expect(
+      within(statusRow).getByRole('link', {name: getShortEventId(statusChangeEventId)})
+    ).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/${groupId}/events/${statusChangeEventId}/`
+    );
+
+    expect(within(openedRow).getByText('#open-period-1')).toBeInTheDocument();
+    expect(within(openedRow).getByText('Issue regressed')).toBeInTheDocument();
+    expect(
+      within(openedRow).getByRole('link', {name: getShortEventId(openedEventId)})
+    ).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/${groupId}/events/${openedEventId}/`
+    );
+
+    expect(screen.queryByText('Resolved')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 1-1 matching open periods')).toBeInTheDocument();
+  });
+});

--- a/tests/js/fixtures/groupOpenPeriod.ts
+++ b/tests/js/fixtures/groupOpenPeriod.ts
@@ -1,12 +1,11 @@
-import type {GroupOpenPeriod} from 'sentry/types/group';
-
-type GroupOpenPeriodActivity = GroupOpenPeriod['activities'][number];
+import type {GroupOpenPeriod, GroupOpenPeriodActivity} from 'sentry/types/group';
 
 const DEFAULT_ACTIVITY: GroupOpenPeriodActivity = {
   id: 'activity-1',
   type: 'opened',
   value: 'high',
   dateCreated: '2024-01-01T00:00:00Z',
+  eventId: 'event-1',
 };
 
 const DEFAULT_OPEN_PERIOD: GroupOpenPeriod = {
@@ -14,7 +13,6 @@ const DEFAULT_OPEN_PERIOD: GroupOpenPeriod = {
   start: '2024-01-01T00:00:00Z',
   end: '2024-01-01T00:05:00Z',
   duration: '5m',
-  eventId: 'event-1',
   isOpen: false,
   lastChecked: '2024-01-01T00:05:00Z',
   activities: [DEFAULT_ACTIVITY],


### PR DESCRIPTION
Ref ISWF-1983

Prior to this we were only showing events that created a new open period, not subsequent events which changed the priority. I'm not sure if this is the final design we will go with, but it does at least show all the events correctly now.

Note that `eventId` will not show up for all activities yet until some other PRs are merged.

<img width="1139" height="387" alt="CleanShot 2026-02-03 at 10 15 35" src="https://github.com/user-attachments/assets/fc7d3f54-c281-4558-99c8-2d912519f612" />
