### PR TITLE
feat(seer): Add analytics for Open in Coding Agent clicks

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -39,6 +39,7 @@ import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
@@ -433,6 +434,7 @@ function AutofixRootCauseDisplay({
 }: AutofixRootCauseProps) {
   const cause = causes[0];
   const organization = useOrganization();
+  const user = useUser();
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
   const [solutionText, setSolutionText] = useState('');
@@ -527,6 +529,13 @@ function AutofixRootCauseDisplay({
     trackAnalytics('autofix.coding_agent.launch_from_root_cause', {
       organization,
       group_id: groupId,
+    });
+    trackAnalytics('coding_integration.send_to_agent_clicked', {
+      organization,
+      group_id: groupId,
+      provider: integration.provider,
+      source: 'autofix',
+      user_id: user.id,
     });
   };
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -50,6 +50,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       organization,
       project_slug: project.slug,
       provider: 'cursor',
+      source: 'cta',
       user_id: user.id,
     });
   }, [organization, project.slug, user.id]);
@@ -63,6 +64,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       organization,
       project_slug: project.slug,
       provider: 'cursor',
+      source: 'cta',
       user_id: user.id,
     });
 

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,3 +1,5 @@
+import {useCallback} from 'react';
+
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -7,13 +9,26 @@ import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAu
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 export function GithubCopilotIntegrationCta() {
   const organization = useOrganization();
+  const user = useUser();
 
   const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
     useCodingAgentIntegrations();
+
+  const handleInstallClick = useCallback(() => {
+    trackAnalytics('coding_integration.install_clicked', {
+      organization,
+      project_slug: '', // GitHub Copilot CTA is not project-specific
+      provider: 'github_copilot',
+      source: 'cta',
+      user_id: user.id,
+    });
+  }, [organization, user.id]);
 
   const githubCopilotIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'github_copilot'
@@ -72,6 +87,7 @@ export function GithubCopilotIntegrationCta() {
               to={`/settings/${organization.slug}/integrations/github_copilot/`}
               priority="default"
               size="sm"
+              onClick={handleInstallClick}
             >
               {t('Install GitHub Copilot Integration')}
             </LinkButton>

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -24,6 +24,13 @@ export type SeerAnalyticsEventsParameters = {
     source: 'cta' | 'settings';
     user_id: string;
   };
+  'coding_integration.send_to_agent_clicked': {
+    group_id: string;
+    organization: Organization;
+    provider: string;
+    source: 'autofix' | 'explorer';
+    user_id: string;
+  };
   'coding_integration.setup_handoff_clicked': {
     organization: Organization;
     project_slug: string;
@@ -73,6 +80,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.coding_agent.launch_from_root_cause':
     'Autofix: Coding Agent Launch From Root Cause',
   'coding_integration.install_clicked': 'Coding Integration: Install Clicked',
+  'coding_integration.send_to_agent_clicked': 'Coding Integration: Send to Agent Clicked',
   'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -21,12 +21,14 @@ export type SeerAnalyticsEventsParameters = {
     organization: Organization;
     project_slug: string;
     provider: string;
+    source: 'cta' | 'settings';
     user_id: string;
   };
   'coding_integration.setup_handoff_clicked': {
     organization: Organization;
     project_slug: string;
     provider: string;
+    source: 'cta' | 'settings_dropdown' | 'settings_toggle';
     user_id: string;
   };
   'seer.autofix.feedback_submitted': {


### PR DESCRIPTION
## Summary
- Add `coding_integration.open_in_agent_clicked` analytics event
- Track when users click "Open in Cursor" or "View Agent" buttons in the CodingAgentCard
- Include `provider` (cursor/github_copilot) and `source` (autofix/explorer) for segmentation

## Test plan
- [ ] Verify analytics event fires when clicking "Open in Cursor" button on a coding agent card