### PR TITLE
feat(seer): Reland trigger_at timestamps with backward compatibility

### DIFF
--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
@@ -48,6 +49,8 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_comment_type: Literal["issue_comment"] | None = None
     trigger_user: str | None = None
     trigger_user_id: int | None = None
+    trigger_at: datetime
+    sentry_received_trigger_at: datetime  # When Sentry received the webhook
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -49,8 +49,8 @@ class SeerCodeReviewConfig(BaseModel):
     trigger_comment_type: Literal["issue_comment"] | None = None
     trigger_user: str | None = None
     trigger_user_id: int | None = None
-    trigger_at: datetime
-    sentry_received_trigger_at: datetime  # When Sentry received the webhook
+    trigger_at: datetime | None = None  # When the trigger event occurred on GitHub
+    sentry_received_trigger_at: datetime | None = None  # When Sentry received the webhook
 
     def is_feature_enabled(self, feature: SeerCodeReviewFeature) -> bool:
         return self.features.get(feature, False)

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import orjson
@@ -24,6 +25,7 @@ from sentry.seer.code_review.utils import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.users.models.user import User
+from sentry.utils import json
 
 
 class TestGetTriggerMetadata:
@@ -32,6 +34,7 @@ class TestGetTriggerMetadata:
             "comment": {
                 "id": 12345,
                 "user": {"login": "test-user", "id": 99999},
+                "updated_at": "2024-01-15T10:30:00Z",
             }
         }
         result = _get_trigger_metadata_for_issue_comment(event_payload)
@@ -39,34 +42,71 @@ class TestGetTriggerMetadata:
         assert result["trigger_user"] == "test-user"
         assert result["trigger_user_id"] == 99999
         assert result["trigger_comment_type"] == "issue_comment"
+        assert result["trigger_at"] == "2024-01-15T10:30:00Z"
+
+    def test_extracts_issue_comment_trigger_at_defaults_to_now_when_missing(self) -> None:
+        event_payload = {
+            "comment": {
+                "id": 12345,
+                "user": {"login": "test-user", "id": 99999},
+            }
+        }
+        result = _get_trigger_metadata_for_issue_comment(event_payload)
+        # Returns ISO string for Celery serialization
+        assert isinstance(result["trigger_at"], str)
+        # Verify it's a valid ISO datetime string
+        datetime.fromisoformat(result["trigger_at"])
+
+    def test_issue_comment_falls_back_to_created_at(self) -> None:
+        event_payload = {
+            "comment": {
+                "id": 12345,
+                "user": {"login": "test-user", "id": 99999},
+                "created_at": "2024-01-15T09:00:00Z",
+            }
+        }
+        result = _get_trigger_metadata_for_issue_comment(event_payload)
+        assert result["trigger_at"] == "2024-01-15T09:00:00Z"
 
     def test_pull_request_uses_sender_rather_than_pr_author(self) -> None:
         event_payload = {
             "sender": {"login": "sender-user", "id": 12345},
-            "pull_request": {"user": {"login": "pr-author", "id": 67890}},
+            "pull_request": {
+                "user": {"login": "pr-author", "id": 67890},
+                "updated_at": "2024-01-15T11:00:00Z",
+            },
         }
         result = _get_trigger_metadata_for_pull_request(event_payload)
         assert result["trigger_user"] == "sender-user"
         assert result["trigger_user_id"] == 12345
         assert result["trigger_comment_id"] is None
         assert result["trigger_comment_type"] is None
+        assert result["trigger_at"] == "2024-01-15T11:00:00Z"
 
     def test_pull_request_falls_back_to_pr_user(self) -> None:
         event_payload = {
-            "pull_request": {"user": {"login": "pr-author", "id": 67890}},
+            "pull_request": {
+                "user": {"login": "pr-author", "id": 67890},
+                "updated_at": "2024-01-15T12:00:00Z",
+            },
         }
         result = _get_trigger_metadata_for_pull_request(event_payload)
         assert result["trigger_user"] == "pr-author"
         assert result["trigger_user_id"] == 67890
         assert result["trigger_comment_id"] is None
         assert result["trigger_comment_type"] is None
+        assert result["trigger_at"] == "2024-01-15T12:00:00Z"
 
