### PR TITLE
feat(seer): Add source field to coding integration analytics and expand coverage

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -39,6 +39,7 @@ import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
@@ -433,6 +434,7 @@ function AutofixRootCauseDisplay({
 }: AutofixRootCauseProps) {
   const cause = causes[0];
   const organization = useOrganization();
+  const user = useUser();
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
   const [solutionText, setSolutionText] = useState('');
@@ -527,6 +529,13 @@ function AutofixRootCauseDisplay({
     trackAnalytics('autofix.coding_agent.launch_from_root_cause', {
       organization,
       group_id: groupId,
+    });
+    trackAnalytics('coding_integration.send_to_agent_clicked', {
+      organization,
+      group_id: groupId,
+      provider: integration.provider,
+      source: 'autofix',
+      user_id: user.id,
     });
   };
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -50,6 +50,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       organization,
       project_slug: project.slug,
       provider: 'cursor',
+      source: 'cta',
       user_id: user.id,
     });
   }, [organization, project.slug, user.id]);
@@ -63,6 +64,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       organization,
       project_slug: project.slug,
       provider: 'cursor',
+      source: 'cta',
       user_id: user.id,
     });
 

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,3 +1,5 @@
+import {useCallback} from 'react';
+
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -7,13 +9,26 @@ import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAu
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 export function GithubCopilotIntegrationCta() {
   const organization = useOrganization();
+  const user = useUser();
 
   const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
     useCodingAgentIntegrations();
+
+  const handleInstallClick = useCallback(() => {
+    trackAnalytics('coding_integration.install_clicked', {
+      organization,
+      project_slug: '', // GitHub Copilot CTA is not project-specific
+      provider: 'github_copilot',
+      source: 'cta',
+      user_id: user.id,
+    });
+  }, [organization, user.id]);
 
   const githubCopilotIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'github_copilot'
@@ -72,6 +87,7 @@ export function GithubCopilotIntegrationCta() {
               to={`/settings/${organization.slug}/integrations/github_copilot/`}
               priority="default"
               size="sm"
+              onClick={handleInstallClick}
             >
               {t('Install GitHub Copilot Integration')}
             </LinkButton>

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -24,6 +24,13 @@ export type SeerAnalyticsEventsParameters = {
     source: 'cta' | 'settings';
     user_id: string;
   };
+  'coding_integration.send_to_agent_clicked': {
+    group_id: string;
+    organization: Organization;
+    provider: string;
+    source: 'autofix' | 'explorer';
+    user_id: string;
+  };
   'coding_integration.setup_handoff_clicked': {
     organization: Organization;
     project_slug: string;
@@ -73,6 +80,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.coding_agent.launch_from_root_cause':
     'Autofix: Coding Agent Launch From Root Cause',
   'coding_integration.install_clicked': 'Coding Integration: Install Clicked',
+  'coding_integration.send_to_agent_clicked': 'Coding Integration: Send to Agent Clicked',
   'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -21,12 +21,14 @@ export type SeerAnalyticsEventsParameters = {
     organization: Organization;
     project_slug: string;
     provider: string;
+    source: 'cta' | 'settings';
     user_id: string;
   };
   'coding_integration.setup_handoff_clicked': {
     organization: Organization;
     project_slug: string;
     provider: string;
+    source: 'cta' | 'settings_dropdown' | 'settings_toggle';
     user_id: string;
   };
   'seer.autofix.feedback_submitted': {


### PR DESCRIPTION
## Summary
Adds comprehensive analytics tracking for coding integration interactions:

### New Events
1. **`coding_integration.install_clicked`** - Tracks clicks on "Install" buttons
   - `source: 'cta'` - From CTA components
   - `source: 'settings'` - From settings page (if applicable)

2. **`coding_integration.setup_handoff_clicked`** - Tracks setup/enable handoff clicks
   - `source: 'cta'` - From CursorIntegrationCta component
   - `source: 'settings_dropdown'` - From legacy Seer settings dropdown
   - `source: 'settings_toggle'` - From new triage-signals-v0 toggle

3. **`coding_integration.send_to_agent_clicked`** - Tracks "Send to Cursor/Copilot" clicks
   - `source: 'autofix'` - From regular autofix root cause page
   - `source: 'explorer'` - From explorer autofix

### Files Changed
- `seerAnalyticsEvents.tsx` - Added event definitions
- `cursorIntegrationCta.tsx` - Added source field to existing events
- `githubCopilotIntegrationCta.tsx` - Added install click tracking
- `projectSeer/index.tsx` - Added tracking for settings dropdown and toggle
- `autofixRootCause.tsx` - Added send to agent tracking
- `useExplorerAutofix.tsx` - Added send to agent tracking for explorer

## Test plan
- [ ] Verify `coding_integration.install_clicked` fires with correct `source` when clicking install buttons
- [ ] Verify `coding_integration.setup_handoff_clicked` fires with correct `source` from CTA, dropdown, and toggle
- [ ] Verify `coding_integration.send_to_agent_clicked` fires when clicking "Send to Cursor/Copilot" in autofix
- [ ] Verify `coding_integration.send_to_agent_clicked` fires when clicking "Send to Cursor/Copilot" in explorer