### PR TITLE
feat(auth): Extend OAuth SSO session duration to 14 days

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -267,13 +267,13 @@ def has_completed_sso(request: HttpRequest, organization_id: int) -> bool:
     # Determine expiry based on provider type:
     # - SAML providers: 7 days (no refresh mechanism)
     # - OAuth providers: 14 days (refresh tokens every 24h via check_auth task)
-    from sentry.models.authprovider import AuthProvider
+    from sentry.auth.services.auth import auth_service
 
-    try:
-        auth_provider = AuthProvider.objects.get(organization_id=organization_id)
+    auth_provider = auth_service.get_auth_provider(organization_id=organization_id)
+    if auth_provider is not None:
         provider = auth_provider.get_provider()
         expiry_time = SSO_EXPIRY_TIME_SAML if provider.is_saml else SSO_EXPIRY_TIME_OAUTH
-    except AuthProvider.DoesNotExist:
+    else:
         # Default to stricter SAML expiry if no provider found
         expiry_time = SSO_EXPIRY_TIME_SAML
 

--- a/tests/sentry/users/api/endpoints/test_auth_index.py
+++ b/tests/sentry/users/api/endpoints/test_auth_index.py
@@ -14,7 +14,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.user import User
-from sentry.utils.auth import SSO_EXPIRY_TIME, SsoSession
+from sentry.utils.auth import SSO_EXPIRY_TIME_OAUTH, SsoSession
 
 
 def create_authenticator(user: User) -> None:
@@ -243,9 +243,10 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
         with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
 
+            # Use SSO_EXPIRY_TIME_OAUTH since "dummy" provider is OAuth-like (14 days)
             sso_session_expired = SsoSession(
                 self.organization.id,
-                datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME - timedelta(hours=1),
+                datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME_OAUTH - timedelta(hours=1),
             )
             self.session[sso_session_expired.session_key] = sso_session_expired.to_dict()
             self.save_session()
@@ -294,9 +295,10 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
         with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
 
+            # Use SSO_EXPIRY_TIME_OAUTH since "dummy" provider is OAuth-like (14 days)
             sso_session_expired = SsoSession(
                 self.organization.id,
-                datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME - timedelta(hours=1),
+                datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME_OAUTH - timedelta(hours=1),
             )
             self.session[sso_session_expired.session_key] = sso_session_expired.to_dict()
             self.save_session()

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -10,10 +10,13 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.user import User
 from sentry.utils.auth import (
+    SSO_EXPIRY_TIME_OAUTH,
+    SSO_EXPIRY_TIME_SAML,
     EmailAuthBackend,
     SsoSession,
     construct_link_with_query,
     get_login_redirect,
+    has_completed_sso,
     login,
 )
 
@@ -190,3 +193,129 @@ def test_construct_link_with_query() -> None:
     expected_path = "foobar"
 
     assert construct_link_with_query(path=path, query_params=query_params) == expected_path