-    def test_pull_request_no_data_returns_none_values(self) -> None:
+    def test_pull_request_no_data_defaults_trigger_at_to_now(self) -> None:
         result = _get_trigger_metadata_for_pull_request({})
         assert result["trigger_comment_id"] is None
         assert result["trigger_comment_type"] is None
         assert result["trigger_user"] is None
         assert result["trigger_user_id"] is None
+        # Returns ISO string for Celery serialization
+        assert isinstance(result["trigger_at"], str)
+        # Verify it's a valid ISO datetime string
+        datetime.fromisoformat(result["trigger_at"])
 
 
 class GetTargetCommitShaTest(TestCase):
@@ -178,6 +218,7 @@ class TestTransformWebhookToCodegenRequest:
             "pull_request": {
                 "number": 42,
                 "user": {"login": "pr-author"},
+                "updated_at": "2024-01-15T10:30:00Z",
             },
             "sender": {"login": "sender-user"},
         }
@@ -211,10 +252,14 @@ class TestTransformWebhookToCodegenRequest:
             "organization_id": organization.id,
             "organization_slug": organization.slug,
         }
-        assert result["data"]["config"] == {
-            "features": {"bug_prediction": True},
-            "trigger": SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value,
-        } | {k: v for k, v in result["data"]["config"].items() if k not in ("features", "trigger")}
+        assert result["data"]["config"]["features"] == {"bug_prediction": True}
+        assert (
+            result["data"]["config"]["trigger"] == SeerCodeReviewTrigger.ON_READY_FOR_REVIEW.value
+        )
+        assert result["data"]["config"]["trigger_at"] == "2024-01-15T10:30:00Z"
+        # sentry_received_trigger_at is set to current time when transform happens
+        assert isinstance(result["data"]["config"]["sentry_received_trigger_at"], str)
+        datetime.fromisoformat(result["data"]["config"]["sentry_received_trigger_at"])
 
     def test_issue_comment_on_pr(
         self, setup_entities: tuple[User, Organization, Project, Repository]
@@ -231,6 +276,7 @@ class TestTransformWebhookToCodegenRequest:
             "comment": {
                 "id": 12345,
                 "user": {"login": "commenter"},
+                "updated_at": "2024-01-15T14:00:00Z",
             },
         }
         result = transform_webhook_to_codegen_request(
@@ -252,6 +298,10 @@ class TestTransformWebhookToCodegenRequest:
         assert config["trigger_comment_id"] == 12345
         assert config["trigger_user"] == "commenter"
         assert config["trigger_comment_type"] == "issue_comment"
+        assert config["trigger_at"] == "2024-01-15T14:00:00Z"
+        # sentry_received_trigger_at is set to current time when transform happens
+        assert isinstance(config["sentry_received_trigger_at"], str)
+        datetime.fromisoformat(config["sentry_received_trigger_at"])
 
     def test_invalid_repo_name_format_raises(
         self, setup_entities: tuple[User, Organization, Project, Repository]
@@ -305,6 +355,63 @@ class TestTransformWebhookToCodegenRequest:
 
         assert result is not None
         assert "integration_id" not in result["data"]["repo"]
+
+    def test_pull_request_payload_is_json_serializable(
+        self, setup_entities: tuple[User, Organization, Project, Repository]
+    ) -> None:
+        """Verify payload can be JSON serialized for Celery task submission."""
+        _, organization, _, repo = setup_entities
+        event_payload = {
+            "action": "opened",
+            "pull_request": {
+                "number": 42,
+                "user": {"login": "pr-author"},
+                "updated_at": "2024-01-15T10:30:00Z",
+            },
+            "sender": {"login": "sender-user"},
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.PULL_REQUEST,
+            "opened",
+            event_payload,
+            organization,
+            repo,
+            "abc123sha",
+        )
+
+        # This would fail if trigger_at is a datetime object instead of string
+        json.dumps(result)  # Should not raise TypeError
+
+    def test_issue_comment_payload_is_json_serializable(
+        self, setup_entities: tuple[User, Organization, Project, Repository]
+    ) -> None:
+        """Verify payload can be JSON serialized for Celery task submission."""
+        _, organization, _, repo = setup_entities
+        event_payload = {
+            "action": "created",
+            "issue": {
+                "number": 42,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42"
+                },
+            },
+            "comment": {
+                "id": 12345,
+                "user": {"login": "commenter"},
+                "updated_at": "2024-01-15T14:00:00Z",
+            },
+        }
+        result = transform_webhook_to_codegen_request(
+            GithubWebhookType.ISSUE_COMMENT,
+            "created",
+            event_payload,
+            organization,
+            repo,
+            "def456sha",
+        )
+
+        # This would fail if trigger_at is a datetime object instead of string
+        json.dumps(result)  # Should not raise TypeError
 
 
 class TestExtractGithubInfo:

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -461,6 +461,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -510,6 +512,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -565,6 +569,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -606,6 +612,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -652,6 +660,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }
@@ -698,6 +708,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 "config": {
                     "features": {"bug_prediction": True},
                     "trigger": "on_new_commit",
+                    "trigger_at": "2024-01-15T10:30:00Z",
+                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
                 },
             },
         }

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -461,8 +461,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
-                    "trigger_at": "2024-01-15T10:30:00Z",
-                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
+                    # Note: trigger_at and sentry_received_trigger_at intentionally
+                    # omitted to test backward compatibility with old payloads
                 },
             },
         }
