### PR TITLE
fix(uptime): Allow disabled uptime monitors to be accessed via project endpoint

### DIFF
--- a/src/sentry/uptime/endpoints/bases.py
+++ b/src/sentry/uptime/endpoints/bases.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.constants import ObjectStatus
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
@@ -30,6 +31,7 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
                 id=uptime_detector_id,
                 type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
                 data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+                status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED],
             )
         except Detector.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/uptime/endpoints/bases.py
+++ b/src/sentry/uptime/endpoints/bases.py
@@ -3,7 +3,6 @@ from rest_framework.request import Request
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.constants import ObjectStatus
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
@@ -31,7 +30,6 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
                 id=uptime_detector_id,
                 type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
                 data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
-                status=ObjectStatus.ACTIVE,
             )
         except Detector.DoesNotExist:
             raise ResourceDoesNotExist


### PR DESCRIPTION
## Summary

Fixes an issue where disabled uptime monitors were not accessible via the project endpoint.

**User-facing issue:**
1. User creates an uptime monitor through the new monitors flow
2. User disables the monitor (e.g., to temporarily pause monitoring)
3. User navigates to the legacy Insights → Uptime UI to view or edit the monitor
4. The page fails to load the monitor, showing "The requested resource does not exist"

This happened because the legacy Insights/Uptime UI uses the project endpoint (`/api/0/projects/{org}/{project}/uptime/{id}/`), which was filtering out disabled monitors.

**Root Cause:** The `ProjectUptimeAlertEndpoint.convert_args()` method filtered by `status=ObjectStatus.ACTIVE`. When monitors are disabled via the new monitors flow, `toggle_detector()` sets `status=ObjectStatus.DISABLED`, causing these monitors to be filtered out.

**Fix:** Changed the filter to explicitly allow both `ACTIVE` and `DISABLED` statuses: `status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED]`. This is more explicit about which statuses are allowed rather than removing the filter entirely.

### Why this is safe

1. **Deletion states are still excluded** - Detectors with `PENDING_DELETION` or `DELETION_IN_PROGRESS` status are still filtered out
2. **List endpoints unchanged** - The index/count endpoints still filter by `ACTIVE` only, so disabled monitors won't appear in lists (correct UX)
3. **Matches existing behavior** - The organization detector details endpoint (`/api/0/organizations/{org}/detectors/{id}/`) does NOT filter by status, so this aligns the project endpoint with that behavior

Fixes NEW-732