### PR TITLE
ref(billing): removed prevent user and prevent review references(BIL-2092)

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -96,8 +96,6 @@ export enum DataCategory {
   SEER_AUTOFIX = 'seerAutofix',
   SEER_SCANNER = 'seerScanner',
   SEER_USER = 'seerUsers',
-  PREVENT_USER = 'preventUsers',
-  PREVENT_REVIEW = 'preventReviews',
   USER_REPORT_V2 = 'feedback',
   TRACE_METRICS = 'traceMetrics',
   SIZE_ANALYSIS = 'sizeAnalyses',

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<T> {
+    interface DOMAttributes<_T> {
       'data-test-id'?: string;
     }
   }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -746,8 +746,8 @@ type FeeInvoiceItemType = (typeof FEE_INVOICE_ITEM_TYPES)[number];
  */
 const _SEER_INVOICE_ITEM_TYPES = [
   'reserved_seer_budget', // Special case: shared budget for seer_autofix and seer_scanner
-  'reserved_seer_users', // Special case: reserved prevent users (PREVENT_USER category maps to this)
-  'activated_seer_users', // Activation-based prevent users billing (PREVENT_USER category)
+  'reserved_seer_users',
+  'activated_seer_users',
 ] as const;
 
 type SeerInvoiceItemType = (typeof _SEER_INVOICE_ITEM_TYPES)[number];

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<_T> {
+    interface DOMAttributes<T> {
       'data-test-id'?: string;
     }
   }


### PR DESCRIPTION
https://linear.app/getsentry/issue/BIL-2092/remove-references-to-datacategoryprevent-user-and-datacategoryprevent

Part 2 of this ticket to remove the unused data categories prevent user and prevent review, first PR merged [here](https://github.com/getsentry/getsentry/pull/19288). 