### PR TITLE
fix(dashboards): fix slideout panels in page summary not filtering based on global filter on transaction

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -92,7 +92,7 @@ function SortableWidget(props: Props) {
       dashboardCreator
     ) && !isPrebuiltDashboard;
 
-  const {hasSlideout, onWidgetClick} = useWidgetSlideout(widget);
+  const {hasSlideout, onWidgetClick} = useWidgetSlideout(widget, dashboardFilters);
 
   const disableTransactionWidget =
     organization.features.includes('discover-saved-queries-deprecation') &&

--- a/static/app/views/dashboards/utils/useWidgetSlideout.tsx
+++ b/static/app/views/dashboards/utils/useWidgetSlideout.tsx
@@ -2,12 +2,19 @@ import {useCallback} from 'react';
 
 import useDrawer from 'sentry/components/globalDrawer';
 import {t} from 'sentry/locale';
-import {SlideoutId, type Widget} from 'sentry/views/dashboards/types';
+import {
+  SlideoutId,
+  type DashboardFilters,
+  type Widget,
+} from 'sentry/views/dashboards/types';
 import {PageOverviewWebVitalsDetailPanel} from 'sentry/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel';
 import {WebVitalsDetailPanel} from 'sentry/views/insights/browser/webVitals/components/webVitalsDetailPanel';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 
-function getSlideoutComponent(slideOutId: SlideoutId): React.ReactNode | null {
+function getSlideoutComponent(
+  slideOutId: SlideoutId,
+  dashboardFilters?: DashboardFilters
+): React.ReactNode | null {
   switch (slideOutId) {
     case SlideoutId.LCP:
     case SlideoutId.FCP:
@@ -21,24 +28,25 @@ function getSlideoutComponent(slideOutId: SlideoutId): React.ReactNode | null {
     case SlideoutId.CLS_SUMMARY:
     case SlideoutId.TTFB_SUMMARY: {
       const webVital = slideOutId.split('-')[0] as WebVitals;
-      // TODO: The PageOverviewWebVitalsDetailPanel currently filters
-      // for a specific page name by checking url paramaters. This should
-      // be updated so the page name filter can be obtained from the
-      // widget and passed into PageOverviewWebVitalsDetailPanel. This
-      // is so the component still works in dashboards where the url
-      // params don't exist.
-      return <PageOverviewWebVitalsDetailPanel webVital={webVital} />;
+      return (
+        <PageOverviewWebVitalsDetailPanel
+          webVital={webVital}
+          dashboardFilters={dashboardFilters}
+        />
+      );
     }
     default:
       return null;
   }
 }
 
-export function useWidgetSlideout(widget: Widget) {
+export function useWidgetSlideout(widget: Widget, dashboardFilters?: DashboardFilters) {
   // We assume the slideout id (if it exists) is always on the first query
   const slideOutId = widget.queries[0]?.slideOutId;
 
-  const component = slideOutId ? getSlideoutComponent(slideOutId) : null;
+  const component = slideOutId
+    ? getSlideoutComponent(slideOutId, dashboardFilters)
+    : null;
 
   const {openDrawer} = useDrawer();
 


### PR DESCRIPTION
The prebuilt Web Vitals Page Summary dashboard relies on dashboard global filters on `transaction`, however the sample slideouts don't currently respect this global filter. Updates slideout so that they now receive and respec the `transaction` global filter.