### PR TITLE
ref(grouping): Make Windows multiprocess grouping inputs more realistic

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/python-multiprocessing-hardcoded-values-in-context-line-bad-rules-windows.json
+++ b/tests/sentry/grouping/grouping_inputs/python-multiprocessing-hardcoded-values-in-context-line-bad-rules-windows.json
@@ -1,170 +1,304 @@
 {
-  "TODO": "The stack here is really a posix stack, not a Windows stack; the only thing Windows-y about this is the arguments passed to 'spawn_main' in the first frame. Admittedly that line is the whole point of having this input - the rest is sort of beside the point - but still, it would be nice to make this more realistic. Once the code for handling python multiprocessing context lines is in prod and we start logging instances of this in projects other than our own internal sentry project, it would be good to find an example which actually is from Windows, and use that to fix this stacktrace. (We'll also need to adjust the bad grouping rule below to match a function in the new stack.)",
   "_grouping": {
-    "enhancements": "stack.function:post_process_group +app v+app +group v+group"
+    "enhancements": "stack.function:run_app +app v+app +group v+group"
   },
   "platform": "python",
-  "message": "Failed to process pipeline step process_rules",
-  "exception": {
+  "message": "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)",
+  "threads": {
     "values": [
       {
-        "type": "TimeoutError",
-        "value": "timed out",
         "stacktrace": {
           "frames": [
             {
               "function": "<module>",
               "module": "__main__",
               "filename": "<string>",
-              "abs_path": "/usr/src/getsentry/<string>",
+              "abs_path": "D:\\engine\\<string>",
               "context_line": "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
             },
             {
               "function": "spawn_main",
               "module": "multiprocessing.spawn",
-              "filename": "multiprocessing/spawn.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "filename": "multiprocessing\\spawn.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\spawn.py",
               "context_line": "exitcode = _main(fd, parent_sentinel)"
             },
             {
               "function": "_main",
               "module": "multiprocessing.spawn",
-              "filename": "multiprocessing/spawn.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "filename": "multiprocessing\\spawn.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\spawn.py",
               "context_line": "return self._bootstrap(parent_sentinel)"
             },
             {
               "function": "_bootstrap",
               "module": "multiprocessing.process",
-              "filename": "multiprocessing/process.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "filename": "multiprocessing\\process.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\process.py",
               "context_line": "self.run()"
             },
             {
               "function": "run",
               "module": "multiprocessing.process",
-              "filename": "multiprocessing/process.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "filename": "multiprocessing\\process.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\process.py",
               "context_line": "self._target(*self._args, **self._kwargs)"
             },
             {
-              "function": "child_process",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "run_worker("
+              "function": "subprocess_started",
+              "module": "uvicorn._subprocess",
+              "filename": "uvicorn\\_subprocess.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\_subprocess.py",
+              "context_line": "target(sockets=sockets)"
             },
             {
-              "function": "run_worker",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "_execute_activation(task_func, inflight.activation)"
+              "function": "run",
+              "module": "uvicorn.server",
+              "filename": "uvicorn\\server.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\server.py",
+              "context_line": "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             },
             {
-              "function": "_execute_activation",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "task_func(*args, **kwargs)"
+              "function": "run",
+              "module": "asyncio.runners",
+              "filename": "asyncio\\runners.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\runners.py",
+              "context_line": "return runner.run(main)"
+            },
+            {
+              "function": "run",
+              "module": "asyncio.runners",
+              "filename": "asyncio\\runners.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\runners.py",
+              "context_line": "return self._loop.run_until_complete(task)"
+            },
+            {
+              "function": "run_until_complete",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "self.run_forever()"
+            },
+            {
+              "function": "run_forever",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "self._run_once()"
+            },
+            {
+              "function": "_run_once",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "handle._run()"
+            },
+            {
+              "function": "_run",
+              "module": "asyncio.events",
+              "filename": "asyncio\\events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\events.py",
+              "context_line": "self._context.run(self._callback, *self._args)"
+            },
+            {
+              "function": "main",
+              "module": "uvicorn.lifespan.on",
+              "filename": "uvicorn\\lifespan\\on.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\lifespan\\on.py",
+              "context_line": "await app(scope, self.receive, self.send)"
             },
             {
               "function": "__call__",
-              "module": "sentry.taskworker.task",
-              "filename": "sentry/taskworker/task.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/task.py",
-              "context_line": "return self._func(*args, **kwargs)"
+              "module": "uvicorn.middleware.proxy_headers",
+              "filename": "uvicorn\\middleware\\proxy_headers.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\middleware\\proxy_headers.py",
+              "context_line": "return await self.app(scope, receive, send)"
             },
             {
-              "function": "post_process_group",
-              "module": "sentry.tasks.post_process",
-              "filename": "sentry/tasks/post_process.py",
-              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
-              "context_line": "run_post_process_job("
+              "function": "__call__",
+              "module": "fastapi.applications",
+              "filename": "fastapi\\applications.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\applications.py",
+              "context_line": "await super().__call__(scope, receive, send)"
             },
             {
-              "function": "run_post_process_job",
-              "module": "sentry.tasks.post_process",
-              "filename": "sentry/tasks/post_process.py",
-              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
-              "context_line": "logger.exception("
+              "function": "__call__",
+              "module": "starlette.applications",
+              "filename": "starlette\\applications.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\applications.py",
+              "context_line": "await self.middleware_stack(scope, receive, send)"
             },
             {
-              "function": "exception",
-              "module": "logging",
-              "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
-              "context_line": "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "function": "__call__",
+              "module": "starlette.middleware.errors",
+              "filename": "starlette\\middleware\\errors.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\errors.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.base",
+              "filename": "starlette\\middleware\\base.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\base.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.cors",
+              "filename": "starlette\\middleware\\cors.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\cors.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.exceptions",
+              "filename": "starlette\\middleware\\exceptions.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\exceptions.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "fastapi.middleware.asyncexitstack",
+              "filename": "fastapi\\middleware\\asyncexitstack.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\middleware\\asyncexitstack.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "await self.middleware_stack(scope, receive, send)"
+            },
+            {
+              "function": "app",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "await self.lifespan(scope, receive, send)"
+            },
+            {
+              "function": "lifespan",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "async with self.lifespan_context(app) as maybe_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "run_app",
+              "module": "app.main",
+              "filename": "app\\main.py",
+              "abs_path": "D:\\engine\\app\\main.py",
+              "context_line": "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            },
+            {
+              "function": "do_log",
+              "module": "app.main",
+              "filename": "app\\main.py",
+              "abs_path": "D:\\engine\\app\\main.py",
+              "context_line": "getattr(logger, level)(msg, *args, **kwargs)"
             },
             {
               "function": "error",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self._log(ERROR, msg, args, **kwargs)"
             },
             {
               "function": "_log",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.handle(record)"
             },
             {
               "function": "handle",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.callHandlers(record)"
             },
             {
               "function": "callHandlers",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "hdlr.handle(record)"
             },
             {
               "function": "handle",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.emit(record)"
-            },
-            {
-              "function": "connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "sock = self._connect()"
-            },
-            {
-              "function": "_connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "raise err"
-            },
-            {
-              "function": "_connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "sock.connect(socket_address)"
             }
           ]
         },
-        "mechanism": {
-          "type": "logging",
-          "handled": true
-        }
+        "crashed": false,
+        "current": true
       }
     ]
   },
   "logentry": {
-    "message": "Failed to process pipeline step %s",
-    "formatted": "Failed to process pipeline step process_rules",
-    "params": ["process_rules"]
+    "formatted": "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)",
+    "params": []
   },
-  "logger": "sentry.tasks.post_process"
+  "logger": "app.main"
 }

--- a/tests/sentry/grouping/grouping_inputs/python-multiprocessing-hardcoded-values-in-context-line-windows.json
+++ b/tests/sentry/grouping/grouping_inputs/python-multiprocessing-hardcoded-values-in-context-line-windows.json
@@ -1,167 +1,301 @@
 {
-  "TODO": "The stack here is really a posix stack, not a Windows stack; the only thing Windows-y about this is the arguments passed to 'spawn_main' in the first frame. Admittedly that line is the whole point of having this input - the rest is sort of beside the point - but still, it would be nice to make this more realistic. Once the code for handling python multiprocessing context lines is in prod and we start logging instances of this in projects other than our own internal sentry project, it would be good to find an example which actually is from Windows, and use that to fix this stacktrace.",
   "platform": "python",
-  "message": "Failed to process pipeline step process_rules",
-  "exception": {
+  "message": "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)",
+  "threads": {
     "values": [
       {
-        "type": "TimeoutError",
-        "value": "timed out",
         "stacktrace": {
           "frames": [
             {
               "function": "<module>",
               "module": "__main__",
               "filename": "<string>",
-              "abs_path": "/usr/src/getsentry/<string>",
+              "abs_path": "D:\\engine\\<string>",
               "context_line": "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
             },
             {
               "function": "spawn_main",
               "module": "multiprocessing.spawn",
-              "filename": "multiprocessing/spawn.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "filename": "multiprocessing\\spawn.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\spawn.py",
               "context_line": "exitcode = _main(fd, parent_sentinel)"
             },
             {
               "function": "_main",
               "module": "multiprocessing.spawn",
-              "filename": "multiprocessing/spawn.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "filename": "multiprocessing\\spawn.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\spawn.py",
               "context_line": "return self._bootstrap(parent_sentinel)"
             },
             {
               "function": "_bootstrap",
               "module": "multiprocessing.process",
-              "filename": "multiprocessing/process.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "filename": "multiprocessing\\process.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\process.py",
               "context_line": "self.run()"
             },
             {
               "function": "run",
               "module": "multiprocessing.process",
-              "filename": "multiprocessing/process.py",
-              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "filename": "multiprocessing\\process.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\multiprocessing\\process.py",
               "context_line": "self._target(*self._args, **self._kwargs)"
             },
             {
-              "function": "child_process",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "run_worker("
+              "function": "subprocess_started",
+              "module": "uvicorn._subprocess",
+              "filename": "uvicorn\\_subprocess.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\_subprocess.py",
+              "context_line": "target(sockets=sockets)"
             },
             {
-              "function": "run_worker",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "_execute_activation(task_func, inflight.activation)"
+              "function": "run",
+              "module": "uvicorn.server",
+              "filename": "uvicorn\\server.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\server.py",
+              "context_line": "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             },
             {
-              "function": "_execute_activation",
-              "module": "sentry.taskworker.workerchild",
-              "filename": "sentry/taskworker/workerchild.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
-              "context_line": "task_func(*args, **kwargs)"
+              "function": "run",
+              "module": "asyncio.runners",
+              "filename": "asyncio\\runners.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\runners.py",
+              "context_line": "return runner.run(main)"
+            },
+            {
+              "function": "run",
+              "module": "asyncio.runners",
+              "filename": "asyncio\\runners.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\runners.py",
+              "context_line": "return self._loop.run_until_complete(task)"
+            },
+            {
+              "function": "run_until_complete",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "self.run_forever()"
+            },
+            {
+              "function": "run_forever",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "self._run_once()"
+            },
+            {
+              "function": "_run_once",
+              "module": "asyncio.base_events",
+              "filename": "asyncio\\base_events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\base_events.py",
+              "context_line": "handle._run()"
+            },
+            {
+              "function": "_run",
+              "module": "asyncio.events",
+              "filename": "asyncio\\events.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\asyncio\\events.py",
+              "context_line": "self._context.run(self._callback, *self._args)"
+            },
+            {
+              "function": "main",
+              "module": "uvicorn.lifespan.on",
+              "filename": "uvicorn\\lifespan\\on.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\lifespan\\on.py",
+              "context_line": "await app(scope, self.receive, self.send)"
             },
             {
               "function": "__call__",
-              "module": "sentry.taskworker.task",
-              "filename": "sentry/taskworker/task.py",
-              "abs_path": "/usr/src/sentry/src/sentry/taskworker/task.py",
-              "context_line": "return self._func(*args, **kwargs)"
+              "module": "uvicorn.middleware.proxy_headers",
+              "filename": "uvicorn\\middleware\\proxy_headers.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\uvicorn\\middleware\\proxy_headers.py",
+              "context_line": "return await self.app(scope, receive, send)"
             },
             {
-              "function": "post_process_group",
-              "module": "sentry.tasks.post_process",
-              "filename": "sentry/tasks/post_process.py",
-              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
-              "context_line": "run_post_process_job("
+              "function": "__call__",
+              "module": "fastapi.applications",
+              "filename": "fastapi\\applications.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\applications.py",
+              "context_line": "await super().__call__(scope, receive, send)"
             },
             {
-              "function": "run_post_process_job",
-              "module": "sentry.tasks.post_process",
-              "filename": "sentry/tasks/post_process.py",
-              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
-              "context_line": "logger.exception("
+              "function": "__call__",
+              "module": "starlette.applications",
+              "filename": "starlette\\applications.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\applications.py",
+              "context_line": "await self.middleware_stack(scope, receive, send)"
             },
             {
-              "function": "exception",
-              "module": "logging",
-              "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
-              "context_line": "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "function": "__call__",
+              "module": "starlette.middleware.errors",
+              "filename": "starlette\\middleware\\errors.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\errors.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.base",
+              "filename": "starlette\\middleware\\base.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\base.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.cors",
+              "filename": "starlette\\middleware\\cors.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\cors.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.middleware.exceptions",
+              "filename": "starlette\\middleware\\exceptions.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\middleware\\exceptions.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "fastapi.middleware.asyncexitstack",
+              "filename": "fastapi\\middleware\\asyncexitstack.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\middleware\\asyncexitstack.py",
+              "context_line": "await self.app(scope, receive, send)"
+            },
+            {
+              "function": "__call__",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "await self.middleware_stack(scope, receive, send)"
+            },
+            {
+              "function": "app",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "await self.lifespan(scope, receive, send)"
+            },
+            {
+              "function": "lifespan",
+              "module": "starlette.routing",
+              "filename": "starlette\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\starlette\\routing.py",
+              "context_line": "async with self.lifespan_context(app) as maybe_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "merged_lifespan",
+              "module": "fastapi.routing",
+              "filename": "fastapi\\routing.py",
+              "abs_path": "D:\\engine\\.venv\\Lib\\site-packages\\fastapi\\routing.py",
+              "context_line": "async with original_context(app) as maybe_original_state:"
+            },
+            {
+              "function": "run_app",
+              "module": "app.main",
+              "filename": "app\\main.py",
+              "abs_path": "D:\\engine\\app\\main.py",
+              "context_line": "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            },
+            {
+              "function": "do_log",
+              "module": "app.main",
+              "filename": "app\\main.py",
+              "abs_path": "D:\\engine\\app\\main.py",
+              "context_line": "getattr(logger, level)(msg, *args, **kwargs)"
             },
             {
               "function": "error",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self._log(ERROR, msg, args, **kwargs)"
             },
             {
               "function": "_log",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.handle(record)"
             },
             {
               "function": "handle",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.callHandlers(record)"
             },
             {
               "function": "callHandlers",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "hdlr.handle(record)"
             },
             {
               "function": "handle",
               "module": "logging",
               "filename": "__init__.py",
-              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "abs_path": "C:\\Users\\maisey\\AppData\\Fetch\\uv\\python\\cpython-3.13.1-windows-x86_64-none\\Lib\\logging\\__init__.py",
               "context_line": "self.emit(record)"
-            },
-            {
-              "function": "connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "sock = self._connect()"
-            },
-            {
-              "function": "_connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "raise err"
-            },
-            {
-              "function": "_connect",
-              "module": "redis.connection",
-              "filename": "redis/connection.py",
-              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
-              "context_line": "sock.connect(socket_address)"
             }
           ]
         },
-        "mechanism": {
-          "type": "logging",
-          "handled": true
-        }
+        "crashed": false,
+        "current": true
       }
     ]
   },
   "logentry": {
-    "message": "Failed to process pipeline step %s",
-    "formatted": "Failed to process pipeline step process_rules",
-    "params": ["process_rules"]
+    "formatted": "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)",
+    "params": []
   },
-  "logger": "sentry.tasks.post_process"
+  "logger": "app.main"
 }

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
-  "stacktrace_location": "exception",
+  "stacktrace_location": "thread",
   "stacktrace_type": "in_app"
 }
 ---
@@ -15,99 +15,265 @@ metrics with tags: {
   },
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
-    "stacktrace_location": "exception",
+    "stacktrace_location": "thread",
     "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
   app*
-    hash: "e9e285f37b2b82b2a3e0fdaf8e1655c1"
-    contributing component: exception
+    hash: "38660ba262e9baab1dcf0a432479f643"
+    contributing component: threads
     hint: None
     root_component:
       app*
-        exception*
+        threads*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "target(sockets=sockets)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return runner.run(main)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
               module*
-                "sentry.taskworker.task"
+                "asyncio.runners"
+              function*
+                "run"
+              context_line*
+                "return self._loop.run_until_complete(task)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
-          type*
-            "TimeoutError"
+                "await super().__call__(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.applications"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.errors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
   system*
-    hash: "7c1fcfc8523ad78a4d0424bfd03bdb13"
-    contributing component: exception
+    hash: "46b9ac9970eba6e39408d3392e619471"
+    contributing component: threads
     hint: None
     root_component:
       system*
-        exception*
+        threads*
           stacktrace*
             frame*
               module*
@@ -146,53 +312,214 @@ contributing variants:
                 "self._target(*self._args, **self._kwargs)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
+                "target(sockets=sockets)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
+                "return runner.run(main)"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "asyncio.runners"
+              function*
+                "run"
+              context_line*
+                "return self._loop.run_until_complete(task)"
             frame*
               module*
-                "sentry.taskworker.task"
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame*
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame*
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame*
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
+                "return await self.app(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
+                "await super().__call__(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "starlette.applications"
               function*
-                "run_post_process_job"
+                "__call__"
               context_line*
-                "logger.exception("
+                "await self.middleware_stack(scope, receive, send)"
             frame*
               module*
-                "logging"
+                "starlette.middleware.errors"
               function*
-                "exception"
+                "__call__"
               context_line*
-                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame*
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame*
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            frame*
+              module*
+                "app.main"
+              function*
+                "do_log"
+              context_line*
+                "getattr(logger, level)(msg, *args, **kwargs)"
             frame*
               module*
                 "logging"
@@ -228,19 +555,3 @@ contributing variants:
                 "handle"
               context_line*
                 "self.emit(record)"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "connect"
-              context_line*
-                "sock = self._connect()"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "_connect"
-              context_line*
-                "raise err"
-          type*
-            "TimeoutError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
-  "stacktrace_location": "exception",
+  "stacktrace_location": "thread",
   "stacktrace_type": "system"
 }
 ---
@@ -15,19 +15,19 @@ metrics with tags: {
   },
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
-    "stacktrace_location": "exception",
+    "stacktrace_location": "thread",
     "stacktrace_type": "system"
   }
 }
 ---
 contributing variants:
   system*
-    hash: "7c1fcfc8523ad78a4d0424bfd03bdb13"
-    contributing component: exception
+    hash: "06218188159a10d97cca346ebca30dda"
+    contributing component: threads
     hint: None
     root_component:
       system*
-        exception*
+        threads*
           stacktrace*
             frame*
               module*
@@ -66,53 +66,158 @@ contributing variants:
                 "self._target(*self._args, **self._kwargs)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
+                "target(sockets=sockets)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
+                "return runner.run(main)"
             frame*
               module*
-                "sentry.taskworker.task"
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame*
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame*
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame*
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
+                "return await self.app(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
+                "await super().__call__(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "starlette.applications"
               function*
-                "run_post_process_job"
+                "__call__"
               context_line*
-                "logger.exception("
+                "await self.middleware_stack(scope, receive, send)"
             frame*
               module*
-                "logging"
+                "starlette.middleware.errors"
               function*
-                "exception"
+                "__call__"
               context_line*
-                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame*
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame*
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            frame*
+              module*
+                "app.main"
+              function*
+                "do_log"
+              context_line*
+                "getattr(logger, level)(msg, *args, **kwargs)"
             frame*
               module*
                 "logging"
@@ -148,19 +253,3 @@ contributing variants:
                 "handle"
               context_line*
                 "self.emit(record)"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "connect"
-              context_line*
-                "sock = self._connect()"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "_connect"
-              context_line*
-                "raise err"
-          type*
-            "TimeoutError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
-  "stacktrace_location": "exception",
+  "stacktrace_location": "thread",
   "stacktrace_type": "in_app"
 }
 ---
@@ -15,103 +15,267 @@ metrics with tags: {
   },
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
-    "stacktrace_location": "exception",
+    "stacktrace_location": "thread",
     "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
   app*
-    hash: "126f65e182d6fbc222480cf9f391a3e1"
-    contributing component: exception
+    hash: "620b9e72c9565c3ef54e519ec997b57a"
+    contributing component: threads
     hint: None
     root_component:
       app*
-        exception*
-          type*
-            "TimeoutError"
+        threads*
           stacktrace*
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
               module*
                 "__main__"
               function*
                 "<module>"
               context_line*
                 "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "spawn_main"
               context_line*
                 "exitcode = _main(fd, parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.spawn"
               function*
                 "_main"
               context_line*
                 "return self._bootstrap(parent_sentinel)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "_bootstrap"
               context_line*
                 "self.run()"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
                 "multiprocessing.process"
               function*
                 "run"
               context_line*
                 "self._target(*self._args, **self._kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "target(sockets=sockets)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return runner.run(main)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
               module*
-                "sentry.taskworker.task"
+                "asyncio.runners"
+              function*
+                "run"
+              context_line*
+                "return self._loop.run_until_complete(task)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
-            frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+                "return await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
+                "await super().__call__(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.applications"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.errors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
   system*
-    hash: "bce0926d11f0ebe7d72ab74b56717aa6"
-    contributing component: exception
+    hash: "ed32779a2628338d3534c4e182caf8e8"
+    contributing component: threads
     hint: None
     root_component:
       system*
-        exception*
-          type*
-            "TimeoutError"
+        threads*
           stacktrace*
-            frame* (un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
               module*
                 "__main__"
               function*
@@ -148,53 +312,214 @@ contributing variants:
                 "self._target(*self._args, **self._kwargs)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
+                "target(sockets=sockets)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
+                "return runner.run(main)"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "asyncio.runners"
+              function*
+                "run"
+              context_line*
+                "return self._loop.run_until_complete(task)"
             frame*
               module*
-                "sentry.taskworker.task"
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame*
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame*
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame*
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
+                "return await self.app(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
+                "await super().__call__(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "starlette.applications"
               function*
-                "run_post_process_job"
+                "__call__"
               context_line*
-                "logger.exception("
+                "await self.middleware_stack(scope, receive, send)"
             frame*
               module*
-                "logging"
+                "starlette.middleware.errors"
               function*
-                "exception"
+                "__call__"
               context_line*
-                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame*
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame*
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            frame*
+              module*
+                "app.main"
+              function*
+                "do_log"
+              context_line*
+                "getattr(logger, level)(msg, *args, **kwargs)"
             frame*
               module*
                 "logging"
@@ -230,17 +555,3 @@ contributing variants:
                 "handle"
               context_line*
                 "self.emit(record)"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "connect"
-              context_line*
-                "sock = self._connect()"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "_connect"
-              context_line*
-                "raise err"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
-  "stacktrace_location": "exception",
+  "stacktrace_location": "thread",
   "stacktrace_type": "system"
 }
 ---
@@ -15,21 +15,19 @@ metrics with tags: {
   },
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
-    "stacktrace_location": "exception",
+    "stacktrace_location": "thread",
     "stacktrace_type": "system"
   }
 }
 ---
 contributing variants:
   system*
