### PR TITLE
fix(dashboards): Respect fieldMeta overrides for timeseries widget types

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -202,7 +202,10 @@ function extractSeriesMetadata<T>({
     if (isSingleAggregateMultiGroup) {
       // Use hardcoded config for all series
       Object.keys(data).forEach(seriesName => {
-        result[seriesName] = getFieldMetaValue(firstMeta);
+        // Don't overwrite fieldMeta values
+        if (!(seriesName in result)) {
+          result[seriesName] = getFieldMetaValue(firstMeta);
+        }
       });
     } else {
       Object.keys(data).forEach(seriesName => {
@@ -213,7 +216,8 @@ function extractSeriesMetadata<T>({
         widgetQuery.aggregates?.forEach(aggregate => {
           // Multi-series can be keyed by aggregate or series name depending on aggregate count
           const key = widgetQuery.aggregates?.length > 1 ? aggregate : seriesName;
-          if (seriesData.meta) {
+          // Don't overwrite fieldMeta values
+          if (seriesData.meta && !(key in result)) {
             result[key] = getMetaField(seriesData.meta, aggregate);
           }
         });
@@ -223,7 +227,8 @@ function extractSeriesMetadata<T>({
     Object.keys(data).forEach(groupName => {
       widgetQuery.aggregates?.forEach(aggregate => {
         const seriesData = data[groupName]?.[aggregate] as EventsStats;
-        if (seriesData?.meta && aggregate) {
+        // Don't overwrite fieldMeta values
+        if (seriesData?.meta && aggregate && !(aggregate in result)) {
           result[aggregate] = getMetaField(seriesData.meta, aggregate);
         }
       });


### PR DESCRIPTION
## Summary
- Fix `extractSeriesMetadata` to not overwrite `fieldMeta` values with API response metadata
- `fieldMeta` values now take precedence as intended for custom type/unit overrides

## Problem
The `fieldMeta` configuration (e.g., `{valueType: 'percentage'}`) was being set first but then immediately overwritten by the API response metadata. This caused custom type overrides to be ignored for timeseries widgets.

## Solution
Check if the key already exists in the result (from `fieldMeta`) before setting from the API response.

## Test plan
- Verify that widgets with `fieldMeta` configuration properly display percentage values instead of raw numbers