@@ -512,8 +512,8 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     "trigger_comment_id": None,
                     "trigger_comment_type": None,
                     "trigger_user": None,
-                    "trigger_at": "2024-01-15T10:30:00Z",
-                    "sentry_received_trigger_at": "2024-01-15T10:30:00Z",
+                    # Note: trigger_at and sentry_received_trigger_at intentionally
+                    # omitted to test backward compatibility with old payloads
                 },
             },
         }

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -69,6 +70,7 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             "comment": {
                 "body": comment_body,
                 "id": comment_id,
+                "created_at": "2024-01-15T10:30:00Z",
             },
             "issue": {
                 "number": 42,
@@ -164,3 +166,9 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "test-user"
             assert payload["data"]["config"]["trigger_comment_id"] == 123456789
             assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
+            # After Pydantic validation, trigger_at is a datetime object
+            assert payload["data"]["config"]["trigger_at"] == datetime(
+                2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
+            )
+            # sentry_received_trigger_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import orjson
@@ -252,6 +253,12 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert payload["data"]["config"]["trigger_user"] == "baxterthehacker"
             assert payload["data"]["config"]["trigger_comment_id"] is None
             assert payload["data"]["config"]["trigger_comment_type"] is None
+            # After Pydantic validation, trigger_at is a datetime object
+            assert payload["data"]["config"]["trigger_at"] == datetime(
+                2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
+            )
+            # sentry_received_trigger_at is set to current time when transform happens
+            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)
             self.mock_reaction.assert_not_called()
 
     def test_pull_request_opened_filtered_when_trigger_disabled_post_ga(self) -> None:


### PR DESCRIPTION
## Summary

Relands #107408 with a fix for backward compatibility.

**Root cause of revert**: Tasks enqueued before the deploy didn't have `trigger_at` or `sentry_received_trigger_at` fields. When the new code tried to process these old tasks, Pydantic validation failed because the fields were mandatory.

**Fix**: Make the timestamp fields optional (`datetime | None = None`) so old in-flight tasks can still be validated.

---

This PR adds timestamp fields to `SeerCodeReviewConfig` to enable accurate latency measurement for PR reviews:

- **`trigger_at`**: When the triggering event occurred on GitHub (from webhook payload)
- **`sentry_received_trigger_at`**: When Sentry received the webhook

This enables Seer to calculate:
- GitHub-side delay: `sentry_received_trigger_at - trigger_at`
- Sentry processing time: `completed_at - sentry_received_trigger_at`
- Total end-to-end latency: `completed_at - trigger_at`

**Changes:**
- Add `trigger_at: datetime | None` field (optional) to `SeerCodeReviewConfig`
- Add `sentry_received_trigger_at: datetime | None` field (optional) to `SeerCodeReviewConfig`
- Extract `trigger_at` from GitHub webhook payload:
  - For `pull_request` events: uses `updated_at` with fallback to `created_at`
  - For `issue_comment` events: uses `updated_at` with fallback to `created_at`
  - Falls back to current time if timestamps unavailable
- Set `sentry_received_trigger_at` to current time when processing webhook
- Return ISO strings from transform functions for Celery JSON serialization (Pydantic parses to datetime)

## Test plan

- [x] Unit tests for trigger metadata extraction
- [x] Unit tests for fallback behavior when timestamps missing
- [x] JSON serialization tests to verify Celery compatibility
- [x] Integration tests verify both timestamps in payload
- [x] Old payloads without timestamp fields validate successfully (optional fields)

Part of CW-706