### PR TITLE
fix(uptime): improve error message when enabling monitor without budget

### DIFF
--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -7,6 +7,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
+from sentry.uptime.endpoints.validators import UPTIME_MONITOR_BUDGET_ERROR
 from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
@@ -309,7 +310,8 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         # The request should have failed with a 400 error
         # Check that we got an error response about seat assignment
-        assert "status" in resp.data or "non_field_errors" in resp.data
+        assert "status" in resp.data
+        assert resp.data["status"] == [UPTIME_MONITOR_BUDGET_ERROR]
 
 
 class ProjectUptimeAlertDetailsDeleteEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -8,6 +8,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import TestCase, UptimeTestCase
 from sentry.uptime.endpoints.validators import (
+    UPTIME_MONITOR_BUDGET_ERROR,
     UptimeDomainCheckFailureValidator,
     UptimeMonitorDataSourceValidator,
     compute_http_request_size,
@@ -272,7 +273,7 @@ class UptimeDomainCheckFailureValidatorTest(UptimeTestCase):
         # Validation should fail due to no seats available
         assert not validator.is_valid()
         assert "enabled" in validator.errors
-        assert validator.errors["enabled"] == ["No seats available"]
+        assert validator.errors["enabled"] == [UPTIME_MONITOR_BUDGET_ERROR]
 
         detector.refresh_from_db()
         # Detector should still be disabled


### PR DESCRIPTION
## Summary
Improves the error message when users try to enable an uptime monitor but don't have enough pay-as-you-go budget.

**Before**: "Unable to update uptime monitor." (vague fallback)

**After**: "You don't have enough budget to enable this uptime monitor. Increase your pay-as-you-go budget on your subscription page to continue."

## Changes
- Add `UPTIME_MONITOR_BUDGET_ERROR` constant with clear, actionable error message
- Update `UptimeMonitorValidator.update()` to use the new message
- Update `UptimeDomainCheckFailureValidator.validate_enabled()` to use the new message

Fixes NEW-61