+
+
+def test_sso_expiry_constants() -> None:
+    """Verify SSO expiry constants are set correctly"""
+    assert SSO_EXPIRY_TIME_SAML == timedelta(days=7)
+    assert SSO_EXPIRY_TIME_OAUTH == timedelta(days=14)
+
+
+def test_sso_session_is_sso_authtime_fresh_with_custom_expiry() -> None:
+    """Test that is_sso_authtime_fresh accepts custom expiry times"""
+    org_id = 1
+
+    # Create a session that's 10 days old
+    ten_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    sso_session = SsoSession(org_id, ten_days_ago)
+
+    # With 7-day expiry (SAML), session should be expired
+    assert not sso_session.is_sso_authtime_fresh(SSO_EXPIRY_TIME_SAML)
+
+    # With 14-day expiry (OAuth), session should still be fresh
+    assert sso_session.is_sso_authtime_fresh(SSO_EXPIRY_TIME_OAUTH)
+
+
+def test_sso_session_is_sso_authtime_fresh_default_expiry() -> None:
+    """Test that is_sso_authtime_fresh uses default expiry when none specified"""
+    org_id = 1
+
+    # Create a fresh session
+    fresh_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    sso_session = SsoSession(org_id, fresh_time)
+
+    # Should be fresh with default expiry
+    assert sso_session.is_sso_authtime_fresh()
+
+
+@control_silo_test
+class HasCompletedSsoProviderExpiryTest(TestCase):
+    """Tests for provider-dependent SSO session expiry"""
+
+    def _make_request(self, org_id: int, session_time: datetime) -> HttpRequest:
+        request = HttpRequest()
+        request.session = SessionBase()
+        # Create an SSO session with the given timestamp
+        sso_session = SsoSession(org_id, session_time)
+        request.session[sso_session.session_key] = sso_session.to_dict()
+        return request
+
+    def test_oauth_provider_uses_14_day_expiry(self) -> None:
+        """OAuth providers should use 14-day expiry"""
+        org = self.create_organization(owner=self.user)
+        # "dummy" provider is OAuth-like (not SAML)
+        self.create_auth_provider(organization_id=org.id, provider="dummy")
+
+        # Session at 10 days should be valid for OAuth
+        ten_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        request = self._make_request(org.id, ten_days_ago)
+
+        assert has_completed_sso(request, org.id) is True
+
+    def test_saml_provider_uses_7_day_expiry(self) -> None:
+        """SAML providers should use 7-day expiry"""
+        org = self.create_organization(owner=self.user)
+        # "saml2" provider is SAML
+        self.create_auth_provider(organization_id=org.id, provider="saml2")
+
+        # Session at 10 days should be expired for SAML
+        ten_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        request = self._make_request(org.id, ten_days_ago)
+
+        assert has_completed_sso(request, org.id) is False
+
+    def test_saml_provider_fresh_session_is_valid(self) -> None:
+        """SAML providers should accept sessions under 7 days old"""
+        org = self.create_organization(owner=self.user)
+        self.create_auth_provider(organization_id=org.id, provider="saml2")
+
+        # Session at 5 days should still be valid for SAML
+        five_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=5)
+        request = self._make_request(org.id, five_days_ago)
+
+        assert has_completed_sso(request, org.id) is True
+
+    def test_no_provider_defaults_to_saml_expiry(self) -> None:
+        """When no AuthProvider exists, default to stricter SAML expiry"""
+        org = self.create_organization(owner=self.user)
+        # No AuthProvider created for this org
+
+        # Session at 10 days should be expired (using SAML default)
+        ten_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        request = self._make_request(org.id, ten_days_ago)
+
+        assert has_completed_sso(request, org.id) is False
+
+    def test_oauth_session_at_boundary(self) -> None:
+        """Test OAuth session exactly at 14-day boundary"""
+        org = self.create_organization(owner=self.user)
+        self.create_auth_provider(organization_id=org.id, provider="dummy")
+
+        # Session at exactly 14 days should be expired
+        fourteen_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=14, seconds=1)
+        request = self._make_request(org.id, fourteen_days_ago)
+
+        assert has_completed_sso(request, org.id) is False
+
+        # Session just under 14 days should be valid
+        just_under_fourteen = datetime.now(tz=timezone.utc) - timedelta(days=13, hours=23)
+        request = self._make_request(org.id, just_under_fourteen)
+
+        assert has_completed_sso(request, org.id) is True
+
+    def test_saml_session_at_boundary(self) -> None:
+        """Test SAML session exactly at 7-day boundary"""
+        org = self.create_organization(owner=self.user)
+        self.create_auth_provider(organization_id=org.id, provider="saml2")
+
+        # Session at exactly 7 days should be expired
+        seven_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=7, seconds=1)
+        request = self._make_request(org.id, seven_days_ago)
+
+        assert has_completed_sso(request, org.id) is False
+
+        # Session just under 7 days should be valid
+        just_under_seven = datetime.now(tz=timezone.utc) - timedelta(days=6, hours=23)
+        request = self._make_request(org.id, just_under_seven)
+
+        assert has_completed_sso(request, org.id) is True


### PR DESCRIPTION
Part of https://github.com/getsentry/getsentry/issues/19297

## Summary

Changes SSO session expiry from a global 7 days to provider-dependent:

- **OAuth providers**: 14 days
- **SAML providers**: 7 days

## Background

OAuth and SAML providers have fundamentally different identity validation mechanisms:

### OAuth Providers (14 days)
OAuth providers have `requires_refresh = True` (the default in `Provider` base class). There are two layers of security:

**1. Continuous identity refresh (every 24 hours)**
The `check_auth` task runs every 24 hours (`AUTH_CHECK_INTERVAL` in `src/sentry/tasks/auth/check_auth.py`) and:
- Finds all `AuthIdentity` records where `last_synced` is older than 24 hours
- Calls `provider.refresh_identity(auth_identity)` to validate the OAuth token with the identity provider
- If validation fails, marks the organization member's SSO as invalid (`sso:invalid` flag)
- If validation succeeds, updates `last_verified` and `last_synced` timestamps

**2. Identity staleness check (7-day hard limit)**
In `auth_identity_is_valid()` (`src/sentry/auth/services/access/service.py:54-57`), if `last_verified` is older than 7 days, the identity is considered invalid regardless of session state. This acts as a safety net - even with a 14-day session, users must have their identity verified within the last 7 days.

Because OAuth identities have both continuous validation AND a 7-day staleness check, extending the session to 14 days is safe. Users with stale or invalid OAuth tokens will be required to re-authenticate.

### SAML Providers (7 days)
SAML providers set `requires_refresh = False` (in `SAML2Provider`). There is no background identity validation and no staleness check - the session expiry is the **only** mechanism that triggers re-authentication. Therefore, SAML providers keep the stricter 7-day expiry.

## Implementation

The provider type is looked up in `has_completed_sso()` when checking session freshness. This approach avoids changing `mark_sso_complete()` or `SsoSession` signatures.

- Added `SSO_EXPIRY_TIME_SAML` (7 days) and `SSO_EXPIRY_TIME_OAUTH` (14 days) constants
- Modified `SsoSession.is_sso_authtime_fresh()` to accept an optional `expiry_time` parameter
- Modified `has_completed_sso()` to look up `AuthProvider` and determine expiry based on `provider.is_saml`
- Defaults to stricter SAML expiry (7 days) if no provider is found