### PR TITLE
refactor(dashboards): Use array for display type ordering

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -21,7 +21,7 @@ import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useI
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
-const typeIcons = {
+const typeIcons: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.AREA]: <IconGraph key="area" type="area" />,
   [DisplayType.BAR]: <IconGraph key="bar" type="bar" />,
   [DisplayType.LINE]: <IconGraph key="line" type="line" />,
@@ -29,14 +29,6 @@ const typeIcons = {
   [DisplayType.BIG_NUMBER]: <IconNumber key="number" />,
   [DisplayType.DETAILS]: <IconSettings key="details" />,
 };
-
-const BASE_DISPLAY_TYPES: Partial<Record<DisplayType, string>> = {
-  [DisplayType.AREA]: t('Area'),
-  [DisplayType.BAR]: t('Bar'),
-  [DisplayType.LINE]: t('Line'),
-  [DisplayType.TABLE]: t('Table'),
-  [DisplayType.BIG_NUMBER]: t('Big Number'),
-} as const;
 
 interface WidgetBuilderTypeSelectorProps {
   error?: Record<string, any>;
@@ -62,10 +54,18 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
     );
   };
 
-  const displayTypes = {...BASE_DISPLAY_TYPES};
-  if (organization.features.includes('dashboards-details-widget')) {
-    displayTypes[DisplayType.DETAILS] = t('Details');
-  }
+  const hasDetailsWidget = organization.features.includes('dashboards-details-widget');
+
+  // Use an array to define display type order explicitly.
+  // Object key ordering in JS is technically specified but easy to break accidentally.
+  const displayTypeOrder: Array<{label: string; type: DisplayType}> = [
+    {type: DisplayType.AREA, label: t('Area')},
+    {type: DisplayType.BAR, label: t('Bar')},
+    {type: DisplayType.LINE, label: t('Line')},
+    {type: DisplayType.TABLE, label: t('Table')},
+    {type: DisplayType.BIG_NUMBER, label: t('Big Number')},
+    ...(hasDetailsWidget ? [{type: DisplayType.DETAILS, label: t('Details')}] : []),
+  ];
 
   // Issue series widgets query a different data source from table widgets.
   // Therefore we need to handle resetting the query on display type change due to incompatibility.
@@ -112,15 +112,13 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
         <Select
           name="displayType"
           value={state.displayType}
-          options={Object.keys(displayTypes).map(value => ({
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            leadingItems: typeIcons[value],
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            label: displayTypes[value],
-            value,
+          options={displayTypeOrder.map(({type, label}) => ({
+            leadingItems: typeIcons[type],
+            label,
+            value: type,
             disabled:
-              !config.supportedDisplayTypes.includes(value as DisplayType) ||
-              shouldDisabledIssueDisplayType(value as DisplayType),
+              !config.supportedDisplayTypes.includes(type) ||
+              shouldDisabledIssueDisplayType(type),
           }))}
           clearable={false}
           onChange={(newValue: any) => {


### PR DESCRIPTION
Replaces object-based display type definitions with an explicit array to make dropdown ordering safer and more maintainable.

Object key ordering in JS is technically specified (ES2015+) but easy to break accidentally during refactoring, and it's annoying to inject new values into. Using an array makes the ordering intent explicit and safer for inserting new display types at specific positions. Also it removed a bunch of awkward TS ignores.