### PR TITLE
chore: Add tracking to the seer configuration reminder

### DIFF
--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -6,7 +6,6 @@ type NavigationEventParameters = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.primary_item_clicked': NavigationItemClicked;
-  'navigation.primary_item_rendered': NavigationItemClicked;
   'navigation.secondary_item_clicked': NavigationItemClicked;
   'navigation.tour_modal_dismissed': Record<string, unknown>;
   'navigation.tour_modal_shown': Record<string, unknown>;
@@ -20,7 +19,6 @@ export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | nu
   'navigation.help_menu_opt_out_stacked_navigation_clicked':
     'Navigation: Help Menu Opt Out Of Stacked Navigation Clicked',
   'navigation.primary_item_clicked': 'Navigation: Primary Item Clicked',
-  'navigation.primary_item_rendered': 'Navigation: Primary Item Rendered',
   'navigation.secondary_item_clicked': 'Navigation: Secondary Item Clicked',
   'navigation.tour_modal_dismissed': 'Navigation: Tour Modal Dismissed',
   'navigation.tour_modal_shown': 'Navigation: Tour Modal Shown',

--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -6,6 +6,7 @@ type NavigationEventParameters = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.primary_item_clicked': NavigationItemClicked;
+  'navigation.primary_item_rendered': NavigationItemClicked;
   'navigation.secondary_item_clicked': NavigationItemClicked;
   'navigation.tour_modal_dismissed': Record<string, unknown>;
   'navigation.tour_modal_shown': Record<string, unknown>;
@@ -19,7 +20,8 @@ export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | nu
   'navigation.help_menu_opt_out_stacked_navigation_clicked':
     'Navigation: Help Menu Opt Out Of Stacked Navigation Clicked',
   'navigation.primary_item_clicked': 'Navigation: Primary Item Clicked',
+  'navigation.primary_item_rendered': 'Navigation: Primary Item Rendered',
   'navigation.secondary_item_clicked': 'Navigation: Secondary Item Clicked',
-  'navigation.tour_modal_shown': 'Navigation: Tour Modal Shown',
   'navigation.tour_modal_dismissed': 'Navigation: Tour Modal Dismissed',
+  'navigation.tour_modal_shown': 'Navigation: Tour Modal Shown',
 };

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -45,6 +45,12 @@ export type SeerAnalyticsEventsParameters = {
     step_type: 'root_cause' | 'solution' | 'changes';
     user_id: string;
   };
