### PR TITLE
chore(page-filters): Reduce selected period if max pickable days is updated

### DIFF
--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -458,6 +458,39 @@ describe('PageFiltersContainer', () => {
       );
     });
 
+    it('resets period when maxPickableDays decreases', async () => {
+      const {rerender} = render(<PageFiltersContainer maxPickableDays={30} />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/test/',
+            query: {statsPeriod: '14d'},
+          },
+          route: '/organizations/:orgId/test/',
+        },
+      });
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime).toEqual({
+          period: '14d',
+          utc: null,
+          start: null,
+          end: null,
+        })
+      );
+
+      rerender(<PageFiltersContainer maxPickableDays={7} />);
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime).toEqual({
+          period: '7d',
+          utc: null,
+          start: null,
+          end: null,
+        })
+      );
+    });
+
     it('does not use maxPickableDays if the query parms do not exceed it', async () => {
       const {router} = render(<PageFiltersContainer maxPickableDays={7} />, {
         organization,

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -491,6 +491,44 @@ describe('PageFiltersContainer', () => {
       );
     });
 
+    it('keeps absolute range when within maxPickableDays on decrease', async () => {
+      const start = moment().subtract(2, 'days').format('YYYY-MM-DDTHH:mm:ss');
+      const end = moment().subtract(1, 'days').format('YYYY-MM-DDTHH:mm:ss');
+
+      const {rerender} = render(<PageFiltersContainer maxPickableDays={30} />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/test/',
+            query: {start, end},
+          },
+          route: '/organizations/:orgId/test/',
+        },
+      });
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime.period).toBeNull()
+      );
+
+      const initialDatetime = PageFiltersStore.getState().selection.datetime;
+
+      rerender(<PageFiltersContainer maxPickableDays={7} />);
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime.period).toBeNull()
+      );
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime.start).toEqual(
+          initialDatetime.start
+        )
+      );
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime.end).toEqual(
+          initialDatetime.end
+        )
+      );
+    });
+
     it('does not use maxPickableDays if the query parms do not exceed it', async () => {
       const {router} = render(<PageFiltersContainer maxPickableDays={7} />, {
         organization,

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -135,6 +135,12 @@ function PageFiltersContainer({
   // When the limit decreases and the current selection exceeds it, reset to the new max.
   const previousMaxPickableDays = usePrevious(maxPickableDays);
   const shouldResetDateTime = useMemo(() => {
+    // Don't act until page filters are initialized - selection.datetime contains
+    // default values until isReady, not the actual URL state
+    if (!isReady) {
+      return false;
+    }
+
     // Only act when maxPickableDays decreases (increasing the limit never invalidates selection)
     if (
       previousMaxPickableDays === maxPickableDays ||
@@ -159,7 +165,7 @@ function PageFiltersContainer({
     }
 
     return false;
-  }, [maxPickableDays, previousMaxPickableDays, selection.datetime]);
+  }, [isReady, maxPickableDays, previousMaxPickableDays, selection.datetime]);
 
   useLayoutEffect(() => {
     if (!shouldResetDateTime) {

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -11,8 +11,8 @@ import {
 } from 'sentry/actionCreators/pageFilters';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {getStartOfPeriodAgo} from 'sentry/utils/dates';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -142,8 +142,10 @@ function PageFiltersContainer({
     }
 
     if (start && end) {
-      const minDate = getStartOfPeriodAgo('days', Math.max(maxPickableDays - 1, 0));
-      return new Date(start).getTime() < minDate.getTime();
+      // Use same calculation as initialization in pageFilters.tsx
+      const maxPeriod = parseStatsPeriod(`${maxPickableDays}d`);
+      const maxStart = new Date(maxPeriod.start);
+      return new Date(start).getTime() < maxStart.getTime();
     }
 
     return false;

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -1,12 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {Fragment, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import isEqual from 'lodash/isEqual';
 
 import type {InitializeUrlStateParams} from 'sentry/actionCreators/pageFilters';
@@ -93,14 +85,14 @@ function PageFiltersContainer({
   const memberProjects = isSuperuser
     ? specifiedProjects
     : specifiedProjects.filter(project => project.isMember);
-  const nonMemberProjects = useMemo(() => {
-    return isSuperuser ? [] : specifiedProjects.filter(project => !project.isMember);
-  }, [isSuperuser, specifiedProjects]);
+  const nonMemberProjects = isSuperuser
+    ? []
+    : specifiedProjects.filter(project => !project.isMember);
 
   const defaultMaxPickableDays = useDefaultMaxPickableDays();
   maxPickableDays = maxPickableDays ?? defaultMaxPickableDays;
 
-  const doInitialization = useCallback(() => {
+  const doInitialization = () => {
     initializeUrlState({
       organization,
       queryParams: location.query,
@@ -118,23 +110,7 @@ function PageFiltersContainer({
       skipInitializeUrlParams,
       storageNamespace,
     });
-  }, [
-    defaultSelection,
-    disablePersistence,
-    forceProject,
-    location.query,
-    maxPickableDays,
-    memberProjects,
-    nonMemberProjects,
-    organization,
-    router,
-    shouldForceProject,
-    showAbsolute,
-    skipInitializeUrlParams,
-    skipLoadLastUsed,
-    skipLoadLastUsedEnvironment,
-    storageNamespace,
-  ]);
+  };
 
   // Initializes GlobalSelectionHeader
   //
@@ -153,16 +129,25 @@ function PageFiltersContainer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectsLoaded]);
 
-  // If the max pickable days is decreased, we need to re-initialize the page filters
+  // If the max pickable days is decreased, we need to update the datetime state to the
+  // new max pickable days
   const previousMaxPickableDays = usePrevious(maxPickableDays);
   useLayoutEffect(() => {
     if (
       previousMaxPickableDays !== maxPickableDays &&
       previousMaxPickableDays > maxPickableDays
     ) {
-      doInitialization();
+      const newDateState = getDatetimeFromState({
+        period: `${maxPickableDays}d`,
+        start: null,
+        end: null,
+        utc: null,
+        environment: [],
+        project: [],
+      });
+      updateDateTime(newDateState, router);
     }
-  }, [doInitialization, maxPickableDays, previousMaxPickableDays]);
+  }, [maxPickableDays, previousMaxPickableDays, router]);
 
   // Update store persistence when `disablePersistence` changes
   useEffect(() => updatePersistence(!disablePersistence), [disablePersistence]);

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -161,13 +161,19 @@ function PageFiltersContainer({
         period: `${maxPickableDays}d`,
         start: null,
         end: null,
-        utc: null,
+        utc: selection.datetime.utc,
         environment: [],
         project: [],
       });
       updateDateTime(newDateState, router);
     }
-  }, [maxPickableDays, previousMaxPickableDays, router, shouldResetDateTime]);
+  }, [
+    maxPickableDays,
+    previousMaxPickableDays,
+    router,
+    selection.datetime.utc,
+    shouldResetDateTime,
+  ]);
 
   // Update store persistence when `disablePersistence` changes
   useEffect(() => updatePersistence(!disablePersistence), [disablePersistence]);

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -1,10 +1,9 @@
 import type {ReactNode} from 'react';
-import {useEffect, useMemo} from 'react';
+import {useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {ButtonBar} from '@sentry/scraps/button';
 
-import {updateDateTime} from 'sentry/actionCreators/pageFilters';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -15,14 +14,12 @@ import {useAssistant} from 'sentry/components/tours/useAssistant';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
-import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {
   useMaxPickableDays,
   type MaxPickableDaysOptions,
 } from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {
   MAX_DAYS_FOR_CROSS_EVENTS,
@@ -107,35 +104,6 @@ function ExploreContentInner() {
 }
 
 function SpansTabWrapper({children}: SpansTabContextProps) {
-  const pageFilters = usePageFilters();
-  const hasCrossEvents = useHasCrossEvents();
-
-  useEffect(() => {
-    if (!pageFilters.isReady || !hasCrossEvents) return;
-
-    const days = statsPeriodToDays(
-      pageFilters.selection.datetime.period,
-      pageFilters.selection.datetime.start,
-      pageFilters.selection.datetime.end
-    );
-
-    if (days > MAX_DAYS_FOR_CROSS_EVENTS) {
-      updateDateTime({
-        period: MAX_PERIOD_FOR_CROSS_EVENTS,
-        start: null,
-        end: null,
-        utc: pageFilters.selection.datetime.utc,
-      });
-    }
-  }, [
-    hasCrossEvents,
-    pageFilters.isReady,
-    pageFilters.selection.datetime.end,
-    pageFilters.selection.datetime.period,
-    pageFilters.selection.datetime.start,
-    pageFilters.selection.datetime.utc,
-  ]);
-
   return (
     <SpansTabTourProvider>
       <SpansTabTourTrigger />


### PR DESCRIPTION
This PR makes some changes to the page filters container. If the max pickable days value changes, and the current selection exceeds the passed in period, it will now update the state and URL to reflect the new max time period.

As well, this PR removes the code around the spans tab that was manually handling this before.