### PR TITLE
fix(onboarding): fix iOS Safari scroll position on welcome screen

### DIFF
--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -131,9 +131,12 @@ const PRODUCT_OPTIONS: ProductOption[] = [
 export function NewWelcomeUI(props: StepProps) {
   useWelcomeAnalyticsEffect();
 
-  // Scroll to top on mount to fix iOS Safari retaining scroll position from previous page
+  // Scroll to top on mount to fix iOS Safari retaining scroll position from previous page.
+  // Skip if there's a hash in the URL to avoid conflicting with anchor-based scrolling.
   useEffect(() => {
-    window.scrollTo(0, 0);
+    if (!window.location.hash) {
+      window.scrollTo(0, 0);
+    }
   }, []);
 
   const handleComplete = useWelcomeHandleComplete(props.onComplete);

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {motion, type MotionProps} from 'framer-motion';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
@@ -129,6 +130,11 @@ const PRODUCT_OPTIONS: ProductOption[] = [
 
 export function NewWelcomeUI(props: StepProps) {
   useWelcomeAnalyticsEffect();
+
+  // Scroll to top on mount to fix iOS Safari retaining scroll position from previous page
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const handleComplete = useWelcomeHandleComplete(props.onComplete);
 


### PR DESCRIPTION
## Summary
Fix iOS Safari retaining scroll position when navigating to the new onboarding welcome screen, which caused the header text to be cut off.

## Changes
Add `useEffect` in `NewWelcomeUI` that scrolls to top on mount.