### PR TITLE
ref(seer): Use button props for coding integration analytics

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -39,7 +39,6 @@ import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
@@ -434,7 +433,6 @@ function AutofixRootCauseDisplay({
 }: AutofixRootCauseProps) {
   const cause = causes[0];
   const organization = useOrganization();
-  const user = useUser();
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
   const [solutionText, setSolutionText] = useState('');
@@ -535,7 +533,6 @@ function AutofixRootCauseDisplay({
       group_id: groupId,
       provider: integration.provider,
       source: 'autofix',
-      user_id: user.id,
     });
   };
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -13,10 +13,8 @@ import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Project} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 
 interface CursorIntegrationCtaProps {
   project: Project;
@@ -24,7 +22,6 @@ interface CursorIntegrationCtaProps {
 
 export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
   const organization = useOrganization();
-  const user = useUser();
 
   const {preference, isFetching: isLoadingPreferences} =
     useProjectSeerPreferences(project);
@@ -45,28 +42,10 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
     project.seerScannerAutomation !== false && project.autofixAutomationTuning !== 'off';
   const isConfigured = Boolean(preference?.automation_handoff) && isAutomationEnabled;
 
-  const handleInstallClick = useCallback(() => {
-    trackAnalytics('coding_integration.install_clicked', {
-      organization,
-      project_slug: project.slug,
-      provider: 'cursor',
-      source: 'cta',
-      user_id: user.id,
-    });
-  }, [organization, project.slug, user.id]);
-
   const handleSetupClick = useCallback(async () => {
     if (!cursorIntegration?.id) {
       throw new Error('Cursor integration not found');
     }
-
-    trackAnalytics('coding_integration.setup_handoff_clicked', {
-      organization,
-      project_slug: project.slug,
-      provider: 'cursor',
-      source: 'cta',
-      user_id: user.id,
-    });
 
     const isAutomationDisabled =
       project.seerScannerAutomation === false ||
@@ -89,15 +68,12 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       },
     });
   }, [
-    organization,
-    project.slug,
     project.seerScannerAutomation,
     project.autofixAutomationTuning,
     updateProjectSeerPreferences,
     updateProjectAutomation,
     preference?.repositories,
     cursorIntegration,
-    user.id,
   ]);
 
   if (!hasCursorIntegrationFeatureFlag) {
@@ -137,7 +113,13 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
               href="/settings/integrations/cursor/"
               priority="default"
               size="sm"
-              onClick={handleInstallClick}
+              analyticsEventKey="coding_integration.install_clicked"
+              analyticsEventName="Coding Integration: Install Clicked"
+              analyticsParams={{
+                project_slug: project.slug,
+                provider: 'cursor',
+                source: 'cta',
+              }}
             >
               {t('Install Cursor Integration')}
             </LinkButton>
@@ -171,7 +153,18 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
             )}
           </Text>
           <div>
