### PR TITLE
ref(arroyo): use arroyo stuck_detector implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "rfc3339-validator>=0.1.2",
     "rfc3986-validator>=0.1.1",
     # [end] jsonschema format validators
-    "sentry-arroyo>=2.37.1",
+    "sentry-arroyo>=2.38.0",
     "sentry-conventions>=0.3.0",
     "sentry-forked-email-reply-parser>=0.5.12.post1",
     "sentry-kafka-schemas>=2.1.22",

--- a/tests/sentry/utils/test_arroyo.py
+++ b/tests/sentry/utils/test_arroyo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pickle
 from unittest.mock import MagicMock, patch
 
-from sentry.utils.arroyo import _import_and_run
+from sentry.utils.arroyo import STUCK_DETECTOR_TIMEOUT_SECONDS, _import_and_run
 
 
 def _test_main_fn() -> None:
@@ -14,15 +14,16 @@ def _test_initializer() -> None:
     pass
 
 
-def test_stuck_detector_thread_started_when_enabled() -> None:
-    """Test that stuck detector thread is started when enabled."""
+def test_stuck_detector_used_when_enabled() -> None:
+    """Test that arroyo's stuck_detector context manager is used when enabled."""
     main_fn_pickle = pickle.dumps(_test_main_fn)
     args_pickle = pickle.dumps(())
 
-    with patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class:
-        mock_thread = MagicMock()
-        mock_thread_class.return_value = mock_thread
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=None)
+    mock_cm.__exit__ = MagicMock(return_value=None)
 
+    with patch("sentry.utils.arroyo.stuck_detector", return_value=mock_cm) as mock_stuck_detector:
         _import_and_run(
             _test_initializer,
             main_fn_pickle,
@@ -30,18 +31,19 @@ def test_stuck_detector_thread_started_when_enabled() -> None:
             use_stuck_detector=True,
         )
 
-        mock_thread_class.assert_called_once()
-        assert mock_thread_class.call_args.kwargs["daemon"] is True
-        assert mock_thread_class.call_args.kwargs["name"] == "stuck-detector"
-        mock_thread.start.assert_called_once()
+        mock_stuck_detector.assert_called_once_with(
+            timeout_seconds=STUCK_DETECTOR_TIMEOUT_SECONDS,
+        )
+        mock_cm.__enter__.assert_called_once()
+        mock_cm.__exit__.assert_called_once()
 
 
-def test_stuck_detector_thread_not_started_when_disabled() -> None:
-    """Test that stuck detector thread is NOT started when disabled."""
+def test_stuck_detector_not_used_when_disabled() -> None:
+    """Test that stuck_detector is NOT used when disabled."""
     main_fn_pickle = pickle.dumps(_test_main_fn)
     args_pickle = pickle.dumps(())
 
-    with patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class:
+    with patch("sentry.utils.arroyo.stuck_detector") as mock_stuck_detector:
         _import_and_run(
             _test_initializer,
             main_fn_pickle,
@@ -49,83 +51,4 @@ def test_stuck_detector_thread_not_started_when_disabled() -> None:
             use_stuck_detector=False,
         )
 
-        mock_thread_class.assert_not_called()
-
-
-def test_init_done_set_after_initialization() -> None:
-    """Test that init_done event is set after initialization completes."""
-    events_set: list[str] = []
-    main_fn_pickle = pickle.dumps(_test_main_fn)
-    args_pickle = pickle.dumps(())
-
-    with (
-        patch("sentry.utils.arroyo.threading.Event") as mock_event_class,
-        patch("sentry.utils.arroyo.threading.Thread") as mock_thread_class,
-    ):
-        mock_event = MagicMock()
-        mock_event.is_set.return_value = True
-        mock_event.set.side_effect = lambda: events_set.append("init_done")
-        mock_event_class.return_value = mock_event
-
-        mock_thread = MagicMock()
-        mock_thread_class.return_value = mock_thread
-
-        assert len(events_set) == 0
-
-        _import_and_run(
-            _test_initializer,
-            main_fn_pickle,
-            args_pickle,
-            use_stuck_detector=True,
-        )
-
-        assert len(events_set) == 1
-
-
-def test_stuck_detector_logs_warning_when_timeout_exceeded() -> None:
-    """Test that stuck detector logs a warning with stack traces when timeout is exceeded."""
-    import logging
-
-    main_fn_pickle = pickle.dumps(_test_main_fn)
-    args_pickle = pickle.dumps(())
-
-    captured_target = None
-
-    def capture_thread_target(*args, **kwargs):
-        nonlocal captured_target
-        captured_target = kwargs.get("target")
-        mock_thread = MagicMock()
-        return mock_thread
-
-    time_values = [0, 0, 35]  # start, first check, second check (past 30s timeout)
-    time_index = [0]
-
-    def mock_time():
-        val = time_values[min(time_index[0], len(time_values) - 1)]
-        time_index[0] += 1
-        return val
-
-    mock_event = MagicMock()
-    mock_event.is_set.return_value = False
-
-    mock_logger = MagicMock()
-
-    with (
-        patch("sentry.utils.arroyo.threading.Thread", side_effect=capture_thread_target),
-        patch("sentry.utils.arroyo.threading.Event", return_value=mock_event),
-        patch("sentry.utils.arroyo.time.time", side_effect=mock_time),
-        patch("sentry.utils.arroyo.time.sleep"),
-        patch("arroyo.processing.processor.get_all_thread_stacks", return_value={"main": "stack"}),
-        patch.object(logging, "getLogger", return_value=mock_logger),
-    ):
-        _import_and_run(
-            _test_initializer,
-            main_fn_pickle,
-            args_pickle,
-            use_stuck_detector=True,
-        )
-
-        assert captured_target is not None
-        captured_target()
-
-        mock_logger.warning.assert_called_once()
+        mock_stuck_detector.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -2191,7 +2191,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = ">=1.2.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
-    { name = "sentry-arroyo", specifier = ">=2.37.1" },
+    { name = "sentry-arroyo", specifier = ">=2.38.0" },
     { name = "sentry-conventions", specifier = ">=0.3.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.22" },
@@ -2285,13 +2285,13 @@ dev = [
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.37.1"
+version = "2.38.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.37.1-py3-none-any.whl", hash = "sha256:eea44ab4e619acbe61b6e7edd0f1400ce84adbbe077bd0f80d17346376d69815" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.38.0-py3-none-any.whl", hash = "sha256:a5f63ed023487c5e9c7e58a2c5e161c161d3ae864f504b4a46fef87915f9ebd2" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bumps `sentry-arroyo` to >=2.38.0 to use arroyo built-in stuck-detector
- Replaces custom stuck detector implementation with arroyo stuck_detector context manager
- Cleans up debug logs