+  'seer.config_reminder.rendered': {
+    has_code_review_beta: boolean;
+    has_legacy_seer: boolean;
+    has_seat_based_seer: boolean;
+    initial_step: string;
+  };
   'seer.explorer.feedback_submitted': {
     block_index: number;
     block_message: string;
@@ -85,6 +91,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
   'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',
+  'seer.config_reminder.rendered': 'Navigation: Primary Item Rendered',
   'seer.explorer.feedback_submitted': 'Seer Explorer: Feedback Submitted',
   'seer.explorer.global_panel.opened': 'Seer Explorer: Global Panel Opened',
   'seer.explorer.global_panel.tool_link_navigation': 'Seer Explorer: Tool Link Visited',

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -32,6 +32,7 @@ interface SidebarItemLinkProps {
   group: PrimaryNavGroup;
   to: string;
   activeTo?: string;
+  analyticsParams?: Record<string, unknown>;
   children?: React.ReactNode;
 }
 
@@ -39,6 +40,7 @@ interface SidebarItemDropdownProps {
   analyticsKey: string;
   items: MenuItemProps[];
   label: string;
+  analyticsParams?: Record<string, unknown>;
   children?: React.ReactNode;
   disableTooltip?: boolean;
   onOpen?: MouseEventHandler<HTMLButtonElement>;
@@ -49,15 +51,21 @@ interface SidebarButtonProps {
   analyticsKey: string;
   children: React.ReactNode;
   label: string;
+  analyticsParams?: Record<string, unknown>;
   buttonProps?: Omit<ButtonProps, 'aria-label'>;
   className?: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-function recordPrimaryItemClick(analyticsKey: string, organization: Organization) {
+function recordPrimaryItemClick(
+  analyticsKey: string,
+  organization: Organization,
+  analyticsParams?: Record<string, unknown>
+) {
   trackAnalytics('navigation.primary_item_clicked', {
     item: analyticsKey,
     organization,
+    ...analyticsParams,
   });
 }
 
@@ -111,6 +119,7 @@ export function SidebarMenu({
   items,
   children,
   analyticsKey,
+  analyticsParams,
   label,
   onOpen,
   disableTooltip,
@@ -140,7 +149,7 @@ export function SidebarMenu({
                 aria-label={showLabel ? undefined : label}
                 onClick={event => {
                   if (organization) {
-                    recordPrimaryItemClick(analyticsKey, organization);
+                    recordPrimaryItemClick(analyticsKey, organization, analyticsParams);
                   }
                   props.onClick?.(event);
                   onOpen?.(event);
@@ -168,6 +177,7 @@ function SidebarNavLink({
   to,
   activeTo = to,
   analyticsKey,
+  analyticsParams,
   group,
 }: SidebarItemLinkProps) {
   const organization = useOrganization();
@@ -188,7 +198,7 @@ function SidebarNavLink({
       aria-current={isActive ? 'page' : undefined}
       isMobile={layout === NavLayout.MOBILE}
       onClick={() => {
-        recordPrimaryItemClick(analyticsKey, organization);
+        recordPrimaryItemClick(analyticsKey, organization, analyticsParams);
       }}
       {...{
         [NAV_PRIMARY_LINK_DATA_ATTRIBUTE]: true,
@@ -214,6 +224,7 @@ export function SidebarLink({
   to,
   activeTo = to,
   analyticsKey,
+  analyticsParams,
   group,
   ...props
 }: SidebarItemLinkProps) {
@@ -225,6 +236,7 @@ export function SidebarLink({
         to={to}
         activeTo={activeTo}
         analyticsKey={analyticsKey}
+        analyticsParams={analyticsParams}
         group={group}
       >
         {children}
@@ -236,6 +248,7 @@ export function SidebarLink({
 export function SidebarButton({
   className,
   analyticsKey,
+  analyticsParams,
   children,
   buttonProps = {},
   onClick,
@@ -249,10 +262,11 @@ export function SidebarButton({
     <SidebarItem label={label} showLabel={showLabel} className={className}>
       <NavButton
         {...buttonProps}
+        analyticsParams={analyticsParams}
         isMobile={layout === NavLayout.MOBILE}
         aria-label={showLabel ? undefined : label}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-          recordPrimaryItemClick(analyticsKey, organization);
+          recordPrimaryItemClick(analyticsKey, organization, analyticsParams);
           buttonProps.onClick?.(e);
           onClick?.(e);
         }}
@@ -424,12 +438,12 @@ type NavButtonProps = ButtonProps & {
   isMobile: boolean;
 };
 
-const NavButton = styled((p: NavButtonProps) => {
+const NavButton = styled((props: NavButtonProps) => {
   return (
     <StyledNavButton
-      {...p}
-      aria-label={p['aria-label'] ?? ''}
-      size={p.isMobile ? 'zero' : undefined}
+      {...props}
+      aria-label={props['aria-label'] ?? ''}
+      size={props.isMobile ? 'zero' : undefined}
     />
   );
 })``;

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -145,9 +145,8 @@ export default function PrimaryNavSeerConfigReminder() {
   // Track impression on mount
   useEffect(() => {
     if (canSeeReminder) {
-      trackAnalytics('navigation.primary_item_rendered', {
+      trackAnalytics('seer.config_reminder.rendered', {
         organization,
-        item: 'seer-config-reminder',
         ...analyticsParams,
       });
     }

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -27,7 +27,7 @@ import {NavLayout} from 'sentry/views/nav/types';
 
 import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 import {useSeerOnboardingStep} from 'getsentry/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep';
-import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
+import {initialStepToName, Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
 // See also: `IntegrationProviderSlug` in sentry/integrations/types.py
 // `vsts` is ignored for now, not on the early roadmap in January 2026.
@@ -96,8 +96,9 @@ function useCanSeeReminder(organization: Organization) {
       has_seat_based_seer: hasSeatBasedSeer,
       has_legacy_seer: hasLegacySeer,
       has_code_review_beta: hasCodeReviewBeta,
+      initial_step: initialStepToName(initialStep),
     }),
-    [hasSeatBasedSeer, hasLegacySeer, hasCodeReviewBeta]
+    [hasSeatBasedSeer, hasLegacySeer, hasCodeReviewBeta, initialStep]
   );
 
   if (!hasSeer) {

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -8,6 +8,8 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -79,13 +81,52 @@ function useScmIntegrations() {
   };
 }
 
-export default function PrimaryNavSeerConfigReminder() {
-  const organization = useOrganization();
+function useCanSeeReminder(organization: Organization) {
   const canWrite = useCanWriteSettings();
   const {isPending, initialStep} = useSeerOnboardingStep();
-
   const {hasOnlyNonGithubScm, isPending: isScmPending} = useScmIntegrations();
 
+  const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
+  const hasLegacySeer = organization.features.includes('seer-added');
+  const hasCodeReviewBeta = organization.features.includes('code-review-beta');
+  const hasSeer = hasSeatBasedSeer || hasLegacySeer || hasCodeReviewBeta;
+
+  const analyticsParams = useMemo(
+    () => ({
+      has_seat_based_seer: hasSeatBasedSeer,
+      has_legacy_seer: hasLegacySeer,
+      has_code_review_beta: hasCodeReviewBeta,
+    }),
+    [hasSeatBasedSeer, hasLegacySeer, hasCodeReviewBeta]
+  );
+
+  if (!hasSeer) {
+    return {canSeeReminder: false, analyticsParams};
+  }
+
+  if (!canWrite && !isActiveSuperuser()) {
+    return {canSeeReminder: false, analyticsParams};
+  }
+
+  if (isPending || isScmPending || initialStep === Steps.WRAP_UP) {
+    return {canSeeReminder: false, analyticsParams};
+  }
+
+  // If org has zero SCM integrations  => show icon
+  // If org has 1 or more GitHub SCM connections => show icon
+  // If org has only BitBucket and/or GitLab SCM's => no icon
+  if (hasOnlyNonGithubScm) {
+    return {canSeeReminder: false, analyticsParams};
+  }
+
+  return {
+    canSeeReminder: true,
+    analyticsParams,
+  };
+}
+
+export default function PrimaryNavSeerConfigReminder() {
+  const organization = useOrganization();
   const {
     isOpen,
     triggerProps: overlayTriggerProps,
@@ -97,24 +138,20 @@ export default function PrimaryNavSeerConfigReminder() {
 
   const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
   const hasLegacySeer = organization.features.includes('seer-added');
-  const hasCodeReviewBeta = organization.features.includes('code-review-beta');
-  const hasSeer = hasSeatBasedSeer || hasLegacySeer || hasCodeReviewBeta;
-  if (!hasSeer) {
-    return null;
-  }
 
-  if (!canWrite && !isActiveSuperuser()) {
-    return null;
-  }
+  const {canSeeReminder, analyticsParams} = useCanSeeReminder(organization);
 
-  if (isPending || isScmPending || initialStep === Steps.WRAP_UP) {
-    return null;
-  }
+  // Track impression on mount
+  useEffect(() => {
+    if (canSeeReminder) {
+      trackAnalytics('seer_config_reminder.rendered', {
+        organization,
+        ...analyticsParams,
+      });
+    }
+  }, [canSeeReminder, analyticsParams, organization]);
 
-  // If org has zero SCM integrations  => show icon
-  // If org has 1 or more GitHub SCM connections => show icon
-  // If org has only BitBucket and/or GitLab SCM's => no icon
-  if (hasOnlyNonGithubScm) {
+  if (!canSeeReminder) {
     return null;
   }
 
@@ -123,7 +160,10 @@ export default function PrimaryNavSeerConfigReminder() {
       <SeerButton
         analyticsKey="seer-config-reminder"
         label={t('Configure Seer')}
-        buttonProps={overlayTriggerProps}
+        buttonProps={{
+          ...overlayTriggerProps,
+          analyticsParams,
+        }}
       >
         <IconSeer />
         <SidebarItemUnreadIndicator
@@ -168,6 +208,7 @@ export default function PrimaryNavSeerConfigReminder() {
                 }}
                 priority="primary"
                 onClick={() => state.close()}
+                analyticsParams={analyticsParams}
               >
                 {t('Configure Now')}
               </LinkButton>

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -144,8 +144,9 @@ export default function PrimaryNavSeerConfigReminder() {
   // Track impression on mount
   useEffect(() => {
     if (canSeeReminder) {
-      trackAnalytics('seer_config_reminder.rendered', {
+      trackAnalytics('navigation.primary_item_rendered', {
         organization,
+        item: 'seer-config-reminder',
         ...analyticsParams,
       });
     }
@@ -159,11 +160,9 @@ export default function PrimaryNavSeerConfigReminder() {
     <Fragment>
       <SeerButton
         analyticsKey="seer-config-reminder"
+        analyticsParams={analyticsParams}
         label={t('Configure Seer')}
-        buttonProps={{
-          ...overlayTriggerProps,
-          analyticsParams,
-        }}
+        buttonProps={overlayTriggerProps}
       >
         <IconSeer />
         <SidebarItemUnreadIndicator
@@ -208,6 +207,7 @@ export default function PrimaryNavSeerConfigReminder() {
                 }}
                 priority="primary"
                 onClick={() => state.close()}
+                analyticsEventName="Seer Config Reminder: Configure Now Clicked"
                 analyticsParams={analyticsParams}
               >
                 {t('Configure Now')}

--- a/static/gsApp/hooks/useButtonTracking.tsx
+++ b/static/gsApp/hooks/useButtonTracking.tsx
@@ -20,7 +20,7 @@ export default function useButtonTracking({
   const routes = useRoutes();
 
   const trackButton = useCallback(() => {
-    const considerSendingAnalytics = organization && routes;
+    const considerSendingAnalytics = organization && Boolean(routes);
 
     if (considerSendingAnalytics) {
       const routeString = getEventPath(routes);

--- a/static/gsApp/views/seerAutomation/onboarding/types.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/types.tsx
@@ -5,3 +5,20 @@ export enum Steps {
   SETUP_DEFAULTS = 4,
   WRAP_UP = 5,
 }
+
+export function initialStepToName(step: Steps): string {
+  switch (step) {
+    case Steps.CONNECT_GITHUB:
+      return 'connect_github';
+    case Steps.SETUP_CODE_REVIEW:
+      return 'setup_code_review';
+    case Steps.SETUP_ROOT_CAUSE_ANALYSIS:
+      return 'setup_root_cause_analysis';
+    case Steps.SETUP_DEFAULTS:
+      return 'setup_defaults';
+    case Steps.WRAP_UP:
+      return 'wrap_up';
+    default:
+      return 'unknown';
+  }
+}


### PR DESCRIPTION
The events emitted are:
```
{
    "eventKey": "navigation.primary_item_rendered",
    "eventName": "Navigation: Primary Item Rendered",
    "organization": {...},
    "has_seat_based_seer": false,
    "has_legacy_seer": true,
    "has_code_review_beta": false,
    "initial_step": "connect_github"
}

{
    "eventKey": "navigation.primary_item_clicked",
    "eventName": "Navigation: Primary Item Clicked",
    "item": "seer-config-reminder",
    "organization": {...},
    "has_seat_based_seer": false,
    "has_legacy_seer": true,
    "has_code_review_beta": false,
    "initial_step": "connect_github"
}

{
    "eventKey": "button_click.settings.seer",
    "eventName": null,
    "organization": {...},
    "parameterized_path": "settings.seer",
    "text": "Configure Now",
    "priority": "primary",
    "has_seat_based_seer": false,
    "has_legacy_seer": true,
    "has_code_review_beta": false,
    "initial_step": "connect_github"
}
```

A big problem though is that the debugging story for manually added `trackAnalytics()` calls is much better than for auto-instrumented buttons. I added console.logs to see that in the depths of our buttons we will send the data, but debugging into the console seems like it's only enabled via the default provider, which is not used in dev anymore. 

This is something I think we can be much better on, at least in terms of creating some layers that may or may not be part of scraps in the future.

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>21d4506</u></sup><!-- /BUGBOT_STATUS -->