### PR TITLE
fix(tracemetrics): Add menu title to show loader

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -5,6 +5,7 @@ import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {t} from 'sentry/locale';
 import usePrevious from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -93,6 +94,7 @@ export function MetricSelector({
       options={isFetching ? previousOptions : (metricOptions ?? [])}
       value={traceMetricSelectValue}
       loading={isFetching}
+      menuTitle={t('Metrics')}
       onSearch={debouncedSetSearch}
       onChange={option => {
         if ('metricType' in option) {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -94,7 +94,7 @@ export function MetricSelector({
       options={isFetching ? previousOptions : (metricOptions ?? [])}
       value={traceMetricSelectValue}
       loading={isFetching}
-      menuTitle={t('Metrics')}
+      menuTitle={t('Metric')}
       onSearch={debouncedSetSearch}
       onChange={option => {
         if ('metricType' in option) {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -94,7 +94,7 @@ export function MetricSelector({
       options={isFetching ? previousOptions : (metricOptions ?? [])}
       value={traceMetricSelectValue}
       loading={isFetching}
-      menuTitle={t('Metric')}
+      menuTitle={t('Metrics')}
       onSearch={debouncedSetSearch}
       onChange={option => {
         if ('metricType' in option) {


### PR DESCRIPTION
By default the compact select won't show the loading indicator if something else in the menu isn't being set. This PR adds in a `menuTitle` prop of `Metric` so that the loader will display indicating to users that data is being fetched while searching.

Ticket: LOGS-566

Before:

https://github.com/user-attachments/assets/b88ef081-61be-4e1a-bbf8-49fa2830ab4a

After:

https://github.com/user-attachments/assets/19d034b0-8cf4-4f62-ac84-3caa6b5e5c70