### PR TITLE
feat(aci): Add ongoing issues component to metric alert details page

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -9,6 +9,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {SectionHeading} from 'sentry/components/charts/styles';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -52,6 +53,7 @@ import {
 import type {TimePeriodType} from './constants';
 import {SELECTOR_RELATIVE_PERIODS} from './constants';
 import MetricChart from './metricChart';
+import {MetricAlertOngoingIssues} from './ongoingIssues';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
 import {MetricDetailsSidebar} from './sidebar';
@@ -253,6 +255,10 @@ export default function MetricDetailsBody({
           />
           <DetailWrapper>
             <Stack flex="1" width="100%">
+              {organization.features.includes('workflow-engine-metric-issues-ui') && (
+                <MetricAlertOngoingIssues project={project} rule={rule} />
+              )}
+              <SectionHeading>{t('Alert History')}</SectionHeading>
               <MetricHistory incidents={incidents} />
               {[Dataset.METRICS, Dataset.SESSIONS, Dataset.ERRORS].includes(dataset) && (
                 <RelatedIssues

--- a/static/app/views/alerts/rules/metric/details/ongoingIssues.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/ongoingIssues.spec.tsx
@@ -1,0 +1,63 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {MetricRuleFixture} from 'sentry-fixture/metricRule';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricAlertOngoingIssues} from 'sentry/views/alerts/rules/metric/details/ongoingIssues';
+
+describe('MetricAlertOngoingIssues', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/users/`,
+      body: [],
+    });
+  });
+
+  it('renders ongoing issues using detector id', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '2'});
+    const rule = MetricRuleFixture({id: '101'});
+
+    const detectorRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rule-detector/`,
+      body: {alertRuleId: rule.id, detectorId: '555', ruleId: rule.id},
+      match: [MockApiClient.matchQuery({alert_rule_id: rule.id})],
+    });
+
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [GroupFixture()],
+      match: [
+        MockApiClient.matchQuery({
+          query: 'detector:555',
+          project: project.id,
+        }),
+      ],
+    });
+
+    render(<MetricAlertOngoingIssues project={project} rule={rule} />, {organization});
+
+    expect(await screen.findByTestId('group')).toBeInTheDocument();
+    expect(detectorRequest).toHaveBeenCalled();
+    expect(issuesRequest).toHaveBeenCalled();
+  });
+
+  it('renders an empty state when detector id is unavailable', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '2'});
+    const rule = MetricRuleFixture({id: '101'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rule-detector/`,
+      body: null,
+      match: [MockApiClient.matchQuery({alert_rule_id: rule.id})],
+    });
+
+    render(<MetricAlertOngoingIssues project={project} rule={rule} />, {organization});
+
+    expect(await screen.findByText('No ongoing issues.')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/alerts/rules/metric/details/ongoingIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/ongoingIssues.tsx
@@ -1,0 +1,84 @@
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import GroupList from 'sentry/components/issues/groupList';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+
+interface Props {
+  project: Project;
+  rule: MetricRule;
+}
+
+interface AlertRuleDetector {
+  alertRuleId: string | null;
+  detectorId: string;
+  ruleId: string | null;
+}
+
+export function MetricAlertOngoingIssues({project, rule}: Props) {
+  const organization = useOrganization();
+  const ruleId = rule.id;
+  const {data: alertRuleDetector, isPending} = useApiQuery<AlertRuleDetector>(
+    [
+      getApiUrl('/organizations/$organizationIdOrSlug/alert-rule-detector/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+      {query: {alert_rule_id: ruleId}},
+    ],
+    {
+      staleTime: 0,
+      enabled: Boolean(ruleId),
+      retry: false,
+    }
+  );
+
+  if (!ruleId) {
+    return null;
+  }
+
+  const emptyMessage = () => {
+    return (
+      <Panel>
+        <PanelBody>
+          <EmptyStateWarning>
+            <p>{t('No ongoing issues.')}</p>
+          </EmptyStateWarning>
+        </PanelBody>
+      </Panel>
+    );
+  };
+
+  if (isPending) {
+    return (
+      <Panel>
+        <PanelBody>
+          <Placeholder height="116px" />
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  if (!alertRuleDetector) {
+    return emptyMessage();
+  }
+
+  return (
+    <GroupList
+      withChart={false}
+      withPagination={false}
+      withColumns={['assignee']}
+      queryParams={{
+        query: `detector:${alertRuleDetector.detectorId}`,
+        project: project.id,
+      }}
+      renderEmptyMessage={emptyMessage}
+      numPlaceholderRows={1}
+    />
+  );
+}

--- a/static/app/views/alerts/rules/metric/details/ongoingIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/ongoingIssues.tsx
@@ -70,7 +70,7 @@ export function MetricAlertOngoingIssues({project, rule}: Props) {
 
   return (
     <GroupList
-      withChart={false}
+      withChart
       withPagination={false}
       withColumns={['assignee']}
       queryParams={{


### PR DESCRIPTION
Closes ISWF-1949

Following the way that issues are shown in the uptime alert detail page.

For metric alerts, unfortunately we need to make a request to convert the alert rule ID to a detector ID before making the issues request.

<img width="1110" height="769" alt="CleanShot 2026-02-03 at 16 26 59" src="https://github.com/user-attachments/assets/7bfb1f47-d3e6-4355-997e-752b6aa230f3" />