-    hash: "1bc764ab44acfab9a38f23ae670038bd"
-    contributing component: exception
+    hash: "a18195beb2cfb93ea25c9331c988dbee"
+    contributing component: threads
     hint: None
     root_component:
       system*
-        exception*
-          type*
-            "TimeoutError"
+        threads*
           stacktrace*
             frame*
               module*
@@ -61,53 +59,158 @@ contributing variants:
                 "self._target(*self._args, **self._kwargs)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn._subprocess"
               function*
-                "child_process"
+                "subprocess_started"
               context_line*
-                "run_worker("
+                "target(sockets=sockets)"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "uvicorn.server"
               function*
-                "run_worker"
+                "run"
               context_line*
-                "_execute_activation(task_func, inflight.activation)"
+                "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
             frame*
               module*
-                "sentry.taskworker.workerchild"
+                "asyncio.runners"
               function*
-                "_execute_activation"
+                "run"
               context_line*
-                "task_func(*args, **kwargs)"
+                "return runner.run(main)"
             frame*
               module*
-                "sentry.taskworker.task"
+                "asyncio.base_events"
+              function*
+                "run_until_complete"
+              context_line*
+                "self.run_forever()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "run_forever"
+              context_line*
+                "self._run_once()"
+            frame*
+              module*
+                "asyncio.base_events"
+              function*
+                "_run_once"
+              context_line*
+                "handle._run()"
+            frame*
+              module*
+                "asyncio.events"
+              function*
+                "_run"
+              context_line*
+                "self._context.run(self._callback, *self._args)"
+            frame*
+              module*
+                "uvicorn.lifespan.on"
+              function*
+                "main"
+              context_line*
+                "await app(scope, self.receive, self.send)"
+            frame*
+              module*
+                "uvicorn.middleware.proxy_headers"
               function*
                 "__call__"
               context_line*