-            <Button onClick={handleSetupClick} priority="default" size="sm">
+            <Button
+              onClick={handleSetupClick}
+              priority="default"
+              size="sm"
+              analyticsEventKey="coding_integration.setup_handoff_clicked"
+              analyticsEventName="Coding Integration: Setup Handoff Clicked"
+              analyticsParams={{
+                project_slug: project.slug,
+                provider: 'cursor',
+                source: 'cta',
+              }}
+            >
               {t('Set Seer to hand off to Cursor')}
             </Button>
           </div>

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,5 +1,3 @@
-import {useCallback} from 'react';
-
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -9,26 +7,13 @@ import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAu
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 
 export function GithubCopilotIntegrationCta() {
   const organization = useOrganization();
-  const user = useUser();
 
   const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
     useCodingAgentIntegrations();
-
-  const handleInstallClick = useCallback(() => {
-    trackAnalytics('coding_integration.install_clicked', {
-      organization,
-      project_slug: '', // GitHub Copilot CTA is not project-specific
-      provider: 'github_copilot',
-      source: 'cta',
-      user_id: user.id,
-    });
-  }, [organization, user.id]);
 
   const githubCopilotIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'github_copilot'
@@ -87,7 +72,13 @@ export function GithubCopilotIntegrationCta() {
               to={`/settings/${organization.slug}/integrations/github_copilot/`}
               priority="default"
               size="sm"
-              onClick={handleInstallClick}
+              analyticsEventKey="coding_integration.install_clicked"
+              analyticsEventName="Coding Integration: Install Clicked"
+              analyticsParams={{
+                project_slug: '',
+                provider: 'github_copilot',
+                source: 'cta',
+              }}
             >
               {t('Install GitHub Copilot Integration')}
             </LinkButton>

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -17,7 +17,6 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import type {
   Artifact,
   Block,
@@ -300,7 +299,6 @@ export function useExplorerAutofix(
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
-  const user = useUser();
   const orgSlug = organization.slug;
 
   const intelligenceLevel = useMemo(() => {
@@ -444,7 +442,6 @@ export function useExplorerAutofix(
         group_id: groupId,
         provider: integration.provider,
         source: 'explorer',
-        user_id: user.id,
       });
 
       addLoadingMessage('Launching coding agent...');
@@ -496,7 +493,7 @@ export function useExplorerAutofix(
         setWaitingForResponse(false);
       }
     },
-    [api, orgSlug, groupId, queryClient, organization, user.id]
+    [api, orgSlug, groupId, queryClient, organization]
   );
 
   // Clear waiting state when we get a response

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -18,25 +18,19 @@ export type SeerAnalyticsEventsParameters = {
     setup_write_integration?: boolean;
   };
   'coding_integration.install_clicked': {
-    organization: Organization;
     project_slug: string;
     provider: string;
     source: 'cta' | 'settings';
-    user_id: string;
   };
   'coding_integration.send_to_agent_clicked': {
     group_id: string;
-    organization: Organization;
     provider: string;
     source: 'autofix' | 'explorer';
-    user_id: string;
   };
   'coding_integration.setup_handoff_clicked': {
-    organization: Organization;
     project_slug: string;
     provider: string;
     source: 'cta' | 'settings_dropdown' | 'settings_toggle';
-    user_id: string;
   };
   'seer.autofix.feedback_submitted': {
     autofix_run_id: string;

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -40,7 +40,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
@@ -197,7 +196,6 @@ function CodingAgentSettings({
 
 function ProjectSeerGeneralForm({project}: {project: Project}) {
   const organization = useOrganization();
-  const user = useUser();
   const queryClient = useQueryClient();
   const {preference} = useProjectSeerPreferences(project);
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
@@ -244,7 +242,6 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           project_slug: project.slug,
           provider: 'cursor',
           source: 'settings_dropdown',
-          user_id: user.id,
         });
         updateProjectSeerPreferences({
           repositories: preference?.repositories || [],
@@ -267,7 +264,6 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     [
       organization,
       project.slug,
-      user.id,
       updateProjectSeerPreferences,
       preference?.repositories,
       cursorIntegration,
@@ -362,7 +358,6 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           project_slug: project.slug,
           provider: 'cursor',
           source: 'settings_toggle',
-          user_id: user.id,
         });
         updateProjectSeerPreferences(
           {
@@ -415,7 +410,6 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     [
       organization,
       project.slug,
-      user.id,
       updateProjectSeerPreferences,
       preference?.repositories,
       cursorIntegration,


### PR DESCRIPTION
## Summary

Refactors coding integration analytics to use button props (`analyticsEventKey`, `analyticsEventName`, `analyticsParams`) instead of manual `trackAnalytics()` calls where possible.

### Changes
- **`cursorIntegrationCta.tsx`** - Use button props for install and setup clicks
- **`githubCopilotIntegrationCta.tsx`** - Use button props for install click
- **`seerAnalyticsEvents.tsx`** - Simplify event type definitions (remove redundant `organization` and `user_id` fields that are auto-included)

### Kept as `trackAnalytics()`
- `autofixRootCause.tsx` - Called inside business logic, not a simple click
- `useExplorerAutofix.tsx` - Called inside hook callback
- `projectSeer/index.tsx` - Triggered by form field changes, not buttons

## Test plan
- [ ] Set `DEBUG_ANALYTICS=1` in localStorage
- [ ] Verify analytics still fire correctly when clicking buttons