### PR TITLE
feat(agent): Expand root JSON path by default in trace drawer

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -231,7 +231,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <TraceDrawerComponents.MultilineJSON value={responseObject} />
+          {renderAIResponse(responseObject)}
         </Fragment>
       )}
       {toolCalls && (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -231,7 +231,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          {renderAIResponse(responseObject)}
+          <TraceDrawerComponents.MultilineJSON value={responseObject} />
         </Fragment>
       )}
       {toolCalls && (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -35,6 +35,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {StructuredData} from 'sentry/components/structuredEventData';
+import {getDefaultExpanded} from 'sentry/components/structuredEventData/utils';
 import {
   IconCircleFill,
   IconEllipsis,
@@ -1319,7 +1320,14 @@ function MultilineJSON({
   const {hoverProps, isHovered} = useHover({});
   const theme = useTheme();
 
-  const json = tryParseJson(value);
+  const json = useMemo(() => tryParseJson(value), [value]);
+
+  // Ensure root ('$') is always expanded, while children follow maxDefaultDepth rules
+  const computedExpandedPaths = useMemo(() => {
+    const childPaths = getDefaultExpanded(maxDefaultDepth, json);
+    return Array.from(new Set(['$', ...childPaths]));
+  }, [maxDefaultDepth, json]);
+
   return (
     <MultilineTextWrapperMonospace {...hoverProps}>
       {isHovered && (
@@ -1355,6 +1363,7 @@ function MultilineJSON({
           }}
           value={json}
           maxDefaultDepth={maxDefaultDepth}
+          initialExpandedPaths={computedExpandedPaths}
           withAnnotatedText
         />
       )}


### PR DESCRIPTION
**Problem**
When MultilineJSON renders JSON with more than 5 root-level children, the entire structure appears collapsed, requiring manual expansion to see any content.

**Solution**
Always expand the root node ($) by default while preserving depth-based auto-collapse rules for nested children. This ensures immediate visibility without overwhelming users with deeply expanded large objects.


closes https://linear.app/getsentry/issue/TET-1818/uncollapse-first-level-of-rendered-object