-                "return self._func(*args, **kwargs)"
+                "return await self.app(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "fastapi.applications"
               function*
-                "post_process_group"
+                "__call__"
               context_line*
-                "run_post_process_job("
+                "await super().__call__(scope, receive, send)"
             frame*
               module*
-                "sentry.tasks.post_process"
+                "starlette.applications"
               function*
-                "run_post_process_job"
+                "__call__"
               context_line*
-                "logger.exception("
+                "await self.middleware_stack(scope, receive, send)"
             frame*
               module*
-                "logging"
+                "starlette.middleware.errors"
               function*
-                "exception"
+                "__call__"
               context_line*
-                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.base"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.cors"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.middleware.exceptions"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "fastapi.middleware.asyncexitstack"
+              function*
+                "__call__"
+              context_line*
+                "await self.app(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "__call__"
+              context_line*
+                "await self.middleware_stack(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "app"
+              context_line*
+                "await self.lifespan(scope, receive, send)"
+            frame*
+              module*
+                "starlette.routing"
+              function*
+                "lifespan"
+              context_line*
+                "async with self.lifespan_context(app) as maybe_state:"
+            frame*
+              module*
+                "fastapi.routing"
+              function*
+                "merged_lifespan"
+              context_line*
+                "async with original_context(app) as maybe_original_state:"
+            frame*
+              module*
+                "app.main"
+              function*
+                "run_app"
+              context_line*
+                "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+            frame*
+              module*
+                "app.main"
+              function*
+                "do_log"
+              context_line*
+                "getattr(logger, level)(msg, *args, **kwargs)"
             frame*
               module*
                 "logging"
