### PR TITLE
feat(seer): Highlight projects that have zero repos connected in Seer>Project list settings

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -5,6 +5,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
   addErrorMessage,
@@ -19,6 +20,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
@@ -155,8 +157,17 @@ export default function SeerProjectTableRow({
       <SimpleTable.RowCell justify="end">
         {isFetchingSettings ? (
           <Placeholder height="20px" width="36px" />
+        ) : autofixSettings.reposCount === 0 ? (
+          <Tooltip
+            title={t('Seer works best on projects with at least one connected repo.')}
+          >
+            <Flex align="center" gap="sm">
+              <IconWarning variant="warning" />
+              <Text tabular>{0}</Text>
+            </Flex>
+          </Tooltip>
         ) : (
-          <Text tabular>{autofixSettings.reposCount || 0}</Text>
+          <Text tabular>{autofixSettings.reposCount}</Text>
         )}
       </SimpleTable.RowCell>
     </SimpleTable.Row>


### PR DESCRIPTION
<img width="246" height="289" alt="Screenshot 2026-02-03 at 5 29 29 PM" src="https://github.com/user-attachments/assets/dc9f1f74-5f8c-4b8e-bc70-04673ec07cc1" />

Fixes https://linear.app/getsentry/issue/CW-746/add-helper-on-repo-list-page-for-missing-repos
Related to https://linear.app/getsentry/issue/CW-753/improve-seer-projects-list-with-repo-and-search-ux