### PR TITLE
fix(ACI): Update receiver to delete orphaned Actions

### DIFF
--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -70,12 +70,13 @@ def update_sentry_app_action_data(
 
         if not installs:
             logger.info(
-                "No sentry app installation found",
+                "No sentry app installation found, deleting the action",
                 extra={
                     "action_id": action.id,
                     "installation_uuid": action.config.get("target_identifier"),
                 },
             )
+            action.delete()
             return
 
         action.config["target_identifier"] = str(installs[0].sentry_app.id)

--- a/tests/sentry/workflow_engine/migrations/test_0106_migrate_actions_sentry_app_data.py
+++ b/tests/sentry/workflow_engine/migrations/test_0106_migrate_actions_sentry_app_data.py
@@ -2,8 +2,10 @@ from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
 
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestMigrations
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
@@ -39,6 +41,22 @@ class TestMigrateActionsSentryAppData(TestMigrations):
             },
         )
 
+        self.sentry_app2 = self.create_sentry_app(name="bar", organization=self.org)
+        self.installation2 = self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app2.slug, user=self.user
+        )
+
+        self.action_to_delete = Action.objects.create(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_type": ActionTarget.SENTRY_APP,
+                "target_identifier": str(self.installation2.uuid),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            },
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.installation2.delete()
+
     def validate_action(self, action: Action) -> None:
         action.refresh_from_db()
         assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
@@ -51,6 +69,8 @@ class TestMigrateActionsSentryAppData(TestMigrations):
 
         self.validate_action(self.installation_uuid_action)
         self.validate_action(self.sentry_app_id_action)
+
+        assert not Action.objects.filter(id=self.action_to_delete.id).exists()
 
     def test_migration_idempotent(self) -> None:
         # execute all the outbox jobs from the initial migration


### PR DESCRIPTION
If we run into this edge case where we can't find the sentry app installation, we've decided we want to delete the action because users can't see it or update it since the app has been uninstalled. See [this doc](https://www.notion.so/sentry/Invalid-Sentry-App-Actions-2f88b10e4b5d8046ac20faae3cfeb7c5) for more context on that decision.

I will need to re-run [the migration](https://github.com/getsentry/sentry/pull/107208) because I missed that we were dual writing actions with the installation uuid (fixed in https://github.com/getsentry/sentry/pull/107436) and we may as well delete the orphaned actions in the same step rather that run a separate migration to do so. It will not be run until https://github.com/getsentry/sentry/pull/107460 is merged.