@@ -143,17 +246,3 @@ contributing variants:
                 "handle"
               context_line*
                 "self.emit(record)"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "connect"
-              context_line*
-                "sock = self._connect()"
-            frame*
-              module*
-                "redis.connection"
-              function*
-                "_connect"
-              context_line*
-                "raise err"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2023-01-11",
   "variants": {
-    "app_exception_stacktrace": {
+    "app_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,27 +14,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -43,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -263,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -282,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -291,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -300,14 +282,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -317,7 +299,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -326,7 +308,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -335,7 +317,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -344,14 +326,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -361,7 +343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -370,7 +352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -379,7 +361,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -388,14 +370,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -405,7 +387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -414,7 +396,271 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -432,14 +678,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -449,7 +695,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -458,7 +704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -467,7 +713,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -476,7 +722,799 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.errors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "errors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
                         ]
                       }
                     ]
@@ -493,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -502,7 +1540,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -511,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "do_log"
                         ]
                       },
                       {
@@ -520,51 +1558,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "non app frame",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "logging"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "__init__.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "exception"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -788,138 +1782,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -928,26 +1790,26 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — in-app frames",
-      "hash": "e9e285f37b2b82b2a3e0fdaf8e1655c1",
+      "description": "thread stacktrace — in-app frames",
+      "hash": "38660ba262e9baab1dcf0a432479f643",
       "hint": null,
-      "key": "app_exception_stacktrace",
+      "key": "app_thread_stacktrace",
       "type": "component"
     },
     "message": {
       "component": {
         "contributes": false,
-        "hint": "ignored because app/system exception takes precedence",
+        "hint": "ignored because app/system threads take precedence",
         "id": "default",
         "name": null,
         "values": [
           {
             "contributes": false,
-            "hint": "ignored because app/system exception takes precedence",
+            "hint": "ignored because app/system threads take precedence",
             "id": "message",
             "name": "message",
             "values": [
-              "Failed to process pipeline step %s"
+              "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
             ]
           }
         ]
@@ -955,11 +1817,11 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "contributes": false,
       "description": "message",
       "hash": null,
-      "hint": "ignored because app/system exception takes precedence",
+      "hint": "ignored because app/system threads take precedence",
       "key": "message",
       "type": "component"
     },
-    "system_exception_stacktrace": {
+    "system_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -969,27 +1831,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -1228,7 +2072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -1237,7 +2081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -1246,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -1255,7 +2099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
@@ -1272,7 +2116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -1281,7 +2125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -1290,7 +2134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -1299,7 +2143,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -1316,7 +2160,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -1325,7 +2169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -1334,7 +2178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -1343,7 +2187,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.runners"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -1360,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -1369,7 +2257,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -1387,7 +2495,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1404,7 +2512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -1413,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1422,7 +2530,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -1431,7 +2539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1448,7 +2556,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "starlette.applications"
                         ]
                       },
                       {
@@ -1457,7 +2565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1466,7 +2574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "__call__"
                         ]
                       },
                       {
@@ -1475,7 +2583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "await self.middleware_stack(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1492,7 +2600,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "logging"
+                          "starlette.middleware.errors"
                         ]
                       },
                       {
@@ -1501,7 +2609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "__init__.py"
+                          "errors.py"
                         ]
                       },
                       {
@@ -1510,7 +2618,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "exception"
+                          "__call__"
                         ]
                       },
                       {
@@ -1519,7 +2627,755 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "do_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -1743,138 +3599,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "ignored due to recursion",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -1883,10 +3607,10 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames",
-      "hash": "7c1fcfc8523ad78a4d0424bfd03bdb13",
+      "description": "thread stacktrace — all frames",
+      "hash": "46b9ac9970eba6e39408d3392e619471",
       "hint": null,
-      "key": "system_exception_stacktrace",
+      "key": "system_thread_stacktrace",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,37 +4,19 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2023-01-11",
   "variants": {
-    "app_exception_stacktrace": {
+    "app_thread_stacktrace": {
       "component": {
         "contributes": false,
-        "hint": "ignored because system exception takes precedence",
+        "hint": "ignored because system threads take precedence",
         "id": "app",
         "name": "in-app",
         "values": [
           {
             "contributes": false,
             "hint": "ignored because this variant does not have a contributing stacktrace, but the system variant does",
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": false,
                 "hint": "ignored because it contains no in-app frames",
@@ -263,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -282,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -291,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -300,7 +282,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.server"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "server.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -317,7 +343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -326,7 +352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -335,7 +361,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -344,7 +370,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return runner.run(main)"
                         ]
                       }
                     ]
@@ -361,7 +387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -370,7 +396,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -379,7 +405,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -388,7 +414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -405,7 +431,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -414,7 +440,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -432,7 +678,799 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await super().__call__(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.errors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "errors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
                         ]
                       }
                     ]
@@ -449,7 +1487,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -458,7 +1496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -467,7 +1505,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "run_app"
                         ]
                       },
                       {
@@ -476,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
                         ]
                       }
                     ]
