### PR TITLE
feat(symbolication): Show malformed errors as malformed

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/status/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/status/index.tsx
@@ -18,11 +18,17 @@ function Status({status, ...props}: Props) {
         </Tag>
       );
     }
-    case CandidateDownloadStatus.ERROR:
-    case CandidateDownloadStatus.MALFORMED: {
+    case CandidateDownloadStatus.ERROR: {
       return (
         <Tag variant="danger" {...props}>
           {t('Failed')}
+        </Tag>
+      );
+    }
+    case CandidateDownloadStatus.MALFORMED: {
+      return (
+        <Tag variant="danger" {...props}>
+          {t('Malformed')}
         </Tag>
       );
     }

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -59,7 +59,7 @@ describe('Debug Meta - Image Details', () => {
     const statusColumns = screen
       .getAllByTestId('status')
       .map(statusColumn => statusColumn.textContent);
-    expect(statusColumns).toEqual(['Failed', 'Failed', 'Failed', 'Deleted']);
+    expect(statusColumns).toEqual(['Malformed', 'Malformed', 'Malformed', 'Deleted']);
 
     // const informationColumn = candidates.find('InformationColumn');
 

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -59,24 +59,24 @@ describe('Debug Meta - Image Details', () => {
     const statusColumns = screen
       .getAllByTestId('status')
       .map(statusColumn => statusColumn.textContent);
-    expect(statusColumns).toEqual(['Malformed', 'Malformed', 'Malformed', 'Deleted']);
+    expect(statusColumns).toEqual(['Malformed', 'Malformed', 'Failed', 'Deleted']);
 
     // const informationColumn = candidates.find('InformationColumn');
 
     // Check source names order.
-    // The UI shall sort the candidates by source name (alphabetical)
+    // The UI shall sort the candidates by source name (alphabetical within each status group)
     const sourceNames = screen
       .getAllByTestId('source-name')
       .map(sourceName => sourceName.textContent);
-    expect(sourceNames).toEqual(['America', 'Austria', 'Belgium', 'Sentry']);
+    expect(sourceNames).toEqual(['Austria', 'Belgium', 'America', 'Sentry']);
 
     // Check location order.
-    // The UI shall sort the candidates by source location (alphabetical)
+    // The UI shall sort the candidates by source location (alphabetical within each status group)
     const locations = screen
       .getAllByTestId('filename-or-location')
       .map(location => location.textContent);
     // Only 3 results are returned, as the UI only displays the Location component
     // when the location is defined and when it is not internal
-    expect(locations).toEqual(['arizona', 'burgenland', 'brussels']);
+    expect(locations).toEqual(['burgenland', 'brussels', 'arizona']);
   });
 });

--- a/tests/js/fixtures/image.ts
+++ b/tests/js/fixtures/image.ts
@@ -50,7 +50,7 @@ export function ImageFixture(params: Partial<Image> = {}): Image {
       },
       {
         download: {
-          status: CandidateDownloadStatus.MALFORMED,
+          status: CandidateDownloadStatus.ERROR,
         },
         location: 'arizona',
         source: 'sentry://project_debug_file/20',


### PR DESCRIPTION
Do not mix download errors with successful downloads of malformed/unsupported files.