### PR TITLE
feat(uptime-issue-assertions-section): Sending assertion failure data…

### DIFF
--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -18,7 +18,7 @@ from sentry.uptime.endpoints.validators import UptimeDomainCheckFailureValidator
 from sentry.uptime.models import UptimeResponseCapture, UptimeSubscription
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
 from sentry.uptime.utils import build_fingerprint, generate_scheduled_check_times_ms
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
 from sentry.workflow_engine.handlers.detector.stateful import (
     DetectorThresholds,
@@ -238,7 +238,7 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
 
         assertion_failure_data = result.get("assertion_failure_data")
         if assertion_failure_data is not None:
-            evidence_data["assertion_failure_data"] = assertion_failure_data
+            evidence_data["assertion_failure_data"] = json.dumps(assertion_failure_data)
 
         occurrence = DetectorOccurrence(
             issue_title=f"Downtime detected for {uptime_subscription.url}",

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -30,6 +30,7 @@ from sentry.uptime.models import UptimeResponseCapture, UptimeSubscription, get_
 from sentry.uptime.subscriptions.subscriptions import resolve_uptime_issue
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.uptime.utils import build_detector_fingerprint_component, build_fingerprint
+from sentry.utils import json
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
@@ -233,8 +234,8 @@ class TestUptimeHandler(UptimeTestCase):
         )
         assert evaluation is not None
         assert isinstance(evaluation.result, IssueOccurrence)
-        assert (
-            evaluation.result.evidence_data["assertion_failure_data"] == MOCK_ASSERTION_FAILURE_DATA
+        assert evaluation.result.evidence_data["assertion_failure_data"] == json.dumps(
+            MOCK_ASSERTION_FAILURE_DATA
         )
 
     def test_occurrence_excludes_old_response_capture(self) -> None:


### PR DESCRIPTION
- Sending in as an object, causes snake -> came case convertions for keys, which we don't want for our usecase