### PR TITLE
chore: Add sentry-analytics Claude skill

### DIFF
--- a/.claude/skills/sentry-analytics/SKILL.md
+++ b/.claude/skills/sentry-analytics/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sentry-analytics
+description: Add frontend analytics events to Sentry codebase. Use when adding tracking for user actions, feature usage, or product metrics. Covers TypeScript trackAnalytics and button click analytics (analyticsEventKey/analyticsEventName props).
+---
+
+# Sentry Analytics
+
+Add analytics events to track user actions and feature usage.
+
+## Quick Reference
+
+| Type           | Location                                 | Pattern                                                  |
+| -------------- | ---------------------------------------- | -------------------------------------------------------- |
+| Button clicks  | Component props                          | `analyticsEventKey`/`analyticsEventName` **(preferred)** |
+| Other tracking | `static/app/utils/analytics/*Events.tsx` | `trackAnalytics()`                                       |
+
+## Button Click Analytics (Preferred)
+
+**Use button props for click tracking whenever possible.** This is the simplest approach and provides automatic tracking.
+
+```tsx
+<Button
+  analyticsEventKey="feature_name.button_clicked"
+  analyticsEventName="Feature Name: Button Clicked" // Optional, enables Amplitude
+  analyticsParams={{customField: 'value'}} // Optional extra params
+  onClick={handleClick}
+>
+  Click Me
+</Button>
+```
+
+- `analyticsEventKey`: Reload event key (required for tracking)
+- `analyticsEventName`: Amplitude event name (optional, enables Amplitude)
+- `analyticsParams`: Additional parameters (optional)
+
+Buttons auto-track: `text`, `priority`, `href`, `parameterized_path`.
+
+## Manual Tracking with trackAnalytics
+
+Use `trackAnalytics()` only when button props aren't applicable (non-click events, effects, form submissions).
+
+### 1. Define event types
+
+Add to appropriate file in `static/app/utils/analytics/` (e.g., `featureAnalyticsEvents.tsx`):
+
+```typescript
+export type FeatureEventParameters = {
+  'feature_name.action_performed': {
+    source: string;
+  };
+  'feature_name.modal_opened': Record<string, unknown>; // No params
+};
+
+export const featureEventMap: Record<keyof FeatureEventParameters, string | null> = {
+  'feature_name.action_performed': 'Feature Name: Action Performed', // Amplitude name
+  'feature_name.modal_opened': null, // null = don't send to Amplitude
+};
+```
+
+### 2. Register in index
+
+Add to `static/app/utils/analytics/index.tsx`:
+
+```typescript
+import {featureEventMap, type FeatureEventParameters} from './featureAnalyticsEvents';
+
+export type EventParameters =
+  // ... existing types
+  FeatureEventParameters;
+
+export const allEventMap = {
+  // ... existing maps
+  ...featureEventMap,
+};
+```
+
+### 3. Track the event
+
+```typescript
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+trackAnalytics('feature_name.action_performed', {
+  organization,
+  source: 'modal',
+});
+```
+
+## Naming Conventions
+
+| Context        | Format           | Example                          |
+| -------------- | ---------------- | -------------------------------- |
+| Event key      | `feature.action` | `issue_details.comment_created`  |
+| Amplitude name | Title Case       | `Issue Details: Comment Created` |
+
+## Testing
+
+Set `DEBUG_ANALYTICS=1` in browser localStorage to log events to console.
+
+## Common Patterns
+
+**Track on mount/effect:**
+
+```typescript
+useEffect(() => {
+  trackAnalytics('feature.viewed', {organization});
+}, [organization]);
+```
+
+**Track form submission:**
+
+```typescript
+const handleSubmit = () => {
+  trackAnalytics('feature.form_submitted', {
+    organization,
+    field_count: fields.length,
+  });
+};
+```


### PR DESCRIPTION
## Summary

Adds a Claude Code skill for adding frontend analytics events to the Sentry codebase.

### What the skill covers

- **Button click analytics** - Using `analyticsEventKey`, `analyticsEventName`, and `analyticsParams` props (preferred approach)
- **Manual trackAnalytics()** - For non-button events like form submissions, effects
- **Event type definitions** - Where to define types and event maps
- **Naming conventions** - Event key and Amplitude name formats

### Usage

The skill will be automatically triggered when asking Claude to add analytics events. It provides guidance on:

1. Using button props for click tracking (preferred)
2. When to use `trackAnalytics()` instead
3. How to define event types in `seerAnalyticsEvents.tsx` or similar
4. Testing with `DEBUG_ANALYTICS=1`

## Test plan
- [ ] Verify skill loads correctly with `/sentry-analytics`
- [ ] Ask Claude to add an analytics event and verify it follows the patterns