### PR TITLE
fix(settings): Update team modal design/copy

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -17,7 +17,7 @@ import ModalStore from 'sentry/stores/modalStore';
 import type {CustomRepoType} from 'sentry/types/debugFiles';
 import type {Event} from 'sentry/types/event';
 import type {IssueOwnership} from 'sentry/types/group';
-import type {MissingMember, Organization, OrgRole, Team} from 'sentry/types/organization';
+import type {MissingMember, Organization, OrgRole} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Theme} from 'sentry/utils/theme';
 import type {AttributeBreakdownViewerModalOptions} from 'sentry/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal';
@@ -80,17 +80,10 @@ export async function openDiffModal(options: OpenDiffModalOptions) {
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
-type CreateTeamModalOptions = {
-  /**
-   * The organization to create a team for
-   */
-  organization: Organization;
-  onClose?: (team: Team) => void;
-  /**
-   * An initial project to add the team to. This may be deprecated soon as we may add a project selection inside of the modal flow
-   */
-  project?: Project;
-};
+type CreateTeamModalOptions = Omit<
+  React.ComponentProps<typeof import('sentry/components/modals/createTeamModal').default>,
+  ModalRenderPropKeys
+>;
 
 export async function openCreateTeamModal(options: CreateTeamModalOptions) {
   const {default: Modal} = await import('sentry/components/modals/createTeamModal');

--- a/static/app/components/modals/createTeamModal.spec.tsx
+++ b/static/app/components/modals/createTeamModal.spec.tsx
@@ -8,7 +8,9 @@ import {makeCloseButton} from 'sentry/components/globalModal/components';
 import CreateTeamModal from 'sentry/components/modals/createTeamModal';
 
 jest.mock('sentry/actionCreators/teams', () => ({
-  createTeam: jest.fn((...args: any[]) => new Promise(resolve => resolve(args))),
+  createTeam: jest.fn(
+    (...args: Parameters<typeof createTeam>) => new Promise(resolve => resolve(args))
+  ),
 }));
 
 describe('CreateTeamModal', () => {
@@ -17,7 +19,7 @@ describe('CreateTeamModal', () => {
   const onClose = jest.fn();
 
   beforeEach(() => {
-    onClose.mockReset();
+    jest.clearAllMocks();
   });
 
   it('calls createTeam action creator on submit', async () => {
@@ -34,7 +36,7 @@ describe('CreateTeamModal', () => {
       />
     );
 
-    await userEvent.type(screen.getByText('Team Name'), 'new-team');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Team Slug'}), 'new-team');
     await userEvent.click(screen.getByLabelText('Create Team'));
 
     await waitFor(() => expect(createTeam).toHaveBeenCalledTimes(1));

--- a/static/app/components/modals/createTeamModal.tsx
+++ b/static/app/components/modals/createTeamModal.tsx
@@ -1,5 +1,7 @@
 import {Fragment} from 'react';
 
+import {Heading} from '@sentry/scraps/text';
+
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {createTeam} from 'sentry/actionCreators/teams';
 import CreateTeamForm from 'sentry/components/teams/createTeamForm';
@@ -34,7 +36,9 @@ function CreateTeamModal({Body, Header, ...props}: Props) {
 
   return (
     <Fragment>
-      <Header closeButton>{t('Create Team')}</Header>
+      <Header closeButton>
+        <Heading as="h5">{t('Create Team')}</Heading>
+      </Header>
       <Body>
         <CreateTeamForm {...props} onSubmit={handleSubmit} />
       </Body>

--- a/static/app/components/modals/createTeamModal.tsx
+++ b/static/app/components/modals/createTeamModal.tsx
@@ -1,7 +1,5 @@
 import {Fragment} from 'react';
 
-import {Heading} from '@sentry/scraps/text';
-
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {createTeam} from 'sentry/actionCreators/teams';
 import CreateTeamForm from 'sentry/components/teams/createTeamForm';
@@ -14,8 +12,7 @@ interface Props extends ModalRenderProps {
   onClose?: (team: Team) => void;
 }
 
-function CreateTeamModal({Body, Header, ...props}: Props) {
-  const {onClose, closeModal, organization} = props;
+function CreateTeamModal({Body, Header, organization, onClose, closeModal}: Props) {
   const api = useApi();
 
   const handleSubmit: React.ComponentProps<typeof CreateTeamForm>['onSubmit'] = async (
@@ -37,10 +34,10 @@ function CreateTeamModal({Body, Header, ...props}: Props) {
   return (
     <Fragment>
       <Header closeButton>
-        <Heading as="h5">{t('Create Team')}</Heading>
+        <h5>{t('Create Team')}</h5>
       </Header>
       <Body>
-        <CreateTeamForm {...props} onSubmit={handleSubmit} />
+        <CreateTeamForm organization={organization} onSubmit={handleSubmit} />
       </Body>
     </Fragment>
   );

--- a/static/app/components/teams/createTeamForm.tsx
+++ b/static/app/components/teams/createTeamForm.tsx
@@ -11,15 +11,15 @@ type Payload = {
 };
 
 type Props = {
-  organization: Organization;
-  onSubmit?: (
+  onSubmit: (
     data: Payload,
     onSuccess: (team: Team) => void,
     onError: (team: Team) => void
   ) => void;
+  organization: Organization;
 };
 
-function CreateTeamForm({organization, ...props}: Props) {
+function CreateTeamForm({organization, onSubmit}: Props) {
   return (
     <Fragment>
       <p>
@@ -31,7 +31,7 @@ function CreateTeamForm({organization, ...props}: Props) {
         apiEndpoint={`/organizations/${organization.slug}/teams/`}
         apiMethod="POST"
         onSubmit={(data, onSuccess, onError) =>
-          props.onSubmit?.(data as Payload, onSuccess, onError)
+          onSubmit(data as Payload, onSuccess, onError)
         }
         requireChanges
       >

--- a/static/app/components/teams/createTeamForm.tsx
+++ b/static/app/components/teams/createTeamForm.tsx
@@ -41,7 +41,7 @@ function CreateTeamForm({organization, onSubmit}: Props) {
           name="slug"
           label={t('Team Slug')}
           transformInput={slugify}
-          placeholder={t('e.g. api-team, web-frontend, mobile-ios')}
+          placeholder={t('e.g. operations, web-frontend, mobile-ios')}
           help={t('Use lowercase letters, numbers, dashes, and underscores.')}
           flexibleControlStateSize
           inline={false}

--- a/static/app/components/teams/createTeamForm.tsx
+++ b/static/app/components/teams/createTeamForm.tsx
@@ -12,22 +12,18 @@ type Payload = {
 
 type Props = {
   organization: Organization;
-  formProps?: Partial<typeof Form>;
   onSubmit?: (
     data: Payload,
     onSuccess: (team: Team) => void,
     onError: (team: Team) => void
   ) => void;
-  onSuccess?: (data: Payload) => void;
 };
 
-function CreateTeamForm({organization, formProps, ...props}: Props) {
+function CreateTeamForm({organization, ...props}: Props) {
   return (
     <Fragment>
       <p>
-        {t(
-          'Members of a team have access to specific areas, such as a new release or a new application feature.'
-        )}
+        {t('Teams group members for issue assignment, ownership, and notifications.')}
       </p>
 
       <Form
@@ -37,19 +33,16 @@ function CreateTeamForm({organization, formProps, ...props}: Props) {
         onSubmit={(data, onSuccess, onError) =>
           props.onSubmit?.(data as Payload, onSuccess, onError)
         }
-        onSubmitSuccess={data => props.onSuccess?.(data)}
         requireChanges
-        data-test-id="create-team-form"
-        {...formProps}
       >
         <TextField
           stacked
           required
           name="slug"
-          label={t('Team Name')}
+          label={t('Team Slug')}
           transformInput={slugify}
-          placeholder={t('e.g. operations, web-frontend, desktop')}
-          help={t('May contain lowercase letters, numbers, dashes and underscores.')}
+          placeholder={t('e.g. api-team, web-frontend, mobile-ios')}
+          help={t('Use lowercase letters, numbers, dashes, and underscores.')}
           flexibleControlStateSize
           inline={false}
           autoFocus

--- a/static/app/data/forms/teamSettingsFields.tsx
+++ b/static/app/data/forms/teamSettingsFields.tsx
@@ -16,7 +16,7 @@ const formGroups: JsonFormObject[] = [
         type: 'string',
         required: true,
         label: t('Team Slug'),
-        placeholder: 'e.g. api-team',
+        placeholder: 'e.g. operations, web-frontend, mobile-ios',
         help: t('A unique ID used to identify the team'),
         transformInput: slugify,
         disabled: ({hasTeamWrite}) => !hasTeamWrite,

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -109,7 +109,6 @@ export function DropdownAddTeam({
             onClick={() => {
               openCreateTeamModal({
                 organization,
-                project,
                 onClose: onCreateTeam,
               });
               closeOverlay();

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -301,7 +301,7 @@ describe('ProjectTeams', () => {
     renderGlobalModal();
     const modal = await screen.findByRole('dialog');
 
-    await userEvent.type(screen.getByRole('textbox', {name: 'Team Name'}), 'new-team');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Team Slug'}), 'new-team');
     await userEvent.click(within(modal).getByRole('button', {name: 'Create Team'}));
 
     await waitFor(() => expect(createTeam).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
- make the header larger
- Remove unused props, remove spreading modal props into the form
- rename input to "Team slug" to match team settings. Team name no longer really exists.

before

<img width="617" height="322" alt="image" src="https://github.com/user-attachments/assets/dc413340-d7ed-4fb8-8525-7b4071a1e726" />


after

<img width="613" height="299" alt="image" src="https://github.com/user-attachments/assets/fb081668-f82b-4d8d-962e-e312440bfc49" />