@@ -493,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -502,7 +1540,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -511,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "do_log"
                         ]
                       },
                       {
@@ -520,51 +1558,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "non app frame",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "logging"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "__init__.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "exception"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -788,138 +1782,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -928,26 +1790,26 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": false,
-      "description": "exception stacktrace — in-app frames",
+      "description": "thread stacktrace — in-app frames",
       "hash": null,
-      "hint": "ignored because system exception takes precedence",
-      "key": "app_exception_stacktrace",
+      "hint": "ignored because system threads take precedence",
+      "key": "app_thread_stacktrace",
       "type": "component"
     },
     "message": {
       "component": {
         "contributes": false,
-        "hint": "ignored because system exception takes precedence",
+        "hint": "ignored because system threads take precedence",
         "id": "default",
         "name": null,
         "values": [
           {
             "contributes": false,
-            "hint": "ignored because system exception takes precedence",
+            "hint": "ignored because system threads take precedence",
             "id": "message",
             "name": "message",
             "values": [
-              "Failed to process pipeline step %s"
+              "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
             ]
           }
         ]
@@ -955,11 +1817,11 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "contributes": false,
       "description": "message",
       "hash": null,
-      "hint": "ignored because system exception takes precedence",
+      "hint": "ignored because system threads take precedence",
       "key": "message",
       "type": "component"
     },
-    "system_exception_stacktrace": {
+    "system_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -969,27 +1831,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -1228,7 +2072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -1237,7 +2081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -1246,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -1255,7 +2099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
@@ -1272,7 +2116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -1281,7 +2125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -1290,7 +2134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -1299,7 +2143,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -1316,7 +2160,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -1325,7 +2169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -1334,7 +2178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -1343,7 +2187,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.runners"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -1360,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -1369,7 +2257,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -1387,7 +2495,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1404,7 +2512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -1413,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1422,7 +2530,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -1431,7 +2539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1448,7 +2556,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "starlette.applications"
                         ]
                       },
                       {
@@ -1457,7 +2565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1466,7 +2574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "__call__"
                         ]
                       },
                       {
@@ -1475,7 +2583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "await self.middleware_stack(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1492,7 +2600,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "logging"
+                          "starlette.middleware.errors"
                         ]
                       },
                       {
@@ -1501,7 +2609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "__init__.py"
+                          "errors.py"
                         ]
                       },
                       {
@@ -1510,7 +2618,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "exception"
+                          "__call__"
                         ]
                       },
                       {
@@ -1519,7 +2627,755 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "do_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -1743,138 +3599,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "ignored due to recursion",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -1883,10 +3607,10 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames",
-      "hash": "7c1fcfc8523ad78a4d0424bfd03bdb13",
+      "description": "thread stacktrace — all frames",
+      "hash": "06218188159a10d97cca346ebca30dda",
       "hint": null,
-      "key": "system_exception_stacktrace",
+      "key": "system_thread_stacktrace",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2026-01-20",
   "variants": {
-    "app_exception_stacktrace": {
+    "app_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -14,27 +14,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -43,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -87,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -263,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -282,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -291,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -300,14 +282,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -317,7 +299,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -326,7 +308,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -335,7 +317,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -344,14 +326,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -361,7 +343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -370,7 +352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -379,7 +361,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -388,14 +370,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -405,7 +387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -414,7 +396,271 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -432,14 +678,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": true,
-                    "hint": "marked in-app by custom stack trace rule (function:post_process_group +app v+app)",
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -449,7 +695,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -458,7 +704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -467,7 +713,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -476,7 +722,799 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.errors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "errors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "marked in-app by custom stack trace rule (function:run_app +app v+app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
                         ]
                       }
                     ]
@@ -493,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -502,7 +1540,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -511,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "do_log"
                         ]
                       },
                       {
@@ -520,58 +1558,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "logging"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "__init__.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "exception"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +1609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -659,7 +1653,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -703,7 +1697,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -747,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -788,138 +1782,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -928,26 +1790,26 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — in-app frames",
-      "hash": "126f65e182d6fbc222480cf9f391a3e1",
+      "description": "thread stacktrace — in-app frames",
+      "hash": "620b9e72c9565c3ef54e519ec997b57a",
       "hint": null,
-      "key": "app_exception_stacktrace",
+      "key": "app_thread_stacktrace",
       "type": "component"
     },
     "message": {
       "component": {
         "contributes": false,
-        "hint": "ignored because app/system exception takes precedence",
+        "hint": "ignored because app/system threads take precedence",
         "id": "default",
         "name": null,
         "values": [
           {
             "contributes": false,
-            "hint": "ignored because app/system exception takes precedence",
+            "hint": "ignored because app/system threads take precedence",
             "id": "message",
             "name": "message",
             "values": [
-              "Failed to process pipeline step %s"
+              "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
             ]
           }
         ]
@@ -955,11 +1817,11 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "contributes": false,
       "description": "message",
       "hash": null,
-      "hint": "ignored because app/system exception takes precedence",
+      "hint": "ignored because app/system threads take precedence",
       "key": "message",
       "type": "component"
     },
-    "system_exception_stacktrace": {
+    "system_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -969,27 +1831,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -998,7 +1842,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": true,
-                    "hint": "un-ignored by custom stack trace rule (function:post_process_group +group v+group)",
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1228,7 +2072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -1237,7 +2081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -1246,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -1255,7 +2099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
@@ -1272,7 +2116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -1281,7 +2125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -1290,7 +2134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -1299,7 +2143,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -1316,7 +2160,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -1325,7 +2169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -1334,7 +2178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -1343,7 +2187,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.runners"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -1360,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -1369,7 +2257,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -1387,7 +2495,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1404,7 +2512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -1413,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1422,7 +2530,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -1431,7 +2539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1448,7 +2556,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "starlette.applications"
                         ]
                       },
                       {
@@ -1457,7 +2565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1466,7 +2574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "__call__"
                         ]
                       },
                       {
@@ -1475,7 +2583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "await self.middleware_stack(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1492,7 +2600,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "logging"
+                          "starlette.middleware.errors"
                         ]
                       },
                       {
@@ -1501,7 +2609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "__init__.py"
+                          "errors.py"
                         ]
                       },
                       {
@@ -1510,7 +2618,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "exception"
+                          "__call__"
                         ]
                       },
                       {
@@ -1519,7 +2627,755 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": "un-ignored by custom stack trace rule (function:run_app +group v+group)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "do_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -1743,138 +3599,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "ignored due to recursion",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -1883,10 +3607,10 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames",
-      "hash": "bce0926d11f0ebe7d72ab74b56717aa6",
+      "description": "thread stacktrace — all frames",
+      "hash": "ed32779a2628338d3534c4e182caf8e8",
       "hint": null,
-      "key": "system_exception_stacktrace",
+      "key": "system_thread_stacktrace",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,37 +4,19 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
 {
   "grouping_config": "newstyle:2026-01-20",
   "variants": {
-    "app_exception_stacktrace": {
+    "app_thread_stacktrace": {
       "component": {
         "contributes": false,
-        "hint": "ignored because system exception takes precedence",
+        "hint": "ignored because system threads take precedence",
         "id": "app",
         "name": "in-app",
         "values": [
           {
             "contributes": false,
             "hint": "ignored because this variant does not have a contributing stacktrace, but the system variant does",
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": false,
                 "hint": "ignored because it contains no in-app frames",
@@ -87,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +113,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -263,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -273,7 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -282,7 +264,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -291,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -300,7 +282,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.server"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "server.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -317,7 +343,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -326,7 +352,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -335,7 +361,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -344,7 +370,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return runner.run(main)"
                         ]
                       }
                     ]
@@ -361,7 +387,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -370,7 +396,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -379,7 +405,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -388,7 +414,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -405,7 +431,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -414,7 +440,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -432,7 +678,799 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await super().__call__(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.applications"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "applications.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.errors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "errors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
                         ]
                       }
                     ]
@@ -449,7 +1487,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -458,7 +1496,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -467,7 +1505,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "run_app"
                         ]
                       },
                       {
@@ -476,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
                         ]
                       }
                     ]
