### PR TITLE
feat(seer): Show the enabled triggers in the Seer > Repo list page

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -1,6 +1,7 @@
 import type {AlertProps} from '@sentry/scraps/alert';
 
 import type {Field} from 'sentry/components/forms/types';
+import type {CodeReviewTrigger} from 'sentry/types/seer';
 import type {
   DISABLED as DISABLED_STATUS,
   INSTALLED,
@@ -86,8 +87,6 @@ export type Repository = {
   status: RepositoryStatus;
   url: string;
 };
-
-type CodeReviewTrigger = 'on_new_commit' | 'on_ready_for_review';
 
 /**
  * Available only when calling API with `expand=settings` query parameter

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -12,10 +12,8 @@ import type {ExternalTeam} from './integrations';
 import type {OnboardingTaskStatus} from './onboarding';
 import type {Project} from './project';
 import type {Relay} from './relay';
+import type {CodeReviewTrigger} from './seer';
 import type {User} from './user';
-
-// Matches `PrReviewTrigger` in Seer
-type CodeReviewTriggers = 'on_ready_for_review' | 'on_new_commit';
 
 /**
  * Organization summaries are sent when you request a list of all organizations
@@ -67,7 +65,7 @@ export interface Organization extends OrganizationSummary {
   dataScrubber: boolean;
   dataScrubberDefaults: boolean;
   debugFilesRole: string;
-  defaultCodeReviewTriggers: CodeReviewTriggers[];
+  defaultCodeReviewTriggers: CodeReviewTrigger[];
   defaultRole: string;
   enhancedPrivacy: boolean;
   eventsMemberAdmin: boolean;

--- a/static/app/types/seer.tsx
+++ b/static/app/types/seer.tsx
@@ -1,0 +1,1 @@
+export type CodeReviewTrigger = 'on_new_commit' | 'on_ready_for_review';

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -7,6 +7,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
@@ -26,6 +27,21 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Name'), key: 'name', sortKey: 'name'},
+  {
+    title: (
+      <Flex gap="sm" align="center">
+        {t('Trigger')}
+        <QuestionTooltip
+          title={tct(
+            'Code review can always be triggered manaully by mentioning [code:@sentry review].',
+            {code: <code />}
+          )}
+          size="xs"
+        />
+      </Flex>
+    ),
+    key: 'trigger',
+  },
   {title: t('Code Review'), key: 'code_review'},
 ];
 

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -4,6 +4,7 @@ import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
 
 import {
   addErrorMessage,
@@ -19,6 +20,7 @@ import {
   RepositoryStatus,
   type RepositoryWithSettings,
 } from 'sentry/types/integrations';
+import type {CodeReviewTrigger} from 'sentry/types/seer';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -97,6 +99,19 @@ export default function SeerRepoTableRow({
         </Stack>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell justify="end">
+        <Text size="sm">
+          {repository.settings?.codeReviewTriggers
+            .sort()
+            .map(triggerToLabel)
+            .map((label, index, array) => (
+              <div key={label}>
+                {label}
+                {index === array.length - 1 ? '' : ', '}
+              </div>
+            ))}
+        </Text>
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell justify="end">
         <Switch
           disabled={!canWrite}
           checked={repository.settings?.enabledCodeReview ?? false}
@@ -145,6 +160,17 @@ export default function SeerRepoTableRow({
       </SimpleTable.RowCell>
     </SimpleTable.Row>
   );
+}
+
+function triggerToLabel(trigger: CodeReviewTrigger) {
+  switch (trigger) {
+    case 'on_new_commit':
+      return t('On New Commit');
+    case 'on_ready_for_review':
+      return t('On Ready for Review');
+    default:
+      return trigger;
+  }
 }
 
 const CheckboxClickTarget = styled('label')`


### PR DESCRIPTION
<img width="499" height="330" alt="Screenshot 2026-02-03 at 4 22 26 PM" src="https://github.com/user-attachments/assets/c3d1264f-3f77-47ff-9da6-80ecec349167" />

There is no bulk edit right now. It could be useful to have, but i think it'd want the backend to support adding/removing triggers. Right now the backend will just replace everything if we pass in a list, which is more of a hammer :(

Per figma: https://www.figma.com/design/GMZ2vapRoc1TcueKOjTyUY/Seer-Activation-Flow?node-id=5656-16005&m=dev

Fixes https://linear.app/getsentry/issue/CW-745/show-code-review-triggers-column-on-repo-list-page