### PR TITLE
fix(traces): Use span.name instead of transaction

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -261,7 +261,7 @@ class TracesExecutor:
                 "sdk.name",
                 "span.op",
                 "parent_span",
-                "transaction",
+                "span.name",
                 "precise.start_ts",
                 "precise.finish_ts",
                 "span.duration",
@@ -353,7 +353,7 @@ class TracesExecutor:
 
             name: tuple[str, str, float] = (
                 span["project"],
-                span["transaction"],
+                span["span.name"],
                 # to minmimize the impact of floating point errors,
                 # multiply by 1e3 first then do the subtraction
                 # once we move to eap_items, this can be just `span["span.duration"]`

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1284,6 +1284,7 @@ class BaseSpansTestCase(SnubaTestCase):
         parent_span_id: str | None = None,
         profile_id: str | None = None,
         transaction: str | None = None,
+        name: str | None = None,
         duration: int = 10,
         exclusive_time: int = 5,
         tags: dict[str, str] | None = None,
@@ -1311,6 +1312,8 @@ class BaseSpansTestCase(SnubaTestCase):
             sentry_tags["status"] = status
         if environment is not None:
             sentry_tags["environment"] = environment
+        if name is not None:
+            sentry_tags["name"] = name
 
         payload = {
             "project_id": project_id,


### PR DESCRIPTION
- on otel, transaction is either not sent, or can be sent with data that doesn't fit our usage here
- Use span.name like our trace view does instead so we have consistency, and so the view is better for otel as well