@@ -493,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "app.main"
                         ]
                       },
                       {
@@ -502,7 +1540,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "main.py"
                         ]
                       },
                       {
@@ -511,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "do_log"
                         ]
                       },
                       {
@@ -520,58 +1558,14 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "logging"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "__init__.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "exception"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +1609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -659,7 +1653,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -703,7 +1697,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -747,7 +1741,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
+                    "hint": "non app frame",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -788,138 +1782,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (path:**/site-packages/** -app)",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -928,26 +1790,26 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": false,
-      "description": "exception stacktrace — in-app frames",
+      "description": "thread stacktrace — in-app frames",
       "hash": null,
-      "hint": "ignored because system exception takes precedence",
-      "key": "app_exception_stacktrace",
+      "hint": "ignored because system threads take precedence",
+      "key": "app_thread_stacktrace",
       "type": "component"
     },
     "message": {
       "component": {
         "contributes": false,
-        "hint": "ignored because system exception takes precedence",
+        "hint": "ignored because system threads take precedence",
         "id": "default",
         "name": null,
         "values": [
           {
             "contributes": false,
-            "hint": "ignored because system exception takes precedence",
+            "hint": "ignored because system threads take precedence",
             "id": "message",
             "name": "message",
             "values": [
-              "Failed to process pipeline step %s"
+              "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
             ]
           }
         ]
@@ -955,11 +1817,11 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       "contributes": false,
       "description": "message",
       "hash": null,
-      "hint": "ignored because system exception takes precedence",
+      "hint": "ignored because system threads take precedence",
       "key": "message",
       "type": "component"
     },
-    "system_exception_stacktrace": {
+    "system_thread_stacktrace": {
       "component": {
         "contributes": true,
         "hint": null,
@@ -969,27 +1831,9 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
           {
             "contributes": true,
             "hint": null,
-            "id": "exception",
-            "name": "exception",
+            "id": "threads",
+            "name": "thread",
             "values": [
-              {
-                "contributes": true,
-                "hint": null,
-                "id": "type",
-                "name": null,
-                "values": [
-                  "TimeoutError"
-                ]
-              },
-              {
-                "contributes": false,
-                "hint": "ignored because stacktrace takes precedence",
-                "id": "value",
-                "name": null,
-                "values": [
-                  "timed out"
-                ]
-              },
               {
                 "contributes": true,
                 "hint": null,
@@ -1228,7 +2072,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn._subprocess"
                         ]
                       },
                       {
@@ -1237,7 +2081,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "_subprocess.py"
                         ]
                       },
                       {
@@ -1246,7 +2090,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "child_process"
+                          "subprocess_started"
                         ]
                       },
                       {
@@ -1255,7 +2099,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_worker("
+                          "target(sockets=sockets)"
                         ]
                       }
                     ]
@@ -1272,7 +2116,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "uvicorn.server"
                         ]
                       },
                       {
@@ -1281,7 +2125,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "server.py"
                         ]
                       },
                       {
@@ -1290,7 +2134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_worker"
+                          "run"
                         ]
                       },
                       {
@@ -1299,7 +2143,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "_execute_activation(task_func, inflight.activation)"
+                          "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
                         ]
                       }
                     ]
@@ -1316,7 +2160,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.workerchild"
+                          "asyncio.runners"
                         ]
                       },
                       {
@@ -1325,7 +2169,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "workerchild.py"
+                          "runners.py"
                         ]
                       },
                       {
@@ -1334,7 +2178,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "_execute_activation"
+                          "run"
                         ]
                       },
                       {
@@ -1343,7 +2187,51 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "task_func(*args, **kwargs)"
+                          "return runner.run(main)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.runners"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "runners.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._loop.run_until_complete(task)"
                         ]
                       }
                     ]
@@ -1360,7 +2248,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.taskworker.task"
+                          "asyncio.base_events"
                         ]
                       },
                       {
@@ -1369,7 +2257,227 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "task.py"
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_until_complete"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run_forever()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_forever"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._run_once()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.base_events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base_events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run_once"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "handle._run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "asyncio.events"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "events.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._context.run(self._callback, *self._args)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.lifespan.on"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "on.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await app(scope, self.receive, self.send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "uvicorn.middleware.proxy_headers"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "proxy_headers.py"
                         ]
                       },
                       {
@@ -1387,7 +2495,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "return self._func(*args, **kwargs)"
+                          "return await self.app(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1404,7 +2512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "fastapi.applications"
                         ]
                       },
                       {
@@ -1413,7 +2521,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1422,7 +2530,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "post_process_group"
+                          "__call__"
                         ]
                       },
                       {
@@ -1431,7 +2539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "run_post_process_job("
+                          "await super().__call__(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1448,7 +2556,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "sentry.tasks.post_process"
+                          "starlette.applications"
                         ]
                       },
                       {
@@ -1457,7 +2565,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "post_process.py"
+                          "applications.py"
                         ]
                       },
                       {
@@ -1466,7 +2574,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "run_post_process_job"
+                          "__call__"
                         ]
                       },
                       {
@@ -1475,7 +2583,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "logger.exception("
+                          "await self.middleware_stack(scope, receive, send)"
                         ]
                       }
                     ]
@@ -1492,7 +2600,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "module",
                         "name": null,
                         "values": [
-                          "logging"
+                          "starlette.middleware.errors"
                         ]
                       },
                       {
@@ -1501,7 +2609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "filename",
                         "name": null,
                         "values": [
-                          "__init__.py"
+                          "errors.py"
                         ]
                       },
                       {
@@ -1510,7 +2618,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "function",
                         "name": null,
                         "values": [
-                          "exception"
+                          "__call__"
                         ]
                       },
                       {
@@ -1519,7 +2627,755 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         "id": "context_line",
                         "name": null,
                         "values": [
-                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.base"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "base.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.cors"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "cors.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.middleware.exceptions"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "exceptions.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.middleware.asyncexitstack"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "asyncexitstack.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.app(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.middleware_stack(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "await self.lifespan(scope, receive, send)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "starlette.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with self.lifespan_context(app) as maybe_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "fastapi.routing"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "routing.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "merged_lifespan"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "async with original_context(app) as maybe_original_state:"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_app"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "app.main"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "main.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "do_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "getattr(logger, level)(msg, *args, **kwargs)"
                         ]
                       }
                     ]
@@ -1743,138 +3599,6 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                         ]
                       }
                     ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock = self._connect()"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": true,
-                    "hint": null,
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "raise err"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "contributes": false,
-                    "hint": "ignored due to recursion",
-                    "id": "frame",
-                    "name": null,
-                    "values": [
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "module",
-                        "name": null,
-                        "values": [
-                          "redis.connection"
-                        ]
-                      },
-                      {
-                        "contributes": false,
-                        "hint": "ignored because module takes precedence",
-                        "id": "filename",
-                        "name": null,
-                        "values": [
-                          "connection.py"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "function",
-                        "name": null,
-                        "values": [
-                          "_connect"
-                        ]
-                      },
-                      {
-                        "contributes": true,
-                        "hint": null,
-                        "id": "context_line",
-                        "name": null,
-                        "values": [
-                          "sock.connect(socket_address)"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -1883,10 +3607,10 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
         ]
       },
       "contributes": true,
-      "description": "exception stacktrace — all frames",
-      "hash": "1bc764ab44acfab9a38f23ae670038bd",
+      "description": "thread stacktrace — all frames",
+      "hash": "a18195beb2cfb93ea25c9331c988dbee",
       "hint": null,
-      "key": "system_exception_stacktrace",
+      "key": "system_thread_stacktrace",
       "type": "component"
     }
   }

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -2,14 +2,14 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "e9e285f37b2b82b2a3e0fdaf8e1655c1"
-  contributing component: exception
+  hash: "38660ba262e9baab1dcf0a432479f643"
+  contributing component: threads
   hint: None
   root_component:
     app*
-      exception*
+      threads*
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -18,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=11, pipe_handle=32)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -27,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -36,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -45,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -54,69 +54,276 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "target(sockets=sockets)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return runner.run(main)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
             module*
-              "sentry.taskworker.task"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "task.py"
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.errors"
+            filename (ignored because module takes precedence)
+              "errors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "run_post_process_job"
+              "do_log"
             context_line*
-              "logger.exception("
-          frame (non app frame)
-            module*
-              "logging"
-            filename (ignored because module takes precedence)
-              "__init__.py"
-            function*
-              "exception"
-            context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame (non app frame)
             module*
               "logging"
@@ -162,54 +369,23 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"
 --------------------------------------------------------------------------
 default:
   hash: null
   contributing component: null
-  hint: ignored because app/system exception takes precedence
+  hint: ignored because app/system threads take precedence
   root_component:
-    default (ignored because app/system exception takes precedence)
-      message (ignored because app/system exception takes precedence)
-        "Failed to process pipeline step %s"
+    default (ignored because app/system threads take precedence)
+      message (ignored because app/system threads take precedence)
+        "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
 --------------------------------------------------------------------------
 system:
-  hash: "7c1fcfc8523ad78a4d0424bfd03bdb13"
-  contributing component: exception
+  hash: "46b9ac9970eba6e39408d3392e619471"
+  contributing component: threads
   hint: None
   root_component:
     system*
-      exception*
+      threads*
         stacktrace*
           frame*
             module*
@@ -258,67 +434,274 @@ system:
               "self._target(*self._args, **self._kwargs)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
+              "target(sockets=sockets)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "asyncio.runners"
+            filename (ignored because module takes precedence)
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
           frame*
             module*
-              "sentry.taskworker.task"
+              "asyncio.base_events"
             filename (ignored because module takes precedence)
-              "task.py"
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame*
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame*
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame*
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "starlette.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "run_post_process_job"
+              "__call__"
             context_line*
-              "logger.exception("
+              "await self.middleware_stack(scope, receive, send)"
           frame*
             module*
-              "logging"
+              "starlette.middleware.errors"
             filename (ignored because module takes precedence)
-              "__init__.py"
+              "errors.py"
             function*
-              "exception"
+              "__call__"
             context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame*
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "do_log"
+            context_line*
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame*
             module*
               "logging"
@@ -364,34 +747,3 @@ system:
               "handle"
             context_line*
               "self.emit(record)"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (ignored due to recursion)
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,10 +4,10 @@ source: tests/sentry/grouping/test_variants.py::test_variants
 app:
   hash: null
   contributing component: null
-  hint: ignored because system exception takes precedence
+  hint: ignored because system threads take precedence
   root_component:
-    app (ignored because system exception takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+    app (ignored because system threads take precedence)
+      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
@@ -54,69 +54,276 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
-          frame (non app frame)
+              "target(sockets=sockets)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame (non app frame)
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
           frame (non app frame)
             module*
-              "sentry.taskworker.task"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "task.py"
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame (non app frame)
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await super().__call__(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.errors"
+            filename (ignored because module takes precedence)
+              "errors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "post_process_group"
+              "run_app"
             context_line*
-              "run_post_process_job("
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "run_post_process_job"
+              "do_log"
             context_line*
-              "logger.exception("
-          frame (non app frame)
-            module*
-              "logging"
-            filename (ignored because module takes precedence)
-              "__init__.py"
-            function*
-              "exception"
-            context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame (non app frame)
             module*
               "logging"
@@ -162,54 +369,23 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
-        type*
-          "TimeoutError"
-        value*
-          "timed out"
 --------------------------------------------------------------------------
 default:
   hash: null
   contributing component: null
-  hint: ignored because system exception takes precedence
+  hint: ignored because system threads take precedence
   root_component:
-    default (ignored because system exception takes precedence)
-      message (ignored because system exception takes precedence)
-        "Failed to process pipeline step %s"
+    default (ignored because system threads take precedence)
+      message (ignored because system threads take precedence)
+        "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
 --------------------------------------------------------------------------
 system:
-  hash: "7c1fcfc8523ad78a4d0424bfd03bdb13"
-  contributing component: exception
+  hash: "06218188159a10d97cca346ebca30dda"
+  contributing component: threads
   hint: None
   root_component:
     system*
-      exception*
+      threads*
         stacktrace*
           frame*
             module*
@@ -258,67 +434,274 @@ system:
               "self._target(*self._args, **self._kwargs)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
+              "target(sockets=sockets)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
+          frame (ignored due to recursion)
+            module*
+              "asyncio.runners"
+            filename (ignored because module takes precedence)
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
           frame*
             module*
-              "sentry.taskworker.task"
+              "asyncio.base_events"
             filename (ignored because module takes precedence)
-              "task.py"
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame*
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame*
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame*
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "starlette.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "run_post_process_job"
+              "__call__"
             context_line*
-              "logger.exception("
+              "await self.middleware_stack(scope, receive, send)"
           frame*
             module*
-              "logging"
+              "starlette.middleware.errors"
             filename (ignored because module takes precedence)
-              "__init__.py"
+              "errors.py"
             function*
-              "exception"
+              "__call__"
             context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame*
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "do_log"
+            context_line*
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame*
             module*
               "logging"
@@ -364,34 +747,3 @@ system:
               "handle"
             context_line*
               "self.emit(record)"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (ignored due to recursion)
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_bad_rules_windows.pysnap
@@ -2,18 +2,14 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "126f65e182d6fbc222480cf9f391a3e1"
-  contributing component: exception
+  hash: "620b9e72c9565c3ef54e519ec997b57a"
+  contributing component: threads
   hint: None
   root_component:
     app*
-      exception*
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"
+      threads*
         stacktrace*
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app) and un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -22,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -31,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -40,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -49,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -58,70 +54,277 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "target(sockets=sockets)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return runner.run(main)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
             module*
-              "sentry.taskworker.task"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "task.py"
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
-          frame* (marked in-app by custom stack trace rule (function:post_process_group +app v+app))
+              "return await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.errors"
+            filename (ignored because module takes precedence)
+              "errors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app) and un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (marked in-app by custom stack trace rule (function:run_app +app v+app))
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "run_post_process_job"
+              "do_log"
             context_line*
-              "logger.exception("
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
-            module*
-              "logging"
-            filename (ignored because module takes precedence)
-              "__init__.py"
-            function*
-              "exception"
-            context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+              "getattr(logger, level)(msg, *args, **kwargs)"
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -130,7 +333,7 @@ app:
               "error"
             context_line*
               "self._log(ERROR, msg, args, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -139,7 +342,7 @@ app:
               "_log"
             context_line*
               "self.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -148,7 +351,7 @@ app:
               "handle"
             context_line*
               "self.callHandlers(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -157,7 +360,7 @@ app:
               "callHandlers"
             context_line*
               "hdlr.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -166,56 +369,25 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
 --------------------------------------------------------------------------
 default:
   hash: null
   contributing component: null
-  hint: ignored because app/system exception takes precedence
+  hint: ignored because app/system threads take precedence
   root_component:
-    default (ignored because app/system exception takes precedence)
-      message (ignored because app/system exception takes precedence)
-        "Failed to process pipeline step %s"
+    default (ignored because app/system threads take precedence)
+      message (ignored because app/system threads take precedence)
+        "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
 --------------------------------------------------------------------------
 system:
-  hash: "bce0926d11f0ebe7d72ab74b56717aa6"
-  contributing component: exception
+  hash: "ed32779a2628338d3534c4e182caf8e8"
+  contributing component: threads
   hint: None
   root_component:
     system*
-      exception*
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"
+      threads*
         stacktrace*
-          frame* (un-ignored by custom stack trace rule (function:post_process_group +group v+group))
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -262,67 +434,274 @@ system:
               "self._target(*self._args, **self._kwargs)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
+              "target(sockets=sockets)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "asyncio.runners"
+            filename (ignored because module takes precedence)
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
           frame*
             module*
-              "sentry.taskworker.task"
+              "asyncio.base_events"
             filename (ignored because module takes precedence)
-              "task.py"
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame*
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame*
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame*
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "starlette.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "run_post_process_job"
+              "__call__"
             context_line*
-              "logger.exception("
+              "await self.middleware_stack(scope, receive, send)"
           frame*
             module*
-              "logging"
+              "starlette.middleware.errors"
             filename (ignored because module takes precedence)
-              "__init__.py"
+              "errors.py"
             function*
-              "exception"
+              "__call__"
             context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame*
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame* (un-ignored by custom stack trace rule (function:run_app +group v+group))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "do_log"
+            context_line*
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame*
             module*
               "logging"
@@ -368,30 +747,3 @@ system:
               "handle"
             context_line*
               "self.emit(record)"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (ignored due to recursion)
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/python_multiprocessing_hardcoded_values_in_context_line_windows.pysnap
@@ -4,14 +4,10 @@ source: tests/sentry/grouping/test_variants.py::test_variants
 app:
   hash: null
   contributing component: null
-  hint: ignored because system exception takes precedence
+  hint: ignored because system threads take precedence
   root_component:
-    app (ignored because system exception takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        type*
-          "TimeoutError"
-        value*
-          "timed out"
+    app (ignored because system threads take precedence)
+      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by built-in stack trace rule (category:internals -app))
             module*
@@ -22,7 +18,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=<int>, pipe_handle=<int>)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -31,7 +27,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -40,7 +36,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -49,7 +45,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -58,70 +54,277 @@ app:
               "run"
             context_line*
               "self._target(*self._args, **self._kwargs)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
-          frame (non app frame)
+              "target(sockets=sockets)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame (non app frame)
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
           frame (non app frame)
             module*
-              "sentry.taskworker.task"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "task.py"
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame (non app frame)
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame (non app frame)
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await super().__call__(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.applications"
+            filename (ignored because module takes precedence)
+              "applications.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.errors"
+            filename (ignored because module takes precedence)
+              "errors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "post_process_group"
+              "run_app"
             context_line*
-              "run_post_process_job("
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
           frame (non app frame)
             module*
-              "sentry.tasks.post_process"
+              "app.main"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "main.py"
             function*
-              "run_post_process_job"
+              "do_log"
             context_line*
-              "logger.exception("
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
-            module*
-              "logging"
-            filename (ignored because module takes precedence)
-              "__init__.py"
-            function*
-              "exception"
-            context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+              "getattr(logger, level)(msg, *args, **kwargs)"
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -130,7 +333,7 @@ app:
               "error"
             context_line*
               "self._log(ERROR, msg, args, **kwargs)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -139,7 +342,7 @@ app:
               "_log"
             context_line*
               "self.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -148,7 +351,7 @@ app:
               "handle"
             context_line*
               "self.callHandlers(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -157,7 +360,7 @@ app:
               "callHandlers"
             context_line*
               "hdlr.handle(record)"
-          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
+          frame (non app frame)
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -166,54 +369,23 @@ app:
               "handle"
             context_line*
               "self.emit(record)"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (marked out of app by built-in stack trace rule (path:**/site-packages/** -app))
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"
 --------------------------------------------------------------------------
 default:
   hash: null
   contributing component: null
-  hint: ignored because system exception takes precedence
+  hint: ignored because system threads take precedence
   root_component:
-    default (ignored because system exception takes precedence)
-      message (ignored because system exception takes precedence)
-        "Failed to process pipeline step %s"
+    default (ignored because system threads take precedence)
+      message (ignored because system threads take precedence)
+        "Error creating HTTP client: cannot import name 'create_http_client' from 'app.utils.http' (D:\\engine\\app\\utils\\http.py)"
 --------------------------------------------------------------------------
 system:
-  hash: "1bc764ab44acfab9a38f23ae670038bd"
-  contributing component: exception
+  hash: "a18195beb2cfb93ea25c9331c988dbee"
+  contributing component: threads
   hint: None
   root_component:
     system*
-      exception*
-        type*
-          "TimeoutError"
-        value (ignored because stacktrace takes precedence)
-          "timed out"
+      threads*
         stacktrace*
           frame (ignored by built-in stack trace rule (category:internals -group))
             module*
@@ -262,67 +434,274 @@ system:
               "self._target(*self._args, **self._kwargs)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn._subprocess"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "_subprocess.py"
             function*
-              "child_process"
+              "subprocess_started"
             context_line*
-              "run_worker("
+              "target(sockets=sockets)"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "uvicorn.server"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "server.py"
             function*
-              "run_worker"
+              "run"
             context_line*
-              "_execute_activation(task_func, inflight.activation)"
+              "return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())"
           frame*
             module*
-              "sentry.taskworker.workerchild"
+              "asyncio.runners"
             filename (ignored because module takes precedence)
-              "workerchild.py"
+              "runners.py"
             function*
-              "_execute_activation"
+              "run"
             context_line*
-              "task_func(*args, **kwargs)"
+              "return runner.run(main)"
+          frame (ignored due to recursion)
+            module*
+              "asyncio.runners"
+            filename (ignored because module takes precedence)
+              "runners.py"
+            function*
+              "run"
+            context_line*
+              "return self._loop.run_until_complete(task)"
           frame*
             module*
-              "sentry.taskworker.task"
+              "asyncio.base_events"
             filename (ignored because module takes precedence)
-              "task.py"
+              "base_events.py"
+            function*
+              "run_until_complete"
+            context_line*
+              "self.run_forever()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "run_forever"
+            context_line*
+              "self._run_once()"
+          frame*
+            module*
+              "asyncio.base_events"
+            filename (ignored because module takes precedence)
+              "base_events.py"
+            function*
+              "_run_once"
+            context_line*
+              "handle._run()"
+          frame*
+            module*
+              "asyncio.events"
+            filename (ignored because module takes precedence)
+              "events.py"
+            function*
+              "_run"
+            context_line*
+              "self._context.run(self._callback, *self._args)"
+          frame*
+            module*
+              "uvicorn.lifespan.on"
+            filename (ignored because module takes precedence)
+              "on.py"
+            function*
+              "main"
+            context_line*
+              "await app(scope, self.receive, self.send)"
+          frame*
+            module*
+              "uvicorn.middleware.proxy_headers"
+            filename (ignored because module takes precedence)
+              "proxy_headers.py"
             function*
               "__call__"
             context_line*
-              "return self._func(*args, **kwargs)"
+              "return await self.app(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "fastapi.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "post_process_group"
+              "__call__"
             context_line*
-              "run_post_process_job("
+              "await super().__call__(scope, receive, send)"
           frame*
             module*
-              "sentry.tasks.post_process"
+              "starlette.applications"
             filename (ignored because module takes precedence)
-              "post_process.py"
+              "applications.py"
             function*
-              "run_post_process_job"
+              "__call__"
             context_line*
-              "logger.exception("
+              "await self.middleware_stack(scope, receive, send)"
           frame*
             module*
-              "logging"
+              "starlette.middleware.errors"
             filename (ignored because module takes precedence)
-              "__init__.py"
+              "errors.py"
             function*
-              "exception"
+              "__call__"
             context_line*
-              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.base"
+            filename (ignored because module takes precedence)
+              "base.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.cors"
+            filename (ignored because module takes precedence)
+              "cors.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.middleware.exceptions"
+            filename (ignored because module takes precedence)
+              "exceptions.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "fastapi.middleware.asyncexitstack"
+            filename (ignored because module takes precedence)
+              "asyncexitstack.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.app(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "__call__"
+            context_line*
+              "await self.middleware_stack(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "app"
+            context_line*
+              "await self.lifespan(scope, receive, send)"
+          frame*
+            module*
+              "starlette.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "lifespan"
+            context_line*
+              "async with self.lifespan_context(app) as maybe_state:"
+          frame*
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame (ignored due to recursion)
+            module*
+              "fastapi.routing"
+            filename (ignored because module takes precedence)
+              "routing.py"
+            function*
+              "merged_lifespan"
+            context_line*
+              "async with original_context(app) as maybe_original_state:"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "run_app"
+            context_line*
+              "do_log(\"error\", f\"Error creating HTTP client: {e}\")"
+          frame*
+            module*
+              "app.main"
+            filename (ignored because module takes precedence)
+              "main.py"
+            function*
+              "do_log"
+            context_line*
+              "getattr(logger, level)(msg, *args, **kwargs)"
           frame*
             module*
               "logging"
@@ -368,30 +747,3 @@ system:
               "handle"
             context_line*
               "self.emit(record)"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "connect"
-            context_line*
-              "sock = self._connect()"
-          frame*
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "raise err"
-          frame (ignored due to recursion)
-            module*
-              "redis.connection"
-            filename (ignored because module takes precedence)
-              "connection.py"
-            function*
-              "_connect"
-            context_line*
-              "sock.connect(socket_address)"


### PR DESCRIPTION
When we [added grouping test inputs](https://github.com/getsentry/sentry/pull/103185) for the windows version of hard-coded values in multiprocessing calls, we did so using posix stacktraces, because that's the only examples we had. Each input therefore included the following entry:

```json
"TODO": "The stack here is really a posix stack, not a Windows stack; the only thing Windows-y about this is the arguments passed to 'spawn_main' in the first frame. Admittedly that line is the whole point of having this input - the rest is sort of beside the point - but still, it would be nice to make this more realistic. Once the code for handling python multiprocessing context lines is in prod and we start logging instances of this in projects other than our own internal sentry project, it would be good to find an example which actually is from Windows, and use that to fix this stacktrace.",
```

We've since seen a few events come in from actual Windows machines, so we can now handle the aforementioned task. (Note: This uses data from a customer event for structure, but all in-app function names, code lines, and filepaths have been changed, as has the error message - only frames from the third-party server framework and from Python itself have been used as is.)