### PR TITLE
Issue event release filter

### DIFF
--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -174,10 +174,6 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         return Response(data)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 @region_silo_endpoint
 class EventJsonEndpoint(ProjectEndpoint):
     owner = ApiOwner.ISSUES

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -146,16 +146,17 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         # Parse query parameter to apply filters for next/previous event navigation
         query = request.GET.get("query")
         conditions: list[Condition] = []
-        
+
         # Get the group for query filtering
         group = event.group if hasattr(event, "group") and event.group else None
         if not group and group_id:
             from sentry.models.group import Group
+
             try:
                 group = Group.objects.get(id=group_id, project=project)
             except Group.DoesNotExist:
                 group = None
-        
+
         if query and group:
             from sentry.issues.endpoints.group_event_details import issue_search_query_to_conditions
 

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 
@@ -16,7 +18,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import IssueEventSerializer, serialize
 from sentry.api.serializers.models.event import IssueEventSerializerResponse
 from sentry.api.utils import get_date_range_from_params
-from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -146,12 +146,22 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         # Parse query parameter to apply filters for next/previous event navigation
         query = request.GET.get("query")
         conditions: list[Condition] = []
-        if query and event.group:
+        
+        # Get the group for query filtering
+        group = event.group if hasattr(event, "group") and event.group else None
+        if not group and group_id:
+            from sentry.models.group import Group
+            try:
+                group = Group.objects.get(id=group_id, project=project)
+            except Group.DoesNotExist:
+                group = None
+        
+        if query and group:
             from sentry.issues.endpoints.group_event_details import issue_search_query_to_conditions
 
             try:
                 conditions = issue_search_query_to_conditions(
-                    query, event.group, request.user, environments
+                    query, group, request.user, environments
                 )
             except Exception:
                 # If query parsing fails, log and continue without filters

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -158,6 +158,10 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
                 # to avoid breaking the endpoint
                 sentry_sdk.capture_exception()
 
+        # Add environment filter if specified
+        if environments:
+            conditions.append(Condition(Column("environment"), Op.IN, environment_names))
+
         data = wrap_event_response(
             request_user=request.user,
             event=event,

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -145,9 +145,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         query = request.GET.get("query")
         conditions: list[Condition] = []
         if query and event.group:
-            from sentry.issues.endpoints.group_event_details import (
-                issue_search_query_to_conditions,
-            )
+            from sentry.issues.endpoints.group_event_details import issue_search_query_to_conditions
 
             try:
                 conditions = issue_search_query_to_conditions(

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -214,7 +214,11 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 "organization_id_or_slug": self.project.organization.slug,
             },
         )
-        response = self.client.get(url, format="json", data={"query": f"release:{release_version}"})
+        response = self.client.get(
+            url,
+            format="json",
+            data={"group_id": event_with_release_2.group.id, "query": f"release:{release_version}"},
+        )
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(event_with_release_2.event_id)

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -214,9 +214,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 "organization_id_or_slug": self.project.organization.slug,
             },
         )
-        response = self.client.get(
-            url, format="json", data={"query": f"release:{release_version}"}
-        )
+        response = self.client.get(url, format="json", data={"query": f"release:{release_version}"})
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(event_with_release_2.event_id)

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -198,7 +198,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         # Event without release (should be filtered out)
         self.store_event(
             data={
-                "event_id": "g" * 32,
+                "event_id": "1" * 32,
                 "timestamp": before_now(minutes=9).isoformat(),
                 "fingerprint": ["group-1"],
             },


### PR DESCRIPTION
This PR fixes an issue where the Next/Previous event buttons in the Issue details view did not respect applied filters (e.g., release filters).

Previously, the `ProjectEventDetailsEndpoint` was not parsing the `query` parameter from the request, which contains these filters. This led to adjacent events being fetched without applying the specified criteria.

This change modifies `ProjectEventDetailsEndpoint` to:
1. Parse the `query` parameter using `issue_search_query_to_conditions`.
2. Apply the resulting Snuba conditions when fetching adjacent events.
3. Ensure environment filters are consistently applied.

A new test case has been added to verify that release filters are correctly applied during event navigation.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1319](https://linear.app/getsentry/issue/ID-1319/issues-nextprevious-buttons-dont-show-events-from-selected-release)

<a href="https://cursor.com/background-agent?bcId=bc-c332998a-5a62-4cb7-8a58-c773c096d948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c332998a-5a62-4cb7-8a58-c773c096d948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

