### PR TITLE
feat(ai-conversations): do not allow querying for data older than 30d

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -59,6 +59,9 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         # Ignore statsPeriod so old links don't fail when opened later
         mutable_query = request.GET.copy()
         mutable_query.pop("statsPeriod", None)
+        # Temporal hack: Use 29d due to EAP sampling behavior - anything with
+        # statsPeriod longer than 30d will go to tier 8
+        mutable_query["statsPeriod"] = "29d"
         request.GET = mutable_query  # type: ignore[assignment]
 
         try:


### PR DESCRIPTION
After 30d, EAP only keeps data in tier_8, they drop it form tier_1 which we would need to make this work.

So for now restrict this endpoint to the at most 30d in past, otherwise return 400